### PR TITLE
feat(subscription): reusable Blocks subscription module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,9 @@ ENV ASPNETCORE_ENVIRONMENT=Production \
 
 EXPOSE 5000
 
-RUN apk add --no-cache icu-libs
+# icu-libs backs globalization; tzdata backs TimeZoneInfo. Alpine ships neither, and without
+# tzdata every FindSystemTimeZoneById throws here while passing on a developer machine.
+RUN apk add --no-cache icu-libs tzdata
 
 COPY --from=publish /app/publish .
 RUN chown -R app:app /app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -39,7 +39,9 @@ ENV DOTNET_ENVIRONMENT=Production \
     DOTNET_RUNNING_IN_CONTAINER=true \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-RUN apk add --no-cache icu-libs
+# icu-libs backs globalization; tzdata backs TimeZoneInfo. Alpine ships neither, and without
+# tzdata every FindSystemTimeZoneById throws here while passing on a developer machine.
+RUN apk add --no-cache icu-libs tzdata
 
 COPY --from=publish /app/publish .
 RUN chown -R app:app /app

--- a/server/Api/Api.csproj
+++ b/server/Api/Api.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\Utility.DomainService\Utility.DomainService.csproj" />
     <!--<ProjectReference Include="..\Mail.DomainService\Mail.DomainService.csproj" />-->
     <ProjectReference Include="..\Payment.DomainService\Payment.DomainService.csproj" />
+    <ProjectReference Include="..\Subscription.DomainService\Subscription.DomainService.csproj" />
     <!--<ProjectReference Include="..\Notification.DomainService\Notification.DomainService.csproj" />-->
   </ItemGroup>
 </Project>

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -517,6 +517,21 @@
             something failed.
             </remarks>
         </member>
+        <member name="T:Api.Controllers.SubscriptionUsageController">
+            <summary>
+            Metered usage. Served under <c>/api/subscription-usage</c>.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionUsageController.Record(Subscription.DomainService.Requests.RecordUsageRequest,System.Threading.CancellationToken)">
+            <summary>
+            Records usage and reports where that leaves the allowance.
+            </summary>
+            <remarks>
+            This is the authoritative gate, not <c>GET /api/entitlements</c>. The figures returned
+            include this call, so two callers at the boundary get different answers; a caller that
+            must not exceed its allowance should set <c>enforce</c> and act on <c>allowed</c>.
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.TemplateEngineController">
             <summary>
             API Controller for managing template engine operations

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -530,6 +530,16 @@
             something failed.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.Cancel(System.String,System.Boolean,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Cancels a subscription.
+            </summary>
+            <remarks>
+            By default the subscription keeps granting until the period already paid for runs out,
+            and simply stops renewing. Pass <c>immediately</c> only where the customer is entitled
+            to stop at once.
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.SubscriptionUsageController">
             <summary>
             Metered usage. Served under <c>/api/subscription-usage</c>.

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -492,6 +492,11 @@
             
             <returns></returns>
         </member>
+        <member name="T:Api.Controllers.SubscriptionPlansController">
+            <summary>
+            What a tenant sells. Served under <c>/api/subscription-plans</c>.
+            </summary>
+        </member>
         <member name="T:Api.Controllers.TemplateEngineController">
             <summary>
             API Controller for managing template engine operations
@@ -590,6 +595,16 @@
             ProjectKey: Project key for multi-tenancy
             </remarks>
             <returns>CreateMultipleFileWithFilteredMongoQueryResponse</returns>
+        </member>
+        <member name="T:Api.Utilities.SubscriptionApiResults">
+            <summary>
+            Maps a subscription result onto an HTTP response.
+            </summary>
+            <remarks>
+            One mapping for every subscription controller. Repeated per controller, the switches drift:
+            one starts returning 404 where another returns 409 for the same failure, and clients end up
+            coding against whichever endpoint they met first.
+            </remarks>
         </member>
         <member name="T:BlocksTemplate.Api.GlobalApiRoutePrefixConvention">
             <summary>Prepends a segment (e.g. <c>api</c>) to every controller’s attribute route template.</summary>

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -540,6 +540,16 @@
             to stop at once.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.ChangePlan(System.String,Subscription.DomainService.Requests.ChangeSubscriptionPlanRequest,System.Threading.CancellationToken)">
+            <summary>
+            Moves the subscription to a different price, mid-period.
+            </summary>
+            <remarks>
+            An upgrade is charged immediately for the prorated difference; a downgrade is credited
+            toward future renewals rather than refunded. A trial has paid nothing yet, so its plan
+            simply swaps with no charge or credit either way.
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.SubscriptionUsageController">
             <summary>
             Metered usage. Served under <c>/api/subscription-usage</c>.

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -4,6 +4,19 @@
         <name>Api</name>
     </assembly>
     <members>
+        <member name="T:Api.Controllers.EntitlementsController">
+            <summary>
+            What the caller's organization may do. Served under <c>/api/entitlements</c>.
+            </summary>
+            <remarks>
+            The hot path: called on every gated action, answered from our own data, and never dependent
+            on a payment provider being reachable.
+            <para>
+            Advisory for anything metered. Two callers can both be told they have one unit left; only
+            recording the usage settles which of them actually did.
+            </para>
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.GeolocationController.#ctor(Utility.DomainService.Geolocation.service.IGeolocationService)">
             <summary>
             Initializes a new instance of the <see cref="T:Api.Controllers.GeolocationController"/> class.

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -497,6 +497,26 @@
             What a tenant sells. Served under <c>/api/subscription-plans</c>.
             </summary>
         </member>
+        <member name="T:Api.Controllers.SubscriptionsController">
+            <summary>
+            An organization's own subscription. Served under <c>/api/subscriptions</c>.
+            </summary>
+            <remarks>
+            No endpoint here takes an organization. Every one resolves it from the authenticated
+            caller, because an identifier in a URL is something anyone can change.
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionsController.GetCurrent(System.Threading.CancellationToken)">
+            <summary>
+            The caller's own subscription.
+            </summary>
+            <remarks>
+            Immediately after paying this may still report <c>Incomplete</c>: the shopper's browser
+            usually returns before the provider's webhook lands, and only the webhook is treated as
+            proof that money moved. Clients should expect a short pending state rather than assume
+            something failed.
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.TemplateEngineController">
             <summary>
             API Controller for managing template engine operations

--- a/server/Api/Controllers/EntitlementsController.cs
+++ b/server/Api/Controllers/EntitlementsController.cs
@@ -1,0 +1,65 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// What the caller's organization may do. Served under <c>/api/entitlements</c>.
+/// </summary>
+/// <remarks>
+/// The hot path: called on every gated action, answered from our own data, and never dependent
+/// on a payment provider being reachable.
+/// <para>
+/// Advisory for anything metered. Two callers can both be told they have one unit left; only
+/// recording the usage settles which of them actually did.
+/// </para>
+/// </remarks>
+[ApiController]
+[Authorize]
+[Route("entitlements")]
+public sealed class EntitlementsController : ControllerBase
+{
+    private readonly IEntitlementService _entitlements;
+
+    public EntitlementsController(IEntitlementService entitlements) =>
+        _entitlements = entitlements;
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<EntitlementSnapshotResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ApiResponse<EntitlementSnapshotResponse>), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> GetAll(
+        [FromQuery] bool fresh,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _entitlements.GetAsync(fresh, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    [HttpGet("{entitlementKey}")]
+    [ProducesResponseType(typeof(ApiResponse<EntitlementResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Get(
+        string entitlementKey,
+        [FromQuery] bool fresh,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _entitlements.GetAsync(
+            entitlementKey,
+            fresh,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -1,0 +1,93 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// What a tenant sells. Served under <c>/api/subscription-plans</c>.
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("subscription-plans")]
+public sealed class SubscriptionPlansController : ControllerBase
+{
+    private readonly IPlanCatalogueService _catalogue;
+
+    public SubscriptionPlansController(IPlanCatalogueService catalogue) =>
+        _catalogue = catalogue;
+
+    [HttpGet]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<PlanResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<PlanResponse>>), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> ListPlans(CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _catalogue.ListPlansAsync(correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    [HttpGet("{planId}")]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetPlan(
+        string planId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _catalogue.GetPlanAsync(
+            planId,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CreatePlan(
+        [FromBody] CreatePlanRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _catalogue.CreatePlanAsync(
+            request,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    [HttpPost("prices")]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CreatePrice(
+        [FromBody] CreatePriceRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _catalogue.CreatePriceAsync(
+            request,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Controllers/SubscriptionUsageController.cs
+++ b/server/Api/Controllers/SubscriptionUsageController.cs
@@ -1,0 +1,60 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// Metered usage. Served under <c>/api/subscription-usage</c>.
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("subscription-usage")]
+public sealed class SubscriptionUsageController : ControllerBase
+{
+    private readonly IUsageRecordingService _usage;
+
+    public SubscriptionUsageController(IUsageRecordingService usage) => _usage = usage;
+
+    /// <summary>
+    /// Records usage and reports where that leaves the allowance.
+    /// </summary>
+    /// <remarks>
+    /// This is the authoritative gate, not <c>GET /api/entitlements</c>. The figures returned
+    /// include this call, so two callers at the boundary get different answers; a caller that
+    /// must not exceed its allowance should set <c>enforce</c> and act on <c>allowed</c>.
+    /// </remarks>
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<UsageResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<UsageResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<UsageResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Record(
+        [FromBody] RecordUsageRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _usage.RecordAsync(request, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    [HttpGet("current")]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<UsageResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<UsageResponse>>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetCurrent(CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _usage.GetCurrentUsageAsync(correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -22,9 +22,15 @@ namespace Api.Controllers;
 public sealed class SubscriptionsController : ControllerBase
 {
     private readonly ISubscriptionCheckoutService _checkout;
+    private readonly ISubscriptionCancellationService _cancellation;
 
-    public SubscriptionsController(ISubscriptionCheckoutService checkout) =>
+    public SubscriptionsController(
+        ISubscriptionCheckoutService checkout,
+        ISubscriptionCancellationService cancellation)
+    {
         _checkout = checkout;
+        _cancellation = cancellation;
+    }
 
     [HttpPost]
     [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
@@ -64,6 +70,37 @@ public sealed class SubscriptionsController : ControllerBase
         var correlationId = HttpContext.TraceIdentifier;
 
         var result = await _checkout.GetCurrentAsync(correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Cancels a subscription.
+    /// </summary>
+    /// <remarks>
+    /// By default the subscription keeps granting until the period already paid for runs out,
+    /// and simply stops renewing. Pass <c>immediately</c> only where the customer is entitled
+    /// to stop at once.
+    /// </remarks>
+    [HttpDelete("{subscriptionId}")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Cancel(
+        string subscriptionId,
+        [FromQuery] bool immediately,
+        [FromQuery] string? reason,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _cancellation.CancelAsync(
+            subscriptionId,
+            immediately,
+            reason,
+            correlationId,
+            cancellationToken);
 
         return result.ToActionResult(correlationId);
     }

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -1,0 +1,70 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// An organization's own subscription. Served under <c>/api/subscriptions</c>.
+/// </summary>
+/// <remarks>
+/// No endpoint here takes an organization. Every one resolves it from the authenticated
+/// caller, because an identifier in a URL is something anyone can change.
+/// </remarks>
+[ApiController]
+[Authorize]
+[Route("subscriptions")]
+public sealed class SubscriptionsController : ControllerBase
+{
+    private readonly ISubscriptionCheckoutService _checkout;
+
+    public SubscriptionsController(ISubscriptionCheckoutService checkout) =>
+        _checkout = checkout;
+
+    [HttpPost]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> Subscribe(
+        [FromBody] CreateSubscriptionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _checkout.SubscribeAsync(
+            request,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// The caller's own subscription.
+    /// </summary>
+    /// <remarks>
+    /// Immediately after paying this may still report <c>Incomplete</c>: the shopper's browser
+    /// usually returns before the provider's webhook lands, and only the webhook is treated as
+    /// proof that money moved. Clients should expect a short pending state rather than assume
+    /// something failed.
+    /// </remarks>
+    [HttpGet("current")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetCurrent(CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _checkout.GetCurrentAsync(correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -23,13 +23,16 @@ public sealed class SubscriptionsController : ControllerBase
 {
     private readonly ISubscriptionCheckoutService _checkout;
     private readonly ISubscriptionCancellationService _cancellation;
+    private readonly ISubscriptionPlanChangeService _planChange;
 
     public SubscriptionsController(
         ISubscriptionCheckoutService checkout,
-        ISubscriptionCancellationService cancellation)
+        ISubscriptionCancellationService cancellation,
+        ISubscriptionPlanChangeService planChange)
     {
         _checkout = checkout;
         _cancellation = cancellation;
+        _planChange = planChange;
     }
 
     [HttpPost]
@@ -99,6 +102,36 @@ public sealed class SubscriptionsController : ControllerBase
             subscriptionId,
             immediately,
             reason,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Moves the subscription to a different price, mid-period.
+    /// </summary>
+    /// <remarks>
+    /// An upgrade is charged immediately for the prorated difference; a downgrade is credited
+    /// toward future renewals rather than refunded. A trial has paid nothing yet, so its plan
+    /// simply swaps with no charge or credit either way.
+    /// </remarks>
+    [HttpPut("{subscriptionId}/plan")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> ChangePlan(
+        string subscriptionId,
+        [FromBody] ChangeSubscriptionPlanRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _planChange.ChangePlanAsync(
+            subscriptionId,
+            request,
             correlationId,
             cancellationToken);
 

--- a/server/Api/Program.cs
+++ b/server/Api/Program.cs
@@ -9,6 +9,7 @@ using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
 using SeliseBlocks.ConfigurationDriver;
 using Scalar.AspNetCore;
+using Subscription.DomainService.Utilities;
 using Utility.DomainService.MagicLink.Utilities;
 using Utility.DomainService.Messaging;
 using Utility.DomainService.PdfGenerator.Utilities;
@@ -77,6 +78,7 @@ ApplyFrontendRuntimeSettings(builder.Configuration, wwwrootPath);
 
 services.AddSingleton<IVault>(_ => paymentVault);
 services.RegisterPaymentDomainServices(builder.Configuration);
+services.RegisterSubscriptionDomainServices(builder.Configuration);
 services.RegisterUtilityServices();
 
 var app = builder.Build();

--- a/server/Api/Utilities/SubscriptionApiResults.cs
+++ b/server/Api/Utilities/SubscriptionApiResults.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Api.Utilities;
+
+/// <summary>
+/// Maps a subscription result onto an HTTP response.
+/// </summary>
+/// <remarks>
+/// One mapping for every subscription controller. Repeated per controller, the switches drift:
+/// one starts returning 404 where another returns 409 for the same failure, and clients end up
+/// coding against whichever endpoint they met first.
+/// </remarks>
+public static class SubscriptionApiResults
+{
+    public static IActionResult ToActionResult<TValue>(
+        this SubscriptionOperationResult<TValue> result,
+        string correlationId)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.IsSuccess)
+        {
+            return new OkObjectResult(
+                ApiResponse<TValue>.Ok(result.Value!, correlationId));
+        }
+
+        var response = ApiResponse<TValue>.Fail(
+            result.ErrorCode ?? "subscription_failed",
+            result.ErrorMessage ?? "The subscription operation failed.",
+            correlationId,
+            result.ValidationErrors?.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value,
+                StringComparer.Ordinal));
+
+        return new ObjectResult(response) { StatusCode = StatusCodeFor(result.FailureKind) };
+    }
+
+    private static int StatusCodeFor(PaymentFailureKind kind) => kind switch
+    {
+        PaymentFailureKind.Validation => StatusCodes.Status400BadRequest,
+        PaymentFailureKind.NotFound => StatusCodes.Status404NotFound,
+        PaymentFailureKind.Conflict => StatusCodes.Status409Conflict,
+        PaymentFailureKind.RateLimited => StatusCodes.Status429TooManyRequests,
+        PaymentFailureKind.ProviderRejected => StatusCodes.Status422UnprocessableEntity,
+        PaymentFailureKind.ProviderFailure => StatusCodes.Status502BadGateway,
+        PaymentFailureKind.Unavailable => StatusCodes.Status503ServiceUnavailable,
+        PaymentFailureKind.Timeout => StatusCodes.Status504GatewayTimeout,
+        _ => StatusCodes.Status500InternalServerError
+    };
+}

--- a/server/Blocks.slnx
+++ b/server/Blocks.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="Api/Api.csproj" />
   <Project Path="Payment.DomainService/Payment.DomainService.csproj" />
+  <Project Path="Subscription.DomainService/Subscription.DomainService.csproj" />
   <Project Path="Utility.DomainService/Utility.DomainService.csproj" />
   <Project Path="Worker/Worker.csproj" />
   <Project Path="XUnitTest/XUnitTest.csproj" />

--- a/server/Payment.DomainService/Entities/StoredPaymentMethod.cs
+++ b/server/Payment.DomainService/Entities/StoredPaymentMethod.cs
@@ -11,15 +11,39 @@ public sealed class StoredPaymentMethod
     public string TenantId { get; set; } = string.Empty;
 
     /// <summary>
-    /// The organization whose merchant account holds this card.
+    /// The organization a shopper's card listing is scoped to.
     /// </summary>
     /// <remarks>
-    /// A provider token is only usable at the merchant account that issued it, and
-    /// organizations within a tenant may be separate businesses with their own accounts. So a
-    /// card belongs to one organization: offering it from another would show the shopper a card
-    /// that cannot be charged. Null for a card saved through a tenant-level configuration.
+    /// Visibility only: which caller this card is offered to. It is <b>not</b> necessarily the
+    /// organization whose merchant account issued the token — see
+    /// <see cref="EncryptionOrganizationId"/> for that. The two coincide when every organization
+    /// is its own merchant, and diverge when organizations are subscribers of one tenant-level
+    /// account, which is why they are two fields rather than one.
     /// </remarks>
     public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// The organization whose key ring protects <see cref="ProviderTokenCiphertext"/> — the
+    /// resolved provider configuration's own organization, i.e. the merchant account that
+    /// issued the token. Null means the tenant-level ring.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately separate from <see cref="OrganizationId"/>. A provider token is only usable
+    /// at the merchant account that issued it, so encryption has to follow that account, not the
+    /// caller who happened to save the card. Only meaningful when
+    /// <see cref="EncryptionScopeResolvedAtUtc"/> is set — see
+    /// <see cref="Utilities.PaymentEncryptionScope.From(StoredPaymentMethod)"/> for how a record
+    /// written before this field existed still decrypts.
+    /// </remarks>
+    public string? EncryptionOrganizationId { get; set; }
+
+    /// <summary>
+    /// When <see cref="EncryptionOrganizationId"/> was resolved and recorded. Null on a record
+    /// written before this distinction existed, which is the signal to fall back to
+    /// <see cref="OrganizationId"/> instead — the only behaviour available at the time it was
+    /// written, and still correct for a merchant-scoped organization.
+    /// </summary>
+    public DateTime? EncryptionScopeResolvedAtUtc { get; set; }
     public string ShopperReference { get; set; } = string.Empty;
     public string ProviderName { get; set; } = string.Empty;
     public string? StoredPaymentMethodToken { get; set; }

--- a/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
@@ -1,0 +1,71 @@
+using Payment.DomainService.Entities;
+
+namespace Payment.DomainService.Providers.Stripe;
+
+/// <summary>
+/// Raises a standalone Stripe Invoice for one charge attempt — no Stripe Subscription object,
+/// so Stripe never decides when the next attempt happens.
+/// </summary>
+/// <remarks>
+/// Four calls, each explicit rather than left to Stripe's own background advancement
+/// (<c>auto_advance</c> is off on creation): an invoice item, the invoice itself, finalizing it,
+/// and paying it. The caller decides when each step happens, which is what keeps this on the
+/// same billing clock as every other renewal attempt instead of starting a second one.
+/// </remarks>
+public interface IStripeInvoiceClient
+{
+    Task<StripeInvoiceCallResult> CreateInvoiceItemAsync(
+        PaymentProvider provider,
+        string customerId,
+        long amountMinor,
+        string currencyCode,
+        string description,
+        string idempotencyKey,
+        CancellationToken cancellationToken);
+
+    Task<StripeInvoiceCallResult> CreateInvoiceAsync(
+        PaymentProvider provider,
+        string customerId,
+        string idempotencyKey,
+        CancellationToken cancellationToken);
+
+    Task<StripeInvoiceCallResult> FinalizeInvoiceAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        string idempotencyKey,
+        CancellationToken cancellationToken);
+
+    Task<StripeInvoiceCallResult> PayInvoiceAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        string paymentMethodId,
+        string idempotencyKey,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Best-effort cleanup for an invoice that will not be paid — no result to act on, since a
+    /// void failing must never mask the decline that caused it.
+    /// </summary>
+    Task VoidInvoiceAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        CancellationToken cancellationToken);
+}
+
+public enum StripeInvoiceOutcome
+{
+    Success,
+    Rejected,
+    Unavailable,
+    Timeout,
+    OutcomeUnknown
+}
+
+public sealed record StripeInvoiceCallResult(
+    StripeInvoiceOutcome Outcome,
+    string? InvoiceOrItemId = null,
+    string? Status = null,
+    string? SafeErrorCode = null)
+{
+    public bool IsSuccess => Outcome == StripeInvoiceOutcome.Success;
+}

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoice.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoice.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace Payment.DomainService.Providers.Stripe;
+
+/// <summary>
+/// Stripe Invoice, as returned by creation, finalization, payment and voiding — all four answer
+/// with the invoice in its new state rather than an operation-specific object.
+/// </summary>
+public sealed class StripeInvoice
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary><c>draft</c>, <c>open</c>, <c>paid</c>, <c>uncollectible</c> or <c>void</c>.</summary>
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    [JsonPropertyName("amount_due")]
+    public long? AmountDue { get; set; }
+
+    [JsonPropertyName("currency")]
+    public string? Currency { get; set; }
+
+    /// <summary>Present instead of the invoice fields when Stripe rejects the call.</summary>
+    [JsonPropertyName("error")]
+    public StripeError? Error { get; set; }
+}

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
@@ -1,0 +1,248 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Providers.HostedCheckout;
+using Payment.DomainService.Utilities;
+
+namespace Payment.DomainService.Providers.Stripe;
+
+/// <summary>Raw Stripe Invoice API calls — one method per endpoint, no domain interpretation.</summary>
+public sealed class StripeInvoiceClient : IStripeInvoiceClient
+{
+    private readonly IHttpService _httpService;
+    private readonly StripeEndpointPolicy _endpointPolicy;
+    private readonly IOptionsMonitor<PaymentOptions> _options;
+    private readonly ILogger<StripeInvoiceClient> _logger;
+
+    public StripeInvoiceClient(
+        IHttpService httpService,
+        StripeEndpointPolicy endpointPolicy,
+        IOptionsMonitor<PaymentOptions> options,
+        ILogger<StripeInvoiceClient> logger)
+    {
+        _httpService = httpService;
+        _endpointPolicy = endpointPolicy;
+        _options = options;
+        _logger = logger;
+    }
+
+    public Task<StripeInvoiceCallResult> CreateInvoiceItemAsync(
+        PaymentProvider provider,
+        string customerId,
+        long amountMinor,
+        string currencyCode,
+        string description,
+        string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        var form = new StripeForm()
+            .Add("customer", customerId)
+            .Add("amount", amountMinor)
+            .Add("currency", currencyCode.ToLowerInvariant())
+            .Add("description", description);
+
+        return PostInvoiceObjectAsync(
+            provider,
+            "v1/invoiceitems",
+            form,
+            idempotencyKey,
+            "invoice item",
+            cancellationToken);
+    }
+
+    public Task<StripeInvoiceCallResult> CreateInvoiceAsync(
+        PaymentProvider provider,
+        string customerId,
+        string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        var form = new StripeForm()
+            .Add("customer", customerId)
+            .Add("collection_method", "charge_automatically")
+            // Blocks decides when this advances, not Stripe's own background job — the same
+            // discipline that keeps this off a second billing clock.
+            .Add("auto_advance", false);
+
+        return PostInvoiceObjectAsync(
+            provider,
+            "v1/invoices",
+            form,
+            idempotencyKey,
+            "invoice",
+            cancellationToken);
+    }
+
+    public Task<StripeInvoiceCallResult> FinalizeInvoiceAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        string idempotencyKey,
+        CancellationToken cancellationToken) =>
+        PostInvoiceObjectAsync(
+            provider,
+            $"v1/invoices/{Uri.EscapeDataString(invoiceId)}/finalize",
+            new StripeForm(),
+            idempotencyKey,
+            "invoice finalization",
+            cancellationToken);
+
+    public Task<StripeInvoiceCallResult> PayInvoiceAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        string paymentMethodId,
+        string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        var form = new StripeForm().Add("payment_method", paymentMethodId);
+
+        return PostInvoiceObjectAsync(
+            provider,
+            $"v1/invoices/{Uri.EscapeDataString(invoiceId)}/pay",
+            form,
+            idempotencyKey,
+            "invoice payment",
+            cancellationToken,
+            // A pay call answering with the invoice still open is a decline, not a transport
+            // failure — the call itself succeeded, the charge did not.
+            requiresPaidStatus: true);
+    }
+
+    public async Task VoidInvoiceAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        CancellationToken cancellationToken)
+    {
+        if (!_endpointPolicy.IsAllowed(provider.ApiBaseUrl))
+        {
+            return;
+        }
+
+        try
+        {
+            await _httpService.SendFormUrlEncoded<StripeInvoice>(
+                HttpMethod.Post,
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                StripeUrl.Build(
+                    provider.ApiBaseUrl,
+                    $"v1/invoices/{Uri.EscapeDataString(invoiceId)}/void"),
+                StripeRequestHeaders.Create(provider, $"void:{invoiceId}"),
+                cancellationToken,
+                Math.Clamp(_options.CurrentValue.ProviderTimeoutSeconds, 1, 60));
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // A void that could not complete leaves an open invoice behind — harmless, since
+            // nothing else will ever pay it, just untidy. Not worth failing the caller over.
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "Voiding a declined Stripe invoice failed InvoiceHash={InvoiceHash} ExceptionType={ExceptionType}",
+                PaymentLogValue.Hash(invoiceId),
+                exception.GetType().Name);
+        }
+    }
+
+    private async Task<StripeInvoiceCallResult> PostInvoiceObjectAsync(
+        PaymentProvider provider,
+        string path,
+        StripeForm form,
+        string idempotencyKey,
+        string operation,
+        CancellationToken cancellationToken,
+        bool requiresPaidStatus = false)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        if (!_endpointPolicy.IsAllowed(provider.ApiBaseUrl))
+        {
+            return new StripeInvoiceCallResult(StripeInvoiceOutcome.Unavailable);
+        }
+
+        try
+        {
+            var (invoice, error) = await _httpService.SendFormUrlEncoded<StripeInvoice>(
+                HttpMethod.Post,
+                form.Fields,
+                StripeUrl.Build(provider.ApiBaseUrl, path),
+                StripeRequestHeaders.Create(provider, idempotencyKey),
+                cancellationToken,
+                Math.Clamp(_options.CurrentValue.ProviderTimeoutSeconds, 1, 60));
+
+            if (invoice is { Id: not null, Error: null })
+            {
+                if (!requiresPaidStatus ||
+                    string.Equals(invoice.Status, "paid", StringComparison.Ordinal))
+                {
+                    return new StripeInvoiceCallResult(
+                        StripeInvoiceOutcome.Success,
+                        invoice.Id,
+                        invoice.Status);
+                }
+
+                return new StripeInvoiceCallResult(
+                    StripeInvoiceOutcome.Rejected,
+                    invoice.Id,
+                    invoice.Status,
+                    ProviderRejectionParser.SanitizeErrorCode(invoice.Status));
+            }
+
+            return Classify(provider, invoice?.Error, error, operation);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new StripeInvoiceCallResult(StripeInvoiceOutcome.Timeout);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                "Stripe invoice call failed Operation={Operation} Provider={Provider} ExceptionType={ExceptionType}",
+                operation,
+                PaymentLogValue.Label(provider.ProviderName),
+                exception.GetType().Name);
+
+            return new StripeInvoiceCallResult(StripeInvoiceOutcome.OutcomeUnknown);
+        }
+    }
+
+    private StripeInvoiceCallResult Classify(
+        PaymentProvider provider,
+        StripeError? stripeError,
+        string? transportError,
+        string operation)
+    {
+        if (stripeError != null)
+        {
+            return new StripeInvoiceCallResult(
+                StripeOutcomeMapper.Map(stripeError) switch
+                {
+                    ProviderClientOutcome.Unavailable => StripeInvoiceOutcome.Unavailable,
+                    ProviderClientOutcome.Rejected => StripeInvoiceOutcome.Rejected,
+                    _ => StripeInvoiceOutcome.OutcomeUnknown
+                },
+                SafeErrorCode: StripeOutcomeMapper.SafeCode(stripeError));
+        }
+
+        if (ProviderRejectionParser.TryGetValidationErrorCode(
+                transportError,
+                out var safeErrorCode))
+        {
+            return new StripeInvoiceCallResult(StripeInvoiceOutcome.Rejected, SafeErrorCode: safeErrorCode);
+        }
+
+        _logger.LogWarning(
+            "Stripe invoice call returned no usable response Operation={Operation} Provider={Provider} HasPackageError={HasPackageError}",
+            operation,
+            PaymentLogValue.Label(provider.ProviderName),
+            !string.IsNullOrWhiteSpace(transportError));
+
+        return new StripeInvoiceCallResult(
+            StripeUnavailable.IsTransient(transportError)
+                ? StripeInvoiceOutcome.Unavailable
+                : StripeInvoiceOutcome.OutcomeUnknown);
+    }
+}

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoiceItem.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoiceItem.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace Payment.DomainService.Providers.Stripe;
+
+/// <summary>Stripe Invoice Item, as returned by <c>POST /v1/invoiceitems</c>.</summary>
+public sealed class StripeInvoiceItem
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>Present instead of the item fields when Stripe rejects the call.</summary>
+    [JsonPropertyName("error")]
+    public StripeError? Error { get; set; }
+}

--- a/server/Payment.DomainService/README.md
+++ b/server/Payment.DomainService/README.md
@@ -461,6 +461,28 @@ charge it, and the shopper sees a decline on a card that looks perfectly good.
 
 So the safety is the organization filter; matching keys are merely tolerated.
 
+### Which ring protects the token
+
+Visibility and encryption are scoped by different organizations, and `StoredPaymentMethod`
+carries a field for each: `OrganizationId` for the former, `EncryptionOrganizationId` for the
+latter.
+
+They agree whenever the caller's organization is itself a merchant with its own provider
+configuration — the ordinary case in this module. They diverge when a tenant registers one
+provider configuration at tenant level and its organizations are subscribers of that account
+rather than merchants in their own right, which is how `Subscription.DomainService` uses this
+module. There, a card's visibility is still scoped to the organization that saved it, but the
+token is only usable at the tenant's merchant account, so that is what has to encrypt it.
+
+`EncryptionOrganizationId` is resolved from the provider configuration actually used for the
+token event — not derived from `OrganizationId` — and stamped alongside
+`EncryptionScopeResolvedAtUtc` at write time. `PaymentEncryptionScope.From(StoredPaymentMethod)`
+reads both: a record with a resolved scope uses it, and a record written before this
+distinction existed (no `EncryptionScopeResolvedAtUtc`) falls back to `OrganizationId`, which was
+the correct answer at the time — every organization was still a merchant when it was written.
+Token protection fails closed if no provider configuration resolves, rather than guessing which
+ring to use.
+
 ## Which payments a caller sees
 
 | Caller | Sees |

--- a/server/Payment.DomainService/README.md
+++ b/server/Payment.DomainService/README.md
@@ -572,3 +572,30 @@ Production messaging infrastructure must provision
 `blocks_payment_work_listener` as a queue consumed by the utility worker. API
 instances require send permission and worker instances require receive
 permission for that queue.
+
+# What subscriptions depend on
+
+`Subscription.DomainService` references this project. It is the only domain service that
+references another, and the dependency runs one way only —
+`XUnitTest/Subscription/SubscriptionBoundaryTests` fails the build if anything here starts
+naming a subscription type.
+
+Treat these as a contract rather than internals, and check that suite before changing them:
+
+- `IPaymentService.MakePaymentAsync`, for the first charge of a subscription
+- `IPaymentRepository.GetByIdAsync` and `GetByIdempotencyKeyAsync`, for activation and for
+  recovering a charge that was raised but never recorded
+- `IStoredPaymentMethodRepository.GetAsync`, for the provider's customer reference
+- `IPaymentExecutionContextResolver` and `IPaymentTenantContextScopeFactory`
+- `ICurrencyMinorUnitResolver`
+- `PaymentFailureKind`, `ApiResponse<T>`, `PaymentLogValue`
+
+`PaymentWorkCommandConsumer` also runs the subscription activation and outbox processors, so a
+subscription activates on the same tick as the webhook that paid for it.
+
+One thing to know when reading that module: **its organizations are subscribers, not
+merchants.** A tenant registers one provider configuration at tenant level and every
+organization under it buys from that account. Charges raised from there deliberately name no
+organization. That is the reverse of the model organization-scoped provider configuration
+exists for, and the two must not be conflated — see the note on encryption scope in
+`Subscription.DomainService/README.md`.

--- a/server/Payment.DomainService/Services/StoredPaymentMethodLifecycleService.cs
+++ b/server/Payment.DomainService/Services/StoredPaymentMethodLifecycleService.cs
@@ -385,11 +385,41 @@ public sealed class StoredPaymentMethodLifecycleService :
         CancellationToken cancellationToken)
     {
         var payload = webhook.NormalizedPayload;
+        var providerName =
+            payload.ProviderName ??
+            PaymentConstants.AdyenOnlineProvider;
 
-        // The card is protected under the organization that will charge it, which is also the
-        // organization whose ring must be able to read it back.
+        // The token is only usable at the merchant account that issued it, so the ring that
+        // protects it must be that account's — the resolved provider configuration's own
+        // organization — not the caller's. The two agree when every organization is its own
+        // merchant and diverge when organizations are subscribers of one tenant-level account;
+        // see PaymentEncryptionScope.From(StoredPaymentMethod) and the module README.
+        var provider = await _providers.GetAsync(
+            webhook.TenantId,
+            organizationId,
+            providerName,
+            () => _payments.GetProviderAsync(
+                webhook.TenantId,
+                organizationId,
+                providerName,
+                cancellationToken));
+
+        if (provider == null)
+        {
+            _logger.LogWarning(
+                "Stored payment method encryption scope could not be resolved because no " +
+                "provider configuration matched TenantHash={TenantHash} Provider={Provider}",
+                PaymentLogValue.Hash(webhook.TenantId),
+                PaymentLogValue.Label(providerName));
+
+            throw new InvalidOperationException(
+                "No payment provider configuration resolves for this token event.");
+        }
+
+        var encryptionScope = PaymentEncryptionScope.From(provider);
+
         var protection = await _tokenProtector.ProtectAsync(
-            new PaymentEncryptionScope(webhook.TenantId, organizationId),
+            encryptionScope,
             payload.StoredPaymentMethodToken!,
             cancellationToken);
 
@@ -405,11 +435,11 @@ public sealed class StoredPaymentMethodLifecycleService :
         {
             TenantId = webhook.TenantId,
             OrganizationId = organizationId,
+            EncryptionOrganizationId = encryptionScope.OrganizationId,
+            EncryptionScopeResolvedAtUtc = DateTime.UtcNow,
             ShopperReference = payload.ShopperReference!,
             ProviderPayerReference = payload.ProviderPayerReference,
-            ProviderName =
-                payload.ProviderName ??
-                PaymentConstants.AdyenOnlineProvider,
+            ProviderName = providerName,
             ProviderTokenCiphertext =
                 protectedToken.Ciphertext,
             ProviderTokenFingerprint =

--- a/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -171,6 +171,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             IStoredPaymentChargeProviderGatewayResolver,
             StoredPaymentChargeProviderGatewayResolver>();
+        services.AddSingleton<IStripeInvoiceClient, StripeInvoiceClient>();
         services.AddSingleton<ICheckoutResultValidator, CheckoutResultValidator>();
         services.AddSingleton<ICheckoutStatusMapper, AdyenCheckoutStatusMapper>();
         services.AddSingleton<ICheckoutStatusMapper, StripeCheckoutStatusMapper>();

--- a/server/Payment.DomainService/Utilities/PaymentEncryptionScope.cs
+++ b/server/Payment.DomainService/Utilities/PaymentEncryptionScope.cs
@@ -50,13 +50,29 @@ public readonly record struct PaymentEncryptionScope
     /// from the caller, so webhook intake and background work — which have no request context —
     /// resolve the same ring the token was written under.
     /// </summary>
+    /// <remarks>
+    /// A token is only usable at the merchant account that issued it, so this follows
+    /// <see cref="StoredPaymentMethod.EncryptionOrganizationId"/> — the resolved provider
+    /// configuration's own organization — rather than <see cref="StoredPaymentMethod.OrganizationId"/>,
+    /// which is card-listing visibility and may name a different organization entirely when
+    /// organizations are subscribers of one tenant-level merchant account rather than merchants
+    /// in their own right.
+    /// <para>
+    /// A record written before that distinction existed carries no
+    /// <see cref="StoredPaymentMethod.EncryptionScopeResolvedAtUtc"/>, and falls back to
+    /// <see cref="StoredPaymentMethod.OrganizationId"/> — every organization was its own merchant
+    /// when such a record was written, so the two were the same value at the time.
+    /// </para>
+    /// </remarks>
     public static PaymentEncryptionScope From(StoredPaymentMethod method)
     {
         ArgumentNullException.ThrowIfNull(method);
 
         return new PaymentEncryptionScope(
             method.TenantId,
-            method.OrganizationId);
+            method.EncryptionScopeResolvedAtUtc.HasValue
+                ? method.EncryptionOrganizationId
+                : method.OrganizationId);
     }
 
     public override string ToString() =>

--- a/server/Payment.DomainService/Utilities/PaymentLogValue.cs
+++ b/server/Payment.DomainService/Utilities/PaymentLogValue.cs
@@ -45,7 +45,11 @@ public static class PaymentLogValue
             return "missing";
         }
 
-        var safeCharacters = value
+        // Newlines are stripped as their own step, ahead of the allow-list filter below, so a
+        // value can never forge a second log entry even before the rest of the filtering runs.
+        var withoutLineBreaks = value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+        var safeCharacters = withoutLineBreaks
             .Where(character =>
                 char.IsLetterOrDigit(character) ||
                 character is '_' or '-' or '.')

--- a/server/Subscription.DomainService/Entities/BillingAccount.cs
+++ b/server/Subscription.DomainService/Entities/BillingAccount.cs
@@ -1,0 +1,44 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// An organization's standing with one payment provider.
+/// </summary>
+/// <remarks>
+/// The record the payment module never had: a provider's customer id survives there only on a
+/// saved card, which cannot carry a subscription and disappears when the card is removed.
+/// <para>
+/// <see cref="ProviderCustomerId"/> is filled in when the first charge confirms rather than
+/// created up front. Hosted checkout creates its own customer, so pre-creating one we cannot
+/// pin to the session would leave an orphan behind on every signup.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class BillingAccount
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string ProviderName { get; set; } = string.Empty;
+
+    /// <summary>The provider's identifier for this customer. Null until the first charge confirms.</summary>
+    public string? ProviderCustomerId { get; set; }
+
+    public string? BillingEmail { get; set; }
+
+    public string? BillingName { get; set; }
+
+    /// <summary>The saved method a renewal would charge.</summary>
+    public string? DefaultPaymentMethodId { get; set; }
+
+    public int Version { get; set; } = 1;
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/BillingSchedule.cs
+++ b/server/Subscription.DomainService/Entities/BillingSchedule.cs
@@ -1,0 +1,38 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// A recurring cadence, expressed so every future boundary can be recomputed rather than
+/// remembered.
+/// </summary>
+/// <remarks>
+/// <see cref="AnchorDayOfMonth"/> holds the day the subscriber actually chose and is never
+/// overwritten with a clamped one. A subscription anchored on the 31st bills on the 28th in
+/// February and returns to the 31st in March; persisting February's clamp would quietly drag
+/// every later period earlier for the life of the subscription.
+/// <para>
+/// The time zone is stored per subscription because "the 1st" has no meaning without one, and
+/// a server's own zone is not the customer's.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class BillingSchedule
+{
+    public BillingInterval Interval { get; set; } = BillingInterval.Month;
+
+    public int IntervalCount { get; set; } = 1;
+
+    /// <summary>The instant the cadence starts counting from.</summary>
+    public DateTime AnchorInstantUtc { get; set; }
+
+    /// <summary>An IANA identifier such as <c>Europe/Zurich</c>.</summary>
+    public string TimeZoneId { get; set; } = "UTC";
+
+    /// <summary>The originally chosen day, 1 to 31. Clamped on read, never on write.</summary>
+    public int AnchorDayOfMonth { get; set; } = 1;
+
+    /// <summary>Local time of day for a boundary, as minutes from midnight.</summary>
+    public int AnchorMinutesFromMidnight { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/DiscountTerms.cs
+++ b/server/Subscription.DomainService/Entities/DiscountTerms.cs
@@ -1,0 +1,30 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// A reduction applied to this subscription's charges.
+/// </summary>
+/// <remarks>
+/// Held as data in phase 1 and applied to the first charge. Percentages are basis points so a
+/// third off is exact rather than 33.33 rounded somewhere unpredictable.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class DiscountTerms
+{
+    public string Code { get; set; } = string.Empty;
+
+    public DiscountKind Kind { get; set; } = DiscountKind.Percent;
+
+    /// <summary>Basis points off, when the kind is a percentage. 2500 is a quarter off.</summary>
+    public int? PercentBasisPoints { get; set; }
+
+    /// <summary>Minor units off, when the kind is a fixed amount.</summary>
+    public long? AmountMinor { get; set; }
+
+    /// <summary>How many periods it applies to. Null runs for the life of the subscription.</summary>
+    public int? DurationPeriods { get; set; }
+
+    public DateTime? ExpiresAtUtc { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/MeterRateTable.cs
+++ b/server/Subscription.DomainService/Entities/MeterRateTable.cs
@@ -1,0 +1,18 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// A meter's rate bands for one currency.
+/// </summary>
+/// <remarks>
+/// A list rather than a currency-keyed map: BSON keys carry escaping rules a currency code does
+/// not need, and the rate table is always read whole.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class MeterRateTable
+{
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    public List<MeterTier> Tiers { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Entities/MeterTier.cs
+++ b/server/Subscription.DomainService/Entities/MeterTier.cs
@@ -1,0 +1,19 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One band of a graduated rate table.
+/// </summary>
+/// <remarks>
+/// Defined now and priced later: phase 1 records usage but does not rate it. Laying the shape
+/// down with the meter keeps a later phase from having to migrate live plans.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class MeterTier
+{
+    /// <summary>Upper bound of the band. Null is the final, unbounded tier.</summary>
+    public long? UpToQuantity { get; set; }
+
+    public long UnitAmountMinor { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/Plan.cs
+++ b/server/Subscription.DomainService/Entities/Plan.cs
@@ -1,0 +1,71 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// Something a tenant sells.
+/// </summary>
+/// <remarks>
+/// <see cref="OrganizationId"/> is nullable and resolves the way payment configuration does:
+/// an organization's own plan wins, otherwise the tenant's. Plans are sold *to* organizations
+/// *by* the tenant, so requiring one would mean copying every plan for every customer.
+/// Subscriptions, usage and entitlement remain strictly organization-scoped — only the
+/// catalogue is shared.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class Plan
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string? OrganizationId { get; set; }
+
+    /// <summary>A stable key configuration points at. The display name may change; this may not.</summary>
+    public string Code { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public CatalogueStatus Status { get; set; } = CatalogueStatus.Draft;
+
+    /// <summary>
+    /// Free-form plan features as the JSON text they were authored in, stored verbatim and
+    /// handed back untouched.
+    /// </summary>
+    /// <remarks>
+    /// Text rather than a parsed document on purpose. Nothing here ever branches on a feature,
+    /// so there is nothing to query into, and keeping the original text avoids both the
+    /// extended-JSON artefacts a BSON round trip introduces and any temptation to start
+    /// interpreting what a product put in here.
+    /// </remarks>
+    public string? FeaturesJson { get; set; }
+
+    public List<PlanEntitlement> Entitlements { get; set; } = [];
+
+    public List<PlanMeter> Meters { get; set; } = [];
+
+    public List<PlanQuantityItem> QuantityItems { get; set; } = [];
+
+    /// <summary>Trial length in days. Null means the plan offers no trial.</summary>
+    public int? TrialDays { get; set; }
+
+    /// <summary>Whether a trial collects a payment method before it starts.</summary>
+    public bool TrialRequiresPaymentMethod { get; set; } = true;
+
+    /// <summary>
+    /// How much of each meter a trial includes. A free trial of something with a real
+    /// per-unit cost is otherwise an open invitation.
+    /// </summary>
+    public List<TrialMeterGrant> TrialGrants { get; set; } = [];
+
+    /// <summary>Starts at 1: a zero version cannot be told apart from an absent field.</summary>
+    public int Version { get; set; } = 1;
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/PlanEntitlement.cs
+++ b/server/Subscription.DomainService/Entities/PlanEntitlement.cs
@@ -1,0 +1,30 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One thing a plan permits, in the form the entitlement API answers in.
+/// </summary>
+/// <remarks>
+/// A <see cref="EntitlementLimitKind.Count"/> entitlement names the meter that draws it down;
+/// the two are separate because a meter can be recorded without gating anything, and an
+/// entitlement can gate without counting.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class PlanEntitlement
+{
+    /// <summary>The product's own key, such as <c>pep_screening</c>. Never interpreted here.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    public EntitlementLimitKind LimitKind { get; set; } =
+        EntitlementLimitKind.Boolean;
+
+    /// <summary>The cap, when the kind is a count.</summary>
+    public long? Limit { get; set; }
+
+    /// <summary>The meter that draws this entitlement down, when the kind is a count.</summary>
+    public string? MeterKey { get; set; }
+
+    public string? UnitLabel { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/PlanMeter.cs
+++ b/server/Subscription.DomainService/Entities/PlanMeter.cs
@@ -1,0 +1,38 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// A named thing the plan counts.
+/// </summary>
+/// <remarks>
+/// The key is the product's word — "screening" for one client, "envelope" for another — and the
+/// platform treats it as an opaque name throughout. Nothing here knows what is being counted,
+/// which is what lets a second product be onboarded as configuration.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class PlanMeter
+{
+    public string MeterKey { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string UnitLabel { get; set; } = string.Empty;
+
+    public MeterAggregation Aggregation { get; set; } = MeterAggregation.Sum;
+
+    /// <summary>How much of this meter the plan includes each usage period.</summary>
+    public long IncludedQuantity { get; set; }
+
+    /// <summary>Whether usage past the included quantity is permitted and billed.</summary>
+    public bool OverageAllowed { get; set; } = true;
+
+    /// <summary>
+    /// Percentages of the included quantity that raise an event when first crossed, such as
+    /// 80 and 100. Each fires once per period.
+    /// </summary>
+    public List<int> ThresholdPercents { get; set; } = [];
+
+    public List<MeterRateTable> RateTables { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Entities/PlanQuantityItem.cs
+++ b/server/Subscription.DomainService/Entities/PlanQuantityItem.cs
@@ -1,0 +1,26 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// Something a subscriber buys a number of, priced per unit.
+/// </summary>
+/// <remarks>
+/// The platform has no idea what the unit is. One product sells seats, another sells users or
+/// workspaces; the label is the product's word and travels through to the caller untouched.
+/// A field called <c>Seats</c> here would have made the module one client's billing system.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class PlanQuantityItem
+{
+    public string ItemKey { get; set; } = string.Empty;
+
+    /// <summary>The product's own word, shown to its users. "seat", "user", "workspace".</summary>
+    public string UnitLabel { get; set; } = string.Empty;
+
+    public long MinQuantity { get; set; } = 1;
+
+    public long? MaxQuantity { get; set; }
+
+    public long DefaultQuantity { get; set; } = 1;
+}

--- a/server/Subscription.DomainService/Entities/PlanSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PlanSnapshot.cs
@@ -1,0 +1,36 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The plan's terms as they stood when the subscription was created, copied rather than
+/// referenced.
+/// </summary>
+/// <remarks>
+/// Two things follow, and both are wanted. Entitlement becomes a single document read, with no
+/// join to a catalogue that may since have moved. And editing a plan stops being retroactive:
+/// a subscriber keeps what they were sold until something deliberately migrates them, which is
+/// the correct billing semantic as well as the fast one.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class PlanSnapshot
+{
+    public string PlanId { get; set; } = string.Empty;
+
+    public string Code { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? FeaturesJson { get; set; }
+
+    public List<PlanEntitlement> Entitlements { get; set; } = [];
+
+    public List<PlanMeter> Meters { get; set; } = [];
+
+    public List<PlanQuantityItem> QuantityItems { get; set; } = [];
+
+    /// <summary>The plan version this was taken from, so a migration can tell what is stale.</summary>
+    public int PlanVersion { get; set; }
+
+    public DateTime CapturedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/Price.cs
+++ b/server/Subscription.DomainService/Entities/Price.cs
@@ -37,6 +37,13 @@ public sealed class Price
     /// </summary>
     public string? QuantityItemKey { get; set; }
 
+    /// <summary>
+    /// Tax to add on top, in basis points out of 10,000 — the same idiom
+    /// <see cref="DiscountTerms.PercentBasisPoints"/> uses. Null means not taxable. Authored by
+    /// whoever sets up the price, the same way its currency is: manual, not jurisdiction-derived.
+    /// </summary>
+    public int? TaxRateBasisPoints { get; set; }
+
     public CatalogueStatus Status { get; set; } = CatalogueStatus.Draft;
 
     public List<ProviderPriceMirror> ProviderMirrors { get; set; } = [];

--- a/server/Subscription.DomainService/Entities/Price.cs
+++ b/server/Subscription.DomainService/Entities/Price.cs
@@ -1,0 +1,49 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// What a plan costs, in one currency, on one cadence.
+/// </summary>
+/// <remarks>
+/// Prices are authored per currency, never converted. A rate-converted price moves every month,
+/// which makes invoices unstable and refunds lossy; and nobody sells at 92.47 anyway.
+/// <para>
+/// Amounts are minor units in a <see cref="long"/> — 8900 is CHF 89.00, and 8900 is also
+/// JPY 8900. A currency is meaningless without its exponent, so the two always travel together.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class Price
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string PlanId { get; set; } = string.Empty;
+
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    public long UnitAmountMinor { get; set; }
+
+    public BillingInterval Interval { get; set; } = BillingInterval.Month;
+
+    public int IntervalCount { get; set; } = 1;
+
+    /// <summary>
+    /// Which quantity item this price charges for. Null is a flat fee that does not multiply.
+    /// </summary>
+    public string? QuantityItemKey { get; set; }
+
+    public CatalogueStatus Status { get; set; } = CatalogueStatus.Draft;
+
+    public List<ProviderPriceMirror> ProviderMirrors { get; set; } = [];
+
+    public int Version { get; set; } = 1;
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/PriceSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PriceSnapshot.cs
@@ -25,6 +25,8 @@ public sealed class PriceSnapshot
 
     public string? QuantityItemKey { get; set; }
 
+    public int? TaxRateBasisPoints { get; set; }
+
     public int PriceVersion { get; set; }
 
     public DateTime CapturedAtUtc { get; set; } = DateTime.UtcNow;

--- a/server/Subscription.DomainService/Entities/PriceSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PriceSnapshot.cs
@@ -1,0 +1,31 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The price as sold, copied onto the subscription.
+/// </summary>
+/// <remarks>
+/// A subscriber's price must not move because someone edited the catalogue. Repricing a plan
+/// affects new subscriptions only.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class PriceSnapshot
+{
+    public string PriceId { get; set; } = string.Empty;
+
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    public long UnitAmountMinor { get; set; }
+
+    public BillingInterval Interval { get; set; } = BillingInterval.Month;
+
+    public int IntervalCount { get; set; } = 1;
+
+    public string? QuantityItemKey { get; set; }
+
+    public int PriceVersion { get; set; }
+
+    public DateTime CapturedAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/ProviderPriceMirror.cs
+++ b/server/Subscription.DomainService/Entities/ProviderPriceMirror.cs
@@ -1,0 +1,23 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The provider's own identifiers for a price we mirrored to it.
+/// </summary>
+/// <remarks>
+/// Mirroring exists so a later invoice can name a real provider price. It deliberately does not
+/// create a provider-side subscription: the billing clock is ours, and a provider running its
+/// own would bill the same period twice.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class ProviderPriceMirror
+{
+    public string ProviderName { get; set; } = string.Empty;
+
+    public string? ProviderProductId { get; set; }
+
+    public string? ProviderPriceId { get; set; }
+
+    public DateTime MirroredAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -73,6 +73,15 @@ public sealed class SubscriptionDetail
 
     public string? InitialPaymentDetailId { get; set; }
 
+    /// <summary>The most recent renewal's payment, for support traceability.</summary>
+    public string? LastRenewalPaymentDetailId { get; set; }
+
+    /// <summary>When the current dunning cycle started. Null outside <see cref="SubscriptionStatus.PastDue"/>.</summary>
+    public DateTime? PastDueSinceUtc { get; set; }
+
+    /// <summary>Renewal attempts made in the current dunning cycle. Resets to 0 on every successful charge.</summary>
+    public int DunningAttemptCount { get; set; }
+
     public DateTime CurrentPeriodStartUtc { get; set; }
 
     public DateTime CurrentPeriodEndUtc { get; set; }

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -1,0 +1,103 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// An organization's subscription to a plan. The aggregate everything else hangs off.
+/// </summary>
+/// <remarks>
+/// Named <c>SubscriptionDetail</c> rather than <c>Subscription</c> because a type sharing its
+/// name with the root namespace is ambiguous to the compiler — the same reason payments have a
+/// <c>PaymentDetail</c> and no <c>Payment</c>.
+/// <para>
+/// The organization here is the <em>subscriber</em> — the customer who pays — not a merchant.
+/// The tenant holds the merchant configuration; its organizations are its customers.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionDetail
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>The subscribing organization. Always present: entitlement without one is meaningless.</summary>
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string BillingAccountId { get; set; } = string.Empty;
+
+    public SubscriptionStatus Status { get; set; } =
+        SubscriptionStatus.Incomplete;
+
+    /// <summary>
+    /// Fixed for the life of the subscription. Refunds must return in the currency they
+    /// arrived in, and invoice history that spans currencies cannot be totalled.
+    /// </summary>
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    public PlanSnapshot Plan { get; set; } = new();
+
+    public PriceSnapshot Price { get; set; } = new();
+
+    public List<SubscriptionQuantityItem> QuantityItems { get; set; } = [];
+
+    /// <summary>When the subscription fee falls due.</summary>
+    public BillingSchedule FeeSchedule { get; set; } = new();
+
+    /// <summary>
+    /// When metered usage is counted and settled. Independent of the fee schedule on purpose:
+    /// an annual plan still meters monthly, since waiting a year to bill usage is a year of
+    /// unsecured credit.
+    /// </summary>
+    public BillingSchedule UsageSchedule { get; set; } = new();
+
+    public TrialTerms? Trial { get; set; }
+
+    public DiscountTerms? Discount { get; set; }
+
+    /// <summary>
+    /// Derived from the subscription id and stored, so a charge can be found again after a
+    /// crash between raising it and recording the link to it.
+    /// </summary>
+    public string OrderId { get; set; } = string.Empty;
+
+    public string? InitialPaymentDetailId { get; set; }
+
+    public DateTime CurrentPeriodStartUtc { get; set; }
+
+    public DateTime CurrentPeriodEndUtc { get; set; }
+
+    public DateTime? NextFeeBillingAtUtc { get; set; }
+
+    public DateTime CurrentUsagePeriodStartUtc { get; set; }
+
+    public DateTime CurrentUsagePeriodEndUtc { get; set; }
+
+    public DateTime? NextUsageBillingAtUtc { get; set; }
+
+    public DateTime? ActivatedAtUtc { get; set; }
+
+    /// <summary>Whether cancellation has been requested but not yet taken effect.</summary>
+    public bool CancelAtPeriodEnd { get; set; }
+
+    /// <summary>When cancellation was asked for — separate from when it takes effect.</summary>
+    public DateTime? CanceledAtUtc { get; set; }
+
+    /// <summary>When entitlement actually stopped.</summary>
+    public DateTime? EndedAtUtc { get; set; }
+
+    public string? CancellationReason { get; set; }
+
+    public List<SubscriptionOutboxEvent> OutboxEvents { get; set; } = [];
+
+    /// <summary>Starts at 1: a zero version cannot be told apart from an absent field.</summary>
+    public int Version { get; set; } = 1;
+
+    public string CorrelationId { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -58,6 +58,14 @@ public sealed class SubscriptionDetail
     public DiscountTerms? Discount { get; set; }
 
     /// <summary>
+    /// How many periods <see cref="Discount"/> has already reduced the charge for. Set to 1 at
+    /// creation when a discount was applied to the first charge; the renewal service increments
+    /// it further whenever it applies the discount again, so <see cref="DiscountTerms.DurationPeriods"/>
+    /// can be enforced without re-deriving history from past charges.
+    /// </summary>
+    public int DiscountPeriodsApplied { get; set; }
+
+    /// <summary>
     /// Derived from the subscription id and stored, so a charge can be found again after a
     /// crash between raising it and recording the link to it.
     /// </summary>

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -66,6 +66,12 @@ public sealed class SubscriptionDetail
     public int DiscountPeriodsApplied { get; set; }
 
     /// <summary>
+    /// Banked value from a downgrade's unused time, in this subscription's own currency.
+    /// Consumed automatically by future renewals before anything is charged — never paid out.
+    /// </summary>
+    public long CreditBalanceMinor { get; set; }
+
+    /// <summary>
     /// Derived from the subscription id and stored, so a charge can be found again after a
     /// crash between raising it and recording the link to it.
     /// </summary>

--- a/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
@@ -1,0 +1,41 @@
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// What is published to the lifecycle topic when something happens to a subscription.
+/// </summary>
+/// <remarks>
+/// The platform states the fact; each product decides what it means. A quota alert is an event
+/// here rather than an email because what counts as "warn the customer" differs per product,
+/// and this service has no business owning that decision — or a mail server.
+/// </remarks>
+public sealed class SubscriptionLifecycleEvent
+{
+    public string EventId { get; set; } = string.Empty;
+
+    public string EventType { get; set; } = string.Empty;
+
+    public int SchemaVersion { get; set; } = 1;
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public string PlanCode { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>Set on usage events; absent on lifecycle transitions.</summary>
+    public string? MeterKey { get; set; }
+
+    public long? ThresholdPercent { get; set; }
+
+    public long? Balance { get; set; }
+
+    public long? Limit { get; set; }
+
+    public string CorrelationId { get; set; } = string.Empty;
+
+    public DateTime OccurredAtUtc { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
@@ -35,6 +35,12 @@ public sealed class SubscriptionLifecycleEvent
 
     public long? Limit { get; set; }
 
+    /// <summary>Set on renewal and dunning events; absent otherwise.</summary>
+    public string? PeriodKey { get; set; }
+
+    /// <summary>The dunning attempt this event resulted from, 1-based.</summary>
+    public int? AttemptNumber { get; set; }
+
     public string CorrelationId { get; set; } = string.Empty;
 
     public DateTime OccurredAtUtc { get; set; }

--- a/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
@@ -24,6 +24,9 @@ public sealed class SubscriptionLifecycleEvent
 
     public string PlanCode { get; set; } = string.Empty;
 
+    /// <summary>Set only on a plan-change event; <see cref="PlanCode"/> already carries the new one.</summary>
+    public string? PreviousPlanCode { get; set; }
+
     public string Status { get; set; } = string.Empty;
 
     /// <summary>Set on usage events; absent on lifecycle transitions.</summary>

--- a/server/Subscription.DomainService/Entities/SubscriptionOutboxEvent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionOutboxEvent.cs
@@ -1,0 +1,57 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// A domain event appended in the same write as the state change that caused it.
+/// </summary>
+/// <remarks>
+/// Mongo and the message bus share no transaction, so publishing directly would lose events
+/// whenever the write succeeded and the publish did not. Appending the event to the document
+/// makes the two atomic, and a processor publishes afterwards.
+/// <para>
+/// <see cref="CorrelationId"/> and <see cref="CausationId"/> are persisted rather than passed,
+/// because publication happens on another thread in another process: without them the trace
+/// ends at the queue.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionOutboxEvent
+{
+    public string EventId { get; set; } = Guid.NewGuid().ToString();
+
+    public string EventType { get; set; } = string.Empty;
+
+    public int SchemaVersion { get; set; } = 1;
+
+    /// <summary>
+    /// Makes appending the event idempotent. The same transition attempted twice appends once.
+    /// </summary>
+    public string DeduplicationKey { get; set; } = string.Empty;
+
+    public string Payload { get; set; } = string.Empty;
+
+    public SubscriptionOutboxStatus Status { get; set; } =
+        SubscriptionOutboxStatus.Pending;
+
+    public int AttemptCount { get; set; }
+
+    public DateTime? NextAttemptAtUtc { get; set; }
+
+    public string? LeaseId { get; set; }
+
+    public DateTime? LeaseExpiresAtUtc { get; set; }
+
+    public string? LastError { get; set; }
+
+    /// <summary>The request this event originated in, carried across the queue hop.</summary>
+    public string CorrelationId { get; set; } = string.Empty;
+
+    /// <summary>What directly caused it, when that is not the originating request.</summary>
+    public string? CausationId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime? PublishedAtUtc { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionPaymentLink.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionPaymentLink.cs
@@ -1,0 +1,49 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// Ties a payment to the subscription it was raised for, and tracks whether its outcome has
+/// been applied.
+/// </summary>
+/// <remarks>
+/// A separate record rather than a field on either side, because the two are written by
+/// different processes at different times and the link is what a sweep can scan for.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionPaymentLink
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public string PaymentDetailId { get; set; } = string.Empty;
+
+    public string OrderId { get; set; } = string.Empty;
+
+    public SubscriptionPaymentPurpose Purpose { get; set; } =
+        SubscriptionPaymentPurpose.InitialCharge;
+
+    public SubscriptionPaymentLinkState State { get; set; } =
+        SubscriptionPaymentLinkState.Pending;
+
+    public int AttemptCount { get; set; }
+
+    /// <summary>When the sweep should look at this link again.</summary>
+    public DateTime? NextCheckAtUtc { get; set; }
+
+    public string? LastError { get; set; }
+
+    /// <summary>Carried so the sweep's work can be traced back to the request that started it.</summary>
+    public string CorrelationId { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionQuantityItem.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionQuantityItem.cs
@@ -1,0 +1,23 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// How many of a quantity item this subscription holds, and what each was sold at.
+/// </summary>
+/// <remarks>
+/// The amount is snapshotted alongside the quantity so adding units later charges the price the
+/// subscriber agreed to, not today's. Quantity and price are separate decisions and changing
+/// one must not move the other.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionQuantityItem
+{
+    public string ItemKey { get; set; } = string.Empty;
+
+    public string UnitLabel { get; set; } = string.Empty;
+
+    public long Quantity { get; set; }
+
+    public long UnitAmountMinor { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageCounter.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageCounter.cs
@@ -1,0 +1,66 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The running total for one subscription, meter and usage period.
+/// </summary>
+/// <remarks>
+/// A derived read model, kept so entitlement is a point read rather than an aggregation over
+/// the ledger. The ledger stays authoritative: if the two ever disagree the counter is rebuilt,
+/// never the other way round.
+/// <para>
+/// The identifier is composed rather than random, so the counter for a given period can be
+/// found — and created — by a single upsert with no prior read, and so crossing a period
+/// boundary simply addresses a different document instead of needing a rollover job.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionUsageCounter
+{
+    /// <summary><c>{subscriptionId}:{meterKey}:{periodKey}</c>.</summary>
+    [BsonId]
+    public string ItemId { get; set; } = string.Empty;
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public string MeterKey { get; set; } = string.Empty;
+
+    public string PeriodKey { get; set; } = string.Empty;
+
+    public long Balance { get; set; }
+
+    /// <summary>
+    /// How many ledger entries are reflected in the balance. Disagreement with the ledger's own
+    /// count is what tells the repair sweep this counter needs recomputing.
+    /// </summary>
+    public long AppliedRecordCount { get; set; }
+
+    /// <summary>
+    /// The allowance as it stood when this period opened. Copied so that editing a plan
+    /// mid-period cannot re-fire thresholds that have already been reported.
+    /// </summary>
+    public long? LimitSnapshot { get; set; }
+
+    /// <summary>Threshold percentages already reported. The deduplication authority for alerts.</summary>
+    public List<int> NotifiedThresholds { get; set; } = [];
+
+    public DateTime PeriodStartUtc { get; set; }
+
+    public DateTime PeriodEndUtc { get; set; }
+
+    /// <summary>When this derived document may be discarded. The ledger behind it is kept.</summary>
+    public DateTime ExpiresAtUtc { get; set; }
+
+    public DateTime LastUpdatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public static string CreateId(
+        string subscriptionId,
+        string meterKey,
+        string periodKey) =>
+        $"{subscriptionId}:{meterKey}:{periodKey}";
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageInvoice.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageInvoice.cs
@@ -1,0 +1,56 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One usage period's overage, priced and tracked toward being charged.
+/// </summary>
+/// <remarks>
+/// Created before the charge is attempted, the same discipline
+/// <see cref="SubscriptionPaymentLink"/> uses for the initial charge — a crash mid-attempt is
+/// recoverable by re-reading this same record rather than losing track of what was already
+/// billed or double-charging a retry.
+/// <para>
+/// Deliberately its own invoice, independent of the fee renewal: a decline here never touches
+/// the subscription's <c>Status</c> or the fee-side dunning cycle. See the module README.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionUsageInvoice
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public string PeriodKey { get; set; } = string.Empty;
+
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    public long TotalAmountMinor { get; set; }
+
+    public List<UsageInvoiceLine> Lines { get; set; } = [];
+
+    public SubscriptionUsageInvoiceState State { get; set; } =
+        SubscriptionUsageInvoiceState.Pending;
+
+    public int AttemptCount { get; set; }
+
+    /// <summary>When the charge sweep should look at this invoice again. Null once terminal.</summary>
+    public DateTime? NextAttemptAtUtc { get; set; }
+
+    public string? PaymentDetailId { get; set; }
+
+    public string? LastError { get; set; }
+
+    public string CorrelationId { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageInvoice.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageInvoice.cs
@@ -34,6 +34,9 @@ public sealed class SubscriptionUsageInvoice
 
     public long TotalAmountMinor { get; set; }
 
+    /// <summary>The portion of <see cref="TotalAmountMinor"/> that is tax, for traceability only.</summary>
+    public long TaxAmountMinor { get; set; }
+
     public List<UsageInvoiceLine> Lines { get; set; } = [];
 
     public SubscriptionUsageInvoiceState State { get; set; } =

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageRecord.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageRecord.cs
@@ -1,0 +1,63 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One entry in the append-only usage ledger.
+/// </summary>
+/// <remarks>
+/// Never updated in place. A mistake is corrected by a <see cref="UsageEntryType.Reversal"/>
+/// entry, so the history can always explain the figure a customer was billed — which a mutable
+/// counter alone cannot.
+/// <para>
+/// The ledger is the truth and is never expired; the counter beside it is a derived read model
+/// that can be rebuilt from these rows.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionUsageRecord
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public string MeterKey { get; set; } = string.Empty;
+
+    /// <summary>Which usage period this belongs to. Stamped on write so it can never drift.</summary>
+    public string PeriodKey { get; set; } = string.Empty;
+
+    public UsageEntryType EntryType { get; set; } = UsageEntryType.Consumption;
+
+    /// <summary>Signed: consumption raises the balance, a reversal lowers it.</summary>
+    public long Delta { get; set; }
+
+    /// <summary>
+    /// Unique per subscription and meter. The guard against billing a customer twice for one
+    /// event when a caller retries, which at-least-once delivery guarantees will happen.
+    /// </summary>
+    public string IdempotencyKey { get; set; } = string.Empty;
+
+    /// <summary>The entry this one reverses, when it is a correction.</summary>
+    public string? CompensatesRecordId { get; set; }
+
+    /// <summary>When the usage happened, which may not be when it was reported.</summary>
+    public DateTime OccurredAtUtc { get; set; }
+
+    public DateTime RecordedAtUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Bounded free-form context supplied by the calling product. Billing needs a count, not a
+    /// dossier — see the module README on keeping identifying detail out of this.
+    /// </summary>
+    public Dictionary<string, string> Metadata { get; set; } = [];
+
+    public string? RecordedByUserId { get; set; }
+
+    public string CorrelationId { get; set; } = string.Empty;
+}

--- a/server/Subscription.DomainService/Entities/TrialMeterGrant.cs
+++ b/server/Subscription.DomainService/Entities/TrialMeterGrant.cs
@@ -1,0 +1,19 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// How much of one meter a trial includes.
+/// </summary>
+/// <remarks>
+/// Separate from the plan's own included quantity because a trial is not a free month. Where
+/// each unit costs the seller real money, an uncapped trial is both a direct loss and an
+/// obvious way in for anyone willing to sign up repeatedly.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class TrialMeterGrant
+{
+    public string MeterKey { get; set; } = string.Empty;
+
+    public long IncludedQuantity { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/TrialTerms.cs
+++ b/server/Subscription.DomainService/Entities/TrialTerms.cs
@@ -1,0 +1,23 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The trial this subscription started on, if any.
+/// </summary>
+[BsonIgnoreExtraElements]
+public sealed class TrialTerms
+{
+    public DateTime StartsAtUtc { get; set; }
+
+    public DateTime EndsAtUtc { get; set; }
+
+    /// <summary>
+    /// Whether a card was taken up front. When false the subscription starts without any
+    /// charge at all, because a zero-amount payment is not something the money path accepts.
+    /// </summary>
+    public bool RequiresPaymentMethod { get; set; } = true;
+
+    /// <summary>Per-meter allowances for the trial, capped independently of the plan's own.</summary>
+    public List<TrialMeterGrant> Grants { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Entities/UsageInvoiceLine.cs
+++ b/server/Subscription.DomainService/Entities/UsageInvoiceLine.cs
@@ -1,0 +1,21 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One meter's contribution to a usage invoice's total.
+/// </summary>
+/// <remarks>
+/// Support traceability only — the charge itself is always the invoice's single aggregated
+/// total, never one charge per line, so a decline or a dashboard entry doesn't fragment across
+/// meters that happened to overage in the same period.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class UsageInvoiceLine
+{
+    public string MeterKey { get; set; } = string.Empty;
+
+    public long OverageQuantity { get; set; }
+
+    public long AmountMinor { get; set; }
+}

--- a/server/Subscription.DomainService/Enums/BillingInterval.cs
+++ b/server/Subscription.DomainService/Enums/BillingInterval.cs
@@ -1,0 +1,13 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// The unit of a billing cadence. Paired with a count, so quarterly is three months and
+/// fortnightly is two weeks — there is no member per marketable cadence.
+/// </summary>
+public enum BillingInterval
+{
+    Day = 0,
+    Week = 1,
+    Month = 2,
+    Year = 3
+}

--- a/server/Subscription.DomainService/Enums/CatalogueStatus.cs
+++ b/server/Subscription.DomainService/Enums/CatalogueStatus.cs
@@ -1,0 +1,12 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Whether a plan or price may be sold. Retiring one never removes it: existing subscribers
+/// hold a snapshot and keep running on terms that are no longer on the menu.
+/// </summary>
+public enum CatalogueStatus
+{
+    Draft = 0,
+    Active = 1,
+    Archived = 2
+}

--- a/server/Subscription.DomainService/Enums/DiscountKind.cs
+++ b/server/Subscription.DomainService/Enums/DiscountKind.cs
@@ -1,0 +1,13 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// How a discount reduces a charge.
+/// </summary>
+public enum DiscountKind
+{
+    /// <summary>A proportion, held in basis points so a third off is exact.</summary>
+    Percent = 0,
+
+    /// <summary>A fixed amount in the subscription's own currency.</summary>
+    FixedAmount = 1
+}

--- a/server/Subscription.DomainService/Enums/EntitlementLimitKind.cs
+++ b/server/Subscription.DomainService/Enums/EntitlementLimitKind.cs
@@ -1,0 +1,17 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// What kind of answer an entitlement gives. The platform never interprets the entitlement's
+/// meaning — only whether it is on, capped, or uncapped.
+/// </summary>
+public enum EntitlementLimitKind
+{
+    /// <summary>On or off. No counting.</summary>
+    Boolean = 0,
+
+    /// <summary>Capped at a number, drawn down by a meter.</summary>
+    Count = 1,
+
+    /// <summary>Present and uncapped. Never reports a limit reached.</summary>
+    Unlimited = 2
+}

--- a/server/Subscription.DomainService/Enums/EntitlementReason.cs
+++ b/server/Subscription.DomainService/Enums/EntitlementReason.cs
@@ -1,0 +1,25 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Why an entitlement decision came out the way it did.
+/// </summary>
+/// <remarks>
+/// Carried on every decision and logged with it, so a support engineer answering "why was this
+/// firm blocked" reads an answer instead of inferring one from an absent subscription.
+/// </remarks>
+public enum EntitlementReason
+{
+    Allowed = 0,
+
+    /// <summary>The organization has no subscription at all.</summary>
+    NoSubscription = 1,
+
+    /// <summary>A subscription exists but its status grants nothing.</summary>
+    SubscriptionNotActive = 2,
+
+    /// <summary>The plan does not carry this entitlement key.</summary>
+    NotInPlan = 3,
+
+    /// <summary>Capped, and the cap is used up.</summary>
+    LimitReached = 4
+}

--- a/server/Subscription.DomainService/Enums/MeterAggregation.cs
+++ b/server/Subscription.DomainService/Enums/MeterAggregation.cs
@@ -1,0 +1,20 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// How a meter's entries combine into the figure a period is judged on.
+/// </summary>
+/// <remarks>
+/// Phase 1 implements <see cref="Sum"/> only; the others are defined so the enum does not have
+/// to widen later, and are refused explicitly rather than silently treated as a sum.
+/// </remarks>
+public enum MeterAggregation
+{
+    /// <summary>Entries add up. The ordinary "how many did they use" meter.</summary>
+    Sum = 0,
+
+    /// <summary>The highest value seen in the period, for peak-based pricing.</summary>
+    Max = 1,
+
+    /// <summary>The most recent value, for a gauge such as stored bytes.</summary>
+    LastValue = 2
+}

--- a/server/Subscription.DomainService/Enums/SubscriptionOutboxStatus.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionOutboxStatus.cs
@@ -1,0 +1,14 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Where an outbox event has got to. Mirrors the payment outbox rather than sharing it: the two
+/// lifecycles are independent and will diverge.
+/// </summary>
+public enum SubscriptionOutboxStatus
+{
+    Pending = 0,
+    Processing = 1,
+    Published = 2,
+    RetryScheduled = 3,
+    Abandoned = 4
+}

--- a/server/Subscription.DomainService/Enums/SubscriptionPaymentLinkState.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionPaymentLinkState.cs
@@ -1,0 +1,16 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// How far a subscription's payment has been carried into the subscription's own state.
+/// </summary>
+public enum SubscriptionPaymentLinkState
+{
+    /// <summary>Raised, outcome not yet applied.</summary>
+    Pending = 0,
+
+    /// <summary>The outcome has been applied to the subscription. Terminal.</summary>
+    Applied = 1,
+
+    /// <summary>The payment failed or was never completed. Terminal.</summary>
+    Abandoned = 2
+}

--- a/server/Subscription.DomainService/Enums/SubscriptionPaymentPurpose.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionPaymentPurpose.cs
@@ -1,0 +1,13 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Why a payment was raised for a subscription.
+/// </summary>
+public enum SubscriptionPaymentPurpose
+{
+    /// <summary>The first charge, which activates the subscription.</summary>
+    InitialCharge = 0,
+
+    /// <summary>A period renewal. Reachable once a billing clock exists.</summary>
+    Renewal = 1
+}

--- a/server/Subscription.DomainService/Enums/SubscriptionStatus.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionStatus.cs
@@ -1,0 +1,38 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// The whole lifecycle, defined now so later phases add transitions rather than columns.
+/// </summary>
+/// <remarks>
+/// Phase 1 drives only <see cref="Incomplete"/> to <see cref="Trialing"/> or
+/// <see cref="Active"/>, <see cref="Incomplete"/> to <see cref="IncompleteExpired"/>, and
+/// cancellation. <see cref="PastDue"/> and <see cref="Unpaid"/> are reachable only once a
+/// billing clock exists, but entitlement already answers correctly for them.
+/// <para>
+/// Values are explicit because they are persisted: inserting a member without one would
+/// renumber every value after it and silently reinterpret stored documents.
+/// </para>
+/// </remarks>
+public enum SubscriptionStatus
+{
+    /// <summary>Created, first charge not yet confirmed. Grants nothing.</summary>
+    Incomplete = 0,
+
+    /// <summary>The first charge never completed. Terminal.</summary>
+    IncompleteExpired = 1,
+
+    /// <summary>Entitled, nobody has paid yet. Distinct from active so reporting can tell them apart.</summary>
+    Trialing = 2,
+
+    /// <summary>Entitled and paid.</summary>
+    Active = 3,
+
+    /// <summary>A renewal failed and the provider is still retrying. Entitled during the grace period.</summary>
+    PastDue = 4,
+
+    /// <summary>Retries are exhausted. Not entitled, but not yet ended.</summary>
+    Unpaid = 5,
+
+    /// <summary>Ended, by request or by non-payment. Terminal.</summary>
+    Canceled = 6
+}

--- a/server/Subscription.DomainService/Enums/SubscriptionUsageInvoiceState.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionUsageInvoiceState.cs
@@ -1,0 +1,17 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>How far a usage period's overage invoice has been carried toward being charged.</summary>
+public enum SubscriptionUsageInvoiceState
+{
+    /// <summary>Priced, not yet charged — or a retry is still due.</summary>
+    Pending = 0,
+
+    /// <summary>Charged successfully. Terminal.</summary>
+    Charged = 1,
+
+    /// <summary>The period had no overage; nothing was ever owed. Terminal.</summary>
+    NoCharge = 2,
+
+    /// <summary>Every retry was spent without success. Terminal.</summary>
+    Abandoned = 3
+}

--- a/server/Subscription.DomainService/Enums/UsageEntryType.cs
+++ b/server/Subscription.DomainService/Enums/UsageEntryType.cs
@@ -1,0 +1,21 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// What a usage ledger entry represents. The ledger is append-only, so a mistake is corrected
+/// by a <see cref="Reversal"/> rather than by editing what was written.
+/// </summary>
+public enum UsageEntryType
+{
+    /// <summary>Something was used. Raises the balance.</summary>
+    Consumption = 0,
+
+    /// <summary>Something used was undone or never happened. Lowers the balance.</summary>
+    Reversal = 1,
+
+    /// <summary>
+    /// Allowance added to the period. Unused in phase 1, and the reason the ledger is a ledger:
+    /// prepaid credits are the same drawdown with money attached, and retrofitting them onto a
+    /// bare counter would mean rebuilding history nobody kept.
+    /// </summary>
+    Grant = 2
+}

--- a/server/Subscription.DomainService/Outbox/ISubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionActivationProcessor.cs
@@ -1,0 +1,21 @@
+namespace Subscription.DomainService.Outbox;
+
+public interface ISubscriptionActivationProcessor
+{
+    /// <summary>
+    /// Carries confirmed payment outcomes into the subscriptions waiting on them.
+    /// </summary>
+    /// <returns>How many links were settled.</returns>
+    Task<int> ProcessDueAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Finds subscriptions whose first charge was raised but never recorded, and either
+    /// recovers the link or gives up on them.
+    /// </summary>
+    /// <remarks>
+    /// Covers the window between raising a charge and writing the link. Without it, a crash
+    /// there leaves a subscription that took the customer's money and grants nothing, with
+    /// nothing scanning for it.
+    /// </remarks>
+    Task<int> RecoverStaleAsync(string tenantId, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
@@ -32,4 +32,11 @@ public interface ISubscriptionOutboxEventFactory
         SubscriptionDetail subscription,
         string previousPlanCode,
         string correlationId);
+
+    /// <summary>A usage invoice's terminal outcome — charged, or abandoned after every retry.</summary>
+    SubscriptionOutboxEvent CreateUsageRatingOutcome(
+        SubscriptionDetail subscription,
+        string eventType,
+        string periodKey,
+        string correlationId);
 }

--- a/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
@@ -1,0 +1,18 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Outbox;
+
+public interface ISubscriptionOutboxEventFactory
+{
+    SubscriptionOutboxEvent Create(
+        SubscriptionDetail subscription,
+        string eventType,
+        string correlationId,
+        string? causationId = null);
+
+    SubscriptionOutboxEvent CreateUsageThreshold(
+        SubscriptionDetail subscription,
+        SubscriptionUsageCounter counter,
+        int thresholdPercent,
+        string correlationId);
+}

--- a/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
@@ -15,4 +15,12 @@ public interface ISubscriptionOutboxEventFactory
         SubscriptionUsageCounter counter,
         int thresholdPercent,
         string correlationId);
+
+    /// <summary>A renewal or dunning attempt's outcome, scoped to the period it charged.</summary>
+    SubscriptionOutboxEvent CreateRenewalOutcome(
+        SubscriptionDetail subscription,
+        string eventType,
+        string periodKey,
+        int attemptNumber,
+        string correlationId);
 }

--- a/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionOutboxEventFactory.cs
@@ -23,4 +23,13 @@ public interface ISubscriptionOutboxEventFactory
         string periodKey,
         int attemptNumber,
         string correlationId);
+
+    /// <summary>
+    /// A plan change. <paramref name="subscription"/>'s own <c>Plan.Code</c> must already be the
+    /// new one — this only needs told what it changed <em>from</em>.
+    /// </summary>
+    SubscriptionOutboxEvent CreatePlanChanged(
+        SubscriptionDetail subscription,
+        string previousPlanCode,
+        string correlationId);
 }

--- a/server/Subscription.DomainService/Outbox/ISubscriptionOutboxProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionOutboxProcessor.cs
@@ -1,0 +1,10 @@
+namespace Subscription.DomainService.Outbox;
+
+public interface ISubscriptionOutboxProcessor
+{
+    /// <summary>
+    /// Publishes the events that have been appended to subscriptions but not yet sent.
+    /// </summary>
+    /// <returns>How many were published.</returns>
+    Task<int> PublishDueAsync(string tenantId, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Outbox/ISubscriptionRenewalProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionRenewalProcessor.cs
@@ -1,0 +1,8 @@
+namespace Subscription.DomainService.Outbox;
+
+/// <summary>Sweeps subscriptions due for a renewal charge or a dunning retry.</summary>
+public interface ISubscriptionRenewalProcessor
+{
+    /// <returns>How many subscriptions were processed, whether they renewed or declined.</returns>
+    Task<int> ProcessDueAsync(string tenantId, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
@@ -1,0 +1,8 @@
+namespace Subscription.DomainService.Outbox;
+
+/// <summary>Closes usage periods that have ended and invoices their overage.</summary>
+public interface ISubscriptionUsageRatingProcessor
+{
+    /// <returns>How many usage periods were closed out, across every subscription swept.</returns>
+    Task<int> CloseDuePeriodsAsync(string tenantId, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
@@ -5,4 +5,7 @@ public interface ISubscriptionUsageRatingProcessor
 {
     /// <returns>How many usage periods were closed out, across every subscription swept.</returns>
     Task<int> CloseDuePeriodsAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <returns>How many invoices were attempted, whether they charged, retried or were abandoned.</returns>
+    Task<int> ChargeDueInvoicesAsync(string tenantId, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -1,0 +1,401 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Outbox;
+
+/// <summary>
+/// Turns a confirmed payment into an active subscription.
+/// </summary>
+/// <remarks>
+/// Activation waits for the provider's webhook, never the shopper's return. A browser redirect
+/// can be replayed, forged, bookmarked or simply lost when someone shuts the laptop; the
+/// webhook is signed and arrives regardless. Where the two disagree, the webhook is right.
+/// </remarks>
+public sealed class SubscriptionActivationProcessor : ISubscriptionActivationProcessor
+{
+    /// <summary>Payment statuses that mean the money is ours.</summary>
+    private static readonly string[] ConfirmedStatuses =
+    [
+        PaymentStatuses.Authorized,
+        PaymentStatuses.Captured,
+        PaymentStatuses.PartiallyCaptured
+    ];
+
+    /// <summary>Payment statuses that will never become confirmed.</summary>
+    private static readonly string[] TerminalFailureStatuses =
+    [
+        PaymentStatuses.Refused,
+        PaymentStatuses.Cancelled,
+        PaymentStatuses.MakePaymentFailed
+    ];
+
+    private readonly ISubscriptionPaymentLinkRepository _links;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly IBillingAccountRepository _billingAccounts;
+    private readonly ISubscriptionOutboxEventFactory _events;
+    private readonly IPaymentRepository _payments;
+    private readonly IStoredPaymentMethodRepository _storedMethods;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionActivationProcessor> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionActivationProcessor(
+        ISubscriptionPaymentLinkRepository links,
+        ISubscriptionRepository subscriptions,
+        IBillingAccountRepository billingAccounts,
+        ISubscriptionOutboxEventFactory events,
+        IPaymentRepository payments,
+        IStoredPaymentMethodRepository storedMethods,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<SubscriptionActivationProcessor> logger,
+        TimeProvider? time = null)
+    {
+        _links = links;
+        _subscriptions = subscriptions;
+        _billingAccounts = billingAccounts;
+        _events = events;
+        _payments = payments;
+        _storedMethods = storedMethods;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<int> ProcessDueAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var due = await _links.ListDueAsync(
+            tenantId,
+            now,
+            Math.Max(1, options.ActivationBatchSize),
+            cancellationToken);
+
+        var settled = 0;
+
+        foreach (var link in due)
+        {
+            if (await SettleAsync(link, options, now, cancellationToken))
+            {
+                settled++;
+            }
+        }
+
+        return settled;
+    }
+
+    public async Task<int> RecoverStaleAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+        var cutoff = now.AddMinutes(-Math.Max(1, options.InitialChargeGraceMinutes));
+
+        var stale = await _subscriptions.ListStaleAsync(
+            tenantId,
+            SubscriptionStatus.Incomplete,
+            cutoff,
+            Math.Max(1, options.ActivationBatchSize),
+            cancellationToken);
+
+        var recovered = 0;
+
+        foreach (var subscription in stale)
+        {
+            var link = await _links.FindBySubscriptionAsync(
+                tenantId,
+                subscription.ItemId,
+                cancellationToken);
+
+            if (link is not null)
+            {
+                continue;
+            }
+
+            // No link, so the charge either never happened or was lost before it was recorded.
+            // The idempotency key is derived from the subscription, which is what makes the
+            // payment findable at all — and it is uniquely indexed, so this is a point read.
+            var payment = await _payments.GetByIdempotencyKeyAsync(
+                tenantId,
+                SubscriptionConstants.InitialChargeKeyFor(subscription.ItemId),
+                cancellationToken);
+
+            if (payment is null)
+            {
+                await ExpireAsync(subscription, cancellationToken);
+                recovered++;
+
+                continue;
+            }
+
+            await _links.TryCreateAsync(
+                new SubscriptionPaymentLink
+                {
+                    TenantId = tenantId,
+                    OrganizationId = subscription.OrganizationId,
+                    SubscriptionId = subscription.ItemId,
+                    PaymentDetailId = payment.ItemId,
+                    OrderId = subscription.OrderId,
+                    Purpose = SubscriptionPaymentPurpose.InitialCharge,
+                    CorrelationId = subscription.CorrelationId
+                },
+                cancellationToken);
+
+            _logger.LogWarning(
+                "Recovered an unrecorded subscription charge TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(tenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                subscription.CorrelationId);
+
+            recovered++;
+        }
+
+        return recovered;
+    }
+
+    private async Task<bool> SettleAsync(
+        SubscriptionPaymentLink link,
+        SubscriptionOptions options,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["TenantHash"] = PaymentLogValue.Hash(link.TenantId),
+            ["SubscriptionHash"] = PaymentLogValue.Hash(link.SubscriptionId),
+            ["CorrelationId"] = link.CorrelationId
+        });
+
+        var payment = await _payments.GetByIdAsync(
+            link.TenantId,
+            link.PaymentDetailId,
+            cancellationToken);
+
+        if (payment is null)
+        {
+            await RescheduleAsync(link, options, now, "payment_not_found", cancellationToken);
+
+            return false;
+        }
+
+        if (IsConfirmed(payment))
+        {
+            return await ActivateAsync(link, payment, cancellationToken);
+        }
+
+        if (TerminalFailureStatuses.Contains(payment.PaymentStatus, StringComparer.Ordinal))
+        {
+            return await AbandonAsync(link, cancellationToken);
+        }
+
+        await RescheduleAsync(
+            link,
+            options,
+            now,
+            $"awaiting_confirmation:{PaymentLogValue.Label(payment.PaymentStatus)}",
+            cancellationToken);
+
+        return false;
+    }
+
+    /// <summary>
+    /// Confirmed means both an accepting status <em>and</em> a webhook that said so.
+    /// </summary>
+    private static bool IsConfirmed(PaymentDetail payment) =>
+        ConfirmedStatuses.Contains(payment.PaymentStatus, StringComparer.Ordinal) &&
+        payment.WebhookConfirmedAtUtc is not null;
+
+    private async Task<bool> ActivateAsync(
+        SubscriptionPaymentLink link,
+        PaymentDetail payment,
+        CancellationToken cancellationToken)
+    {
+        var subscription = await _subscriptions.GetByIdAsync(
+            link.TenantId,
+            link.SubscriptionId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            return await AbandonAsync(link, cancellationToken);
+        }
+
+        if (subscription.Status != SubscriptionStatus.Incomplete)
+        {
+            // Already carried across by an earlier pass. Settle the link so it stops coming back.
+            return await _links.TrySettleAsync(
+                link.TenantId,
+                link.ItemId,
+                SubscriptionPaymentLinkState.Applied,
+                cancellationToken);
+        }
+
+        var target = subscription.Trial is null
+            ? SubscriptionStatus.Active
+            : SubscriptionStatus.Trialing;
+
+        var eventType = target == SubscriptionStatus.Trialing
+            ? SubscriptionConstants.SubscriptionTrialStarted
+            : SubscriptionConstants.SubscriptionActivated;
+
+        var applied = await _subscriptions.TryTransitionAsync(
+            link.TenantId,
+            link.SubscriptionId,
+            new SubscriptionTransition(SubscriptionStatus.Incomplete, target)
+            {
+                ActivatedAtUtc = _time.GetUtcNow().UtcDateTime,
+                InitialPaymentDetailId = payment.ItemId,
+                Event = _events.Create(
+                    subscription,
+                    eventType,
+                    link.CorrelationId,
+                    payment.ItemId)
+            },
+            cancellationToken);
+
+        if (!applied)
+        {
+            // Another worker got there first. Its transition is as good as this one's.
+            return false;
+        }
+
+        await AdoptProviderCustomerAsync(subscription, payment, cancellationToken);
+
+        _logger.LogInformation(
+            "Subscription activated Status={Status} PaymentHash={PaymentHash}",
+            PaymentLogValue.Label(target.ToString()),
+            PaymentLogValue.Hash(payment.ItemId));
+
+        return await _links.TrySettleAsync(
+            link.TenantId,
+            link.ItemId,
+            SubscriptionPaymentLinkState.Applied,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Records the provider's customer from the card the charge saved.
+    /// </summary>
+    /// <remarks>
+    /// Taken from the payment rather than created up front: hosted checkout makes its own
+    /// customer, so pre-creating one we cannot pin to the session would leave an orphan behind
+    /// on every signup. The renewal needs this identifier, so a failure here is logged rather
+    /// than swallowed — but it does not undo an activation the customer has already paid for.
+    /// </remarks>
+    private async Task AdoptProviderCustomerAsync(
+        SubscriptionDetail subscription,
+        PaymentDetail payment,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(payment.StoredPaymentMethodPublicId))
+        {
+            return;
+        }
+
+        var method = await _storedMethods.GetAsync(
+            subscription.TenantId,
+            payment.StoredPaymentMethodPublicId,
+            cancellationToken);
+
+        if (method?.ProviderPayerReference is not { Length: > 0 } customerId)
+        {
+            _logger.LogWarning(
+                "No provider customer recorded for a subscription; renewals will need one");
+
+            return;
+        }
+
+        await _billingAccounts.TrySetProviderCustomerAsync(
+            subscription.TenantId,
+            subscription.BillingAccountId,
+            customerId,
+            method.ItemId,
+            cancellationToken);
+    }
+
+    private async Task<bool> AbandonAsync(
+        SubscriptionPaymentLink link,
+        CancellationToken cancellationToken)
+    {
+        var subscription = await _subscriptions.GetByIdAsync(
+            link.TenantId,
+            link.SubscriptionId,
+            cancellationToken);
+
+        if (subscription is not null)
+        {
+            await ExpireAsync(subscription, cancellationToken);
+        }
+
+        _logger.LogInformation("Subscription activation abandoned after a failed charge");
+
+        return await _links.TrySettleAsync(
+            link.TenantId,
+            link.ItemId,
+            SubscriptionPaymentLinkState.Abandoned,
+            cancellationToken);
+    }
+
+    private async Task ExpireAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken) =>
+        await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            new SubscriptionTransition(
+                SubscriptionStatus.Incomplete,
+                SubscriptionStatus.IncompleteExpired)
+            {
+                EndedAtUtc = _time.GetUtcNow().UtcDateTime,
+                ClearNextFeeBillingAt = true,
+                Event = _events.Create(
+                    subscription,
+                    SubscriptionConstants.SubscriptionActivationFailed,
+                    subscription.CorrelationId)
+            },
+            cancellationToken);
+
+    private async Task RescheduleAsync(
+        SubscriptionPaymentLink link,
+        SubscriptionOptions options,
+        DateTime now,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        var attempt = link.AttemptCount + 1;
+
+        if (attempt >= Math.Max(1, options.ActivationMaxAttempts))
+        {
+            await AbandonAsync(link, cancellationToken);
+
+            return;
+        }
+
+        // Backs off linearly rather than exponentially: this is waiting on a webhook that
+        // usually lands in seconds, so a doubling delay would leave a paid subscription
+        // inactive for far longer than the payment took.
+        var delay = TimeSpan.FromSeconds(
+            Math.Max(1, options.ActivationRetrySeconds) * attempt);
+
+        await _links.RescheduleAsync(
+            link.TenantId,
+            link.ItemId,
+            attempt,
+            now.Add(delay),
+            reason,
+            cancellationToken);
+    }
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
@@ -109,6 +109,28 @@ public sealed class SubscriptionOutboxEventFactory : ISubscriptionOutboxEventFac
             null);
     }
 
+    public SubscriptionOutboxEvent CreateUsageRatingOutcome(
+        SubscriptionDetail subscription,
+        string eventType,
+        string periodKey,
+        string correlationId)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var payload = NewPayload(subscription, eventType);
+        payload.PeriodKey = periodKey;
+
+        return Build(
+            subscription,
+            eventType,
+            // No attempt number: unlike a renewal's per-attempt events, this fires exactly once
+            // — at the invoice's terminal outcome, whichever attempt that turns out to be.
+            $"{subscription.ItemId}:{eventType}:{periodKey}",
+            payload,
+            correlationId,
+            null);
+    }
+
     private static SubscriptionOutboxEvent Build(
         SubscriptionDetail subscription,
         string eventType,

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
@@ -88,6 +88,27 @@ public sealed class SubscriptionOutboxEventFactory : ISubscriptionOutboxEventFac
             null);
     }
 
+    public SubscriptionOutboxEvent CreatePlanChanged(
+        SubscriptionDetail subscription,
+        string previousPlanCode,
+        string correlationId)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var payload = NewPayload(subscription, Utilities.SubscriptionConstants.SubscriptionPlanChanged);
+        payload.PreviousPlanCode = previousPlanCode;
+
+        return Build(
+            subscription,
+            Utilities.SubscriptionConstants.SubscriptionPlanChanged,
+            // Version is already unique per mutation, so it is free scoping — no period key or
+            // attempt number applies to a plan change the way it does to a renewal.
+            $"{subscription.ItemId}:{Utilities.SubscriptionConstants.SubscriptionPlanChanged}:{subscription.Version}",
+            payload,
+            correlationId,
+            null);
+    }
+
     private static SubscriptionOutboxEvent Build(
         SubscriptionDetail subscription,
         string eventType,

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
@@ -64,6 +64,30 @@ public sealed class SubscriptionOutboxEventFactory : ISubscriptionOutboxEventFac
             null);
     }
 
+    public SubscriptionOutboxEvent CreateRenewalOutcome(
+        SubscriptionDetail subscription,
+        string eventType,
+        string periodKey,
+        int attemptNumber,
+        string correlationId)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var payload = NewPayload(subscription, eventType);
+        payload.PeriodKey = periodKey;
+        payload.AttemptNumber = attemptNumber;
+
+        return Build(
+            subscription,
+            eventType,
+            // Scoped to the attempt: each dunning retry is a distinct outcome, not a replay of
+            // the one before it, and a downstream consumer needs to tell them apart.
+            $"{subscription.ItemId}:{eventType}:{periodKey}:{attemptNumber}",
+            payload,
+            correlationId,
+            null);
+    }
+
     private static SubscriptionOutboxEvent Build(
         SubscriptionDetail subscription,
         string eventType,

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxEventFactory.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Outbox;
+
+/// <summary>
+/// Builds the events appended alongside a state change.
+/// </summary>
+/// <remarks>
+/// The deduplication key is what makes appending idempotent: a transition retried after a
+/// partial failure adds the event once, so a subscriber cannot be told twice that the same
+/// thing happened.
+/// </remarks>
+public sealed class SubscriptionOutboxEventFactory : ISubscriptionOutboxEventFactory
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public SubscriptionOutboxEvent Create(
+        SubscriptionDetail subscription,
+        string eventType,
+        string correlationId,
+        string? causationId = null)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        return Build(
+            subscription,
+            eventType,
+            $"{subscription.ItemId}:{eventType}",
+            NewPayload(subscription, eventType),
+            correlationId,
+            causationId);
+    }
+
+    public SubscriptionOutboxEvent CreateUsageThreshold(
+        SubscriptionDetail subscription,
+        SubscriptionUsageCounter counter,
+        int thresholdPercent,
+        string correlationId)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+        ArgumentNullException.ThrowIfNull(counter);
+
+        var payload = NewPayload(
+            subscription,
+            Utilities.SubscriptionConstants.UsageThresholdReached);
+
+        payload.MeterKey = counter.MeterKey;
+        payload.ThresholdPercent = thresholdPercent;
+        payload.Balance = counter.Balance;
+        payload.Limit = counter.LimitSnapshot;
+
+        return Build(
+            subscription,
+            Utilities.SubscriptionConstants.UsageThresholdReached,
+            // Scoped to the period and threshold: crossing 80% in September is a different
+            // event from crossing it in August, and both must be told.
+            $"{subscription.ItemId}:usage:{counter.MeterKey}:{counter.PeriodKey}:{thresholdPercent}",
+            payload,
+            correlationId,
+            null);
+    }
+
+    private static SubscriptionOutboxEvent Build(
+        SubscriptionDetail subscription,
+        string eventType,
+        string deduplicationKey,
+        SubscriptionLifecycleEvent payload,
+        string correlationId,
+        string? causationId)
+    {
+        var eventId = Guid.NewGuid().ToString();
+        payload.EventId = eventId;
+
+        return new SubscriptionOutboxEvent
+        {
+            EventId = eventId,
+            EventType = eventType,
+            DeduplicationKey = deduplicationKey,
+            Payload = JsonSerializer.Serialize(payload, SerializerOptions),
+            CorrelationId = correlationId,
+            CausationId = causationId
+        };
+    }
+
+    private static SubscriptionLifecycleEvent NewPayload(
+        SubscriptionDetail subscription,
+        string eventType) => new()
+    {
+        EventType = eventType,
+        TenantId = subscription.TenantId,
+        OrganizationId = subscription.OrganizationId,
+        SubscriptionId = subscription.ItemId,
+        PlanCode = subscription.Plan.Code,
+        Status = subscription.Status.ToString(),
+        OccurredAtUtc = DateTime.UtcNow
+    };
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
@@ -1,0 +1,184 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Outbox;
+
+/// <summary>
+/// Sends the events that were written alongside a state change.
+/// </summary>
+/// <remarks>
+/// The two-step — append with the change, publish afterwards — exists because MongoDB and the
+/// message bus share no transaction. Publishing inline would drop events exactly when something
+/// went wrong; this way the event is already durable and the worst case is that it is sent late
+/// or twice, both of which a consumer can handle.
+/// </remarks>
+public sealed class SubscriptionOutboxProcessor : ISubscriptionOutboxProcessor
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly IMessageClient _messageClient;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionOutboxProcessor> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionOutboxProcessor(
+        ISubscriptionRepository subscriptions,
+        IMessageClient messageClient,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<SubscriptionOutboxProcessor> logger,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _messageClient = messageClient;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<int> PublishDueAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var subscriptions = await _subscriptions.ListWithDueEventsAsync(
+            tenantId,
+            now,
+            Math.Max(1, options.OutboxBatchSize),
+            cancellationToken);
+
+        var published = 0;
+
+        foreach (var subscription in subscriptions)
+        {
+            foreach (var pending in DueEventsOf(subscription, now))
+            {
+                if (await PublishAsync(subscription, pending, options, now, cancellationToken))
+                {
+                    published++;
+                }
+            }
+        }
+
+        return published;
+    }
+
+    private static IEnumerable<SubscriptionOutboxEvent> DueEventsOf(
+        SubscriptionDetail subscription,
+        DateTime now) =>
+        subscription.OutboxEvents.Where(outboxEvent =>
+            outboxEvent.Status is not SubscriptionOutboxStatus.Published
+                and not SubscriptionOutboxStatus.Abandoned &&
+            (outboxEvent.NextAttemptAtUtc is null ||
+             outboxEvent.NextAttemptAtUtc <= now));
+
+    private async Task<bool> PublishAsync(
+        SubscriptionDetail subscription,
+        SubscriptionOutboxEvent pending,
+        SubscriptionOptions options,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var leaseId = Guid.NewGuid().ToString("N");
+
+        var claimed = await _subscriptions.TryClaimEventAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            pending.EventId,
+            leaseId,
+            now.AddSeconds(Math.Max(1, options.OutboxLeaseSeconds)),
+            cancellationToken);
+
+        if (claimed is null)
+        {
+            // Another worker holds it. Publishing anyway is what would make a duplicate.
+            return false;
+        }
+
+        using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["TenantHash"] = PaymentLogValue.Hash(subscription.TenantId),
+            ["SubscriptionHash"] = PaymentLogValue.Hash(subscription.ItemId),
+            ["EventType"] = PaymentLogValue.Label(claimed.EventType),
+            ["CorrelationId"] = claimed.CorrelationId
+        });
+
+        try
+        {
+            await _messageClient.SendToMassConsumerAsync(
+                new ConsumerMessage<string>
+                {
+                    ConsumerName = SubscriptionConstants.LifecycleTopic,
+                    Payload = claimed.Payload
+                });
+
+            await _subscriptions.MarkEventPublishedAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                claimed.EventId,
+                leaseId,
+                now,
+                cancellationToken);
+
+            _logger.LogInformation("Subscription event published");
+
+            return true;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            await RecordFailureAsync(
+                subscription,
+                claimed,
+                leaseId,
+                options,
+                now,
+                exception,
+                cancellationToken);
+
+            return false;
+        }
+    }
+
+    private async Task RecordFailureAsync(
+        SubscriptionDetail subscription,
+        SubscriptionOutboxEvent claimed,
+        string leaseId,
+        SubscriptionOptions options,
+        DateTime now,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var attempt = claimed.AttemptCount + 1;
+        var exhausted = attempt >= Math.Max(1, options.OutboxMaxAttempts);
+
+        // Backs off exponentially, capped: a broker that is down stays down for minutes, and
+        // hammering it makes recovery slower for everyone.
+        var delay = TimeSpan.FromSeconds(
+            Math.Min(300, Math.Pow(2, Math.Min(attempt, 8))));
+
+        await _subscriptions.MarkEventFailedAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            claimed.EventId,
+            leaseId,
+            exhausted
+                ? SubscriptionOutboxStatus.Abandoned
+                : SubscriptionOutboxStatus.RetryScheduled,
+            attempt,
+            now.Add(delay),
+            exception.Message,
+            cancellationToken);
+
+        _logger.Log(
+            exhausted ? LogLevel.Error : LogLevel.Warning,
+            "Subscription event publication failed Attempt={Attempt} Exhausted={Exhausted}",
+            attempt,
+            exhausted);
+    }
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionRenewalProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionRenewalProcessor.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Outbox;
+
+/// <summary>
+/// The periodic sweep for renewals: everything the fee schedule says is due right now, whether
+/// that is a normal renewal or the next dunning retry.
+/// </summary>
+public sealed class SubscriptionRenewalProcessor : ISubscriptionRenewalProcessor
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionRenewalService _renewals;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionRenewalProcessor> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionRenewalProcessor(
+        ISubscriptionRepository subscriptions,
+        ISubscriptionRenewalService renewals,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<SubscriptionRenewalProcessor> logger,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _renewals = renewals;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<int> ProcessDueAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var due = await _subscriptions.ListDueForRenewalAsync(
+            tenantId,
+            now,
+            Math.Max(1, options.RenewalBatchSize),
+            cancellationToken);
+
+        foreach (var subscription in due)
+        {
+            using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["TenantHash"] = PaymentLogValue.Hash(tenantId),
+                ["SubscriptionHash"] = PaymentLogValue.Hash(subscription.ItemId)
+            });
+
+            // A lost compare-and-set inside RenewAsync (another worker got there first) is not
+            // an error here — its outcome stands, and this pass simply moves on.
+            await _renewals.RenewAsync(subscription, cancellationToken);
+        }
+
+        return due.Count;
+    }
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -26,6 +26,9 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     private readonly ISubscriptionRepository _subscriptions;
     private readonly ISubscriptionUsageRepository _usage;
     private readonly ISubscriptionUsageInvoiceRepository _usageInvoices;
+    private readonly IBillingAccountRepository _billingAccounts;
+    private readonly ISubscriptionBillingGateway _gateway;
+    private readonly ISubscriptionOutboxEventFactory _events;
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<SubscriptionUsageRatingProcessor> _logger;
     private readonly TimeProvider _time;
@@ -34,6 +37,9 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         ISubscriptionRepository subscriptions,
         ISubscriptionUsageRepository usage,
         ISubscriptionUsageInvoiceRepository usageInvoices,
+        IBillingAccountRepository billingAccounts,
+        ISubscriptionBillingGateway gateway,
+        ISubscriptionOutboxEventFactory events,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<SubscriptionUsageRatingProcessor> logger,
         TimeProvider? time = null)
@@ -41,6 +47,9 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         _subscriptions = subscriptions;
         _usage = usage;
         _usageInvoices = usageInvoices;
+        _billingAccounts = billingAccounts;
+        _gateway = gateway;
+        _events = events;
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
@@ -215,5 +224,167 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 CorrelationId = subscription.CorrelationId
             },
             cancellationToken);
+    }
+
+    public async Task<int> ChargeDueInvoicesAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var due = await _usageInvoices.ListDueAsync(
+            tenantId,
+            now,
+            Math.Max(1, options.UsageRatingBatchSize),
+            cancellationToken);
+
+        foreach (var invoice in due)
+        {
+            using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["TenantHash"] = PaymentLogValue.Hash(tenantId),
+                ["SubscriptionHash"] = PaymentLogValue.Hash(invoice.SubscriptionId)
+            });
+
+            await ChargeInvoiceAsync(invoice, options, now, cancellationToken);
+        }
+
+        return due.Count;
+    }
+
+    private async Task ChargeInvoiceAsync(
+        SubscriptionUsageInvoice invoice,
+        SubscriptionOptions options,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var subscription = await _subscriptions.GetByIdAsync(
+            invoice.TenantId,
+            invoice.SubscriptionId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            // The subscription is gone; there is nothing left this invoice could be applied to.
+            await _usageInvoices.TryMarkAbandonedAsync(invoice.TenantId, invoice.ItemId, cancellationToken);
+
+            return;
+        }
+
+        var account = await _billingAccounts.GetAsync(
+            invoice.TenantId,
+            subscription.BillingAccountId,
+            cancellationToken);
+
+        var attemptNumber = invoice.AttemptCount + 1;
+
+        if (string.IsNullOrWhiteSpace(account?.DefaultPaymentMethodId))
+        {
+            await FailAttemptAsync(
+                subscription, invoice, attemptNumber, options, now, "no_payment_method", cancellationToken);
+
+            return;
+        }
+
+        var outcome = await _gateway.ChargeAsync(
+            new SubscriptionChargeRequest
+            {
+                TenantId = invoice.TenantId,
+                OrganizationId = invoice.OrganizationId,
+                ProviderName = account.ProviderName,
+                StoredPaymentMethodId = account.DefaultPaymentMethodId,
+                ProviderCustomerId = account.ProviderCustomerId,
+                AmountMinor = invoice.TotalAmountMinor,
+                CurrencyCode = invoice.CurrencyCode,
+                OrderId = SubscriptionConstants.UsageInvoiceOrderIdFor(
+                    invoice.SubscriptionId,
+                    invoice.PeriodKey),
+                Description = "Metered usage overage"
+            },
+            SubscriptionConstants.UsageInvoiceKeyFor(invoice.SubscriptionId, invoice.PeriodKey, attemptNumber),
+            invoice.CorrelationId,
+            cancellationToken);
+
+        if (!outcome.IsSuccess)
+        {
+            _logger.LogWarning(
+                "Usage invoice charge declined AttemptNumber={AttemptNumber} Reason={Reason}",
+                attemptNumber,
+                PaymentLogValue.Label(outcome.ErrorCode ?? "unknown"));
+
+            await FailAttemptAsync(
+                subscription, invoice, attemptNumber, options, now,
+                outcome.ErrorCode ?? "unknown", cancellationToken);
+
+            return;
+        }
+
+        if (!await _usageInvoices.TryMarkChargedAsync(
+                invoice.TenantId, invoice.ItemId, outcome.Value!, cancellationToken))
+        {
+            // Another worker already settled this invoice. Its outcome stands.
+            return;
+        }
+
+        await _subscriptions.TryAppendEventAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            _events.CreateUsageRatingOutcome(
+                subscription, SubscriptionConstants.UsageRated, invoice.PeriodKey, invoice.CorrelationId),
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Usage invoice charged AttemptNumber={AttemptNumber} PeriodKey={PeriodKey}",
+            attemptNumber,
+            PaymentLogValue.Label(invoice.PeriodKey));
+    }
+
+    /// <summary>
+    /// Retries a declined or unpayable invoice up to the attempt ceiling, then abandons it —
+    /// never touching the subscription's own status, since this is deliberately a second,
+    /// independent invoice from the fee renewal.
+    /// </summary>
+    private async Task FailAttemptAsync(
+        SubscriptionDetail subscription,
+        SubscriptionUsageInvoice invoice,
+        int attemptNumber,
+        SubscriptionOptions options,
+        DateTime now,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        var maxAttempts = Math.Max(1, options.UsageRatingMaxAttempts);
+
+        if (attemptNumber < maxAttempts)
+        {
+            await _usageInvoices.RescheduleAsync(
+                invoice.TenantId,
+                invoice.ItemId,
+                attemptNumber,
+                now.AddHours(Math.Max(1, options.UsageRatingRetryHours)),
+                reason,
+                cancellationToken);
+
+            return;
+        }
+
+        if (!await _usageInvoices.TryMarkAbandonedAsync(
+                invoice.TenantId, invoice.ItemId, cancellationToken))
+        {
+            return;
+        }
+
+        await _subscriptions.TryAppendEventAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            _events.CreateUsageRatingOutcome(
+                subscription, SubscriptionConstants.UsageRatingFailed, invoice.PeriodKey, invoice.CorrelationId),
+            cancellationToken);
+
+        _logger.LogWarning(
+            "Usage invoice abandoned after every retry PeriodKey={PeriodKey} Reason={Reason}",
+            PaymentLogValue.Label(invoice.PeriodKey),
+            PaymentLogValue.Label(reason));
     }
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -1,0 +1,219 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Outbox;
+
+/// <summary>
+/// Closes usage periods that have ended and prices their overage into a
+/// <see cref="SubscriptionUsageInvoice"/> — the usage clock's own sweep, independent of the fee
+/// renewal sweep the way the two schedules themselves are independent.
+/// </summary>
+public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingProcessor
+{
+    /// <summary>
+    /// Guards the loop that closes every period a long-outaged sweep missed, not just the most
+    /// recent one. Bounded the same defensive way <c>BillingPeriodCalculator</c> bounds its own
+    /// index correction — a subscription this far behind means something else is wrong.
+    /// </summary>
+    private const int MaximumPeriodsPerSweep = 24;
+
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly ISubscriptionUsageInvoiceRepository _usageInvoices;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionUsageRatingProcessor> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionUsageRatingProcessor(
+        ISubscriptionRepository subscriptions,
+        ISubscriptionUsageRepository usage,
+        ISubscriptionUsageInvoiceRepository usageInvoices,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<SubscriptionUsageRatingProcessor> logger,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _usage = usage;
+        _usageInvoices = usageInvoices;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<int> CloseDuePeriodsAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var due = await _subscriptions.ListDueForUsageRatingAsync(
+            tenantId,
+            now,
+            Math.Max(1, options.UsageRatingBatchSize),
+            cancellationToken);
+
+        var closed = 0;
+
+        foreach (var subscription in due)
+        {
+            using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["TenantHash"] = PaymentLogValue.Hash(tenantId),
+                ["SubscriptionHash"] = PaymentLogValue.Hash(subscription.ItemId)
+            });
+
+            closed += await CloseSubscriptionAsync(subscription, now, cancellationToken);
+        }
+
+        return closed;
+    }
+
+    private async Task<int> CloseSubscriptionAsync(
+        SubscriptionDetail subscription,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var periodsClosed = 0;
+
+        for (var iteration = 0; iteration < MaximumPeriodsPerSweep; iteration++)
+        {
+            if (subscription.CurrentUsagePeriodEndUtc > now)
+            {
+                break;
+            }
+
+            var periodKey = PeriodKey.Create(
+                BillingInterval.Month,
+                subscription.CurrentUsagePeriodStartUtc);
+
+            await EnsureInvoiceAsync(subscription, periodKey, cancellationToken);
+
+            if (!BillingPeriodCalculator.TryGetPeriod(
+                    subscription.UsageSchedule,
+                    subscription.CurrentUsagePeriodEndUtc,
+                    out var nextPeriod))
+            {
+                _logger.LogError(
+                    "A usage period could not be advanced; the schedule's time zone may no " +
+                    "longer be valid");
+
+                break;
+            }
+
+            var applied = await _subscriptions.TryTransitionAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                new SubscriptionTransition(subscription.Status, subscription.Status)
+                {
+                    CurrentUsagePeriodStartUtc = nextPeriod.StartUtc,
+                    CurrentUsagePeriodEndUtc = nextPeriod.EndUtc,
+                    NextUsageBillingAtUtc = nextPeriod.EndUtc
+                },
+                cancellationToken);
+
+            if (!applied)
+            {
+                // Another worker is already advancing this subscription's usage clock.
+                break;
+            }
+
+            subscription.CurrentUsagePeriodStartUtc = nextPeriod.StartUtc;
+            subscription.CurrentUsagePeriodEndUtc = nextPeriod.EndUtc;
+            subscription.NextUsageBillingAtUtc = nextPeriod.EndUtc;
+            periodsClosed++;
+        }
+
+        return periodsClosed;
+    }
+
+    /// <summary>
+    /// Prices the closed period's overage and records it, unless a crash already left one behind
+    /// — <c>TryCreateAsync</c>'s uniqueness index is what makes this safe to call twice.
+    /// </summary>
+    private async Task EnsureInvoiceAsync(
+        SubscriptionDetail subscription,
+        string periodKey,
+        CancellationToken cancellationToken)
+    {
+        var existing = await _usageInvoices.GetAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            periodKey,
+            cancellationToken);
+
+        if (existing is not null)
+        {
+            return;
+        }
+
+        var counters = await _usage.ListCountersAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            periodKey,
+            cancellationToken);
+
+        var lines = new List<UsageInvoiceLine>();
+
+        foreach (var counter in counters)
+        {
+            var meter = subscription.Plan.Meters.Find(
+                planMeter => string.Equals(
+                    planMeter.MeterKey,
+                    counter.MeterKey,
+                    StringComparison.Ordinal));
+
+            // The meter was removed from the plan after this usage was recorded — nothing left
+            // to rate it against. Not expected in practice; skipped rather than blocking every
+            // other meter's charge.
+            if (meter is null)
+            {
+                continue;
+            }
+
+            var amount = SubscriptionUsageRater.OverageAmountMinor(
+                meter,
+                counter.Balance,
+                subscription.CurrencyCode);
+
+            if (amount <= 0)
+            {
+                continue;
+            }
+
+            lines.Add(new UsageInvoiceLine
+            {
+                MeterKey = counter.MeterKey,
+                OverageQuantity = Math.Max(0, counter.Balance - meter.IncludedQuantity),
+                AmountMinor = amount
+            });
+        }
+
+        var total = lines.Sum(line => line.AmountMinor);
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        await _usageInvoices.TryCreateAsync(
+            new SubscriptionUsageInvoice
+            {
+                TenantId = subscription.TenantId,
+                OrganizationId = subscription.OrganizationId,
+                SubscriptionId = subscription.ItemId,
+                PeriodKey = periodKey,
+                CurrencyCode = subscription.CurrencyCode,
+                TotalAmountMinor = total,
+                Lines = lines,
+                State = total > 0
+                    ? SubscriptionUsageInvoiceState.Pending
+                    : SubscriptionUsageInvoiceState.NoCharge,
+                NextAttemptAtUtc = total > 0 ? now : null,
+                CorrelationId = subscription.CorrelationId
+            },
+            cancellationToken);
+    }
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -204,7 +204,11 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             });
         }
 
-        var total = lines.Sum(line => line.AmountMinor);
+        // Tax is on the aggregate, not per meter — the same "one charge, not one per meter"
+        // scope this invoice already keeps for the charge itself.
+        var subtotal = lines.Sum(line => line.AmountMinor);
+        var tax = SubscriptionAmountCalculator.TaxAmountMinor(subtotal, subscription.Price.TaxRateBasisPoints);
+        var total = subtotal + tax;
         var now = _time.GetUtcNow().UtcDateTime;
 
         await _usageInvoices.TryCreateAsync(
@@ -216,6 +220,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 PeriodKey = periodKey,
                 CurrencyCode = subscription.CurrencyCode,
                 TotalAmountMinor = total,
+                TaxAmountMinor = tax,
                 Lines = lines,
                 State = total > 0
                     ? SubscriptionUsageInvoiceState.Pending

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1,0 +1,220 @@
+# Subscriptions
+
+Plans, subscriptions, entitlement and metered usage. Blocks owns all of it; a payment provider
+moves the money.
+
+This is phase 1. An organization can be put on a plan, and the product can ask *"what is this
+organization allowed to do right now?"* and get a fast, trustworthy answer. Renewal billing,
+invoices, tax, dunning, proration and the rating of metered usage are later phases — their
+fields and status values exist already, so those phases add transitions rather than columns.
+
+## The rule everything else follows from
+
+**The platform never learns a domain word.** There is no `Seats` column and no
+`ScreeningCount`. Quantities carry a unit label the product chooses; usage flows through meters
+the product names; plan features are a JSON bag stored verbatim and never interpreted.
+
+The test when adding a field: *would a digital-signature client recognise this name?* One
+product sells seats and meters screenings; another sells workspaces and meters envelopes. Both
+are configuration.
+
+## What talks to what
+
+Subscriptions depend on `Payment.DomainService`; nothing in payments may depend on
+subscriptions. `XUnitTest/Subscription/SubscriptionBoundaryTests` fails the build if that
+reverses. The surface relied on:
+
+| Type | Used for |
+| --- | --- |
+| `IPaymentService.MakePaymentAsync` | raising the first charge through hosted checkout |
+| `IPaymentRepository` | reading payment state during activation, and recovering a lost charge |
+| `IStoredPaymentMethodRepository` | reading the provider's customer from the saved card |
+| `IPaymentExecutionContextResolver` | tenant, organization and actor from the request |
+| `IPaymentTenantContextScopeFactory` | establishing a tenant for background sweeps |
+| `ICurrencyMinorUnitResolver` | converting at the one boundary where money leaves this module |
+| `PaymentFailureKind`, `ApiResponse<T>` | result and envelope shapes, reused not copied |
+| `PaymentLogValue` | hashing identifiers before they reach a log |
+
+## Organizations are subscribers, not merchants
+
+The tenant holds the merchant configuration; its organizations are its customers. A tenant
+registers one provider configuration at tenant level and every organization under it buys from
+that account.
+
+This is the opposite of what the payment module's own organization scoping is for, where an
+organization may be a separate business with its own merchant account. Both models work — they
+are distinguished by whether the provider configuration names an organization — but they must
+not be confused, and a charge raised from here deliberately names no organization.
+
+> **Known issue, tracked separately.** A saved card's provider token is encrypted under a key
+> ring scoped to the *caller's* organization. That is right when organizations are merchants and
+> wrong when they are customers: the token belongs to the tenant's merchant account. Today
+> `Payment:FallBackToSharedEncryptionKeyRing` (default `true`) absorbs it silently. Setting that
+> flag to `false` — which the payment README's migration tells you to do — would make every
+> customer organization's saved card undecryptable at once. Fix the scope to follow the resolved
+> provider's organization before this module drives card saves at volume.
+
+## Status
+
+`Incomplete → IncompleteExpired`, `Incomplete → Trialing | Active`, and cancellation are the
+transitions phase 1 drives. `PastDue` and `Unpaid` need a billing clock to reach, but
+entitlement already answers correctly for them.
+
+| Status | Grants? |
+| --- | --- |
+| `Incomplete` | no — created, first charge unconfirmed |
+| `IncompleteExpired` | no — the first charge never completed |
+| `Trialing` | yes, subject to trial grants |
+| `Active` | yes |
+| `PastDue` | yes, during the grace period |
+| `Unpaid` | no |
+| `Canceled` | no |
+
+Enum values are explicit because they are persisted. Adding a member without a number renumbers
+everything after it and silently reinterprets stored documents — a canceled subscription reading
+back as active, with nothing thrown. `SubscriptionEnumStabilityTests` pins them.
+
+## Snapshots
+
+The plan and price are **copied** onto the subscription when it is created, not referenced.
+
+Entitlement is then one document read with no join, and editing the catalogue stops being
+retroactive: a subscriber keeps the terms they were sold until something deliberately migrates
+them. That is the correct billing semantic as well as the faster read.
+
+## Periods are derived, never advanced
+
+`BillingPeriodCalculator` is pure and static, and the instant is always a parameter. Asking
+which period an instant falls in recomputes it; nothing has to notice a boundary passing.
+
+So metered usage rolls over with no scheduled job and no possibility of a rollover running
+twice or not at all. The counter's identifier contains the period key, so crossing a boundary
+simply addresses a different document, which the next write upserts at zero.
+
+Two rules inside it are worth knowing:
+
+- **Month ends clamp on read, never on write.** An anchor on the 31st bills on the 28th in
+  February and returns to the 31st in March. Persisting February's clamp would drag every later
+  period earlier for the life of the subscription.
+- **Daylight saving is resolved, not thrown.** A boundary inside a spring-forward gap moves to
+  the first instant that exists; one that happens twice in autumn consistently takes the earlier.
+
+> The runtime images must carry `tzdata`. They are Alpine, which ships neither it nor ICU, and
+> without it every IANA identifier fails — in production only, since developer machines have a
+> system time zone database. Both Dockerfiles install it.
+
+## Two schedules
+
+A subscription has a fee cadence and a usage cadence, and they are independent. The fee follows
+the price; usage is always monthly. Waiting a year to settle metered usage on an annual plan is
+a year of unsecured credit.
+
+## Entitlement is advisory; recording is enforcement
+
+`GET /api/entitlements` reads only our own database — the subscription, then one counter per
+metered entitlement. `EntitlementService` takes no provider gateway and no HTTP client in its
+constructor, which is how the guarantee is held: **if the provider is down, every existing
+customer keeps working.**
+
+It is deliberately *advisory* for anything metered. Two callers at 499 of 500 will both be told
+they have one left. The authoritative answer is the balance returned by
+`POST /api/subscription-usage`, which already includes the caller's own contribution — so the
+two get different answers and only one of them is over.
+
+A caller that must not exceed an allowance sets `enforce` and acts on `allowed`. A refused call
+is rolled back with a compensating entry, leaving the balance where it was.
+
+The subscription is cached for `Subscription:EntitlementCacheSeconds` (default 10) and
+invalidated on change. **Usage counters are never cached** — they are the volatile half, and a
+stale one would let a caller past an allowance already spent. `?fresh=true` bypasses the cache.
+
+## The usage ledger
+
+Append-only. A correction is a `Reversal` entry, never an edit, so the history can always
+explain a bill.
+
+The ledger is written **before** the counter. A crash between the two leaves the counter
+under-counting, which can be recomputed from the ledger; the other order over-counts with
+nothing left to prove it, and the customer is billed for it.
+
+An idempotency key is mandatory, unique per subscription and meter. At-least-once delivery makes
+a repeated call a certainty rather than a risk.
+
+Counters expire (`Subscription:CounterRetentionDays`, default 400). **The ledger never does.**
+
+> **Keep identifying data out of `metadata`.** Billing needs a count, not a dossier. This is a
+> shared billing store, retained for years and exported for invoicing; anything naming a person
+> belongs in the calling product's own records with an opaque reference here.
+
+## Events
+
+Appended in the same write as the state change that caused them, then published to
+`blocks_subscription_lifecycle_topic` by a processor. MongoDB and the bus share no transaction,
+so publishing inline would drop events precisely when something went wrong.
+
+`SubscriptionCreated`, `SubscriptionTrialStarted`, `SubscriptionActivated`,
+`SubscriptionActivationFailed`, `SubscriptionCancellationRequested`, `SubscriptionCanceled`,
+`UsageThresholdReached`.
+
+> **Nothing consumes this topic, and there is no email path in this repository** —
+> `Notification.DomainService` and `Mail.DomainService` contain only build output, no source. A
+> quota threshold raises an event and has no user-visible effect in this phase. That is the
+> intended shape: the platform states the fact, each product decides what it means.
+
+Every event carries a correlation id, persisted at write time, because publication happens later
+in another process. Without it the trace ends at the queue.
+
+## Activation waits for the webhook
+
+A subscription becomes active only when the payment carries both a confirming status **and**
+`WebhookConfirmedAtUtc`. The shopper's return from checkout is not evidence: a redirect can be
+replayed, forged, bookmarked, or lost when someone shuts the laptop.
+
+Clients should therefore expect a brief `Incomplete` window after paying — the browser usually
+comes back before the webhook lands.
+
+Activation runs on the payment work tick, which every inbound webhook already dispatches, so it
+happens within milliseconds. `SubscriptionReconciliationBackgroundService` is the safety net for
+what no message carries: a compare-and-set lost to a worker that then crashed, a charge raised
+but never recorded, a webhook that arrived during a restart.
+
+> The sweep does nothing unless `Subscription:TenantIds` is set, and says so loudly at startup.
+> Nothing else discovers tenants.
+
+## Settings
+
+Under the `Subscription` section. The ones whose default is a decision:
+
+| Setting | Default | Why it matters |
+| --- | --- | --- |
+| `TenantIds` | *(empty)* | Which tenants the sweep covers. An omitted tenant is never reconciled. |
+| `EntitlementCacheSeconds` | `10` | How stale an entitlement answer may be. Counters are never cached. |
+| `CounterRetentionDays` | `400` | How long a finished period's counter is kept. Long enough for a billing dispute. |
+| `InitialChargeGraceMinutes` | `60` | How long an unpaid subscription waits before it is treated as abandoned. |
+| `ReconciliationPollSeconds` | `120` | Clamped to a 30 second minimum. |
+| `MaximumUsageMetadataEntries` | `10` | Bounds what a product can attach to a billing record. |
+
+A currency must also exist in `Payment:CurrencyMinorUnits` or a price in it can never be
+charged. That is validated when the price is authored rather than at checkout, where the same
+mistake reaches a customer who has already chosen a plan.
+
+## Before the first tenant goes live
+
+Provision the tenant-level payment key ring — `payment-keyring-{tenantSlug}` via
+`scripts/payment-key-vault/Provision-PaymentKeyRing.ps1`. Provider registration fails closed
+without one.
+
+## Testing
+
+```bash
+dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName~XUnitTest.Subscription"
+```
+
+Uniqueness, atomic increments and compare-and-set are enforced by MongoDB, not by this code, so
+the tests that prove them live in `XUnitTest/Integration` and need a running mongod
+(`BLOCKS_IT_MONGO` to point elsewhere). Mocking those would test the mock.
+
+**None of this has met live provider traffic.** Every Stripe defect this project has had was
+found by real traffic while the unit suite stayed green, and the off-session charge path this
+module builds on has itself never been exercised live. Treat a green suite as necessary and not
+sufficient.

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -46,13 +46,18 @@ organization may be a separate business with its own merchant account. Both mode
 are distinguished by whether the provider configuration names an organization — but they must
 not be confused, and a charge raised from here deliberately names no organization.
 
-> **Known issue, tracked separately.** A saved card's provider token is encrypted under a key
-> ring scoped to the *caller's* organization. That is right when organizations are merchants and
-> wrong when they are customers: the token belongs to the tenant's merchant account. Today
-> `Payment:FallBackToSharedEncryptionKeyRing` (default `true`) absorbs it silently. Setting that
-> flag to `false` — which the payment README's migration tells you to do — would make every
-> customer organization's saved card undecryptable at once. Fix the scope to follow the resolved
-> provider's organization before this module drives card saves at volume.
+> **Fixed.** A saved card's provider token used to be encrypted under a key ring scoped to the
+> *caller's* organization, which is right when organizations are merchants and wrong when they
+> are customers — the token belongs to the tenant's merchant account. `StoredPaymentMethod` now
+> carries `EncryptionOrganizationId`, resolved from the actual provider configuration at write
+> time and independent of `OrganizationId` (which stays the caller's, for card-listing
+> visibility). See `PaymentEncryptionScope.From(StoredPaymentMethod)` in the payment module.
+>
+> Cards saved **before** this fix carry no `EncryptionScopeResolvedAtUtc` and keep decrypting
+> under the old derivation — `PaymentEncryptionScope.From` falls back to `OrganizationId` for
+> them, which was correct at the time they were written because every organization was still a
+> merchant. `Payment:FallBackToSharedEncryptionKeyRing` remains the safety net for those records
+> until they are backfilled or re-saved; don't set it to `false` until they are.
 
 ## Status
 

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -3,10 +3,12 @@
 Plans, subscriptions, entitlement and metered usage. Blocks owns all of it; a payment provider
 moves the money.
 
-This is phase 1. An organization can be put on a plan, and the product can ask *"what is this
-organization allowed to do right now?"* and get a fast, trustworthy answer. Renewal billing,
-invoices, tax, dunning, proration and the rating of metered usage are later phases — their
-fields and status values exist already, so those phases add transitions rather than columns.
+Phase 1 got an organization onto a plan and answered *"what is this organization allowed to do
+right now?"* fast and correctly. Phase 2 adds the billing clock: a subscription now renews on its
+own, and a decline moves it through dunning to `PastDue` and then `Unpaid` without anyone
+watching it happen. Invoices, tax, SCA recovery, proration and the rating of metered usage into a
+bill are still later phases — their fields exist already, so those phases add transitions rather
+than columns.
 
 ## The rule everything else follows from
 
@@ -29,6 +31,7 @@ reverses. The surface relied on:
 | `IPaymentService.MakePaymentAsync` | raising the first charge through hosted checkout |
 | `IPaymentRepository` | reading payment state during activation, and recovering a lost charge |
 | `IStoredPaymentMethodRepository` | reading the provider's customer from the saved card |
+| `IRecurringPaymentService.CreateRecurringPaymentAsync` | charging the stored card for a renewal or a dunning retry, off-session |
 | `IPaymentExecutionContextResolver` | tenant, organization and actor from the request |
 | `IPaymentTenantContextScopeFactory` | establishing a tenant for background sweeps |
 | `ICurrencyMinorUnitResolver` | converting at the one boundary where money leaves this module |
@@ -61,9 +64,10 @@ not be confused, and a charge raised from here deliberately names no organizatio
 
 ## Status
 
-`Incomplete → IncompleteExpired`, `Incomplete → Trialing | Active`, and cancellation are the
-transitions phase 1 drives. `PastDue` and `Unpaid` need a billing clock to reach, but
-entitlement already answers correctly for them.
+`Incomplete → IncompleteExpired`, `Incomplete → Trialing | Active`, cancellation, renewal, and
+dunning through `PastDue → Unpaid` are all driven now. Entitlement's answer for every status
+below was already correct in phase 1 — phase 2 only added what reaches `PastDue` and `Unpaid` in
+the first place.
 
 | Status | Grants? |
 | --- | --- |
@@ -114,6 +118,58 @@ A subscription has a fee cadence and a usage cadence, and they are independent. 
 the price; usage is always monthly. Waiting a year to settle metered usage on an annual plan is
 a year of unsecured credit.
 
+## Renewal and dunning
+
+`SubscriptionRenewalProcessor` sweeps every live subscription whose `NextFeeBillingAtUtc` has
+arrived and hands it to `SubscriptionRenewalService`, which charges it and applies the outcome —
+one method for a normal renewal, a dunning retry, and a trial converting to paid, because all
+three are "charge the stored card for the period that is due" and none needs to know which of
+the three it is.
+
+```
+Active/Trialing --success--> Active (period advances, dunning cleared)
+Active/Trialing --decline--> PastDue (attempt 1, retry scheduled)
+PastDue         --decline, attempts remaining--> PastDue (attempt N, retry scheduled)
+PastDue         --decline, attempts exhausted--> Unpaid
+any             --no stored payment method--> Unpaid (immediately, no retries)
+```
+
+A subscription with no `BillingAccount.DefaultPaymentMethodId` skips dunning entirely and goes
+straight to `Unpaid` — retrying a charge with nothing to charge cannot succeed on attempt two
+any more than it did on attempt one. This is also how a trial that never took a card behaves at
+its end: `TrialTerms.EndsAtUtc` is the subscription's `NextFeeBillingAtUtc` from the moment it is
+created, so the sweep picks it up the same way it picks up a renewal, and finds no card to charge.
+
+**Renewal reuses `IRecurringPaymentService`, the existing off-session charge stack, rather than a
+new Stripe Invoice integration** — called through `ISubscriptionBillingGateway`, owned by this
+module. That interface is the seam a future Stripe Invoice integration replaces: everything that
+decides *when* and *how much* to charge — this state machine, the amount calculator — depends
+only on the interface, never on how the charge is actually raised. Dunning is therefore Blocks'
+own responsibility in this phase, not delegated to a provider's retry engine; that is the cost of
+shipping renewals now instead of building Invoices first.
+
+The gateway is **provider-neutral, not Stripe-specific**: it passes `BillingAccount.ProviderName`
+straight through to `IRecurringPaymentService`, which already resolves the real charge gateway
+per provider. A subscriber on Adyen needs no new code here — only that tenant's `BillingAccount`
+naming Adyen.
+
+Each renewal attempt gets its own order id, scoped to the period it charges
+(`sub:{subscriptionId}:{periodKey}`), because the payment module allows only one recurring
+payment per order id, ever — a shared order id across periods would reject every renewal after
+the first. The idempotency key additionally carries the attempt number
+(`sub-renew:{subscriptionId}:{periodKey}:{attempt}`): unlike the initial charge, a dunning retry
+is a genuinely new attempt, not a replay of the one before it.
+
+A discount reduces a renewal only while `DiscountTerms.DurationPeriods` and `ExpiresAtUtc` still
+allow it; `SubscriptionDetail.DiscountPeriodsApplied` tracks how many periods it has already
+reduced, so an expired discount's absence is detected without re-deriving history from past
+charges.
+
+`Subscription:DunningMaxAttempts` (default 4, including the first decline) and
+`Subscription:DunningRetryIntervalHours` (default 24, a fixed interval rather than exponential
+backoff — this is a business cadence for asking a customer to fix a card, not load-shedding
+against a failing dependency) govern the cycle.
+
 ## Entitlement is advisory; recording is enforcement
 
 `GET /api/entitlements` reads only our own database — the subscription, then one counter per
@@ -159,7 +215,8 @@ so publishing inline would drop events precisely when something went wrong.
 
 `SubscriptionCreated`, `SubscriptionTrialStarted`, `SubscriptionActivated`,
 `SubscriptionActivationFailed`, `SubscriptionCancellationRequested`, `SubscriptionCanceled`,
-`UsageThresholdReached`.
+`UsageThresholdReached`, `SubscriptionRenewed`, `SubscriptionRenewalFailed`,
+`SubscriptionPastDue`, `SubscriptionUnpaid`.
 
 > **Nothing consumes this topic, and there is no email path in this repository** —
 > `Notification.DomainService` and `Mail.DomainService` contain only build output, no source. A
@@ -197,6 +254,9 @@ Under the `Subscription` section. The ones whose default is a decision:
 | `CounterRetentionDays` | `400` | How long a finished period's counter is kept. Long enough for a billing dispute. |
 | `InitialChargeGraceMinutes` | `60` | How long an unpaid subscription waits before it is treated as abandoned. |
 | `ReconciliationPollSeconds` | `120` | Clamped to a 30 second minimum. |
+| `RenewalBatchSize` | `50` | How many due subscriptions one sweep pass takes. |
+| `DunningMaxAttempts` | `4` | Attempts, including the first decline, before a subscription moves to `Unpaid`. |
+| `DunningRetryIntervalHours` | `24` | Fixed interval between dunning attempts. |
 | `MaximumUsageMetadataEntries` | `10` | Bounds what a product can attach to a billing record. |
 
 A currency must also exist in `Payment:CurrencyMinorUnits` or a price in it can never be

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -4,11 +4,12 @@ Plans, subscriptions, entitlement and metered usage. Blocks owns all of it; a pa
 moves the money.
 
 Phase 1 got an organization onto a plan and answered *"what is this organization allowed to do
-right now?"* fast and correctly. Phase 2 adds the billing clock: a subscription now renews on its
-own, and a decline moves it through dunning to `PastDue` and then `Unpaid` without anyone
-watching it happen. Invoices, tax, SCA recovery, proration and the rating of metered usage into a
-bill are still later phases — their fields exist already, so those phases add transitions rather
-than columns.
+right now?"* fast and correctly. Phase 2 added the billing clock: a subscription renews on its
+own, a decline moves it through dunning to `PastDue` and then `Unpaid`, a Stripe renewal produces
+a real invoice document, a mid-period plan change is prorated, and metered overage is priced from
+the plan's rate tiers and charged as its own, independent invoice. Tax and SCA recovery are still
+later work — nothing here calculates or reports tax, and the fields for it exist already so that
+work adds transitions rather than columns.
 
 ## The rule everything else follows from
 
@@ -264,6 +265,52 @@ Counters expire (`Subscription:CounterRetentionDays`, default 400). **The ledger
 > shared billing store, retained for years and exported for invoicing; anything naming a person
 > belongs in the calling product's own records with an opaque reference here.
 
+## Usage rating
+
+`PlanMeter.RateTables` existed from the first commit but priced nothing until now — usage was
+recorded and enforced, never turned into a charge. `SubscriptionUsageRatingProcessor` closes that
+gap on the usage clock's own schedule, independent of the fee renewal:
+
+**Closing a period** (`CloseDuePeriodsAsync`, driven by `NextUsageBillingAtUtc` — set at creation
+since Phase 1 but not read again until this) prices every counter's balance against the plan
+snapshot's matching meter via `SubscriptionUsageRater`, and records a `SubscriptionUsageInvoice`
+before advancing the period. Only the **overage** is priced — `usage − IncludedQuantity` — with
+tier boundaries counted from the first overage unit, inclusive; `IncludedQuantity` stays the only
+place a plan's free allowance lives, so a rate table never needs a zero-cost first tier to
+represent it. A meter with no rate table in the subscription's own currency rates to zero rather
+than blocking every other meter's charge over one misconfigured plan.
+
+A sweep that missed several months (worker downtime) closes every intervening period, not just
+the most recent one — the loop is capped at 24 iterations, the same defensive bound
+`BillingPeriodCalculator` places on its own index correction.
+
+**Charging an invoice** (`ChargeDueInvoicesAsync`) goes through the same `ISubscriptionBillingGateway`
+a renewal and a plan change use — this module's fourth caller of that seam. The order id is
+stable per period (the payment module allows only one recurring payment per order id, ever), but
+the idempotency key carries the attempt number: reusing one key across retries would replay a
+declined attempt's cached result forever rather than actually trying again, the same reasoning a
+renewal's dunning retry already follows.
+
+> **This is deliberately a second, independent invoice from the fee renewal.** A decline retries
+> on its own bounded schedule (`Subscription:UsageRatingMaxAttempts`/`UsageRatingRetryHours`,
+> separate settings from the fee-side dunning cycle) and is abandoned — never charged again, never
+> retried further — once that runs out. It never touches the subscription's `Status`. A customer
+> whose card is declined for last month's overage keeps whatever the fee renewal already paid for.
+
+`SubscriptionUsageInvoice` is created *before* the charge is attempted, the same discipline
+`SubscriptionPaymentLink` uses for the initial charge, so a crash mid-attempt is recoverable by
+re-reading the same record. Its uniqueness index on `(TenantId, SubscriptionId, PeriodKey)` is the
+double-billing guard.
+
+**Known gaps, stated rather than built around:**
+
+- **One aggregated charge per period, not one per meter.** `ISubscriptionBillingGateway.ChargeAsync`
+  takes one amount and one description; per-meter line items are still recorded on the invoice
+  itself for support traceability, but the actual charge is always the total.
+- **A `Canceled` subscription's still-open final period is never rated.** An immediate
+  cancellation clears `NextUsageBillingAtUtc` the moment entitlement stops, so any usage recorded
+  in that unrated final stretch has no billing path today.
+
 ## Events
 
 Appended in the same write as the state change that caused them, then published to
@@ -273,7 +320,8 @@ so publishing inline would drop events precisely when something went wrong.
 `SubscriptionCreated`, `SubscriptionTrialStarted`, `SubscriptionActivated`,
 `SubscriptionActivationFailed`, `SubscriptionCancellationRequested`, `SubscriptionCanceled`,
 `UsageThresholdReached`, `SubscriptionRenewed`, `SubscriptionRenewalFailed`,
-`SubscriptionPastDue`, `SubscriptionUnpaid`, `SubscriptionPlanChanged`.
+`SubscriptionPastDue`, `SubscriptionUnpaid`, `SubscriptionPlanChanged`, `UsageRated`,
+`UsageRatingFailed`.
 
 > **Nothing consumes this topic, and there is no email path in this repository** —
 > `Notification.DomainService` and `Mail.DomainService` contain only build output, no source. A
@@ -314,6 +362,9 @@ Under the `Subscription` section. The ones whose default is a decision:
 | `RenewalBatchSize` | `50` | How many due subscriptions one sweep pass takes. |
 | `DunningMaxAttempts` | `4` | Attempts, including the first decline, before a subscription moves to `Unpaid`. |
 | `DunningRetryIntervalHours` | `24` | Fixed interval between dunning attempts. |
+| `UsageRatingBatchSize` | `50` | How many subscriptions one usage-closing sweep pass takes. |
+| `UsageRatingMaxAttempts` | `3` | Overage-charge attempts before an invoice is abandoned. Independent of `DunningMaxAttempts` — a failed overage charge never affects the subscription. |
+| `UsageRatingRetryHours` | `24` | Fixed interval between overage-charge retries. |
 | `MaximumUsageMetadataEntries` | `10` | Bounds what a product can attach to a billing record. |
 
 A currency must also exist in `Payment:CurrencyMinorUnits` or a price in it can never be

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -6,10 +6,9 @@ moves the money.
 Phase 1 got an organization onto a plan and answered *"what is this organization allowed to do
 right now?"* fast and correctly. Phase 2 added the billing clock: a subscription renews on its
 own, a decline moves it through dunning to `PastDue` and then `Unpaid`, a Stripe renewal produces
-a real invoice document, a mid-period plan change is prorated, and metered overage is priced from
-the plan's rate tiers and charged as its own, independent invoice. Tax and SCA recovery are still
-later work — nothing here calculates or reports tax, and the fields for it exist already so that
-work adds transitions rather than columns.
+a real invoice document, a mid-period plan change is prorated, metered overage is priced from the
+plan's rate tiers and charged as its own, independent invoice, and every one of those charges can
+carry tax. SCA recovery is still later work.
 
 ## The rule everything else follows from
 
@@ -190,6 +189,32 @@ charges.
 `Subscription:DunningRetryIntervalHours` (default 24, a fixed interval rather than exponential
 backoff — this is a business cadence for asking a customer to fix a card, not load-shedding
 against a failing dependency) govern the cycle.
+
+## Tax
+
+`PriceSnapshot.TaxRateBasisPoints` — manual, not jurisdiction-derived. Whoever authors a price
+sets its tax rate the same way they already set its currency; there is no address collection, no
+jurisdiction detection, and no external tax service behind it. That is a deliberate build-now
+trade-off: it taxes every charge path correctly today — first charge, renewal, plan-change
+proration and usage overage all already share `SubscriptionAmountCalculator`/
+`SubscriptionProrationCalculator`, so one pipeline stage covers all four — at the cost of not
+automatically knowing *which* rate applies to *which* customer. The person authoring the price
+still has to know that.
+
+The pipeline is **gross → discount → tax → credit**. Tax is computed on the *discounted* amount,
+not gross — the same base the customer is actually being asked to pay. A banked credit is then
+consumed against the tax-inclusive total: a credit offsets what the subscriber owes including
+tax, it does not shrink the taxable base. A mid-period plan change taxes each side of the
+comparison at *that side's own* price's rate before netting them, so a change between two
+differently-taxed prices is still correct. A usage invoice taxes the aggregate total once, after
+every meter's line is summed — the same "one charge, not one per meter" scope usage invoices
+already keep for the charge itself, not a second, narrower exception to it.
+
+`ISubscriptionBillingGateway`, `SubscriptionChargeRequest`, and both gateway implementations are
+completely unaware tax exists — it is folded into the amount before a charge is ever raised. That
+is also exactly why a future move to Stripe's own automatic tax would be a real migration, not an
+extension: that model computes tax *outside* this module against a real customer address and
+expects the gateway to read it back from the provider, the opposite of folding it in beforehand.
 
 ## Plan changes and proration
 

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -190,6 +190,43 @@ charges.
 backoff — this is a business cadence for asking a customer to fix a card, not load-shedding
 against a failing dependency) govern the cycle.
 
+## Plan changes and proration
+
+`PUT /api/subscriptions/{id}/plan` moves a live subscription to a different price mid-period.
+`SubscriptionProrationCalculator` prices the change by comparing the unused value of the current
+period against the cost of the same remaining time on the target price, both run through the
+exact gross-and-discount math a renewal uses
+(`SubscriptionAmountCalculator.GrossAmountMinor`/`ApplyDiscount`, made `internal` so this can
+reuse them rather than duplicate them) — the subscriber's discount applies to both sides
+identically, since it belongs to them, not to whichever plan they happen to be on.
+
+**An upgrade is charged immediately** for the prorated difference, through the same
+`ISubscriptionBillingGateway` a renewal uses — this is the seam's third caller. A decline leaves
+the subscription untouched; no partial change is ever written. **A downgrade is never charged.**
+Its value is banked as `SubscriptionDetail.CreditBalanceMinor` and spent automatically — an
+existing balance is applied to a later upgrade before anything new is charged, and any of it
+still unspent is consumed by the next renewal, `PeriodAmountMinor` subtracting it after the
+discount and never below zero. **There is no refund path.** A credit is only ever applied to a
+future charge; it is never paid out, and nothing in this module ever produces a negative amount.
+
+**A trial changes plan with no charge and no credit at all** — nothing has been paid for yet, so
+there is nothing to prorate. The plan, price and quantity snapshot simply swap.
+
+Two restrictions keep this a contained piece of work rather than a rewrite of the billing clock:
+
+- **Same currency, same billing interval only.** A different interval would mean rebuilding
+  `FeeSchedule` and the current period's boundaries mid-flight, which is a separately-tricky
+  problem this does not attempt — refused as a validation error rather than attempted.
+- **`Trialing` and `Active` only.** `PastDue`/`Unpaid` is refused as a conflict: a customer who
+  owes money changing plans is a support decision, not something to automate.
+
+> **Known gap.** If a charge succeeds but the compare-and-set that records the plan change loses
+> a race immediately after, the money has moved and the write has not. This is the same shape of
+> risk the initial checkout has — and that one has a dedicated recovery sweep
+> (`SubscriptionActivationProcessor.RecoverStaleAsync`) for exactly this reason. A plan change
+> does not have an equivalent sweep yet; the case is rare (a genuine concurrent write to the same
+> subscription, not a network failure) and is called out here rather than left to be discovered.
+
 ## Entitlement is advisory; recording is enforcement
 
 `GET /api/entitlements` reads only our own database — the subscription, then one counter per
@@ -236,7 +273,7 @@ so publishing inline would drop events precisely when something went wrong.
 `SubscriptionCreated`, `SubscriptionTrialStarted`, `SubscriptionActivated`,
 `SubscriptionActivationFailed`, `SubscriptionCancellationRequested`, `SubscriptionCanceled`,
 `UsageThresholdReached`, `SubscriptionRenewed`, `SubscriptionRenewalFailed`,
-`SubscriptionPastDue`, `SubscriptionUnpaid`.
+`SubscriptionPastDue`, `SubscriptionUnpaid`, `SubscriptionPlanChanged`.
 
 > **Nothing consumes this topic, and there is no email path in this repository** —
 > `Notification.DomainService` and `Mail.DomainService` contain only build output, no source. A

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -140,25 +140,45 @@ any more than it did on attempt one. This is also how a trial that never took a 
 its end: `TrialTerms.EndsAtUtc` is the subscription's `NextFeeBillingAtUtc` from the moment it is
 created, so the sweep picks it up the same way it picks up a renewal, and finds no card to charge.
 
-**Renewal reuses `IRecurringPaymentService`, the existing off-session charge stack, rather than a
-new Stripe Invoice integration** — called through `ISubscriptionBillingGateway`, owned by this
-module. That interface is the seam a future Stripe Invoice integration replaces: everything that
-decides *when* and *how much* to charge — this state machine, the amount calculator — depends
-only on the interface, never on how the charge is actually raised. Dunning is therefore Blocks'
-own responsibility in this phase, not delegated to a provider's retry engine; that is the cost of
-shipping renewals now instead of building Invoices first.
+Renewal is called through `ISubscriptionBillingGateway`, owned by this module — everything that
+decides *when* and *how much* to charge (this state machine, the amount calculator) depends only
+on the interface, never on how the charge is actually raised.
+`SubscriptionBillingGatewayResolver` picks which implementation by
+`SubscriptionChargeRequest.ProviderName`:
 
-The gateway is **provider-neutral, not Stripe-specific**: it passes `BillingAccount.ProviderName`
-straight through to `IRecurringPaymentService`, which already resolves the real charge gateway
-per provider. A subscriber on Adyen needs no new code here — only that tenant's `BillingAccount`
-naming Adyen.
+- **Stripe → `StripeInvoiceBillingGateway`.** Raises a standalone Stripe Invoice per attempt — an
+  item, the invoice itself (`auto_advance=false`, so Blocks controls every step rather than
+  Stripe's own background job), finalize, pay, and a void on decline. **No Stripe Subscription
+  object exists behind this**, on purpose: a real Subscription would run Stripe's own Smart
+  Retries and billing clock in parallel with this one, and the two would drift — Phase 1 rejected
+  creating one for exactly that reason, and this task does not revisit it. Dunning is therefore
+  still entirely Blocks' own responsibility; what changes is that a successful renewal now
+  produces a real Stripe Invoice document (line item, invoice number, a path to Stripe Tax later)
+  instead of a bare PaymentIntent.
+- **Everything else → `RecurringChargeBillingGateway`.** The plain off-session PaymentIntent
+  charge through `IRecurringPaymentService`, unchanged since it was written. A subscriber on Adyen
+  needs no new code — the resolver falls through to this gateway for any non-Stripe provider name,
+  so Adyen's behavior is exactly what it was before the Stripe Invoice gateway existed.
+
+`StripeInvoiceBillingGateway` claims and unprotects the stored card directly against
+`Payment.DomainService`'s repositories (`IStoredPaymentMethodRepository.TryClaimForPaymentAsync`,
+`IProviderTokenProtector.UnprotectAsync`) rather than through `RecurringPaymentInitiationService`:
+that service is built around `PaymentDetail`'s Authorized/Captured/Refused model, which an
+invoice's draft/open/paid/uncollectible lifecycle does not map onto — routing through it would
+teach the payment module the word "Invoice," which is exactly what this module's dependency rule
+exists to prevent. `Payment.DomainService` is otherwise untouched by this beyond a new, standalone
+Stripe Invoice HTTP client (`Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs`) that
+nothing else calls.
 
 Each renewal attempt gets its own order id, scoped to the period it charges
 (`sub:{subscriptionId}:{periodKey}`), because the payment module allows only one recurring
 payment per order id, ever — a shared order id across periods would reject every renewal after
 the first. The idempotency key additionally carries the attempt number
 (`sub-renew:{subscriptionId}:{periodKey}:{attempt}`): unlike the initial charge, a dunning retry
-is a genuinely new attempt, not a replay of the one before it.
+is a genuinely new attempt, not a replay of the one before it. `StripeInvoiceBillingGateway` in
+turn suffixes that key per Stripe call (`:item`, `:invoice`, `:finalize`, `:pay`) — Stripe scopes
+idempotency by endpoint, and the same raw key sent to four different endpoints in immediate
+succession is not something to trust silently.
 
 A discount reduces a renewal only while `DiscountTerms.DurationPeriods` and `ExpiresAtUtc` still
 allow it; `SubscriptionDetail.DiscountPeriodsApplied` tracks how many periods it has already

--- a/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
@@ -1,0 +1,151 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class BillingAccountRepository : IBillingAccountRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public BillingAccountRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Accounts(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateBillingAccountIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<BillingAccount> GetOrCreateAsync(
+        BillingAccount account,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(account);
+
+        await EnsureIndexesAsync(account.TenantId, cancellationToken);
+
+        var existing = await FindAsync(
+            account.TenantId,
+            account.OrganizationId,
+            account.ProviderName,
+            cancellationToken);
+
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        try
+        {
+            await Accounts(account.TenantId)
+                .InsertOneAsync(account, cancellationToken: cancellationToken);
+
+            return account;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Another request created it between the read and the insert. Its document is as
+            // good as the one this call would have written.
+            return await FindAsync(
+                       account.TenantId,
+                       account.OrganizationId,
+                       account.ProviderName,
+                       cancellationToken)
+                   ?? account;
+        }
+    }
+
+    public async Task<BillingAccount?> GetAsync(
+        string tenantId,
+        string billingAccountId,
+        CancellationToken cancellationToken) =>
+        await Accounts(tenantId)
+            .Find(Builders<BillingAccount>.Filter.And(
+                Builders<BillingAccount>.Filter.Eq(
+                    account => account.TenantId,
+                    tenantId),
+                Builders<BillingAccount>.Filter.Eq(
+                    account => account.ItemId,
+                    billingAccountId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<bool> TrySetProviderCustomerAsync(
+        string tenantId,
+        string billingAccountId,
+        string providerCustomerId,
+        string? defaultPaymentMethodId,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<BillingAccount>.Filter.And(
+            Builders<BillingAccount>.Filter.Eq(
+                account => account.TenantId,
+                tenantId),
+            Builders<BillingAccount>.Filter.Eq(
+                account => account.ItemId,
+                billingAccountId),
+            Builders<BillingAccount>.Filter.Or(
+                Builders<BillingAccount>.Filter.Eq(
+                    account => account.ProviderCustomerId,
+                    null),
+                Builders<BillingAccount>.Filter.Eq(
+                    account => account.ProviderCustomerId,
+                    providerCustomerId)));
+
+        var update = Builders<BillingAccount>.Update
+            .Set(account => account.ProviderCustomerId, providerCustomerId)
+            .Set(account => account.LastUpdatedDateUtc, DateTime.UtcNow)
+            .Inc(account => account.Version, 1);
+
+        if (!string.IsNullOrWhiteSpace(defaultPaymentMethodId))
+        {
+            update = update.Set(
+                account => account.DefaultPaymentMethodId,
+                defaultPaymentMethodId);
+        }
+
+        var result = await Accounts(tenantId).UpdateOneAsync(
+            filter,
+            update,
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    private async Task<BillingAccount?> FindAsync(
+        string tenantId,
+        string organizationId,
+        string providerName,
+        CancellationToken cancellationToken) =>
+        await Accounts(tenantId)
+            .Find(Builders<BillingAccount>.Filter.And(
+                Builders<BillingAccount>.Filter.Eq(
+                    account => account.TenantId,
+                    tenantId),
+                Builders<BillingAccount>.Filter.Eq(
+                    account => account.OrganizationId,
+                    organizationId),
+                Builders<BillingAccount>.Filter.Eq(
+                    account => account.ProviderName,
+                    providerName)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    private IMongoCollection<BillingAccount> Accounts(string tenantId) =>
+        SubscriptionCollections.Of<BillingAccount>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.BillingAccounts);
+}

--- a/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
@@ -1,0 +1,39 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface IBillingAccountRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the organization's account with this provider, creating it if there is none.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent by way of the unique index: two concurrent signups both attempt the insert,
+    /// one loses on the duplicate key and reads what the other wrote.
+    /// </remarks>
+    Task<BillingAccount> GetOrCreateAsync(
+        BillingAccount account,
+        CancellationToken cancellationToken);
+
+    Task<BillingAccount?> GetAsync(
+        string tenantId,
+        string billingAccountId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Records the provider's identifiers once the first charge has confirmed them.
+    /// </summary>
+    /// <remarks>
+    /// Only fills a blank customer id, never overwrites one. A second charge naming a different
+    /// customer means something is wrong, and quietly adopting it would strand every saved card
+    /// on the first.
+    /// </remarks>
+    Task<bool> TrySetProviderCustomerAsync(
+        string tenantId,
+        string billingAccountId,
+        string providerCustomerId,
+        string? defaultPaymentMethodId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
@@ -1,0 +1,59 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionCatalogueRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    Task<bool> TryCreatePlanAsync(Plan plan, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Finds a plan by its code, preferring the organization's own over the tenant's.
+    /// </summary>
+    /// <remarks>
+    /// The same fallback payment configuration uses. Plans are sold to organizations by the
+    /// tenant, so requiring one per organization would mean copying every plan for every
+    /// customer; an organization that needs its own terms can still have them.
+    /// </remarks>
+    Task<Plan?> FindPlanByCodeAsync(
+        string tenantId,
+        string? organizationId,
+        string code,
+        CancellationToken cancellationToken);
+
+    Task<Plan?> GetPlanAsync(
+        string tenantId,
+        string planId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Plan>> ListPlansAsync(
+        string tenantId,
+        string? organizationId,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryUpdatePlanAsync(
+        string tenantId,
+        string planId,
+        int expectedVersion,
+        Plan plan,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryCreatePriceAsync(Price price, CancellationToken cancellationToken);
+
+    Task<Price?> GetPriceAsync(
+        string tenantId,
+        string priceId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Price>> ListPricesAsync(
+        string tenantId,
+        string planId,
+        CancellationToken cancellationToken);
+
+    Task<bool> TrySetPriceMirrorAsync(
+        string tenantId,
+        string priceId,
+        ProviderPriceMirror mirror,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionPaymentLinkRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionPaymentLinkRepository.cs
@@ -1,0 +1,48 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionPaymentLinkRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    Task<bool> TryCreateAsync(
+        SubscriptionPaymentLink link,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionPaymentLink?> FindByPaymentAsync(
+        string tenantId,
+        string paymentDetailId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionPaymentLink?> FindBySubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken);
+
+    /// <summary>Pending links the activation sweep should look at now.</summary>
+    Task<IReadOnlyList<SubscriptionPaymentLink>> ListDueAsync(
+        string tenantId,
+        DateTime dueAtUtc,
+        int limit,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Settles a link, but only if it is still pending — so a sweep that runs twice, or two
+    /// workers that both pick it up, apply the outcome once.
+    /// </summary>
+    Task<bool> TrySettleAsync(
+        string tenantId,
+        string linkId,
+        SubscriptionPaymentLinkState state,
+        CancellationToken cancellationToken);
+
+    Task RescheduleAsync(
+        string tenantId,
+        string linkId,
+        int attemptCount,
+        DateTime nextCheckAtUtc,
+        string? failureReason,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -1,0 +1,115 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Inserts a subscription, returning false when the organization already has a live one.
+    /// </summary>
+    /// <remarks>
+    /// The database decides, through a partial unique index, rather than a read followed by a
+    /// write — two concurrent signups would both pass the read.
+    /// </remarks>
+    Task<bool> TryCreateAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reads one subscription, scoped to the organization that owns it.</summary>
+    Task<SubscriptionDetail?> GetAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reads without an organization filter, for background work that has no caller.</summary>
+    Task<SubscriptionDetail?> GetByIdAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken);
+
+    /// <summary>The organization's subscription that currently grants something, if any.</summary>
+    Task<SubscriptionDetail?> GetLiveAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionDetail?> GetByOrderIdAsync(
+        string tenantId,
+        string orderId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Moves a subscription from one status to another, writing the transition's other fields
+    /// and its event in the same update.
+    /// </summary>
+    /// <returns>
+    /// False when the subscription is no longer in the expected status — someone else got there
+    /// first, and the caller must not assume its own view is current.
+    /// </returns>
+    Task<bool> TryTransitionAsync(
+        string tenantId,
+        string subscriptionId,
+        SubscriptionTransition transition,
+        CancellationToken cancellationToken);
+
+    /// <summary>Changes a quantity item, guarded by the version the caller read.</summary>
+    Task<bool> TryUpdateQuantityAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedVersion,
+        string itemKey,
+        long quantity,
+        CancellationToken cancellationToken);
+
+    /// <summary>Subscriptions whose first charge never completed, for the recovery sweep.</summary>
+    Task<IReadOnlyList<SubscriptionDetail>> ListStaleAsync(
+        string tenantId,
+        SubscriptionStatus status,
+        DateTime olderThanUtc,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryAppendEventAsync(
+        string tenantId,
+        string subscriptionId,
+        SubscriptionOutboxEvent outboxEvent,
+        CancellationToken cancellationToken);
+
+    /// <summary>Takes a lease on one pending event so two workers cannot publish it twice.</summary>
+    Task<SubscriptionOutboxEvent?> TryClaimEventAsync(
+        string tenantId,
+        string subscriptionId,
+        string eventId,
+        string leaseId,
+        DateTime leaseExpiresAtUtc,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SubscriptionDetail>> ListWithDueEventsAsync(
+        string tenantId,
+        DateTime dueAtUtc,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task MarkEventPublishedAsync(
+        string tenantId,
+        string subscriptionId,
+        string eventId,
+        string leaseId,
+        DateTime publishedAtUtc,
+        CancellationToken cancellationToken);
+
+    Task MarkEventFailedAsync(
+        string tenantId,
+        string subscriptionId,
+        string eventId,
+        string leaseId,
+        SubscriptionOutboxStatus status,
+        int attemptCount,
+        DateTime nextAttemptAtUtc,
+        string failureReason,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -106,6 +106,13 @@ public interface ISubscriptionRepository
         int limit,
         CancellationToken cancellationToken);
 
+    /// <summary>Subscriptions whose usage period has closed and needs its overage rated.</summary>
+    Task<IReadOnlyList<SubscriptionDetail>> ListDueForUsageRatingAsync(
+        string tenantId,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken);
+
     Task<bool> TryAppendEventAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -73,6 +73,16 @@ public interface ISubscriptionRepository
         int limit,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Subscriptions due for a renewal charge or a dunning retry — anything live whose next
+    /// billing instant has arrived.
+    /// </summary>
+    Task<IReadOnlyList<SubscriptionDetail>> ListDueForRenewalAsync(
+        string tenantId,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken);
+
     Task<bool> TryAppendEventAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -65,6 +65,29 @@ public interface ISubscriptionRepository
         long quantity,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Swaps the plan, price and quantity snapshot, guarded by the version the caller read.
+    /// </summary>
+    /// <remarks>
+    /// Guarded by <c>Version</c> rather than <c>Status</c>, unlike <see cref="TryTransitionAsync"/>:
+    /// a plan change does not move the subscription's status, so there is no expected status to
+    /// assert. The two are separate methods rather than one extended primitive because they
+    /// write disjoint field sets for a reason — a status transition never touches the catalogue
+    /// snapshot, and this never touches status.
+    /// </remarks>
+    /// <returns>False when the version has moved on — someone else changed this subscription first.</returns>
+    Task<bool> TryChangePlanAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedVersion,
+        PlanSnapshot newPlan,
+        PriceSnapshot newPrice,
+        List<SubscriptionQuantityItem> newQuantityItems,
+        long newCreditBalanceMinor,
+        string? planChangePaymentDetailId,
+        SubscriptionOutboxEvent outboxEvent,
+        CancellationToken cancellationToken);
+
     /// <summary>Subscriptions whose first charge never completed, for the recovery sweep.</summary>
     Task<IReadOnlyList<SubscriptionDetail>> ListStaleAsync(
         string tenantId,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageInvoiceRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageInvoiceRepository.cs
@@ -1,0 +1,54 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionUsageInvoiceRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Inserts an invoice, returning false when one already exists for this subscription and
+    /// period — the double-billing guard, enforced by the database rather than a read-then-write.
+    /// </summary>
+    Task<bool> TryCreateAsync(
+        SubscriptionUsageInvoice invoice,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionUsageInvoice?> GetAsync(
+        string tenantId,
+        string subscriptionId,
+        string periodKey,
+        CancellationToken cancellationToken);
+
+    /// <summary>Pending invoices the charge sweep should look at now.</summary>
+    Task<IReadOnlyList<SubscriptionUsageInvoice>> ListDueAsync(
+        string tenantId,
+        DateTime dueAtUtc,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryMarkChargedAsync(
+        string tenantId,
+        string invoiceId,
+        string paymentDetailId,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryMarkNoChargeAsync(
+        string tenantId,
+        string invoiceId,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryMarkAbandonedAsync(
+        string tenantId,
+        string invoiceId,
+        CancellationToken cancellationToken);
+
+    Task RescheduleAsync(
+        string tenantId,
+        string invoiceId,
+        int attemptCount,
+        DateTime nextAttemptAtUtc,
+        string? failureReason,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
@@ -1,0 +1,83 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionUsageRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Appends a ledger entry, returning false when this idempotency key has already been used.
+    /// </summary>
+    /// <remarks>
+    /// Written before the counter moves, deliberately. A crash between the two leaves the
+    /// counter under-counting, which the repair sweep can correct from the ledger; the other
+    /// order would over-count, and there would be nothing left to prove it.
+    /// </remarks>
+    Task<bool> TryAppendRecordAsync(
+        SubscriptionUsageRecord record,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Applies a delta to the period's counter and returns the counter as it now stands.
+    /// </summary>
+    /// <remarks>
+    /// One upsert with an atomic increment: no read, no rollover job, and no window in which
+    /// two callers can both act on the same figure. Crossing a period boundary simply addresses
+    /// a different document.
+    /// </remarks>
+    Task<SubscriptionUsageCounter> ApplyDeltaAsync(
+        SubscriptionUsageCounter seed,
+        long delta,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionUsageCounter?> GetCounterAsync(
+        string tenantId,
+        string counterId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SubscriptionUsageCounter>> ListCountersAsync(
+        string tenantId,
+        string subscriptionId,
+        string periodKey,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Records that a threshold has been reported, returning true only for the caller that got
+    /// there first — which is the one that should raise the event.
+    /// </summary>
+    Task<bool> TryMarkThresholdNotifiedAsync(
+        string tenantId,
+        string counterId,
+        int thresholdPercent,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionUsageRecord?> FindRecordByKeyAsync(
+        string tenantId,
+        string subscriptionId,
+        string idempotencyKey,
+        CancellationToken cancellationToken);
+
+    /// <summary>The ledger's own view of a period, used to rebuild a counter that has drifted.</summary>
+    Task<(long Balance, long RecordCount)> SummariseLedgerAsync(
+        string tenantId,
+        string subscriptionId,
+        string meterKey,
+        string periodKey,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryRepairCounterAsync(
+        string tenantId,
+        string counterId,
+        long balance,
+        long appliedRecordCount,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SubscriptionUsageRecord>> ListRecordsAsync(
+        string tenantId,
+        string subscriptionId,
+        string? meterKey,
+        string? periodKey,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -1,0 +1,256 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionCatalogueRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Plans(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreatePlanIndexes(),
+            cancellationToken);
+
+        await Prices(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreatePriceIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<bool> TryCreatePlanAsync(
+        Plan plan,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        try
+        {
+            await EnsureIndexesAsync(plan.TenantId, cancellationToken);
+
+            await Plans(plan.TenantId)
+                .InsertOneAsync(plan, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task<Plan?> FindPlanByCodeAsync(
+        string tenantId,
+        string? organizationId,
+        string code,
+        CancellationToken cancellationToken)
+    {
+        var plans = Plans(tenantId);
+        var baseFilter = Builders<Plan>.Filter.And(
+            Builders<Plan>.Filter.Eq(plan => plan.TenantId, tenantId),
+            Builders<Plan>.Filter.Eq(plan => plan.Code, code),
+            Builders<Plan>.Filter.Eq(plan => plan.Status, CatalogueStatus.Active));
+
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            var owned = await plans
+                .Find(Builders<Plan>.Filter.And(
+                    baseFilter,
+                    Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, organizationId)))
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (owned is not null)
+            {
+                return owned;
+            }
+        }
+
+        // The tenant's own catalogue, serving every organization without one of its own.
+        return await plans
+            .Find(Builders<Plan>.Filter.And(
+                baseFilter,
+                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null)))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<Plan?> GetPlanAsync(
+        string tenantId,
+        string planId,
+        CancellationToken cancellationToken) =>
+        await Plans(tenantId)
+            .Find(Builders<Plan>.Filter.And(
+                Builders<Plan>.Filter.Eq(plan => plan.TenantId, tenantId),
+                Builders<Plan>.Filter.Eq(plan => plan.ItemId, planId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<Plan>> ListPlansAsync(
+        string tenantId,
+        string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var visible = string.IsNullOrWhiteSpace(organizationId)
+            ? Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null)
+            : Builders<Plan>.Filter.Or(
+                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, organizationId),
+                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null));
+
+        var plans = await Plans(tenantId)
+            .Find(Builders<Plan>.Filter.And(
+                Builders<Plan>.Filter.Eq(plan => plan.TenantId, tenantId),
+                Builders<Plan>.Filter.Eq(plan => plan.Status, CatalogueStatus.Active),
+                visible))
+            .ToListAsync(cancellationToken);
+
+        // An organization's own plan hides the tenant's of the same code, matching what
+        // FindPlanByCodeAsync would resolve. Showing both would offer a choice that
+        // subscribing cannot honour.
+        return plans
+            .GroupBy(plan => plan.Code, StringComparer.Ordinal)
+            .Select(group =>
+                group.FirstOrDefault(plan => plan.OrganizationId is not null) ??
+                group.First())
+            .OrderBy(plan => plan.Code, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public async Task<bool> TryUpdatePlanAsync(
+        string tenantId,
+        string planId,
+        int expectedVersion,
+        Plan plan,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var filter = Builders<Plan>.Filter.And(
+            Builders<Plan>.Filter.Eq(existing => existing.TenantId, tenantId),
+            Builders<Plan>.Filter.Eq(existing => existing.ItemId, planId),
+            Builders<Plan>.Filter.Eq(existing => existing.Version, expectedVersion));
+
+        var update = Builders<Plan>.Update
+            .Set(existing => existing.DisplayName, plan.DisplayName)
+            .Set(existing => existing.Description, plan.Description)
+            .Set(existing => existing.Status, plan.Status)
+            .Set(existing => existing.FeaturesJson, plan.FeaturesJson)
+            .Set(existing => existing.Entitlements, plan.Entitlements)
+            .Set(existing => existing.Meters, plan.Meters)
+            .Set(existing => existing.QuantityItems, plan.QuantityItems)
+            .Set(existing => existing.TrialDays, plan.TrialDays)
+            .Set(existing => existing.TrialRequiresPaymentMethod, plan.TrialRequiresPaymentMethod)
+            .Set(existing => existing.TrialGrants, plan.TrialGrants)
+            .Set(existing => existing.LastUpdatedDateUtc, DateTime.UtcNow)
+            .Inc(existing => existing.Version, 1);
+
+        var result = await Plans(tenantId).UpdateOneAsync(
+            filter,
+            update,
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<bool> TryCreatePriceAsync(
+        Price price,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+
+        try
+        {
+            await EnsureIndexesAsync(price.TenantId, cancellationToken);
+
+            await Prices(price.TenantId)
+                .InsertOneAsync(price, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task<Price?> GetPriceAsync(
+        string tenantId,
+        string priceId,
+        CancellationToken cancellationToken) =>
+        await Prices(tenantId)
+            .Find(Builders<Price>.Filter.And(
+                Builders<Price>.Filter.Eq(price => price.TenantId, tenantId),
+                Builders<Price>.Filter.Eq(price => price.ItemId, priceId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<Price>> ListPricesAsync(
+        string tenantId,
+        string planId,
+        CancellationToken cancellationToken) =>
+        await Prices(tenantId)
+            .Find(Builders<Price>.Filter.And(
+                Builders<Price>.Filter.Eq(price => price.TenantId, tenantId),
+                Builders<Price>.Filter.Eq(price => price.PlanId, planId),
+                Builders<Price>.Filter.Eq(price => price.Status, CatalogueStatus.Active)))
+            .ToListAsync(cancellationToken);
+
+    public async Task<bool> TrySetPriceMirrorAsync(
+        string tenantId,
+        string priceId,
+        ProviderPriceMirror mirror,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(mirror);
+
+        // Replacing any existing mirror for the same provider keeps this idempotent: mirroring
+        // twice leaves one entry, not two competing identifiers for the same price.
+        var filter = Builders<Price>.Filter.And(
+            Builders<Price>.Filter.Eq(price => price.TenantId, tenantId),
+            Builders<Price>.Filter.Eq(price => price.ItemId, priceId));
+
+        await Prices(tenantId).UpdateOneAsync(
+            filter,
+            Builders<Price>.Update.PullFilter(
+                price => price.ProviderMirrors,
+                existing => existing.ProviderName == mirror.ProviderName),
+            cancellationToken: cancellationToken);
+
+        var result = await Prices(tenantId).UpdateOneAsync(
+            filter,
+            Builders<Price>.Update
+                .Push(price => price.ProviderMirrors, mirror)
+                .Set(price => price.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    private IMongoCollection<Plan> Plans(string tenantId) =>
+        SubscriptionCollections.Of<Plan>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.Plans);
+
+    private IMongoCollection<Price> Prices(string tenantId) =>
+        SubscriptionCollections.Of<Price>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.Prices);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -20,6 +20,7 @@ internal static class SubscriptionCollections
     public const string UsageRecords = "SubscriptionUsageRecords";
     public const string UsageCounters = "SubscriptionUsageCounters";
     public const string PaymentLinks = "SubscriptionPaymentLinks";
+    public const string UsageInvoices = "SubscriptionUsageInvoices";
 
     public static IMongoCollection<TDocument> Of<TDocument>(
         IDbContextProvider dbContextProvider,

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -1,0 +1,37 @@
+using Blocks.Genesis;
+using MongoDB.Driver;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// Resolves a tenant's collections.
+/// </summary>
+/// <remarks>
+/// The tenant selects the database, so it travels as an argument on every repository call
+/// rather than being read from ambient context. That keeps repositories singleton and usable
+/// from background work, which has no request to read a tenant from.
+/// </remarks>
+internal static class SubscriptionCollections
+{
+    public const string Plans = "SubscriptionPlans";
+    public const string Prices = "SubscriptionPrices";
+    public const string BillingAccounts = "SubscriptionBillingAccounts";
+    public const string Subscriptions = "Subscriptions";
+    public const string UsageRecords = "SubscriptionUsageRecords";
+    public const string UsageCounters = "SubscriptionUsageCounters";
+    public const string PaymentLinks = "SubscriptionPaymentLinks";
+
+    public static IMongoCollection<TDocument> Of<TDocument>(
+        IDbContextProvider dbContextProvider,
+        string tenantId,
+        string collectionName) =>
+        dbContextProvider
+            .GetDatabase(RequireTenant(tenantId))
+            .GetCollection<TDocument>(collectionName);
+
+    private static string RequireTenant(string tenantId) =>
+        !string.IsNullOrWhiteSpace(tenantId)
+            ? tenantId
+            : throw new InvalidOperationException(
+                "A tenant id is required for subscription persistence.");
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -52,6 +52,12 @@ public static class SubscriptionIndexDefinitions
     public const string PaymentLinkSweepIndexName =
         "ix_subscription_link_tenant_state_next_check";
 
+    public const string UsageInvoiceUniqueIndexName =
+        "ux_subscription_usageinvoice_tenant_subscription_period";
+
+    public const string UsageInvoiceSweepIndexName =
+        "ix_subscription_usageinvoice_tenant_state_next_attempt";
+
     /// <summary>
     /// One live subscription per organization, enforced by the database rather than by a
     /// read-then-write, so two concurrent signups cannot both succeed.
@@ -201,5 +207,29 @@ public static class SubscriptionIndexDefinitions
                 .Ascending(link => link.State)
                 .Ascending(link => link.NextCheckAtUtc),
             new CreateIndexOptions { Name = PaymentLinkSweepIndexName })
+    ];
+
+    /// <summary>
+    /// The double-billing guard for usage rating: one invoice per subscription per usage period,
+    /// enforced by the database rather than a read-then-write.
+    /// </summary>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionUsageInvoice>> CreateUsageInvoiceIndexes() =>
+    [
+        new(
+            Builders<SubscriptionUsageInvoice>.IndexKeys
+                .Ascending(invoice => invoice.TenantId)
+                .Ascending(invoice => invoice.SubscriptionId)
+                .Ascending(invoice => invoice.PeriodKey),
+            new CreateIndexOptions
+            {
+                Unique = true,
+                Name = UsageInvoiceUniqueIndexName
+            }),
+        new(
+            Builders<SubscriptionUsageInvoice>.IndexKeys
+                .Ascending(invoice => invoice.TenantId)
+                .Ascending(invoice => invoice.State)
+                .Ascending(invoice => invoice.NextAttemptAtUtc),
+            new CreateIndexOptions { Name = UsageInvoiceSweepIndexName })
     ];
 }

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -28,6 +28,9 @@ public static class SubscriptionIndexDefinitions
     public const string SubscriptionRenewalDueIndexName =
         "ix_subscription_tenant_status_next_fee_billing";
 
+    public const string SubscriptionUsageRatingDueIndexName =
+        "ix_subscription_tenant_status_next_usage_billing";
+
     public const string PlanCodeIndexName =
         "ux_subscription_plan_tenant_org_code";
 
@@ -105,7 +108,13 @@ public static class SubscriptionIndexDefinitions
                 .Ascending(subscription => subscription.TenantId)
                 .Ascending(subscription => subscription.Status)
                 .Ascending(subscription => subscription.NextFeeBillingAtUtc),
-            new CreateIndexOptions { Name = SubscriptionRenewalDueIndexName })
+            new CreateIndexOptions { Name = SubscriptionRenewalDueIndexName }),
+        new(
+            Builders<SubscriptionDetail>.IndexKeys
+                .Ascending(subscription => subscription.TenantId)
+                .Ascending(subscription => subscription.Status)
+                .Ascending(subscription => subscription.NextUsageBillingAtUtc),
+            new CreateIndexOptions { Name = SubscriptionUsageRatingDueIndexName })
     ];
 
     public static IReadOnlyCollection<CreateIndexModel<Plan>> CreatePlanIndexes() =>

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -1,0 +1,194 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// The indexes this module relies on for correctness, not only for speed.
+/// </summary>
+/// <remarks>
+/// Kept separate from the payment module's definitions on purpose. Payment guards index
+/// creation with a per-process record of which tenants it has already done; adding subscription
+/// indexes there would mean any tenant that process had already touched never gets them, and
+/// the first sign would be duplicate billing in production.
+/// </remarks>
+public static class SubscriptionIndexDefinitions
+{
+    public const string ActiveSubscriptionIndexName =
+        "ux_subscription_tenant_org_live";
+
+    public const string SubscriptionOrganizationIndexName =
+        "ix_subscription_tenant_org_status";
+
+    public const string SubscriptionOrderIndexName =
+        "ix_subscription_tenant_order";
+
+    public const string PlanCodeIndexName =
+        "ux_subscription_plan_tenant_org_code";
+
+    public const string PricePlanIndexName =
+        "ix_subscription_price_tenant_plan";
+
+    public const string BillingAccountIndexName =
+        "ux_subscription_account_tenant_org_provider";
+
+    public const string UsageIdempotencyIndexName =
+        "ux_subscription_usage_tenant_subscription_key";
+
+    public const string UsagePeriodIndexName =
+        "ix_subscription_usage_tenant_subscription_meter_period";
+
+    public const string UsageCounterExpiryIndexName =
+        "ttl_subscription_usage_counter_expires";
+
+    public const string PaymentLinkPaymentIndexName =
+        "ux_subscription_link_tenant_payment";
+
+    public const string PaymentLinkSweepIndexName =
+        "ix_subscription_link_tenant_state_next_check";
+
+    /// <summary>
+    /// One live subscription per organization, enforced by the database rather than by a
+    /// read-then-write, so two concurrent signups cannot both succeed.
+    /// </summary>
+    /// <remarks>
+    /// Partial on the statuses that grant something: ended subscriptions must be allowed to
+    /// accumulate, or an organization could never resubscribe after cancelling.
+    /// </remarks>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionDetail>> CreateSubscriptionIndexes() =>
+    [
+        new(
+            Builders<SubscriptionDetail>.IndexKeys
+                .Ascending(subscription => subscription.TenantId)
+                .Ascending(subscription => subscription.OrganizationId),
+            new CreateIndexOptions<SubscriptionDetail>
+            {
+                Unique = true,
+                Name = ActiveSubscriptionIndexName,
+                PartialFilterExpression = new BsonDocument(
+                    nameof(SubscriptionDetail.Status),
+                    new BsonDocument(
+                        "$in",
+                        new BsonArray
+                        {
+                            (int)SubscriptionStatus.Trialing,
+                            (int)SubscriptionStatus.Active,
+                            (int)SubscriptionStatus.PastDue
+                        }))
+            }),
+        new(
+            Builders<SubscriptionDetail>.IndexKeys
+                .Ascending(subscription => subscription.TenantId)
+                .Ascending(subscription => subscription.OrganizationId)
+                .Ascending(subscription => subscription.Status),
+            new CreateIndexOptions { Name = SubscriptionOrganizationIndexName }),
+        new(
+            Builders<SubscriptionDetail>.IndexKeys
+                .Ascending(subscription => subscription.TenantId)
+                .Ascending(subscription => subscription.OrderId),
+            new CreateIndexOptions { Name = SubscriptionOrderIndexName })
+    ];
+
+    public static IReadOnlyCollection<CreateIndexModel<Plan>> CreatePlanIndexes() =>
+    [
+        new(
+            Builders<Plan>.IndexKeys
+                .Ascending(plan => plan.TenantId)
+                .Ascending(plan => plan.OrganizationId)
+                .Ascending(plan => plan.Code),
+            new CreateIndexOptions
+            {
+                Unique = true,
+                Name = PlanCodeIndexName
+            })
+    ];
+
+    public static IReadOnlyCollection<CreateIndexModel<Price>> CreatePriceIndexes() =>
+    [
+        new(
+            Builders<Price>.IndexKeys
+                .Ascending(price => price.TenantId)
+                .Ascending(price => price.PlanId),
+            new CreateIndexOptions { Name = PricePlanIndexName })
+    ];
+
+    public static IReadOnlyCollection<CreateIndexModel<BillingAccount>> CreateBillingAccountIndexes() =>
+    [
+        new(
+            Builders<BillingAccount>.IndexKeys
+                .Ascending(account => account.TenantId)
+                .Ascending(account => account.OrganizationId)
+                .Ascending(account => account.ProviderName),
+            new CreateIndexOptions
+            {
+                Unique = true,
+                Name = BillingAccountIndexName
+            })
+    ];
+
+    /// <summary>
+    /// The guard against billing a customer twice for one event.
+    /// </summary>
+    /// <remarks>
+    /// Callers retry — a timeout, a redelivery, a double click — and at-least-once delivery
+    /// makes that a certainty rather than a risk. Uniqueness here is what turns a retry into a
+    /// no-op instead of a second charge.
+    /// </remarks>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionUsageRecord>> CreateUsageRecordIndexes() =>
+    [
+        new(
+            Builders<SubscriptionUsageRecord>.IndexKeys
+                .Ascending(record => record.TenantId)
+                .Ascending(record => record.SubscriptionId)
+                .Ascending(record => record.IdempotencyKey),
+            new CreateIndexOptions
+            {
+                Unique = true,
+                Name = UsageIdempotencyIndexName
+            }),
+        new(
+            Builders<SubscriptionUsageRecord>.IndexKeys
+                .Ascending(record => record.TenantId)
+                .Ascending(record => record.SubscriptionId)
+                .Ascending(record => record.MeterKey)
+                .Ascending(record => record.PeriodKey),
+            new CreateIndexOptions { Name = UsagePeriodIndexName })
+    ];
+
+    /// <summary>
+    /// Counters expire; the ledger behind them does not. A counter is a derived read model and
+    /// can always be recomputed, whereas the ledger is the record that has to explain a bill.
+    /// </summary>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionUsageCounter>> CreateUsageCounterIndexes() =>
+    [
+        new(
+            Builders<SubscriptionUsageCounter>.IndexKeys
+                .Ascending(counter => counter.ExpiresAtUtc),
+            new CreateIndexOptions
+            {
+                Name = UsageCounterExpiryIndexName,
+                ExpireAfter = TimeSpan.Zero
+            })
+    ];
+
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionPaymentLink>> CreatePaymentLinkIndexes() =>
+    [
+        new(
+            Builders<SubscriptionPaymentLink>.IndexKeys
+                .Ascending(link => link.TenantId)
+                .Ascending(link => link.PaymentDetailId),
+            new CreateIndexOptions
+            {
+                Unique = true,
+                Name = PaymentLinkPaymentIndexName
+            }),
+        new(
+            Builders<SubscriptionPaymentLink>.IndexKeys
+                .Ascending(link => link.TenantId)
+                .Ascending(link => link.State)
+                .Ascending(link => link.NextCheckAtUtc),
+            new CreateIndexOptions { Name = PaymentLinkSweepIndexName })
+    ];
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -25,6 +25,9 @@ public static class SubscriptionIndexDefinitions
     public const string SubscriptionOrderIndexName =
         "ix_subscription_tenant_order";
 
+    public const string SubscriptionRenewalDueIndexName =
+        "ix_subscription_tenant_status_next_fee_billing";
+
     public const string PlanCodeIndexName =
         "ux_subscription_plan_tenant_org_code";
 
@@ -88,7 +91,15 @@ public static class SubscriptionIndexDefinitions
             Builders<SubscriptionDetail>.IndexKeys
                 .Ascending(subscription => subscription.TenantId)
                 .Ascending(subscription => subscription.OrderId),
-            new CreateIndexOptions { Name = SubscriptionOrderIndexName })
+            new CreateIndexOptions { Name = SubscriptionOrderIndexName }),
+        // What the renewal sweep queries: every subscription that could possibly be due,
+        // narrowed by status first since most subscriptions are not near their billing date.
+        new(
+            Builders<SubscriptionDetail>.IndexKeys
+                .Ascending(subscription => subscription.TenantId)
+                .Ascending(subscription => subscription.Status)
+                .Ascending(subscription => subscription.NextFeeBillingAtUtc),
+            new CreateIndexOptions { Name = SubscriptionRenewalDueIndexName })
     ];
 
     public static IReadOnlyCollection<CreateIndexModel<Plan>> CreatePlanIndexes() =>

--- a/server/Subscription.DomainService/Repositories/SubscriptionPaymentLinkRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionPaymentLinkRepository.cs
@@ -1,0 +1,156 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionPaymentLinkRepository : ISubscriptionPaymentLinkRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionPaymentLinkRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Links(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreatePaymentLinkIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<bool> TryCreateAsync(
+        SubscriptionPaymentLink link,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(link);
+
+        try
+        {
+            await EnsureIndexesAsync(link.TenantId, cancellationToken);
+
+            await Links(link.TenantId)
+                .InsertOneAsync(link, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task<SubscriptionPaymentLink?> FindByPaymentAsync(
+        string tenantId,
+        string paymentDetailId,
+        CancellationToken cancellationToken) =>
+        await Links(tenantId)
+            .Find(Builders<SubscriptionPaymentLink>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionPaymentLink>.Filter.Eq(
+                    link => link.PaymentDetailId,
+                    paymentDetailId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<SubscriptionPaymentLink?> FindBySubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken) =>
+        await Links(tenantId)
+            .Find(Builders<SubscriptionPaymentLink>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionPaymentLink>.Filter.Eq(
+                    link => link.SubscriptionId,
+                    subscriptionId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<SubscriptionPaymentLink>> ListDueAsync(
+        string tenantId,
+        DateTime dueAtUtc,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Links(tenantId)
+            .Find(Builders<SubscriptionPaymentLink>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionPaymentLink>.Filter.Eq(
+                    link => link.State,
+                    SubscriptionPaymentLinkState.Pending),
+                Builders<SubscriptionPaymentLink>.Filter.Or(
+                    Builders<SubscriptionPaymentLink>.Filter.Eq(
+                        link => link.NextCheckAtUtc,
+                        null),
+                    Builders<SubscriptionPaymentLink>.Filter.Lte(
+                        link => link.NextCheckAtUtc,
+                        dueAtUtc))))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
+    public async Task<bool> TrySettleAsync(
+        string tenantId,
+        string linkId,
+        SubscriptionPaymentLinkState state,
+        CancellationToken cancellationToken)
+    {
+        var result = await Links(tenantId).UpdateOneAsync(
+            Builders<SubscriptionPaymentLink>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionPaymentLink>.Filter.Eq(
+                    link => link.ItemId,
+                    linkId),
+                Builders<SubscriptionPaymentLink>.Filter.Eq(
+                    link => link.State,
+                    SubscriptionPaymentLinkState.Pending)),
+            Builders<SubscriptionPaymentLink>.Update
+                .Set(link => link.State, state)
+                .Set(link => link.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task RescheduleAsync(
+        string tenantId,
+        string linkId,
+        int attemptCount,
+        DateTime nextCheckAtUtc,
+        string? failureReason,
+        CancellationToken cancellationToken) =>
+        await Links(tenantId).UpdateOneAsync(
+            Builders<SubscriptionPaymentLink>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionPaymentLink>.Filter.Eq(
+                    link => link.ItemId,
+                    linkId)),
+            Builders<SubscriptionPaymentLink>.Update
+                .Set(link => link.AttemptCount, attemptCount)
+                .Set(link => link.NextCheckAtUtc, nextCheckAtUtc)
+                .Set(link => link.LastError, Shorten(failureReason))
+                .Set(link => link.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+    private static FilterDefinition<SubscriptionPaymentLink> TenantFilter(string tenantId) =>
+        Builders<SubscriptionPaymentLink>.Filter.Eq(
+            link => link.TenantId,
+            tenantId);
+
+    private static string? Shorten(string? value) =>
+        value is null || value.Length <= 500 ? value : value[..500];
+
+    private IMongoCollection<SubscriptionPaymentLink> Links(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionPaymentLink>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.PaymentLinks);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -387,6 +387,36 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
                 paymentDetailId);
         }
 
+        if (transition.LastRenewalPaymentDetailId is { } renewalPaymentDetailId)
+        {
+            update = update.Set(
+                subscription => subscription.LastRenewalPaymentDetailId,
+                renewalPaymentDetailId);
+        }
+
+        if (transition.DunningAttemptCount is { } dunningAttemptCount)
+        {
+            update = update.Set(
+                subscription => subscription.DunningAttemptCount,
+                dunningAttemptCount);
+        }
+
+        if (transition.DiscountPeriodsApplied is { } discountPeriodsApplied)
+        {
+            update = update.Set(
+                subscription => subscription.DiscountPeriodsApplied,
+                discountPeriodsApplied);
+        }
+
+        if (transition.ClearPastDueSinceAt)
+        {
+            update = update.Set(subscription => subscription.PastDueSinceUtc, null);
+        }
+        else if (transition.PastDueSinceUtc is { } pastDueSince)
+        {
+            update = update.Set(subscription => subscription.PastDueSinceUtc, pastDueSince);
+        }
+
         if (transition.CurrentPeriodStartUtc is { } periodStart)
         {
             update = update.Set(

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -1,0 +1,464 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionRepository : ISubscriptionRepository
+{
+    /// <summary>
+    /// Statuses that grant something. The set the live-subscription index is partial on, and the
+    /// one entitlement treats as current.
+    /// </summary>
+    private static readonly SubscriptionStatus[] LiveStatuses =
+    [
+        SubscriptionStatus.Trialing,
+        SubscriptionStatus.Active,
+        SubscriptionStatus.PastDue
+    ];
+
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Subscriptions(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateSubscriptionIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<bool> TryCreateAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        try
+        {
+            await EnsureIndexesAsync(subscription.TenantId, cancellationToken);
+
+            await Subscriptions(subscription.TenantId)
+                .InsertOneAsync(subscription, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task<SubscriptionDetail?> GetAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.OrganizationId,
+                    organizationId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.ItemId,
+                    subscriptionId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<SubscriptionDetail?> GetByIdAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.ItemId,
+                    subscriptionId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<SubscriptionDetail?> GetLiveAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(BuildLiveFilter(tenantId, organizationId))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<SubscriptionDetail?> GetByOrderIdAsync(
+        string tenantId,
+        string orderId,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.OrderId,
+                    orderId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<bool> TryTransitionAsync(
+        string tenantId,
+        string subscriptionId,
+        SubscriptionTransition transition,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+
+        var filter = Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.ItemId,
+                subscriptionId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.Status,
+                transition.ExpectedStatus));
+
+        var result = await Subscriptions(tenantId).UpdateOneAsync(
+            filter,
+            BuildTransitionUpdate(transition),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<bool> TryUpdateQuantityAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedVersion,
+        string itemKey,
+        long quantity,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.ItemId,
+                subscriptionId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.Version,
+                expectedVersion),
+            Builders<SubscriptionDetail>.Filter.ElemMatch(
+                subscription => subscription.QuantityItems,
+                item => item.ItemKey == itemKey));
+
+        var update = Builders<SubscriptionDetail>.Update
+            .Set("QuantityItems.$[item].Quantity", quantity)
+            .Inc(subscription => subscription.Version, 1)
+            .Set(subscription => subscription.LastUpdatedDateUtc, DateTime.UtcNow);
+
+        var options = new UpdateOptions
+        {
+            ArrayFilters =
+            [
+                new BsonDocumentArrayFilterDefinition<SubscriptionQuantityItem>(
+                    new BsonDocument("item.ItemKey", itemKey))
+            ]
+        };
+
+        var result = await Subscriptions(tenantId).UpdateOneAsync(
+            filter,
+            update,
+            options,
+            cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<IReadOnlyList<SubscriptionDetail>> ListStaleAsync(
+        string tenantId,
+        SubscriptionStatus status,
+        DateTime olderThanUtc,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.Status,
+                    status),
+                Builders<SubscriptionDetail>.Filter.Lt(
+                    subscription => subscription.CreatedAtUtc,
+                    olderThanUtc)))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
+    public async Task<bool> TryAppendEventAsync(
+        string tenantId,
+        string subscriptionId,
+        SubscriptionOutboxEvent outboxEvent,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(outboxEvent);
+
+        var filter = Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.ItemId,
+                subscriptionId),
+            NotAlreadyEmitted(outboxEvent.DeduplicationKey));
+
+        var result = await Subscriptions(tenantId).UpdateOneAsync(
+            filter,
+            Builders<SubscriptionDetail>.Update.Push(
+                subscription => subscription.OutboxEvents,
+                outboxEvent),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<SubscriptionOutboxEvent?> TryClaimEventAsync(
+        string tenantId,
+        string subscriptionId,
+        string eventId,
+        string leaseId,
+        DateTime leaseExpiresAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.ItemId,
+                subscriptionId),
+            Builders<SubscriptionDetail>.Filter.ElemMatch(
+                subscription => subscription.OutboxEvents,
+                outboxEvent =>
+                    outboxEvent.EventId == eventId &&
+                    outboxEvent.Status != SubscriptionOutboxStatus.Published &&
+                    outboxEvent.Status != SubscriptionOutboxStatus.Abandoned &&
+                    (outboxEvent.LeaseExpiresAtUtc == null ||
+                     outboxEvent.LeaseExpiresAtUtc <= DateTime.UtcNow)));
+
+        var update = Builders<SubscriptionDetail>.Update
+            .Set("OutboxEvents.$[evt].Status", SubscriptionOutboxStatus.Processing)
+            .Set("OutboxEvents.$[evt].LeaseId", leaseId)
+            .Set("OutboxEvents.$[evt].LeaseExpiresAtUtc", leaseExpiresAtUtc);
+
+        var updated = await Subscriptions(tenantId).FindOneAndUpdateAsync(
+            filter,
+            update,
+            new FindOneAndUpdateOptions<SubscriptionDetail>
+            {
+                ArrayFilters = EventArrayFilter(eventId),
+                ReturnDocument = ReturnDocument.After
+            },
+            cancellationToken);
+
+        return updated?.OutboxEvents
+            .FirstOrDefault(outboxEvent =>
+                string.Equals(outboxEvent.EventId, eventId, StringComparison.Ordinal));
+    }
+
+    public async Task<IReadOnlyList<SubscriptionDetail>> ListWithDueEventsAsync(
+        string tenantId,
+        DateTime dueAtUtc,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.ElemMatch(
+                    subscription => subscription.OutboxEvents,
+                    outboxEvent =>
+                        outboxEvent.Status != SubscriptionOutboxStatus.Published &&
+                        outboxEvent.Status != SubscriptionOutboxStatus.Abandoned &&
+                        (outboxEvent.NextAttemptAtUtc == null ||
+                         outboxEvent.NextAttemptAtUtc <= dueAtUtc))))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
+    public async Task MarkEventPublishedAsync(
+        string tenantId,
+        string subscriptionId,
+        string eventId,
+        string leaseId,
+        DateTime publishedAtUtc,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId).UpdateOneAsync(
+            LeasedEventFilter(tenantId, subscriptionId, eventId, leaseId),
+            Builders<SubscriptionDetail>.Update
+                .Set("OutboxEvents.$[evt].Status", SubscriptionOutboxStatus.Published)
+                .Set("OutboxEvents.$[evt].PublishedAtUtc", publishedAtUtc)
+                .Set("OutboxEvents.$[evt].LeaseId", (string?)null)
+                .Set("OutboxEvents.$[evt].LeaseExpiresAtUtc", (DateTime?)null),
+            new UpdateOptions { ArrayFilters = EventArrayFilter(eventId) },
+            cancellationToken);
+
+    public async Task MarkEventFailedAsync(
+        string tenantId,
+        string subscriptionId,
+        string eventId,
+        string leaseId,
+        SubscriptionOutboxStatus status,
+        int attemptCount,
+        DateTime nextAttemptAtUtc,
+        string failureReason,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId).UpdateOneAsync(
+            LeasedEventFilter(tenantId, subscriptionId, eventId, leaseId),
+            Builders<SubscriptionDetail>.Update
+                .Set("OutboxEvents.$[evt].Status", status)
+                .Set("OutboxEvents.$[evt].AttemptCount", attemptCount)
+                .Set("OutboxEvents.$[evt].NextAttemptAtUtc", nextAttemptAtUtc)
+                .Set("OutboxEvents.$[evt].LastError", Shorten(failureReason))
+                .Set("OutboxEvents.$[evt].LeaseId", (string?)null)
+                .Set("OutboxEvents.$[evt].LeaseExpiresAtUtc", (DateTime?)null),
+            new UpdateOptions { ArrayFilters = EventArrayFilter(eventId) },
+            cancellationToken);
+
+    /// <summary>
+    /// The live-subscription filter, exposed so tenant and organization scoping can be tested
+    /// without a database. A wrong scope still returns plausible rows, which is exactly the
+    /// kind of mistake an integration test will not notice.
+    /// </summary>
+    public static FilterDefinition<SubscriptionDetail> BuildLiveFilter(
+        string tenantId,
+        string organizationId) =>
+        Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.OrganizationId,
+                organizationId),
+            Builders<SubscriptionDetail>.Filter.In(
+                subscription => subscription.Status,
+                LiveStatuses));
+
+    private static UpdateDefinition<SubscriptionDetail> BuildTransitionUpdate(
+        SubscriptionTransition transition)
+    {
+        var update = Builders<SubscriptionDetail>.Update
+            .Set(subscription => subscription.Status, transition.NewStatus)
+            .Set(subscription => subscription.LastUpdatedDateUtc, DateTime.UtcNow)
+            .Inc(subscription => subscription.Version, 1);
+
+        if (transition.ActivatedAtUtc is { } activatedAt)
+        {
+            update = update.Set(
+                subscription => subscription.ActivatedAtUtc,
+                activatedAt);
+        }
+
+        if (transition.CanceledAtUtc is { } canceledAt)
+        {
+            update = update.Set(
+                subscription => subscription.CanceledAtUtc,
+                canceledAt);
+        }
+
+        if (transition.EndedAtUtc is { } endedAt)
+        {
+            update = update.Set(subscription => subscription.EndedAtUtc, endedAt);
+        }
+
+        if (transition.CancelAtPeriodEnd is { } cancelAtPeriodEnd)
+        {
+            update = update.Set(
+                subscription => subscription.CancelAtPeriodEnd,
+                cancelAtPeriodEnd);
+        }
+
+        if (transition.CancellationReason is { } reason)
+        {
+            update = update.Set(
+                subscription => subscription.CancellationReason,
+                Shorten(reason));
+        }
+
+        if (transition.InitialPaymentDetailId is { } paymentDetailId)
+        {
+            update = update.Set(
+                subscription => subscription.InitialPaymentDetailId,
+                paymentDetailId);
+        }
+
+        if (transition.CurrentPeriodStartUtc is { } periodStart)
+        {
+            update = update.Set(
+                subscription => subscription.CurrentPeriodStartUtc,
+                periodStart);
+        }
+
+        if (transition.CurrentPeriodEndUtc is { } periodEnd)
+        {
+            update = update.Set(
+                subscription => subscription.CurrentPeriodEndUtc,
+                periodEnd);
+        }
+
+        if (transition.ClearNextFeeBillingAt)
+        {
+            update = update.Set(
+                subscription => subscription.NextFeeBillingAtUtc,
+                null);
+        }
+        else if (transition.NextFeeBillingAtUtc is { } nextBilling)
+        {
+            update = update.Set(
+                subscription => subscription.NextFeeBillingAtUtc,
+                nextBilling);
+        }
+
+        return transition.Event is null
+            ? update
+            : update.Push(subscription => subscription.OutboxEvents, transition.Event);
+    }
+
+    private static FilterDefinition<SubscriptionDetail> LeasedEventFilter(
+        string tenantId,
+        string subscriptionId,
+        string eventId,
+        string leaseId) =>
+        Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.ItemId,
+                subscriptionId),
+            Builders<SubscriptionDetail>.Filter.ElemMatch(
+                subscription => subscription.OutboxEvents,
+                outboxEvent =>
+                    outboxEvent.EventId == eventId &&
+                    outboxEvent.LeaseId == leaseId));
+
+    private static FilterDefinition<SubscriptionDetail> NotAlreadyEmitted(
+        string deduplicationKey) =>
+        Builders<SubscriptionDetail>.Filter.Not(
+            Builders<SubscriptionDetail>.Filter.ElemMatch(
+                subscription => subscription.OutboxEvents,
+                outboxEvent => outboxEvent.DeduplicationKey == deduplicationKey));
+
+    private static FilterDefinition<SubscriptionDetail> TenantFilter(string tenantId) =>
+        Builders<SubscriptionDetail>.Filter.Eq(
+            subscription => subscription.TenantId,
+            tenantId);
+
+    private static List<ArrayFilterDefinition> EventArrayFilter(string eventId) =>
+    [
+        new BsonDocumentArrayFilterDefinition<SubscriptionOutboxEvent>(
+            new BsonDocument("evt.EventId", eventId))
+    ];
+
+    private static string Shorten(string value) =>
+        value.Length <= 500 ? value : value[..500];
+
+    private IMongoCollection<SubscriptionDetail> Subscriptions(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionDetail>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.Subscriptions);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -180,6 +180,56 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         return result.ModifiedCount == 1;
     }
 
+    public async Task<bool> TryChangePlanAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedVersion,
+        PlanSnapshot newPlan,
+        PriceSnapshot newPrice,
+        List<SubscriptionQuantityItem> newQuantityItems,
+        long newCreditBalanceMinor,
+        string? planChangePaymentDetailId,
+        SubscriptionOutboxEvent outboxEvent,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(newPlan);
+        ArgumentNullException.ThrowIfNull(newPrice);
+        ArgumentNullException.ThrowIfNull(newQuantityItems);
+        ArgumentNullException.ThrowIfNull(outboxEvent);
+
+        var filter = Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.ItemId,
+                subscriptionId),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.Version,
+                expectedVersion));
+
+        var update = Builders<SubscriptionDetail>.Update
+            .Set(subscription => subscription.Plan, newPlan)
+            .Set(subscription => subscription.Price, newPrice)
+            .Set(subscription => subscription.QuantityItems, newQuantityItems)
+            .Set(subscription => subscription.CreditBalanceMinor, newCreditBalanceMinor)
+            .Inc(subscription => subscription.Version, 1)
+            .Set(subscription => subscription.LastUpdatedDateUtc, DateTime.UtcNow)
+            .Push(subscription => subscription.OutboxEvents, outboxEvent);
+
+        if (planChangePaymentDetailId is { Length: > 0 })
+        {
+            update = update.Set(
+                subscription => subscription.LastRenewalPaymentDetailId,
+                planChangePaymentDetailId);
+        }
+
+        var result = await Subscriptions(tenantId).UpdateOneAsync(
+            filter,
+            update,
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     public async Task<IReadOnlyList<SubscriptionDetail>> ListStaleAsync(
         string tenantId,
         SubscriptionStatus status,

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -481,6 +481,13 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
                 discountPeriodsApplied);
         }
 
+        if (transition.CreditBalanceMinor is { } creditBalanceMinor)
+        {
+            update = update.Set(
+                subscription => subscription.CreditBalanceMinor,
+                creditBalanceMinor);
+        }
+
         if (transition.ClearPastDueSinceAt)
         {
             update = update.Set(subscription => subscription.PastDueSinceUtc, null);

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -198,6 +198,29 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             .Limit(limit)
             .ToListAsync(cancellationToken);
 
+    public async Task<IReadOnlyList<SubscriptionDetail>> ListDueForRenewalAsync(
+        string tenantId,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.In(
+                    subscription => subscription.Status,
+                    LiveStatuses),
+                // Explicitly excludes null rather than relying on how $lte treats it: a
+                // cancel-at-period-end subscription clears this field on purpose, and a
+                // cross-type comparison including null in the range would renew it anyway.
+                Builders<SubscriptionDetail>.Filter.Ne(
+                    subscription => subscription.NextFeeBillingAtUtc,
+                    null),
+                Builders<SubscriptionDetail>.Filter.Lte(
+                    subscription => subscription.NextFeeBillingAtUtc,
+                    asOfUtc)))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
     public async Task<bool> TryAppendEventAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -271,6 +271,29 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             .Limit(limit)
             .ToListAsync(cancellationToken);
 
+    public async Task<IReadOnlyList<SubscriptionDetail>> ListDueForUsageRatingAsync(
+        string tenantId,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.In(
+                    subscription => subscription.Status,
+                    LiveStatuses),
+                // Explicitly excludes null rather than relying on how $lte treats it — same
+                // reasoning as the renewal due-query: an immediately-canceled subscription
+                // clears this field on purpose.
+                Builders<SubscriptionDetail>.Filter.Ne(
+                    subscription => subscription.NextUsageBillingAtUtc,
+                    null),
+                Builders<SubscriptionDetail>.Filter.Lte(
+                    subscription => subscription.NextUsageBillingAtUtc,
+                    asOfUtc)))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
     public async Task<bool> TryAppendEventAsync(
         string tenantId,
         string subscriptionId,
@@ -522,6 +545,33 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             update = update.Set(
                 subscription => subscription.NextFeeBillingAtUtc,
                 nextBilling);
+        }
+
+        if (transition.CurrentUsagePeriodStartUtc is { } usagePeriodStart)
+        {
+            update = update.Set(
+                subscription => subscription.CurrentUsagePeriodStartUtc,
+                usagePeriodStart);
+        }
+
+        if (transition.CurrentUsagePeriodEndUtc is { } usagePeriodEnd)
+        {
+            update = update.Set(
+                subscription => subscription.CurrentUsagePeriodEndUtc,
+                usagePeriodEnd);
+        }
+
+        if (transition.ClearNextUsageBillingAt)
+        {
+            update = update.Set(
+                subscription => subscription.NextUsageBillingAtUtc,
+                null);
+        }
+        else if (transition.NextUsageBillingAtUtc is { } nextUsageBilling)
+        {
+            update = update.Set(
+                subscription => subscription.NextUsageBillingAtUtc,
+                nextUsageBilling);
         }
 
         return transition.Event is null

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -29,6 +29,8 @@ public sealed record SubscriptionTransition(
 
     public string? InitialPaymentDetailId { get; init; }
 
+    public string? LastRenewalPaymentDetailId { get; init; }
+
     public DateTime? CurrentPeriodStartUtc { get; init; }
 
     public DateTime? CurrentPeriodEndUtc { get; init; }
@@ -37,6 +39,15 @@ public sealed record SubscriptionTransition(
 
     /// <summary>Explicitly clears the next billing instant, which a null value cannot express.</summary>
     public bool ClearNextFeeBillingAt { get; init; }
+
+    public DateTime? PastDueSinceUtc { get; init; }
+
+    /// <summary>Explicitly clears the dunning start, which a null value cannot express.</summary>
+    public bool ClearPastDueSinceAt { get; init; }
+
+    public int? DunningAttemptCount { get; init; }
+
+    public int? DiscountPeriodsApplied { get; init; }
 
     public SubscriptionOutboxEvent? Event { get; init; }
 }

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -1,0 +1,42 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// One status change and everything that must be written atomically with it.
+/// </summary>
+/// <remarks>
+/// Grouped into a single value rather than passed as a long parameter list, so a caller cannot
+/// set a status without saying what it expected the previous one to be. The event travels here
+/// too because appending it in the same update is what makes publication survive a crash: Mongo
+/// and the bus share no transaction, so a separate write would lose events precisely when
+/// something went wrong.
+/// </remarks>
+public sealed record SubscriptionTransition(
+    SubscriptionStatus ExpectedStatus,
+    SubscriptionStatus NewStatus)
+{
+    public DateTime? ActivatedAtUtc { get; init; }
+
+    public DateTime? CanceledAtUtc { get; init; }
+
+    public DateTime? EndedAtUtc { get; init; }
+
+    public bool? CancelAtPeriodEnd { get; init; }
+
+    public string? CancellationReason { get; init; }
+
+    public string? InitialPaymentDetailId { get; init; }
+
+    public DateTime? CurrentPeriodStartUtc { get; init; }
+
+    public DateTime? CurrentPeriodEndUtc { get; init; }
+
+    public DateTime? NextFeeBillingAtUtc { get; init; }
+
+    /// <summary>Explicitly clears the next billing instant, which a null value cannot express.</summary>
+    public bool ClearNextFeeBillingAt { get; init; }
+
+    public SubscriptionOutboxEvent? Event { get; init; }
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -51,5 +51,14 @@ public sealed record SubscriptionTransition(
 
     public long? CreditBalanceMinor { get; init; }
 
+    public DateTime? CurrentUsagePeriodStartUtc { get; init; }
+
+    public DateTime? CurrentUsagePeriodEndUtc { get; init; }
+
+    public DateTime? NextUsageBillingAtUtc { get; init; }
+
+    /// <summary>Explicitly clears the next usage-rating instant, which a null value cannot express.</summary>
+    public bool ClearNextUsageBillingAt { get; init; }
+
     public SubscriptionOutboxEvent? Event { get; init; }
 }

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -49,5 +49,7 @@ public sealed record SubscriptionTransition(
 
     public int? DiscountPeriodsApplied { get; init; }
 
+    public long? CreditBalanceMinor { get; init; }
+
     public SubscriptionOutboxEvent? Event { get; init; }
 }

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageInvoiceRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageInvoiceRepository.cs
@@ -1,0 +1,183 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionUsageInvoiceRepository : ISubscriptionUsageInvoiceRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionUsageInvoiceRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Invoices(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateUsageInvoiceIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<bool> TryCreateAsync(
+        SubscriptionUsageInvoice invoice,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(invoice);
+
+        try
+        {
+            await EnsureIndexesAsync(invoice.TenantId, cancellationToken);
+
+            await Invoices(invoice.TenantId)
+                .InsertOneAsync(invoice, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task<SubscriptionUsageInvoice?> GetAsync(
+        string tenantId,
+        string subscriptionId,
+        string periodKey,
+        CancellationToken cancellationToken) =>
+        await Invoices(tenantId)
+            .Find(Builders<SubscriptionUsageInvoice>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionUsageInvoice>.Filter.Eq(
+                    invoice => invoice.SubscriptionId,
+                    subscriptionId),
+                Builders<SubscriptionUsageInvoice>.Filter.Eq(
+                    invoice => invoice.PeriodKey,
+                    periodKey)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<SubscriptionUsageInvoice>> ListDueAsync(
+        string tenantId,
+        DateTime dueAtUtc,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Invoices(tenantId)
+            .Find(Builders<SubscriptionUsageInvoice>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionUsageInvoice>.Filter.Eq(
+                    invoice => invoice.State,
+                    SubscriptionUsageInvoiceState.Pending),
+                Builders<SubscriptionUsageInvoice>.Filter.Lte(
+                    invoice => invoice.NextAttemptAtUtc,
+                    dueAtUtc)))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
+    public async Task<bool> TryMarkChargedAsync(
+        string tenantId,
+        string invoiceId,
+        string paymentDetailId,
+        CancellationToken cancellationToken)
+    {
+        var result = await Invoices(tenantId).UpdateOneAsync(
+            PendingFilter(tenantId, invoiceId),
+            Builders<SubscriptionUsageInvoice>.Update
+                .Set(invoice => invoice.State, SubscriptionUsageInvoiceState.Charged)
+                .Set(invoice => invoice.PaymentDetailId, paymentDetailId)
+                .Set(invoice => invoice.NextAttemptAtUtc, null)
+                .Set(invoice => invoice.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<bool> TryMarkNoChargeAsync(
+        string tenantId,
+        string invoiceId,
+        CancellationToken cancellationToken)
+    {
+        var result = await Invoices(tenantId).UpdateOneAsync(
+            PendingFilter(tenantId, invoiceId),
+            Builders<SubscriptionUsageInvoice>.Update
+                .Set(invoice => invoice.State, SubscriptionUsageInvoiceState.NoCharge)
+                .Set(invoice => invoice.NextAttemptAtUtc, null)
+                .Set(invoice => invoice.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<bool> TryMarkAbandonedAsync(
+        string tenantId,
+        string invoiceId,
+        CancellationToken cancellationToken)
+    {
+        var result = await Invoices(tenantId).UpdateOneAsync(
+            PendingFilter(tenantId, invoiceId),
+            Builders<SubscriptionUsageInvoice>.Update
+                .Set(invoice => invoice.State, SubscriptionUsageInvoiceState.Abandoned)
+                .Set(invoice => invoice.NextAttemptAtUtc, null)
+                .Set(invoice => invoice.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task RescheduleAsync(
+        string tenantId,
+        string invoiceId,
+        int attemptCount,
+        DateTime nextAttemptAtUtc,
+        string? failureReason,
+        CancellationToken cancellationToken) =>
+        await Invoices(tenantId).UpdateOneAsync(
+            Builders<SubscriptionUsageInvoice>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionUsageInvoice>.Filter.Eq(
+                    invoice => invoice.ItemId,
+                    invoiceId)),
+            Builders<SubscriptionUsageInvoice>.Update
+                .Set(invoice => invoice.AttemptCount, attemptCount)
+                .Set(invoice => invoice.NextAttemptAtUtc, nextAttemptAtUtc)
+                .Set(invoice => invoice.LastError, Shorten(failureReason))
+                .Set(invoice => invoice.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+    private static FilterDefinition<SubscriptionUsageInvoice> PendingFilter(
+        string tenantId,
+        string invoiceId) =>
+        Builders<SubscriptionUsageInvoice>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionUsageInvoice>.Filter.Eq(
+                invoice => invoice.ItemId,
+                invoiceId),
+            Builders<SubscriptionUsageInvoice>.Filter.Eq(
+                invoice => invoice.State,
+                SubscriptionUsageInvoiceState.Pending));
+
+    private static FilterDefinition<SubscriptionUsageInvoice> TenantFilter(string tenantId) =>
+        Builders<SubscriptionUsageInvoice>.Filter.Eq(
+            invoice => invoice.TenantId,
+            tenantId);
+
+    private static string? Shorten(string? value) =>
+        value is null || value.Length <= 500 ? value : value[..500];
+
+    private IMongoCollection<SubscriptionUsageInvoice> Invoices(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionUsageInvoice>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.UsageInvoices);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
@@ -1,0 +1,271 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionUsageRepository : ISubscriptionUsageRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionUsageRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Records(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateUsageRecordIndexes(),
+            cancellationToken);
+
+        await Counters(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateUsageCounterIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<bool> TryAppendRecordAsync(
+        SubscriptionUsageRecord record,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        try
+        {
+            await EnsureIndexesAsync(record.TenantId, cancellationToken);
+
+            await Records(record.TenantId)
+                .InsertOneAsync(record, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task<SubscriptionUsageCounter> ApplyDeltaAsync(
+        SubscriptionUsageCounter seed,
+        long delta,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(seed);
+
+        var update = Builders<SubscriptionUsageCounter>.Update
+            .Inc(counter => counter.Balance, delta)
+            .Inc(counter => counter.AppliedRecordCount, 1)
+            .Set(counter => counter.LastUpdatedAtUtc, DateTime.UtcNow)
+            .SetOnInsert(counter => counter.TenantId, seed.TenantId)
+            .SetOnInsert(counter => counter.OrganizationId, seed.OrganizationId)
+            .SetOnInsert(counter => counter.SubscriptionId, seed.SubscriptionId)
+            .SetOnInsert(counter => counter.MeterKey, seed.MeterKey)
+            .SetOnInsert(counter => counter.PeriodKey, seed.PeriodKey)
+            .SetOnInsert(counter => counter.PeriodStartUtc, seed.PeriodStartUtc)
+            .SetOnInsert(counter => counter.PeriodEndUtc, seed.PeriodEndUtc)
+            .SetOnInsert(counter => counter.ExpiresAtUtc, seed.ExpiresAtUtc)
+            .SetOnInsert(counter => counter.LimitSnapshot, seed.LimitSnapshot)
+            .SetOnInsert(counter => counter.NotifiedThresholds, []);
+
+        // ReturnDocument.After is what makes this an enforcement point rather than a check:
+        // the balance that comes back already includes this caller's delta, so two callers at
+        // the boundary get different answers and only one of them is over.
+        return await Counters(seed.TenantId).FindOneAndUpdateAsync(
+            Builders<SubscriptionUsageCounter>.Filter.Eq(
+                counter => counter.ItemId,
+                seed.ItemId),
+            update,
+            new FindOneAndUpdateOptions<SubscriptionUsageCounter>
+            {
+                IsUpsert = true,
+                ReturnDocument = ReturnDocument.After
+            },
+            cancellationToken);
+    }
+
+    public async Task<SubscriptionUsageCounter?> GetCounterAsync(
+        string tenantId,
+        string counterId,
+        CancellationToken cancellationToken) =>
+        await Counters(tenantId)
+            .Find(Builders<SubscriptionUsageCounter>.Filter.Eq(
+                counter => counter.ItemId,
+                counterId))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<SubscriptionUsageCounter>> ListCountersAsync(
+        string tenantId,
+        string subscriptionId,
+        string periodKey,
+        CancellationToken cancellationToken) =>
+        await Counters(tenantId)
+            .Find(Builders<SubscriptionUsageCounter>.Filter.And(
+                Builders<SubscriptionUsageCounter>.Filter.Eq(
+                    counter => counter.TenantId,
+                    tenantId),
+                Builders<SubscriptionUsageCounter>.Filter.Eq(
+                    counter => counter.SubscriptionId,
+                    subscriptionId),
+                Builders<SubscriptionUsageCounter>.Filter.Eq(
+                    counter => counter.PeriodKey,
+                    periodKey)))
+            .ToListAsync(cancellationToken);
+
+    public async Task<bool> TryMarkThresholdNotifiedAsync(
+        string tenantId,
+        string counterId,
+        int thresholdPercent,
+        CancellationToken cancellationToken)
+    {
+        // The filter asserting the threshold is absent is what makes this a race the database
+        // settles: every process attempts it, exactly one modifies a document.
+        var filter = Builders<SubscriptionUsageCounter>.Filter.And(
+            Builders<SubscriptionUsageCounter>.Filter.Eq(
+                counter => counter.ItemId,
+                counterId),
+            Builders<SubscriptionUsageCounter>.Filter.Ne(
+                counter => counter.NotifiedThresholds,
+                null),
+            Builders<SubscriptionUsageCounter>.Filter.Not(
+                Builders<SubscriptionUsageCounter>.Filter.AnyEq(
+                    counter => counter.NotifiedThresholds,
+                    thresholdPercent)));
+
+        var result = await Counters(tenantId).UpdateOneAsync(
+            filter,
+            Builders<SubscriptionUsageCounter>.Update.Push(
+                counter => counter.NotifiedThresholds,
+                thresholdPercent),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<SubscriptionUsageRecord?> FindRecordByKeyAsync(
+        string tenantId,
+        string subscriptionId,
+        string idempotencyKey,
+        CancellationToken cancellationToken) =>
+        await Records(tenantId)
+            .Find(Builders<SubscriptionUsageRecord>.Filter.And(
+                Builders<SubscriptionUsageRecord>.Filter.Eq(
+                    record => record.TenantId,
+                    tenantId),
+                Builders<SubscriptionUsageRecord>.Filter.Eq(
+                    record => record.SubscriptionId,
+                    subscriptionId),
+                Builders<SubscriptionUsageRecord>.Filter.Eq(
+                    record => record.IdempotencyKey,
+                    idempotencyKey)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<(long Balance, long RecordCount)> SummariseLedgerAsync(
+        string tenantId,
+        string subscriptionId,
+        string meterKey,
+        string periodKey,
+        CancellationToken cancellationToken)
+    {
+        var records = await Records(tenantId)
+            .Find(Builders<SubscriptionUsageRecord>.Filter.And(
+                Builders<SubscriptionUsageRecord>.Filter.Eq(
+                    record => record.TenantId,
+                    tenantId),
+                Builders<SubscriptionUsageRecord>.Filter.Eq(
+                    record => record.SubscriptionId,
+                    subscriptionId),
+                Builders<SubscriptionUsageRecord>.Filter.Eq(
+                    record => record.MeterKey,
+                    meterKey),
+                Builders<SubscriptionUsageRecord>.Filter.Eq(
+                    record => record.PeriodKey,
+                    periodKey)))
+            .Project(record => record.Delta)
+            .ToListAsync(cancellationToken);
+
+        return (records.Sum(), records.Count);
+    }
+
+    public async Task<bool> TryRepairCounterAsync(
+        string tenantId,
+        string counterId,
+        long balance,
+        long appliedRecordCount,
+        CancellationToken cancellationToken)
+    {
+        var result = await Counters(tenantId).UpdateOneAsync(
+            Builders<SubscriptionUsageCounter>.Filter.And(
+                Builders<SubscriptionUsageCounter>.Filter.Eq(
+                    counter => counter.ItemId,
+                    counterId),
+                Builders<SubscriptionUsageCounter>.Filter.Lt(
+                    counter => counter.AppliedRecordCount,
+                    appliedRecordCount)),
+            Builders<SubscriptionUsageCounter>.Update
+                .Set(counter => counter.Balance, balance)
+                .Set(counter => counter.AppliedRecordCount, appliedRecordCount)
+                .Set(counter => counter.LastUpdatedAtUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<IReadOnlyList<SubscriptionUsageRecord>> ListRecordsAsync(
+        string tenantId,
+        string subscriptionId,
+        string? meterKey,
+        string? periodKey,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<SubscriptionUsageRecord>.Filter.And(
+            Builders<SubscriptionUsageRecord>.Filter.Eq(
+                record => record.TenantId,
+                tenantId),
+            Builders<SubscriptionUsageRecord>.Filter.Eq(
+                record => record.SubscriptionId,
+                subscriptionId));
+
+        if (!string.IsNullOrWhiteSpace(meterKey))
+        {
+            filter &= Builders<SubscriptionUsageRecord>.Filter.Eq(
+                record => record.MeterKey,
+                meterKey);
+        }
+
+        if (!string.IsNullOrWhiteSpace(periodKey))
+        {
+            filter &= Builders<SubscriptionUsageRecord>.Filter.Eq(
+                record => record.PeriodKey,
+                periodKey);
+        }
+
+        return await Records(tenantId)
+            .Find(filter)
+            .SortByDescending(record => record.OccurredAtUtc)
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+    }
+
+    private IMongoCollection<SubscriptionUsageRecord> Records(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionUsageRecord>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.UsageRecords);
+
+    private IMongoCollection<SubscriptionUsageCounter> Counters(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionUsageCounter>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.UsageCounters);
+}

--- a/server/Subscription.DomainService/Requests/ChangeSubscriptionPlanRequest.cs
+++ b/server/Subscription.DomainService/Requests/ChangeSubscriptionPlanRequest.cs
@@ -1,0 +1,11 @@
+namespace Subscription.DomainService.Requests;
+
+public sealed class ChangeSubscriptionPlanRequest
+{
+    public string PlanCode { get; set; } = string.Empty;
+
+    public string PriceId { get; set; } = string.Empty;
+
+    /// <summary>Defaults to the target plan's own defaults for anything left out, same as signup.</summary>
+    public List<SubscriptionQuantityRequest> Quantities { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Requests/CreatePlanRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePlanRequest.cs
@@ -1,0 +1,35 @@
+namespace Subscription.DomainService.Requests;
+
+public sealed class CreatePlanRequest
+{
+    public string Code { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Arbitrary plan features as JSON. Stored verbatim and handed back untouched; nothing here
+    /// interprets it, which is what lets a second product ship its own flags without a change
+    /// to this module.
+    /// </summary>
+    public string? FeaturesJson { get; set; }
+
+    /// <summary>
+    /// Scope the plan to one organization instead of the whole tenant. Omit for the ordinary
+    /// case where the tenant sells the same plan to everyone.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+
+    public int? TrialDays { get; set; }
+
+    public bool TrialRequiresPaymentMethod { get; set; } = true;
+
+    public List<PlanQuantityItemRequest> QuantityItems { get; set; } = [];
+
+    public List<PlanMeterRequest> Meters { get; set; } = [];
+
+    public List<PlanEntitlementRequest> Entitlements { get; set; } = [];
+
+    public List<TrialGrantRequest> TrialGrants { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -21,4 +21,7 @@ public sealed class CreatePriceRequest
 
     /// <summary>Which quantity item this multiplies. Null is a flat fee.</summary>
     public string? QuantityItemKey { get; set; }
+
+    /// <summary>Tax to add on top, in basis points out of 10,000. Null means not taxable.</summary>
+    public int? TaxRateBasisPoints { get; set; }
 }

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -1,0 +1,24 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Requests;
+
+public sealed class CreatePriceRequest
+{
+    public string PlanId { get; set; } = string.Empty;
+
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The amount in minor units — 8900 is CHF 89.00. Never a decimal here: the exponent
+    /// belongs to the currency, and a request carrying both invites them to disagree.
+    /// </summary>
+    public long UnitAmountMinor { get; set; }
+
+    public BillingInterval Interval { get; set; } = BillingInterval.Month;
+
+    /// <summary>Paired with the interval, so three months is a quarter and no enum grows.</summary>
+    public int IntervalCount { get; set; } = 1;
+
+    /// <summary>Which quantity item this multiplies. Null is a flat fee.</summary>
+    public string? QuantityItemKey { get; set; }
+}

--- a/server/Subscription.DomainService/Requests/CreateSubscriptionRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreateSubscriptionRequest.cs
@@ -1,0 +1,38 @@
+namespace Subscription.DomainService.Requests;
+
+public sealed class CreateSubscriptionRequest
+{
+    public string PlanCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Which price to buy at. The currency comes from this price and is fixed for the life of
+    /// the subscription.
+    /// </summary>
+    public string PriceId { get; set; } = string.Empty;
+
+    public List<SubscriptionQuantityRequest> Quantities { get; set; } = [];
+
+    /// <summary>
+    /// The customer's own time zone, as an IANA identifier. Their calendar decides when a
+    /// period turns over, not the server's.
+    /// </summary>
+    public string TimeZoneId { get; set; } = "UTC";
+
+    public string? DiscountCode { get; set; }
+
+    /// <summary>
+    /// Notably absent: the organization. It comes from the authenticated caller, because
+    /// accepting it here would let anyone subscribe — or read — on another organization's
+    /// behalf by naming it.
+    /// </summary>
+    public string? BillingEmail { get; set; }
+
+    public string? BillingName { get; set; }
+}
+
+public sealed class SubscriptionQuantityRequest
+{
+    public string ItemKey { get; set; } = string.Empty;
+
+    public long Quantity { get; set; }
+}

--- a/server/Subscription.DomainService/Requests/PlanPartRequests.cs
+++ b/server/Subscription.DomainService/Requests/PlanPartRequests.cs
@@ -1,0 +1,72 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Requests;
+
+public sealed class PlanQuantityItemRequest
+{
+    public string ItemKey { get; set; } = string.Empty;
+
+    /// <summary>The product's own word for the unit: "seat", "user", "workspace".</summary>
+    public string UnitLabel { get; set; } = string.Empty;
+
+    public long MinQuantity { get; set; } = 1;
+
+    public long? MaxQuantity { get; set; }
+
+    public long DefaultQuantity { get; set; } = 1;
+}
+
+public sealed class PlanMeterRequest
+{
+    public string MeterKey { get; set; } = string.Empty;
+
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string UnitLabel { get; set; } = string.Empty;
+
+    public MeterAggregation Aggregation { get; set; } = MeterAggregation.Sum;
+
+    public long IncludedQuantity { get; set; }
+
+    public bool OverageAllowed { get; set; } = true;
+
+    /// <summary>Percentages of the allowance that raise an event the first time they are crossed.</summary>
+    public List<int> ThresholdPercents { get; set; } = [];
+
+    public List<MeterRateTableRequest> RateTables { get; set; } = [];
+}
+
+public sealed class MeterRateTableRequest
+{
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    public List<MeterTierRequest> Tiers { get; set; } = [];
+}
+
+public sealed class MeterTierRequest
+{
+    /// <summary>Upper bound of the band. Null is the final, unbounded one.</summary>
+    public long? UpToQuantity { get; set; }
+
+    public long UnitAmountMinor { get; set; }
+}
+
+public sealed class PlanEntitlementRequest
+{
+    public string Key { get; set; } = string.Empty;
+
+    public EntitlementLimitKind LimitKind { get; set; } = EntitlementLimitKind.Boolean;
+
+    public long? Limit { get; set; }
+
+    public string? MeterKey { get; set; }
+
+    public string? UnitLabel { get; set; }
+}
+
+public sealed class TrialGrantRequest
+{
+    public string MeterKey { get; set; } = string.Empty;
+
+    public long IncludedQuantity { get; set; }
+}

--- a/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
+++ b/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
@@ -1,0 +1,42 @@
+namespace Subscription.DomainService.Requests;
+
+public sealed class RecordUsageRequest
+{
+    /// <summary>The meter's key, in the calling product's own vocabulary.</summary>
+    public string MeterKey { get; set; } = string.Empty;
+
+    /// <summary>How much was used. One, usually.</summary>
+    public long Quantity { get; set; } = 1;
+
+    /// <summary>
+    /// Unique per subscription and meter. Mandatory, because at-least-once delivery makes a
+    /// repeated call a certainty rather than a risk, and the second one must not be billable.
+    /// </summary>
+    public string IdempotencyKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When it happened, if that is not now. Decides which period it lands in, so a late report
+    /// still bills against the month it belongs to.
+    /// </summary>
+    public DateTime? OccurredAtUtc { get; set; }
+
+    /// <summary>
+    /// Refuse and roll back when the allowance is exhausted, instead of recording overage.
+    /// </summary>
+    /// <remarks>
+    /// This is the only way to actually gate on a limit. Reading the entitlement first and
+    /// deciding is a check, not enforcement: two callers at 99 of 100 both pass it, and only
+    /// the increment can tell them apart.
+    /// </remarks>
+    public bool Enforce { get; set; }
+
+    /// <summary>
+    /// Free-form context, bounded in count and length.
+    /// </summary>
+    /// <remarks>
+    /// Billing needs a count, not a dossier. Anything identifying a person belongs in the
+    /// calling product's own records, not in a shared billing ledger that is retained for years
+    /// and exported for invoicing.
+    /// </remarks>
+    public Dictionary<string, string> Metadata { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Responses/EntitlementResponse.cs
+++ b/server/Subscription.DomainService/Responses/EntitlementResponse.cs
@@ -1,0 +1,60 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// What an organization may do right now.
+/// </summary>
+public sealed class EntitlementSnapshotResponse
+{
+    public bool HasSubscription { get; init; }
+
+    public string Status { get; init; } = string.Empty;
+
+    public string PlanCode { get; init; } = string.Empty;
+
+    public DateTime? CurrentPeriodEndUtc { get; init; }
+
+    public DateTime? TrialEndsAtUtc { get; init; }
+
+    public List<EntitlementQuantityResponse> Quantities { get; init; } = [];
+
+    public List<EntitlementResponse> Entitlements { get; init; } = [];
+
+    /// <summary>
+    /// The plan's own feature bag, verbatim. Stored, versioned and served; never interpreted.
+    /// This is what lets one product ship flags another has never heard of.
+    /// </summary>
+    public string? FeaturesJson { get; init; }
+}
+
+public sealed class EntitlementQuantityResponse
+{
+    public string ItemKey { get; init; } = string.Empty;
+
+    /// <summary>The product's own word — "seat", "user", "workspace".</summary>
+    public string UnitLabel { get; init; } = string.Empty;
+
+    public long Quantity { get; init; }
+}
+
+public sealed class EntitlementResponse
+{
+    public string Key { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Whether it is granted. Advisory: for anything metered, the authoritative answer is the
+    /// balance returned by recording the usage, which cannot be beaten by a second caller.
+    /// </summary>
+    public bool Allowed { get; init; }
+
+    public string Reason { get; init; } = string.Empty;
+
+    public string LimitKind { get; init; } = string.Empty;
+
+    public long? Limit { get; init; }
+
+    public long? Used { get; init; }
+
+    public long? Remaining { get; init; }
+
+    public string? UnitLabel { get; init; }
+}

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -1,0 +1,91 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// A plan as a caller sees it.
+/// </summary>
+/// <remarks>
+/// Deliberately not the entity. The stored document carries a version, timestamps and the
+/// tenant it belongs to; a response that returned them would make internal bookkeeping part of
+/// the public contract.
+/// </remarks>
+public sealed class PlanResponse
+{
+    public string PlanId { get; init; } = string.Empty;
+
+    public string Code { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public string? Description { get; init; }
+
+    /// <summary>The plan's own feature bag, exactly as it was authored.</summary>
+    public string? FeaturesJson { get; init; }
+
+    public int? TrialDays { get; init; }
+
+    public bool TrialRequiresPaymentMethod { get; init; }
+
+    public int Version { get; init; }
+
+    public List<PlanQuantityItemResponse> QuantityItems { get; init; } = [];
+
+    public List<PlanMeterResponse> Meters { get; init; } = [];
+
+    public List<PlanEntitlementResponse> Entitlements { get; init; } = [];
+
+    public List<PlanPriceResponse> Prices { get; init; } = [];
+}
+
+public sealed class PlanQuantityItemResponse
+{
+    public string ItemKey { get; init; } = string.Empty;
+
+    public string UnitLabel { get; init; } = string.Empty;
+
+    public long MinQuantity { get; init; }
+
+    public long? MaxQuantity { get; init; }
+
+    public long DefaultQuantity { get; init; }
+}
+
+public sealed class PlanMeterResponse
+{
+    public string MeterKey { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public string UnitLabel { get; init; } = string.Empty;
+
+    public long IncludedQuantity { get; init; }
+
+    public bool OverageAllowed { get; init; }
+}
+
+public sealed class PlanEntitlementResponse
+{
+    public string Key { get; init; } = string.Empty;
+
+    public string LimitKind { get; init; } = string.Empty;
+
+    public long? Limit { get; init; }
+
+    public string? MeterKey { get; init; }
+
+    public string? UnitLabel { get; init; }
+}
+
+public sealed class PlanPriceResponse
+{
+    public string PriceId { get; init; } = string.Empty;
+
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public long UnitAmountMinor { get; init; }
+
+    public string Interval { get; init; } = string.Empty;
+
+    public int IntervalCount { get; init; }
+
+    public string? QuantityItemKey { get; init; }
+}

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -1,0 +1,54 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// A subscription as its owner sees it.
+/// </summary>
+public sealed class SubscriptionResponse
+{
+    public string SubscriptionId { get; init; } = string.Empty;
+
+    public string Status { get; init; } = string.Empty;
+
+    public string PlanCode { get; init; } = string.Empty;
+
+    public string PlanName { get; init; } = string.Empty;
+
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public long UnitAmountMinor { get; init; }
+
+    public string Interval { get; init; } = string.Empty;
+
+    public int IntervalCount { get; init; }
+
+    public List<SubscriptionQuantityResponse> Quantities { get; init; } = [];
+
+    public DateTime CurrentPeriodStartUtc { get; init; }
+
+    public DateTime CurrentPeriodEndUtc { get; init; }
+
+    /// <summary>When the next payment is expected. Null once cancellation is pending.</summary>
+    public DateTime? NextPaymentAtUtc { get; init; }
+
+    public DateTime? TrialEndsAtUtc { get; init; }
+
+    public bool CancelAtPeriodEnd { get; init; }
+
+    public DateTime? CanceledAtUtc { get; init; }
+
+    /// <summary>
+    /// Where to send the customer to pay. Present only while the first charge is outstanding.
+    /// </summary>
+    public string? CheckoutUrl { get; init; }
+
+    public int Version { get; init; }
+}
+
+public sealed class SubscriptionQuantityResponse
+{
+    public string ItemKey { get; init; } = string.Empty;
+
+    public string UnitLabel { get; init; } = string.Empty;
+
+    public long Quantity { get; init; }
+}

--- a/server/Subscription.DomainService/Responses/UsageResponse.cs
+++ b/server/Subscription.DomainService/Responses/UsageResponse.cs
@@ -1,0 +1,36 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// The state of one meter after a usage call.
+/// </summary>
+public sealed class UsageResponse
+{
+    /// <summary>
+    /// Whether the caller may proceed. Reflects the balance <em>including</em> this call, which
+    /// is what makes it an answer rather than an estimate.
+    /// </summary>
+    public bool Allowed { get; init; }
+
+    public string MeterKey { get; init; } = string.Empty;
+
+    public string UnitLabel { get; init; } = string.Empty;
+
+    public string PeriodKey { get; init; } = string.Empty;
+
+    public DateTime PeriodStartUtc { get; init; }
+
+    public DateTime PeriodEndUtc { get; init; }
+
+    public long Included { get; init; }
+
+    public long Used { get; init; }
+
+    /// <summary>How much of the allowance is left. Never below zero.</summary>
+    public long Remaining { get; init; }
+
+    /// <summary>How much has been used beyond the allowance.</summary>
+    public long Overage { get; init; }
+
+    /// <summary>True when this call repeated one already recorded and changed nothing.</summary>
+    public bool Replayed { get; init; }
+}

--- a/server/Subscription.DomainService/Services/EntitlementService.cs
+++ b/server/Subscription.DomainService/Services/EntitlementService.cs
@@ -1,0 +1,269 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Answers what an organization may do.
+/// </summary>
+/// <remarks>
+/// Called on every gated action in every product built on this, so it reads only our own
+/// database: the subscription, and a point read per metered entitlement. Note what this class
+/// does not take in its constructor — no provider gateway, no HTTP client. That is not an
+/// oversight but the guarantee itself, expressed where the compiler can hold it: if the
+/// provider is down, every existing customer keeps working.
+/// </remarks>
+public sealed class EntitlementService : IEntitlementService
+{
+    private static readonly SubscriptionStatus[] GrantingStatuses =
+    [
+        SubscriptionStatus.Trialing,
+        SubscriptionStatus.Active,
+        SubscriptionStatus.PastDue
+    ];
+
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly IEntitlementSnapshotCache _cache;
+    private readonly TimeProvider _time;
+
+    public EntitlementService(
+        ISubscriptionRepository subscriptions,
+        ISubscriptionUsageRepository usage,
+        ISubscriptionContextResolver contextResolver,
+        IEntitlementSnapshotCache cache,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _usage = usage;
+        _contextResolver = contextResolver;
+        _cache = cache;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<EntitlementSnapshotResponse>> GetAsync(
+        bool fresh,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<EntitlementSnapshotResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        var subscription = await LoadAsync(context, fresh, cancellationToken);
+
+        if (subscription is null || !Grants(subscription))
+        {
+            return SubscriptionOperationResult<EntitlementSnapshotResponse>.Success(
+                NothingGranted(subscription),
+                correlationId);
+        }
+
+        var balances = await BalancesAsync(subscription, cancellationToken);
+
+        return SubscriptionOperationResult<EntitlementSnapshotResponse>.Success(
+            Describe(subscription, balances),
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<EntitlementResponse>> GetAsync(
+        string entitlementKey,
+        bool fresh,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var snapshot = await GetAsync(fresh, correlationId, cancellationToken);
+
+        if (!snapshot.IsSuccess)
+        {
+            return snapshot.ToFailure<EntitlementResponse>();
+        }
+
+        var value = snapshot.Value!;
+
+        var entitlement = value.Entitlements.Find(candidate =>
+            string.Equals(candidate.Key, entitlementKey, StringComparison.Ordinal));
+
+        // The reason matters as much as the answer: "no subscription", "subscription not
+        // active" and "not on this plan" send a support engineer to three different places.
+        var reason = !value.HasSubscription
+            ? EntitlementReason.NoSubscription
+            : value.Entitlements.Count == 0
+                ? EntitlementReason.SubscriptionNotActive
+                : EntitlementReason.NotInPlan;
+
+        return SubscriptionOperationResult<EntitlementResponse>.Success(
+            entitlement ?? Denied(entitlementKey, reason),
+            correlationId);
+    }
+
+    private async Task<SubscriptionDetail?> LoadAsync(
+        SubscriptionContext context,
+        bool fresh,
+        CancellationToken cancellationToken)
+    {
+        if (fresh)
+        {
+            _cache.Invalidate(context.TenantId, context.OrganizationId);
+        }
+
+        return await _cache.GetAsync(
+            context.TenantId,
+            context.OrganizationId,
+            () => _subscriptions.GetLiveAsync(
+                context.TenantId,
+                context.OrganizationId,
+                cancellationToken));
+    }
+
+    /// <summary>
+    /// The balance of every metered entitlement, read by identifier rather than searched for.
+    /// </summary>
+    private async Task<Dictionary<string, long>> BalancesAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        var balances = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        if (!BillingPeriodCalculator.TryGetPeriod(
+                subscription.UsageSchedule,
+                _time.GetUtcNow().UtcDateTime,
+                out var period))
+        {
+            return balances;
+        }
+
+        foreach (var meterKey in subscription.Plan.Entitlements
+                     .Where(entitlement => entitlement.MeterKey is { Length: > 0 })
+                     .Select(entitlement => entitlement.MeterKey!)
+                     .Distinct(StringComparer.Ordinal))
+        {
+            var counter = await _usage.GetCounterAsync(
+                subscription.TenantId,
+                SubscriptionUsageCounter.CreateId(
+                    subscription.ItemId,
+                    meterKey,
+                    period.Key),
+                cancellationToken);
+
+            balances[meterKey] = counter?.Balance ?? 0;
+        }
+
+        return balances;
+    }
+
+    private static bool Grants(SubscriptionDetail subscription) =>
+        GrantingStatuses.Contains(subscription.Status);
+
+    private static EntitlementSnapshotResponse NothingGranted(
+        SubscriptionDetail? subscription) => new()
+    {
+        HasSubscription = subscription is not null,
+        Status = subscription?.Status.ToString() ?? nameof(EntitlementReason.NoSubscription),
+        PlanCode = subscription?.Plan.Code ?? string.Empty
+    };
+
+    private static EntitlementSnapshotResponse Describe(
+        SubscriptionDetail subscription,
+        Dictionary<string, long> balances) => new()
+    {
+        HasSubscription = true,
+        Status = subscription.Status.ToString(),
+        PlanCode = subscription.Plan.Code,
+        CurrentPeriodEndUtc = subscription.CurrentPeriodEndUtc,
+        TrialEndsAtUtc = subscription.Trial?.EndsAtUtc,
+        FeaturesJson = subscription.Plan.FeaturesJson,
+        Quantities = subscription.QuantityItems
+            .Select(item => new EntitlementQuantityResponse
+            {
+                ItemKey = item.ItemKey,
+                UnitLabel = item.UnitLabel,
+                Quantity = item.Quantity
+            })
+            .ToList(),
+        Entitlements = subscription.Plan.Entitlements
+            .Select(entitlement => Describe(subscription, entitlement, balances))
+            .ToList()
+    };
+
+    private static EntitlementResponse Describe(
+        SubscriptionDetail subscription,
+        PlanEntitlement entitlement,
+        Dictionary<string, long> balances)
+    {
+        if (entitlement.LimitKind != EntitlementLimitKind.Count)
+        {
+            return new EntitlementResponse
+            {
+                Key = entitlement.Key,
+                // Unlimited never reports a limit reached; a boolean entitlement present on the
+                // plan is simply granted.
+                Allowed = true,
+                Reason = nameof(EntitlementReason.Allowed),
+                LimitKind = entitlement.LimitKind.ToString(),
+                UnitLabel = entitlement.UnitLabel
+            };
+        }
+
+        var limit = LimitFor(subscription, entitlement);
+        var used = entitlement.MeterKey is { Length: > 0 } meterKey &&
+                   balances.TryGetValue(meterKey, out var balance)
+            ? balance
+            : 0;
+
+        var allowed = used < limit;
+
+        return new EntitlementResponse
+        {
+            Key = entitlement.Key,
+            Allowed = allowed,
+            Reason = allowed
+                ? nameof(EntitlementReason.Allowed)
+                : nameof(EntitlementReason.LimitReached),
+            LimitKind = entitlement.LimitKind.ToString(),
+            Limit = limit,
+            Used = used,
+            Remaining = Math.Max(0, limit - used),
+            UnitLabel = entitlement.UnitLabel
+        };
+    }
+
+    /// <summary>
+    /// A trial's grant replaces the plan's limit, matching how usage recording measures it.
+    /// The two must agree or a caller is told it may act and then refused.
+    /// </summary>
+    private static long LimitFor(
+        SubscriptionDetail subscription,
+        PlanEntitlement entitlement)
+    {
+        var planLimit = entitlement.Limit ?? 0;
+
+        if (subscription.Status != SubscriptionStatus.Trialing ||
+            subscription.Trial is null ||
+            entitlement.MeterKey is not { Length: > 0 } meterKey)
+        {
+            return planLimit;
+        }
+
+        var grant = subscription.Trial.Grants.Find(candidate =>
+            string.Equals(candidate.MeterKey, meterKey, StringComparison.Ordinal));
+
+        return grant?.IncludedQuantity ?? planLimit;
+    }
+
+    private static EntitlementResponse Denied(string key, EntitlementReason reason) => new()
+    {
+        Key = key,
+        Allowed = false,
+        Reason = reason.ToString(),
+        LimitKind = nameof(EntitlementLimitKind.Boolean)
+    };
+}

--- a/server/Subscription.DomainService/Services/EntitlementSnapshotCache.cs
+++ b/server/Subscription.DomainService/Services/EntitlementSnapshotCache.cs
@@ -1,0 +1,82 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Options;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Holds an organization's subscription briefly, so the hot path is not a database read per
+/// gated action.
+/// </summary>
+/// <remarks>
+/// Only the subscription is cached, and only for seconds. Usage counters never are: they are
+/// the volatile half, and a stale one would let a caller past an allowance that is already
+/// spent. The subscription changes rarely and its staleness is bounded and deliberate.
+/// </remarks>
+public sealed class EntitlementSnapshotCache : IEntitlementSnapshotCache
+{
+    private const int MaximumEntries = 5_000;
+
+    private readonly ConcurrentDictionary<string, Entry> _entries =
+        new(StringComparer.Ordinal);
+
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly TimeProvider _time;
+
+    public EntitlementSnapshotCache(
+        IOptionsMonitor<SubscriptionOptions> options,
+        TimeProvider? time = null)
+    {
+        _options = options;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionDetail?> GetAsync(
+        string tenantId,
+        string organizationId,
+        Func<Task<SubscriptionDetail?>> loader)
+    {
+        ArgumentNullException.ThrowIfNull(loader);
+
+        var key = CreateKey(tenantId, organizationId);
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (_entries.TryGetValue(key, out var cached) && cached.ExpiresAtUtc > now)
+        {
+            return cached.Subscription;
+        }
+
+        var subscription = await loader();
+
+        if (_entries.Count >= MaximumEntries)
+        {
+            RemoveExpired(now);
+        }
+
+        _entries[key] = new Entry(
+            subscription,
+            now.AddSeconds(Math.Max(0, _options.CurrentValue.EntitlementCacheSeconds)));
+
+        return subscription;
+    }
+
+    public void Invalidate(string tenantId, string organizationId) =>
+        _entries.TryRemove(CreateKey(tenantId, organizationId), out _);
+
+    private void RemoveExpired(DateTime now)
+    {
+        foreach (var pair in _entries)
+        {
+            if (pair.Value.ExpiresAtUtc <= now)
+            {
+                _entries.TryRemove(pair.Key, out _);
+            }
+        }
+    }
+
+    private static string CreateKey(string tenantId, string organizationId) =>
+        $"{tenantId}:{organizationId}";
+
+    private sealed record Entry(SubscriptionDetail? Subscription, DateTime ExpiresAtUtc);
+}

--- a/server/Subscription.DomainService/Services/IEntitlementService.cs
+++ b/server/Subscription.DomainService/Services/IEntitlementService.cs
@@ -1,0 +1,23 @@
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface IEntitlementService
+{
+    /// <summary>
+    /// Everything the caller's organization is entitled to.
+    /// </summary>
+    /// <param name="fresh">
+    /// Bypass the short-lived cache. Worth setting before something irreversible.
+    /// </param>
+    Task<SubscriptionOperationResult<EntitlementSnapshotResponse>> GetAsync(
+        bool fresh,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<EntitlementResponse>> GetAsync(
+        string entitlementKey,
+        bool fresh,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/IEntitlementSnapshotCache.cs
+++ b/server/Subscription.DomainService/Services/IEntitlementSnapshotCache.cs
@@ -1,0 +1,14 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+public interface IEntitlementSnapshotCache
+{
+    Task<SubscriptionDetail?> GetAsync(
+        string tenantId,
+        string organizationId,
+        Func<Task<SubscriptionDetail?>> loader);
+
+    /// <summary>Drops an organization's cached subscription after it changes.</summary>
+    void Invalidate(string tenantId, string organizationId);
+}

--- a/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
@@ -1,0 +1,26 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface IPlanCatalogueService
+{
+    Task<SubscriptionOperationResult<PlanResponse>> CreatePlanAsync(
+        CreatePlanRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<PlanResponse>> CreatePriceAsync(
+        CreatePriceRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<PlanResponse>> GetPlanAsync(
+        string planId,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/IPlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/IPlanResponseMapper.cs
@@ -1,0 +1,9 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface IPlanResponseMapper
+{
+    PlanResponse ToResponse(Plan plan, IReadOnlyList<Price> prices);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionBillingGateway.cs
@@ -1,0 +1,19 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Charges a subscription's stored payment method for a renewal or a dunning retry.
+/// </summary>
+/// <remarks>
+/// The seam a later Stripe Invoice integration replaces. Everything that decides <em>when</em>
+/// and <em>how much</em> to charge — the renewal and dunning state machine, the amount
+/// calculator — depends only on this interface, never on how the charge is actually raised.
+/// </remarks>
+public interface ISubscriptionBillingGateway
+{
+    /// <summary>Returns the payment's id on success, for support traceability.</summary>
+    Task<SubscriptionOperationResult<string>> ChargeAsync(
+        SubscriptionChargeRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCancellationService.cs
@@ -1,0 +1,20 @@
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface ISubscriptionCancellationService
+{
+    /// <summary>
+    /// Records that a subscription should end.
+    /// </summary>
+    /// <param name="immediately">
+    /// End now rather than at the end of the period already paid for. Reserved for cases where
+    /// the customer is entitled to stop at once; the ordinary answer is false.
+    /// </param>
+    Task<SubscriptionOperationResult<SubscriptionResponse>> CancelAsync(
+        string subscriptionId,
+        bool immediately,
+        string? reason,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCheckoutService.cs
@@ -1,0 +1,19 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface ISubscriptionCheckoutService
+{
+    /// <summary>
+    /// Creates a subscription and, when it needs paying for, raises the first charge.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionResponse>> SubscribeAsync(
+        CreateSubscriptionRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<SubscriptionResponse>> GetCurrentAsync(
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionContextResolver.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionContextResolver.cs
@@ -1,0 +1,18 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Who is asking, and on whose behalf.
+/// </summary>
+public interface ISubscriptionContextResolver
+{
+    /// <summary>
+    /// Resolves the caller's tenant, organization and actor.
+    /// </summary>
+    /// <remarks>
+    /// Unlike the payment resolver this wraps, a blank organization is refused rather than
+    /// treated as "sees everything in the tenant". Entitlement without an organization has no
+    /// meaning, and a machine-to-machine caller with no organization would otherwise receive an
+    /// unscoped answer — which is the shape of an access-control failure, not a convenience.
+    /// </remarks>
+    SubscriptionContextResolution Resolve(string correlationId);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCreationService.cs
@@ -1,0 +1,21 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Services;
+
+public interface ISubscriptionCreationService
+{
+    /// <summary>
+    /// Builds and stores a subscription in its initial state.
+    /// </summary>
+    /// <remarks>
+    /// Stops short of taking money. Whether a charge is needed at all — and how it is raised —
+    /// belongs to the checkout service, so this one stays about turning a chosen plan into a
+    /// durable record.
+    /// </remarks>
+    Task<SubscriptionOperationResult<SubscriptionDetail>> CreateAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionPlanChangeService.cs
@@ -1,0 +1,14 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>Moves a live subscription to a different price, mid-period, with proration.</summary>
+public interface ISubscriptionPlanChangeService
+{
+    Task<SubscriptionOperationResult<SubscriptionResponse>> ChangePlanAsync(
+        string subscriptionId,
+        ChangeSubscriptionPlanRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionRenewalService.cs
@@ -1,0 +1,9 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>Charges one subscription's renewal, or its next dunning retry.</summary>
+public interface ISubscriptionRenewalService
+{
+    Task RenewAsync(SubscriptionDetail subscription, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionResponseMapper.cs
@@ -1,0 +1,11 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface ISubscriptionResponseMapper
+{
+    SubscriptionResponse ToResponse(
+        SubscriptionDetail subscription,
+        string? checkoutUrl = null);
+}

--- a/server/Subscription.DomainService/Services/IUsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/IUsageRecordingService.cs
@@ -1,0 +1,24 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface IUsageRecordingService
+{
+    /// <summary>
+    /// Records usage against a meter and reports where that leaves the allowance.
+    /// </summary>
+    /// <remarks>
+    /// This, not the entitlement endpoint, is the enforcement point. The balance it returns
+    /// already includes the caller's own contribution, so two callers arriving at the boundary
+    /// together get different answers.
+    /// </remarks>
+    Task<SubscriptionOperationResult<UsageResponse>> RecordAsync(
+        RecordUsageRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<IReadOnlyList<UsageResponse>>> GetCurrentUsageAsync(
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/IUsageThresholdEvaluator.cs
+++ b/server/Subscription.DomainService/Services/IUsageThresholdEvaluator.cs
@@ -1,0 +1,16 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+public interface IUsageThresholdEvaluator
+{
+    /// <summary>
+    /// Raises an event for any consumption threshold this increment has just crossed.
+    /// </summary>
+    /// <returns>How many thresholds were reported.</returns>
+    Task<int> EvaluateAsync(
+        SubscriptionDetail subscription,
+        SubscriptionUsageCounter counter,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -145,6 +145,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             Interval = request.Interval,
             IntervalCount = request.IntervalCount,
             QuantityItemKey = request.QuantityItemKey,
+            TaxRateBasisPoints = request.TaxRateBasisPoints,
             Status = CatalogueStatus.Active
         };
 

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -1,0 +1,323 @@
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Authoring and reading what a tenant sells.
+/// </summary>
+public sealed class PlanCatalogueService : IPlanCatalogueService
+{
+    private readonly ISubscriptionCatalogueRepository _catalogue;
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly IValidator<CreatePlanRequest> _planValidator;
+    private readonly IValidator<CreatePriceRequest> _priceValidator;
+    private readonly IPlanResponseMapper _mapper;
+    private readonly ILogger<PlanCatalogueService> _logger;
+
+    public PlanCatalogueService(
+        ISubscriptionCatalogueRepository catalogue,
+        ISubscriptionContextResolver contextResolver,
+        IValidator<CreatePlanRequest> planValidator,
+        IValidator<CreatePriceRequest> priceValidator,
+        IPlanResponseMapper mapper,
+        ILogger<PlanCatalogueService> logger)
+    {
+        _catalogue = catalogue;
+        _contextResolver = contextResolver;
+        _planValidator = planValidator;
+        _priceValidator = priceValidator;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<SubscriptionOperationResult<PlanResponse>> CreatePlanAsync(
+        CreatePlanRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<PlanResponse>(correlationId);
+        }
+
+        var invalid = await SubscriptionValidation.CheckAsync<CreatePlanRequest, PlanResponse>(
+            _planValidator,
+            request,
+            "subscription_plan_invalid",
+            "The plan is invalid.",
+            correlationId,
+            cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var context = resolution.Context!;
+        var plan = BuildPlan(request, context.TenantId);
+
+        if (!await _catalogue.TryCreatePlanAsync(plan, cancellationToken))
+        {
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_exists",
+                "A plan with this code already exists at this scope.",
+                correlationId);
+        }
+
+        _logger.LogInformation(
+            "Subscription plan created TenantHash={TenantHash} PlanHash={PlanHash} Code={Code} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(plan.ItemId),
+            PaymentLogValue.Label(plan.Code),
+            correlationId);
+
+        return SubscriptionOperationResult<PlanResponse>.Success(
+            _mapper.ToResponse(plan, []),
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<PlanResponse>> CreatePriceAsync(
+        CreatePriceRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<PlanResponse>(correlationId);
+        }
+
+        var invalid = await SubscriptionValidation.CheckAsync<CreatePriceRequest, PlanResponse>(
+            _priceValidator,
+            request,
+            "subscription_price_invalid",
+            "The price is invalid.",
+            correlationId,
+            cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var context = resolution.Context!;
+        var plan = await _catalogue.GetPlanAsync(
+            context.TenantId,
+            request.PlanId,
+            cancellationToken);
+
+        if (plan is null)
+        {
+            return NotFound(correlationId);
+        }
+
+        if (!QuantityItemExists(plan, request.QuantityItemKey))
+        {
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_quantity_item_unknown",
+                "The price charges for a quantity item the plan does not define.",
+                correlationId);
+        }
+
+        var price = new Price
+        {
+            TenantId = context.TenantId,
+            PlanId = plan.ItemId,
+            CurrencyCode = request.CurrencyCode.ToUpperInvariant(),
+            UnitAmountMinor = request.UnitAmountMinor,
+            Interval = request.Interval,
+            IntervalCount = request.IntervalCount,
+            QuantityItemKey = request.QuantityItemKey,
+            Status = CatalogueStatus.Active
+        };
+
+        if (!await _catalogue.TryCreatePriceAsync(price, cancellationToken))
+        {
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_price_exists",
+                "A price with these terms already exists for this plan.",
+                correlationId);
+        }
+
+        _logger.LogInformation(
+            "Subscription price created TenantHash={TenantHash} PlanHash={PlanHash} Currency={Currency} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(plan.ItemId),
+            PaymentLogValue.Label(price.CurrencyCode),
+            correlationId);
+
+        return await GetPlanAsync(plan.ItemId, correlationId, cancellationToken);
+    }
+
+    public async Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<IReadOnlyList<PlanResponse>>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        var plans = await _catalogue.ListPlansAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        var responses = new List<PlanResponse>(plans.Count);
+
+        foreach (var plan in plans)
+        {
+            var prices = await _catalogue.ListPricesAsync(
+                context.TenantId,
+                plan.ItemId,
+                cancellationToken);
+
+            responses.Add(_mapper.ToResponse(plan, prices));
+        }
+
+        return SubscriptionOperationResult<IReadOnlyList<PlanResponse>>.Success(
+            responses,
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<PlanResponse>> GetPlanAsync(
+        string planId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<PlanResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        var plan = await _catalogue.GetPlanAsync(
+            context.TenantId,
+            planId,
+            cancellationToken);
+
+        if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
+        {
+            return NotFound(correlationId);
+        }
+
+        var prices = await _catalogue.ListPricesAsync(
+            context.TenantId,
+            plan.ItemId,
+            cancellationToken);
+
+        return SubscriptionOperationResult<PlanResponse>.Success(
+            _mapper.ToResponse(plan, prices),
+            correlationId);
+    }
+
+    /// <summary>
+    /// A plan scoped to another organization reports as missing rather than forbidden, so a
+    /// response cannot be used to confirm that an identifier exists somewhere else.
+    /// </summary>
+    private static bool IsVisibleTo(Plan plan, string organizationId) =>
+        plan.OrganizationId is null ||
+        string.Equals(plan.OrganizationId, organizationId, StringComparison.Ordinal);
+
+    private static bool QuantityItemExists(Plan plan, string? quantityItemKey) =>
+        string.IsNullOrWhiteSpace(quantityItemKey) ||
+        plan.QuantityItems.Exists(item =>
+            string.Equals(item.ItemKey, quantityItemKey, StringComparison.Ordinal));
+
+    private static SubscriptionOperationResult<PlanResponse> NotFound(string correlationId) =>
+        SubscriptionOperationResult<PlanResponse>.Failure(
+            PaymentFailureKind.NotFound,
+            "subscription_plan_not_found",
+            "The plan does not exist.",
+            correlationId);
+
+    private static Plan BuildPlan(CreatePlanRequest request, string tenantId) => new()
+    {
+        TenantId = tenantId,
+        OrganizationId = string.IsNullOrWhiteSpace(request.OrganizationId)
+            ? null
+            : request.OrganizationId,
+        Code = request.Code,
+        DisplayName = request.DisplayName,
+        Description = request.Description,
+        FeaturesJson = request.FeaturesJson,
+        Status = CatalogueStatus.Active,
+        TrialDays = request.TrialDays,
+        TrialRequiresPaymentMethod = request.TrialRequiresPaymentMethod,
+        QuantityItems = request.QuantityItems
+            .Select(item => new PlanQuantityItem
+            {
+                ItemKey = item.ItemKey,
+                UnitLabel = item.UnitLabel,
+                MinQuantity = item.MinQuantity,
+                MaxQuantity = item.MaxQuantity,
+                DefaultQuantity = item.DefaultQuantity
+            })
+            .ToList(),
+        Meters = request.Meters
+            .Select(meter => new PlanMeter
+            {
+                MeterKey = meter.MeterKey,
+                DisplayName = meter.DisplayName,
+                UnitLabel = meter.UnitLabel,
+                Aggregation = meter.Aggregation,
+                IncludedQuantity = meter.IncludedQuantity,
+                OverageAllowed = meter.OverageAllowed,
+                ThresholdPercents = meter.ThresholdPercents.Distinct().Order().ToList(),
+                RateTables = meter.RateTables
+                    .Select(table => new MeterRateTable
+                    {
+                        CurrencyCode = table.CurrencyCode.ToUpperInvariant(),
+                        Tiers = table.Tiers
+                            .Select(tier => new MeterTier
+                            {
+                                UpToQuantity = tier.UpToQuantity,
+                                UnitAmountMinor = tier.UnitAmountMinor
+                            })
+                            .ToList()
+                    })
+                    .ToList()
+            })
+            .ToList(),
+        Entitlements = request.Entitlements
+            .Select(entitlement => new PlanEntitlement
+            {
+                Key = entitlement.Key,
+                LimitKind = entitlement.LimitKind,
+                Limit = entitlement.Limit,
+                MeterKey = entitlement.MeterKey,
+                UnitLabel = entitlement.UnitLabel
+            })
+            .ToList(),
+        TrialGrants = request.TrialGrants
+            .Select(grant => new TrialMeterGrant
+            {
+                MeterKey = grant.MeterKey,
+                IncludedQuantity = grant.IncludedQuantity
+            })
+            .ToList()
+    };
+}

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -1,0 +1,74 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Turns stored plans into responses.
+/// </summary>
+/// <remarks>
+/// Its own type rather than a method on the service, so the service orchestrates and this
+/// decides shape. Enum values cross the wire as their names: a client that has to know
+/// <c>2</c> means monthly is coupled to our storage format.
+/// </remarks>
+public sealed class PlanResponseMapper : IPlanResponseMapper
+{
+    public PlanResponse ToResponse(Plan plan, IReadOnlyList<Price> prices)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(prices);
+
+        return new PlanResponse
+        {
+            PlanId = plan.ItemId,
+            Code = plan.Code,
+            DisplayName = plan.DisplayName,
+            Description = plan.Description,
+            FeaturesJson = plan.FeaturesJson,
+            TrialDays = plan.TrialDays,
+            TrialRequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
+            Version = plan.Version,
+            QuantityItems = plan.QuantityItems
+                .Select(item => new PlanQuantityItemResponse
+                {
+                    ItemKey = item.ItemKey,
+                    UnitLabel = item.UnitLabel,
+                    MinQuantity = item.MinQuantity,
+                    MaxQuantity = item.MaxQuantity,
+                    DefaultQuantity = item.DefaultQuantity
+                })
+                .ToList(),
+            Meters = plan.Meters
+                .Select(meter => new PlanMeterResponse
+                {
+                    MeterKey = meter.MeterKey,
+                    DisplayName = meter.DisplayName,
+                    UnitLabel = meter.UnitLabel,
+                    IncludedQuantity = meter.IncludedQuantity,
+                    OverageAllowed = meter.OverageAllowed
+                })
+                .ToList(),
+            Entitlements = plan.Entitlements
+                .Select(entitlement => new PlanEntitlementResponse
+                {
+                    Key = entitlement.Key,
+                    LimitKind = entitlement.LimitKind.ToString(),
+                    Limit = entitlement.Limit,
+                    MeterKey = entitlement.MeterKey,
+                    UnitLabel = entitlement.UnitLabel
+                })
+                .ToList(),
+            Prices = prices
+                .Select(price => new PlanPriceResponse
+                {
+                    PriceId = price.ItemId,
+                    CurrencyCode = price.CurrencyCode,
+                    UnitAmountMinor = price.UnitAmountMinor,
+                    Interval = price.Interval.ToString(),
+                    IntervalCount = price.IntervalCount,
+                    QuantityItemKey = price.QuantityItemKey
+                })
+                .ToList()
+        };
+    }
+}

--- a/server/Subscription.DomainService/Services/RecurringChargeBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/RecurringChargeBillingGateway.cs
@@ -1,0 +1,80 @@
+using Payment.DomainService.Enums;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Charges a subscription's stored card off-session, through the existing recurring-payment
+/// stack.
+/// </summary>
+/// <remarks>
+/// Provider-neutral by construction, not Stripe-specific: <see
+/// cref="SubscriptionChargeRequest.ProviderName"/> flows straight through to <see
+/// cref="IRecurringPaymentService"/>, which already resolves the real charge gateway per
+/// provider the same way the rest of the payment module does. Adding an Adyen subscriber needs
+/// no new code here — only that tenant's <c>BillingAccount.ProviderName</c> naming Adyen.
+/// <para>
+/// This class is what a later Stripe Invoice integration replaces. Nothing upstream of <see
+/// cref="ISubscriptionBillingGateway"/> changes when that happens.
+/// </para>
+/// </remarks>
+public sealed class RecurringChargeBillingGateway : ISubscriptionBillingGateway
+{
+    private const string RecurringProcessingModel = "Subscription";
+
+    private readonly IRecurringPaymentService _recurringPayments;
+    private readonly ICurrencyMinorUnitResolver _currency;
+
+    public RecurringChargeBillingGateway(
+        IRecurringPaymentService recurringPayments,
+        ICurrencyMinorUnitResolver currency)
+    {
+        _recurringPayments = recurringPayments;
+        _currency = currency;
+    }
+
+    public async Task<SubscriptionOperationResult<string>> ChargeAsync(
+        SubscriptionChargeRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!_currency.TryConvertBack(request.AmountMinor, request.CurrencyCode, out var amount))
+        {
+            return SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_currency_unsupported",
+                "This currency is not configured for payments.",
+                correlationId);
+        }
+
+        var result = await _recurringPayments.CreateRecurringPaymentAsync(
+            new CreateRecurringPaymentRequest
+            {
+                ProviderName = request.ProviderName,
+                StoredPaymentMethodId = request.StoredPaymentMethodId,
+                Amount = amount,
+                CurrencyCode = request.CurrencyCode,
+                OrderId = request.OrderId,
+                RecurringProcessingModel = RecurringProcessingModel,
+                Description = request.Description
+            },
+            idempotencyKey,
+            correlationId,
+            cancellationToken);
+
+        return result.IsSuccess && result.Payment is not null
+            ? SubscriptionOperationResult<string>.Success(
+                result.Payment.PaymentDetailId,
+                correlationId)
+            : SubscriptionOperationResult<string>.Failure(
+                result.FailureKind,
+                result.ErrorCode,
+                result.ErrorMessage,
+                correlationId);
+    }
+}

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -1,0 +1,240 @@
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Charges a subscription's renewal as a standalone Stripe Invoice: an item, an invoice, a
+/// finalize, and a pay — all raised and settled within this one call, on Blocks' own schedule.
+/// </summary>
+/// <remarks>
+/// No Stripe Subscription object exists behind this, so nothing here delegates dunning to
+/// Stripe's own Smart Retries — that stays <see cref="SubscriptionRenewalService"/>'s job, same
+/// as with <see cref="RecurringChargeBillingGateway"/>. What changes is that a successful charge
+/// now produces a real Stripe Invoice document instead of a bare PaymentIntent.
+/// <para>
+/// Claiming and unprotecting the stored card is done directly against
+/// <c>Payment.DomainService</c>'s repositories rather than through
+/// <c>RecurringPaymentInitiationService</c>: that service is built around
+/// <c>PaymentDetail</c>'s Authorized/Captured/Refused model, which an invoice's
+/// draft/open/paid/uncollectible lifecycle does not map onto — forcing it to would teach the
+/// payment module the word "Invoice."
+/// </para>
+/// </remarks>
+public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
+{
+    private readonly IPaymentProviderCache _providers;
+    private readonly IPaymentRepository _payments;
+    private readonly IStoredPaymentMethodRepository _storedMethods;
+    private readonly IProviderTokenProtector _tokenProtector;
+    private readonly IStripeInvoiceClient _invoices;
+    private readonly ILogger<StripeInvoiceBillingGateway> _logger;
+    private readonly TimeProvider _time;
+
+    public StripeInvoiceBillingGateway(
+        IPaymentProviderCache providers,
+        IPaymentRepository payments,
+        IStoredPaymentMethodRepository storedMethods,
+        IProviderTokenProtector tokenProtector,
+        IStripeInvoiceClient invoices,
+        ILogger<StripeInvoiceBillingGateway> logger,
+        TimeProvider? time = null)
+    {
+        _providers = providers;
+        _payments = payments;
+        _storedMethods = storedMethods;
+        _tokenProtector = tokenProtector;
+        _invoices = invoices;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<string>> ChargeAsync(
+        SubscriptionChargeRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (string.IsNullOrWhiteSpace(request.ProviderCustomerId))
+        {
+            _logger.LogWarning(
+                "A Stripe renewal was attempted with no provider customer on record");
+
+            return Unavailable("subscription_customer_unresolved", correlationId);
+        }
+
+        var provider = await _providers.GetAsync(
+            request.TenantId,
+            request.OrganizationId,
+            request.ProviderName,
+            () => _payments.GetProviderAsync(
+                request.TenantId,
+                request.OrganizationId,
+                request.ProviderName,
+                cancellationToken));
+
+        if (provider is not { IsEnabled: true, ApiKey.Length: > 0 })
+        {
+            return Unavailable("subscription_provider_unavailable", correlationId);
+        }
+
+        var method = await _storedMethods.GetAsync(
+            request.TenantId,
+            request.StoredPaymentMethodId,
+            cancellationToken);
+
+        if (method is null)
+        {
+            return Unavailable("stored_payment_method_not_found", correlationId);
+        }
+
+        var leaseId = Guid.NewGuid().ToString("N");
+        var claimed = await _storedMethods.TryClaimForPaymentAsync(
+            request.TenantId,
+            method.ItemId,
+            method.ShopperReference ?? string.Empty,
+            leaseId,
+            _time.GetUtcNow().UtcDateTime.AddSeconds(60),
+            cancellationToken);
+
+        if (claimed is null)
+        {
+            return SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.Conflict,
+                "stored_payment_method_in_use",
+                "The stored payment method is changing or already in use.",
+                correlationId);
+        }
+
+        try
+        {
+            return await ChargeClaimedMethodAsync(
+                provider,
+                claimed,
+                request,
+                idempotencyKey,
+                correlationId,
+                cancellationToken);
+        }
+        finally
+        {
+            await _storedMethods.ReleasePaymentClaimAsync(
+                request.TenantId,
+                claimed.ItemId,
+                leaseId,
+                CancellationToken.None);
+        }
+    }
+
+    private async Task<SubscriptionOperationResult<string>> ChargeClaimedMethodAsync(
+        PaymentProvider provider,
+        StoredPaymentMethod claimed,
+        SubscriptionChargeRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var token = await _tokenProtector.UnprotectAsync(claimed, cancellationToken);
+        var paymentMethodId = token.ProviderToken;
+
+        if (!token.IsRead)
+        {
+            return Unavailable("stored_payment_method_token_unavailable", correlationId);
+        }
+
+        var item = await _invoices.CreateInvoiceItemAsync(
+            provider,
+            request.ProviderCustomerId!,
+            request.AmountMinor,
+            request.CurrencyCode,
+            request.Description ?? "Subscription renewal",
+            $"{idempotencyKey}:item",
+            cancellationToken);
+
+        if (!item.IsSuccess)
+        {
+            paymentMethodId = string.Empty;
+
+            return Rejected(item, "subscription_invoice_item_failed", correlationId);
+        }
+
+        var invoice = await _invoices.CreateInvoiceAsync(
+            provider,
+            request.ProviderCustomerId!,
+            $"{idempotencyKey}:invoice",
+            cancellationToken);
+
+        if (!invoice.IsSuccess)
+        {
+            paymentMethodId = string.Empty;
+
+            return Rejected(invoice, "subscription_invoice_create_failed", correlationId);
+        }
+
+        var finalized = await _invoices.FinalizeInvoiceAsync(
+            provider,
+            invoice.InvoiceOrItemId!,
+            $"{idempotencyKey}:finalize",
+            cancellationToken);
+
+        if (!finalized.IsSuccess)
+        {
+            paymentMethodId = string.Empty;
+            await _invoices.VoidInvoiceAsync(provider, invoice.InvoiceOrItemId!, cancellationToken);
+
+            return Rejected(finalized, "subscription_invoice_finalize_failed", correlationId);
+        }
+
+        var paid = await _invoices.PayInvoiceAsync(
+            provider,
+            invoice.InvoiceOrItemId!,
+            paymentMethodId,
+            $"{idempotencyKey}:pay",
+            cancellationToken);
+        paymentMethodId = string.Empty;
+
+        if (!paid.IsSuccess)
+        {
+            await _invoices.VoidInvoiceAsync(provider, invoice.InvoiceOrItemId!, cancellationToken);
+
+            return Rejected(paid, "subscription_invoice_payment_declined", correlationId);
+        }
+
+        _logger.LogInformation(
+            "Subscription renewal charged through a Stripe invoice InvoiceHash={InvoiceHash}",
+            PaymentLogValue.Hash(invoice.InvoiceOrItemId!));
+
+        return SubscriptionOperationResult<string>.Success(invoice.InvoiceOrItemId!, correlationId);
+    }
+
+    private static SubscriptionOperationResult<string> Rejected(
+        StripeInvoiceCallResult result,
+        string fallbackCode,
+        string correlationId) =>
+        SubscriptionOperationResult<string>.Failure(
+            result.Outcome switch
+            {
+                StripeInvoiceOutcome.Unavailable => PaymentFailureKind.Unavailable,
+                StripeInvoiceOutcome.Timeout => PaymentFailureKind.Timeout,
+                _ => PaymentFailureKind.ProviderRejected
+            },
+            result.SafeErrorCode ?? fallbackCode,
+            "The payment provider declined this charge.",
+            correlationId);
+
+    private static SubscriptionOperationResult<string> Unavailable(
+        string errorCode,
+        string correlationId) =>
+        SubscriptionOperationResult<string>.Failure(
+            PaymentFailureKind.Unavailable,
+            errorCode,
+            "This subscription cannot be charged right now.",
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -13,13 +13,31 @@ namespace Subscription.DomainService.Services;
 /// </remarks>
 public static class SubscriptionAmountCalculator
 {
+    /// <summary>Kept for the first charge, where no prior period and no discount history exist yet.</summary>
     public static long PeriodAmountMinor(SubscriptionDetail subscription)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
         var gross = GrossAmountMinor(subscription);
 
-        return ApplyDiscount(gross, subscription.Discount);
+        return ApplyDiscount(gross, subscription.Discount, 0, DateTime.UtcNow).AmountMinor;
+    }
+
+    /// <summary>
+    /// What a renewal charges, and whether the discount actually reduced it — so the caller
+    /// knows whether to count this period against <see cref="DiscountTerms.DurationPeriods"/>.
+    /// </summary>
+    public static PeriodCharge PeriodAmountMinor(SubscriptionDetail subscription, DateTime nowUtc)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var gross = GrossAmountMinor(subscription);
+
+        return ApplyDiscount(
+            gross,
+            subscription.Discount,
+            subscription.DiscountPeriodsApplied,
+            nowUtc);
     }
 
     private static long GrossAmountMinor(SubscriptionDetail subscription)
@@ -52,11 +70,17 @@ public static class SubscriptionAmountCalculator
         return quantity * unitAmount;
     }
 
-    private static long ApplyDiscount(long amountMinor, DiscountTerms? discount)
+    private static PeriodCharge ApplyDiscount(
+        long amountMinor,
+        DiscountTerms? discount,
+        int periodsApplied,
+        DateTime nowUtc)
     {
-        if (discount is null || amountMinor <= 0)
+        if (discount is null ||
+            amountMinor <= 0 ||
+            !DiscountStillActive(discount, periodsApplied, nowUtc))
         {
-            return amountMinor;
+            return new PeriodCharge(amountMinor, false);
         }
 
         var discounted = discount.Kind switch
@@ -70,6 +94,21 @@ public static class SubscriptionAmountCalculator
 
         // A discount can take a charge to nothing but never below it: a negative charge is a
         // refund, and one must never arrive by arithmetic.
-        return Math.Max(0, discounted);
+        return new PeriodCharge(Math.Max(0, discounted), true);
     }
+
+    /// <summary>
+    /// Whether a discount still covers the period being charged. A duration expires on the
+    /// count of periods it has already reduced, an expiry date on the wall clock — either can
+    /// end it independently of the other.
+    /// </summary>
+    private static bool DiscountStillActive(
+        DiscountTerms discount,
+        int periodsApplied,
+        DateTime nowUtc) =>
+        (discount.DurationPeriods is not { } maxPeriods || periodsApplied < maxPeriods) &&
+        (discount.ExpiresAtUtc is not { } expiresAtUtc || nowUtc < expiresAtUtc);
 }
+
+/// <summary>What a period costs, and whether a discount was the reason it costs that.</summary>
+public readonly record struct PeriodCharge(long AmountMinor, bool DiscountApplied);

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -26,18 +26,29 @@ public static class SubscriptionAmountCalculator
     /// <summary>
     /// What a renewal charges, and whether the discount actually reduced it — so the caller
     /// knows whether to count this period against <see cref="DiscountTerms.DurationPeriods"/>.
+    /// Any banked <see cref="SubscriptionDetail.CreditBalanceMinor"/> is applied after the
+    /// discount, and never below zero.
     /// </summary>
     public static PeriodCharge PeriodAmountMinor(SubscriptionDetail subscription, DateTime nowUtc)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
         var gross = GrossAmountMinor(subscription.Price, subscription.QuantityItems);
-
-        return ApplyDiscount(
+        var discounted = ApplyDiscount(
             gross,
             subscription.Discount,
             subscription.DiscountPeriodsApplied,
             nowUtc);
+
+        var creditConsumed = Math.Min(
+            Math.Max(0, subscription.CreditBalanceMinor),
+            discounted.AmountMinor);
+
+        return discounted with
+        {
+            AmountMinor = discounted.AmountMinor - creditConsumed,
+            CreditConsumedMinor = creditConsumed
+        };
     }
 
     /// <summary>
@@ -120,5 +131,8 @@ public static class SubscriptionAmountCalculator
         (discount.ExpiresAtUtc is not { } expiresAtUtc || nowUtc < expiresAtUtc);
 }
 
-/// <summary>What a period costs, and whether a discount was the reason it costs that.</summary>
-public readonly record struct PeriodCharge(long AmountMinor, bool DiscountApplied);
+/// <summary>What a period costs, whether a discount reduced it, and how much banked credit paid for it.</summary>
+public readonly record struct PeriodCharge(
+    long AmountMinor,
+    bool DiscountApplied,
+    long CreditConsumedMinor = 0);

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -18,7 +18,7 @@ public static class SubscriptionAmountCalculator
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
-        var gross = GrossAmountMinor(subscription);
+        var gross = GrossAmountMinor(subscription.Price, subscription.QuantityItems);
 
         return ApplyDiscount(gross, subscription.Discount, 0, DateTime.UtcNow).AmountMinor;
     }
@@ -31,7 +31,7 @@ public static class SubscriptionAmountCalculator
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
-        var gross = GrossAmountMinor(subscription);
+        var gross = GrossAmountMinor(subscription.Price, subscription.QuantityItems);
 
         return ApplyDiscount(
             gross,
@@ -40,29 +40,35 @@ public static class SubscriptionAmountCalculator
             nowUtc);
     }
 
-    private static long GrossAmountMinor(SubscriptionDetail subscription)
+    /// <summary>
+    /// The undiscounted cost of a price and quantity pair — exposed so proration can price a
+    /// *different* plan the same way a renewal prices the current one, without duplicating this
+    /// logic.
+    /// </summary>
+    internal static long GrossAmountMinor(
+        PriceSnapshot price,
+        IReadOnlyList<SubscriptionQuantityItem> quantityItems)
     {
-        var price = subscription.Price;
+        ArgumentNullException.ThrowIfNull(price);
+        ArgumentNullException.ThrowIfNull(quantityItems);
 
         if (string.IsNullOrWhiteSpace(price.QuantityItemKey))
         {
             return price.UnitAmountMinor;
         }
 
-        var quantity = subscription.QuantityItems
+        var matching = quantityItems
             .Where(item => string.Equals(
                 item.ItemKey,
                 price.QuantityItemKey,
                 StringComparison.Ordinal))
-            .Sum(item => item.Quantity);
+            .ToList();
+
+        var quantity = matching.Sum(item => item.Quantity);
 
         // The amount snapshotted on the item, not the plan's current price: adding units later
         // charges what the subscriber agreed to.
-        var unitAmount = subscription.QuantityItems
-            .Where(item => string.Equals(
-                item.ItemKey,
-                price.QuantityItemKey,
-                StringComparison.Ordinal))
+        var unitAmount = matching
             .Select(item => item.UnitAmountMinor)
             .DefaultIfEmpty(price.UnitAmountMinor)
             .First();
@@ -70,7 +76,11 @@ public static class SubscriptionAmountCalculator
         return quantity * unitAmount;
     }
 
-    private static PeriodCharge ApplyDiscount(
+    /// <summary>
+    /// Applies a discount to a gross amount — exposed so proration can discount a hypothetical
+    /// target plan's cost exactly as a renewal discounts the current one.
+    /// </summary>
+    internal static PeriodCharge ApplyDiscount(
         long amountMinor,
         DiscountTerms? discount,
         int periodsApplied,

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -1,0 +1,75 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// What a subscription's period costs, in minor units.
+/// </summary>
+/// <remarks>
+/// Pure and static so it can be exercised directly. Money arithmetic stays in
+/// <see cref="long"/> throughout: a decimal only appears at the boundary where the payment
+/// module needs one, and never in a calculation.
+/// </remarks>
+public static class SubscriptionAmountCalculator
+{
+    public static long PeriodAmountMinor(SubscriptionDetail subscription)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var gross = GrossAmountMinor(subscription);
+
+        return ApplyDiscount(gross, subscription.Discount);
+    }
+
+    private static long GrossAmountMinor(SubscriptionDetail subscription)
+    {
+        var price = subscription.Price;
+
+        if (string.IsNullOrWhiteSpace(price.QuantityItemKey))
+        {
+            return price.UnitAmountMinor;
+        }
+
+        var quantity = subscription.QuantityItems
+            .Where(item => string.Equals(
+                item.ItemKey,
+                price.QuantityItemKey,
+                StringComparison.Ordinal))
+            .Sum(item => item.Quantity);
+
+        // The amount snapshotted on the item, not the plan's current price: adding units later
+        // charges what the subscriber agreed to.
+        var unitAmount = subscription.QuantityItems
+            .Where(item => string.Equals(
+                item.ItemKey,
+                price.QuantityItemKey,
+                StringComparison.Ordinal))
+            .Select(item => item.UnitAmountMinor)
+            .DefaultIfEmpty(price.UnitAmountMinor)
+            .First();
+
+        return quantity * unitAmount;
+    }
+
+    private static long ApplyDiscount(long amountMinor, DiscountTerms? discount)
+    {
+        if (discount is null || amountMinor <= 0)
+        {
+            return amountMinor;
+        }
+
+        var discounted = discount.Kind switch
+        {
+            DiscountKind.Percent when discount.PercentBasisPoints is { } basisPoints =>
+                amountMinor - (amountMinor * basisPoints / 10_000),
+            DiscountKind.FixedAmount when discount.AmountMinor is { } off =>
+                amountMinor - off,
+            _ => amountMinor
+        };
+
+        // A discount can take a charge to nothing but never below it: a negative charge is a
+        // refund, and one must never arrive by arithmetic.
+        return Math.Max(0, discounted);
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -19,15 +19,18 @@ public static class SubscriptionAmountCalculator
         ArgumentNullException.ThrowIfNull(subscription);
 
         var gross = GrossAmountMinor(subscription.Price, subscription.QuantityItems);
+        var discounted = ApplyDiscount(gross, subscription.Discount, 0, DateTime.UtcNow).AmountMinor;
 
-        return ApplyDiscount(gross, subscription.Discount, 0, DateTime.UtcNow).AmountMinor;
+        return discounted + TaxAmountMinor(discounted, subscription.Price.TaxRateBasisPoints);
     }
 
     /// <summary>
     /// What a renewal charges, and whether the discount actually reduced it — so the caller
     /// knows whether to count this period against <see cref="DiscountTerms.DurationPeriods"/>.
-    /// Any banked <see cref="SubscriptionDetail.CreditBalanceMinor"/> is applied after the
-    /// discount, and never below zero.
+    /// Tax is added to the discounted amount, and any banked
+    /// <see cref="SubscriptionDetail.CreditBalanceMinor"/> is then consumed against that
+    /// tax-inclusive total, never below zero — a credit offsets what the subscriber owes
+    /// including tax, it does not shrink the taxable base.
     /// </summary>
     public static PeriodCharge PeriodAmountMinor(SubscriptionDetail subscription, DateTime nowUtc)
     {
@@ -40,13 +43,17 @@ public static class SubscriptionAmountCalculator
             subscription.DiscountPeriodsApplied,
             nowUtc);
 
+        var tax = TaxAmountMinor(discounted.AmountMinor, subscription.Price.TaxRateBasisPoints);
+        var taxInclusive = discounted.AmountMinor + tax;
+
         var creditConsumed = Math.Min(
             Math.Max(0, subscription.CreditBalanceMinor),
-            discounted.AmountMinor);
+            taxInclusive);
 
         return discounted with
         {
-            AmountMinor = discounted.AmountMinor - creditConsumed,
+            AmountMinor = taxInclusive - creditConsumed,
+            TaxAmountMinor = tax,
             CreditConsumedMinor = creditConsumed
         };
     }
@@ -129,10 +136,23 @@ public static class SubscriptionAmountCalculator
         DateTime nowUtc) =>
         (discount.DurationPeriods is not { } maxPeriods || periodsApplied < maxPeriods) &&
         (discount.ExpiresAtUtc is not { } expiresAtUtc || nowUtc < expiresAtUtc);
+
+    /// <summary>
+    /// Tax on an already-discounted amount — exposed so proration can tax each side of a plan
+    /// change at that side's own price's rate.
+    /// </summary>
+    internal static long TaxAmountMinor(long discountedAmountMinor, int? taxRateBasisPoints) =>
+        taxRateBasisPoints is { } basisPoints && discountedAmountMinor > 0
+            ? discountedAmountMinor * basisPoints / 10_000
+            : 0;
 }
 
-/// <summary>What a period costs, whether a discount reduced it, and how much banked credit paid for it.</summary>
+/// <summary>
+/// What a period costs, whether a discount reduced it, how much of the total is tax, and how
+/// much banked credit paid for it.
+/// </summary>
 public readonly record struct PeriodCharge(
     long AmountMinor,
     bool DiscountApplied,
-    long CreditConsumedMinor = 0);
+    long CreditConsumedMinor = 0,
+    long TaxAmountMinor = 0);

--- a/server/Subscription.DomainService/Services/SubscriptionBillingGatewayResolver.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionBillingGatewayResolver.cs
@@ -1,0 +1,46 @@
+using Payment.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Picks which billing gateway charges a renewal, by provider name.
+/// </summary>
+/// <remarks>
+/// The "Strategy + Resolver" pattern this module already uses for provider variation elsewhere —
+/// a second provider gets a new implementation and a resolver entry, never a <c>switch</c> inside
+/// <see cref="SubscriptionRenewalService"/>. Stripe gets real Invoice documents;
+/// everything else — Adyen included — falls through to <see cref="RecurringChargeBillingGateway"/>
+/// exactly as it did before this resolver existed, so adding Stripe Invoices changes nothing
+/// about any other provider's behavior.
+/// </remarks>
+public sealed class SubscriptionBillingGatewayResolver : ISubscriptionBillingGateway
+{
+    private readonly StripeInvoiceBillingGateway _stripeInvoices;
+    private readonly RecurringChargeBillingGateway _recurringCharge;
+
+    public SubscriptionBillingGatewayResolver(
+        StripeInvoiceBillingGateway stripeInvoices,
+        RecurringChargeBillingGateway recurringCharge)
+    {
+        _stripeInvoices = stripeInvoices;
+        _recurringCharge = recurringCharge;
+    }
+
+    public Task<SubscriptionOperationResult<string>> ChargeAsync(
+        SubscriptionChargeRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var gateway = string.Equals(
+            request.ProviderName,
+            PaymentConstants.StripeProvider,
+            StringComparison.OrdinalIgnoreCase)
+            ? (ISubscriptionBillingGateway)_stripeInvoices
+            : _recurringCharge;
+
+        return gateway.ChargeAsync(request, idempotencyKey, correlationId, cancellationToken);
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -172,6 +172,11 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 EndedAtUtc = now,
                 CancellationReason = reason,
                 ClearNextFeeBillingAt = true,
+                // Nothing more will be metered once entitlement stops immediately, so the usage
+                // sweep should stop looking at this subscription too. Any usage already recorded
+                // in the still-open final period goes unrated — a known, stated gap, not a
+                // built recovery path.
+                ClearNextUsageBillingAt = true,
                 Event = _events.Create(
                     subscription,
                     SubscriptionConstants.SubscriptionCanceled,

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -1,0 +1,219 @@
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Ending a subscription.
+/// </summary>
+/// <remarks>
+/// Cancelling ordinarily changes almost nothing today. The customer has paid through the end of
+/// the period, so they keep what they bought and the subscription simply stops renewing —
+/// taking access away on the day someone cancels is charging for a month and delivering part of
+/// one.
+/// <para>
+/// When it was asked for and when it takes effect are separate fields because they are separate
+/// facts, and support questions are usually about the gap between them.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionCancellationService : ISubscriptionCancellationService
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly ISubscriptionOutboxEventFactory _events;
+    private readonly ISubscriptionResponseMapper _mapper;
+    private readonly IEntitlementSnapshotCache _cache;
+    private readonly ILogger<SubscriptionCancellationService> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionCancellationService(
+        ISubscriptionRepository subscriptions,
+        ISubscriptionContextResolver contextResolver,
+        ISubscriptionOutboxEventFactory events,
+        ISubscriptionResponseMapper mapper,
+        IEntitlementSnapshotCache cache,
+        ILogger<SubscriptionCancellationService> logger,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _contextResolver = contextResolver;
+        _events = events;
+        _mapper = mapper;
+        _cache = cache;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionResponse>> CancelAsync(
+        string subscriptionId,
+        bool immediately,
+        string? reason,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+
+        var subscription = await _subscriptions.GetAsync(
+            context.TenantId,
+            context.OrganizationId,
+            subscriptionId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            // Another organization's subscription reports as missing rather than forbidden, so
+            // a response cannot be used to confirm an identifier exists elsewhere.
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "The subscription does not exist.",
+                correlationId);
+        }
+
+        if (subscription.Status is SubscriptionStatus.Canceled
+            or SubscriptionStatus.IncompleteExpired)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_already_ended",
+                "The subscription has already ended.",
+                correlationId);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var applied = immediately
+            ? await EndNowAsync(subscription, reason, now, correlationId, cancellationToken)
+            : await EndAtPeriodEndAsync(subscription, reason, now, correlationId, cancellationToken);
+
+        if (!applied)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_transition_conflict",
+                "The subscription changed while it was being cancelled.",
+                correlationId);
+        }
+
+        // The cached snapshot decides what the customer may do, so it has to go now rather
+        // than in a few seconds' time.
+        _cache.Invalidate(context.TenantId, context.OrganizationId);
+
+        _logger.LogInformation(
+            "Subscription cancellation recorded TenantHash={TenantHash} " +
+            "OrganizationHash={OrganizationHash} SubscriptionHash={SubscriptionHash} " +
+            "Immediate={Immediate} FromStatus={FromStatus} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(context.OrganizationId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            immediately,
+            PaymentLogValue.Label(subscription.Status.ToString()),
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Success(
+            _mapper.ToResponse(Reflect(subscription, immediately, now, reason)),
+            correlationId);
+    }
+
+    /// <summary>
+    /// The ordinary case: stop renewing, keep granting until the paid period ends.
+    /// </summary>
+    private async Task<bool> EndAtPeriodEndAsync(
+        SubscriptionDetail subscription,
+        string? reason,
+        DateTime now,
+        string correlationId,
+        CancellationToken cancellationToken) =>
+        await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            // The status does not move: the customer paid through the end of the period and
+            // keeps what they bought. Only the intention is recorded.
+            new SubscriptionTransition(subscription.Status, subscription.Status)
+            {
+                CancelAtPeriodEnd = true,
+                CanceledAtUtc = now,
+                CancellationReason = reason,
+                ClearNextFeeBillingAt = true,
+                Event = _events.Create(
+                    subscription,
+                    SubscriptionConstants.SubscriptionCancellationRequested,
+                    correlationId)
+            },
+            cancellationToken);
+
+    private async Task<bool> EndNowAsync(
+        SubscriptionDetail subscription,
+        string? reason,
+        DateTime now,
+        string correlationId,
+        CancellationToken cancellationToken) =>
+        await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            new SubscriptionTransition(subscription.Status, SubscriptionStatus.Canceled)
+            {
+                CancelAtPeriodEnd = false,
+                CanceledAtUtc = now,
+                EndedAtUtc = now,
+                CancellationReason = reason,
+                ClearNextFeeBillingAt = true,
+                Event = _events.Create(
+                    subscription,
+                    SubscriptionConstants.SubscriptionCanceled,
+                    correlationId)
+            },
+            cancellationToken);
+
+    /// <summary>
+    /// Applies the transition to the copy being returned, so the caller sees what was written
+    /// without a second read.
+    /// </summary>
+    private static SubscriptionDetail Reflect(
+        SubscriptionDetail subscription,
+        bool immediately,
+        DateTime now,
+        string? reason)
+    {
+        subscription.CanceledAtUtc = now;
+        subscription.CancellationReason = reason;
+        subscription.NextFeeBillingAtUtc = null;
+
+        if (immediately)
+        {
+            subscription.Status = SubscriptionStatus.Canceled;
+            subscription.EndedAtUtc = now;
+        }
+        else
+        {
+            subscription.CancelAtPeriodEnd = true;
+        }
+
+        return subscription;
+    }
+
+    private static SubscriptionOperationResult<SubscriptionResponse> Failure(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId) =>
+        SubscriptionOperationResult<SubscriptionResponse>.Failure(
+            kind,
+            errorCode,
+            errorMessage,
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
@@ -6,9 +6,16 @@ namespace Subscription.DomainService.Services;
 /// </summary>
 public sealed class SubscriptionChargeRequest
 {
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
     public string ProviderName { get; set; } = string.Empty;
 
     public string StoredPaymentMethodId { get; set; } = string.Empty;
+
+    /// <summary>The provider's customer id, for gateways that need one (e.g. a Stripe Invoice).</summary>
+    public string? ProviderCustomerId { get; set; }
 
     /// <summary>Minor units — converted to a decimal only inside the gateway implementation.</summary>
     public long AmountMinor { get; set; }

--- a/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
@@ -1,0 +1,21 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// What a renewal or dunning retry charges. Provider-neutral: <see cref="ProviderName"/> is
+/// whatever the subscription's <c>BillingAccount</c> names, not a hardcoded gateway.
+/// </summary>
+public sealed class SubscriptionChargeRequest
+{
+    public string ProviderName { get; set; } = string.Empty;
+
+    public string StoredPaymentMethodId { get; set; } = string.Empty;
+
+    /// <summary>Minor units — converted to a decimal only inside the gateway implementation.</summary>
+    public long AmountMinor { get; set; }
+
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    public string OrderId { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -167,8 +167,8 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                 SavePaymentMethod = true
             },
             // Derived from the subscription, so a retried request finds the same payment
-            // instead of raising a second one.
-            $"sub-init:{subscription.ItemId}",
+            // instead of raising a second one — and so the recovery sweep can find it too.
+            SubscriptionConstants.InitialChargeKeyFor(subscription.ItemId),
             correlationId,
             cancellationToken);
 

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -1,0 +1,278 @@
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Subscribing, end to end: create the record, then take the money if there is any to take.
+/// </summary>
+/// <remarks>
+/// Orchestration only. Building the subscription belongs to the creation service, computing the
+/// amount to the calculator, and moving money to the payment module — this decides the order
+/// and what to do when a step declines.
+/// </remarks>
+public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
+{
+    private readonly ISubscriptionCreationService _creation;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionPaymentLinkRepository _links;
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly ISubscriptionOutboxEventFactory _events;
+    private readonly ISubscriptionResponseMapper _mapper;
+    private readonly IPaymentService _payments;
+    private readonly ICurrencyMinorUnitResolver _currency;
+    private readonly ILogger<SubscriptionCheckoutService> _logger;
+
+    public SubscriptionCheckoutService(
+        ISubscriptionCreationService creation,
+        ISubscriptionRepository subscriptions,
+        ISubscriptionPaymentLinkRepository links,
+        ISubscriptionContextResolver contextResolver,
+        ISubscriptionOutboxEventFactory events,
+        ISubscriptionResponseMapper mapper,
+        IPaymentService payments,
+        ICurrencyMinorUnitResolver currency,
+        ILogger<SubscriptionCheckoutService> logger)
+    {
+        _creation = creation;
+        _subscriptions = subscriptions;
+        _links = links;
+        _contextResolver = contextResolver;
+        _events = events;
+        _mapper = mapper;
+        _payments = payments;
+        _currency = currency;
+        _logger = logger;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionResponse>> SubscribeAsync(
+        CreateSubscriptionRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+
+        var created = await _creation.CreateAsync(
+            request,
+            context,
+            correlationId,
+            cancellationToken);
+
+        if (!created.IsSuccess)
+        {
+            return created.ToFailure<SubscriptionResponse>();
+        }
+
+        var subscription = created.Value!;
+        var amountMinor = SubscriptionAmountCalculator.PeriodAmountMinor(subscription);
+
+        return RequiresPayment(subscription, amountMinor)
+            ? await ChargeAsync(subscription, amountMinor, correlationId, cancellationToken)
+            : await StartWithoutPaymentAsync(subscription, correlationId, cancellationToken);
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionResponse>> GetCurrentAsync(
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+
+        var subscription = await _subscriptions.GetLiveAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        return subscription is null
+            ? SubscriptionOperationResult<SubscriptionResponse>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "This organization has no active subscription.",
+                correlationId)
+            : SubscriptionOperationResult<SubscriptionResponse>.Success(
+                _mapper.ToResponse(subscription),
+                correlationId);
+    }
+
+    /// <summary>
+    /// Whether money has to move before this subscription grants anything.
+    /// </summary>
+    /// <remarks>
+    /// A card-free trial and a fully discounted first period both come to nothing payable, and
+    /// a zero-amount charge is not something the money path accepts — the currency resolver
+    /// refuses anything at or below zero. So these start directly rather than being sent to a
+    /// checkout that would decline them.
+    /// </remarks>
+    private static bool RequiresPayment(SubscriptionDetail subscription, long amountMinor)
+    {
+        if (subscription.Trial is { RequiresPaymentMethod: false })
+        {
+            return false;
+        }
+
+        return amountMinor > 0;
+    }
+
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>> ChargeAsync(
+        SubscriptionDetail subscription,
+        long amountMinor,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (!_currency.TryConvertBack(
+                amountMinor,
+                subscription.CurrencyCode,
+                out var amount))
+        {
+            return Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_currency_unsupported",
+                "This currency is not configured for payments.",
+                correlationId);
+        }
+
+        var payment = await _payments.MakePaymentAsync(
+            new MakePaymentRequest
+            {
+                ProviderName = PaymentConstants.StripeProvider,
+                Amount = amount,
+                CurrencyCode = subscription.CurrencyCode,
+                OrderId = subscription.OrderId,
+                Description = $"{subscription.Plan.DisplayName} subscription",
+                // The renewal in a month charges this card with nobody present, which the
+                // provider only permits if the mandate was established when it was saved.
+                SavePaymentMethod = true
+            },
+            // Derived from the subscription, so a retried request finds the same payment
+            // instead of raising a second one.
+            $"sub-init:{subscription.ItemId}",
+            correlationId,
+            cancellationToken);
+
+        if (!payment.IsSuccess || payment.Payment is null)
+        {
+            _logger.LogWarning(
+                "Subscription initial charge failed TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} Reason={Reason} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(payment.ErrorCode),
+                correlationId);
+
+            // The subscription stays incomplete and grants nothing. The customer can try
+            // again from a clean state, and the recovery sweep tidies it if they do not.
+            return Failure(
+                payment.FailureKind,
+                payment.ErrorCode,
+                payment.ErrorMessage,
+                correlationId);
+        }
+
+        await _links.TryCreateAsync(
+            new SubscriptionPaymentLink
+            {
+                TenantId = subscription.TenantId,
+                OrganizationId = subscription.OrganizationId,
+                SubscriptionId = subscription.ItemId,
+                PaymentDetailId = payment.Payment.PaymentDetailId,
+                OrderId = subscription.OrderId,
+                Purpose = SubscriptionPaymentPurpose.InitialCharge,
+                State = SubscriptionPaymentLinkState.Pending,
+                CorrelationId = correlationId
+            },
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Subscription checkout started TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
+            "PaymentHash={PaymentHash} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Hash(payment.Payment.PaymentDetailId),
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Success(
+            _mapper.ToResponse(subscription, payment.Payment.RedirectUrl),
+            correlationId);
+    }
+
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>> StartWithoutPaymentAsync(
+        SubscriptionDetail subscription,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var target = subscription.Trial is null
+            ? SubscriptionStatus.Active
+            : SubscriptionStatus.Trialing;
+
+        var eventType = target == SubscriptionStatus.Trialing
+            ? SubscriptionConstants.SubscriptionTrialStarted
+            : SubscriptionConstants.SubscriptionActivated;
+
+        var applied = await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            new SubscriptionTransition(SubscriptionStatus.Incomplete, target)
+            {
+                ActivatedAtUtc = DateTime.UtcNow,
+                Event = _events.Create(subscription, eventType, correlationId)
+            },
+            cancellationToken);
+
+        if (!applied)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_transition_conflict",
+                "The subscription changed while it was being started.",
+                correlationId);
+        }
+
+        subscription.Status = target;
+
+        _logger.LogInformation(
+            "Subscription started without payment TenantHash={TenantHash} " +
+            "SubscriptionHash={SubscriptionHash} Status={Status} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Label(target.ToString()),
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Success(
+            _mapper.ToResponse(subscription),
+            correlationId);
+    }
+
+    private static SubscriptionOperationResult<SubscriptionResponse> Failure(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId) =>
+        SubscriptionOperationResult<SubscriptionResponse>.Failure(
+            kind,
+            errorCode,
+            errorMessage,
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionContext.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionContext.cs
@@ -1,0 +1,14 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// The caller, resolved. Every value comes from the authenticated context, never the request.
+/// </summary>
+/// <remarks>
+/// Taking the organization from the request instead would let anyone read or change another
+/// organization's subscription by naming it, which no amount of filtering downstream can undo.
+/// </remarks>
+public sealed record SubscriptionContext(
+    string TenantId,
+    string OrganizationId,
+    string ActorId,
+    string? UserId);

--- a/server/Subscription.DomainService/Services/SubscriptionContextResolution.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionContextResolution.cs
@@ -1,0 +1,44 @@
+using Payment.DomainService.Enums;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// A resolved caller, or the failure explaining why there is none.
+/// </summary>
+public sealed class SubscriptionContextResolution
+{
+    private SubscriptionContextResolution()
+    {
+    }
+
+    public SubscriptionContext? Context { get; private init; }
+
+    public PaymentFailureKind FailureKind { get; private init; }
+
+    public string? ErrorCode { get; private init; }
+
+    public string? ErrorMessage { get; private init; }
+
+    public bool IsSuccess => Context is not null;
+
+    public static SubscriptionContextResolution Resolved(SubscriptionContext context) =>
+        new() { Context = context };
+
+    public static SubscriptionContextResolution Unresolved(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage) =>
+        new()
+        {
+            FailureKind = kind,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage
+        };
+
+    public SubscriptionOperationResult<TValue> ToFailure<TValue>(string correlationId) =>
+        SubscriptionOperationResult<TValue>.Failure(
+            FailureKind,
+            ErrorCode ?? "subscription_context_missing",
+            ErrorMessage ?? "The caller context is unavailable.",
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionContextResolver.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionContextResolver.cs
@@ -1,0 +1,46 @@
+using Payment.DomainService.Enums;
+using Payment.DomainService.Services;
+
+namespace Subscription.DomainService.Services;
+
+public sealed class SubscriptionContextResolver : ISubscriptionContextResolver
+{
+    private readonly IPaymentExecutionContextResolver _paymentContextResolver;
+
+    public SubscriptionContextResolver(
+        IPaymentExecutionContextResolver paymentContextResolver) =>
+        _paymentContextResolver = paymentContextResolver;
+
+    public SubscriptionContextResolution Resolve(string correlationId)
+    {
+        var resolution = _paymentContextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Unavailable,
+                "subscription_context_missing",
+                "Authenticated tenant context is unavailable.");
+        }
+
+        var context = resolution.Context;
+
+        if (string.IsNullOrWhiteSpace(context.OrganizationId))
+        {
+            // Fails closed rather than falling back to tenant-wide scope. A subscription
+            // belongs to an organization, so a caller without one has nothing to be told about
+            // — and answering anyway would mean answering for somebody else.
+            return SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Unavailable,
+                "subscription_organization_missing",
+                "An organization is required to resolve a subscription.");
+        }
+
+        return SubscriptionContextResolution.Resolved(
+            new SubscriptionContext(
+                context.TenantId,
+                context.OrganizationId,
+                context.ActorId,
+                context.UserId));
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -71,7 +71,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         }
 
         var (plan, price) = terms.Value;
-        var quantities = BuildQuantities(request, plan, price);
+        var quantities = SubscriptionQuantityBuilder.Build(request.Quantities, plan, price);
 
         if (quantities is null)
         {
@@ -199,59 +199,6 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         return SubscriptionOperationResult<(Plan, Price)>.Success(
             (plan, price),
             correlationId);
-    }
-
-    /// <summary>
-    /// Matches requested quantities to the plan's items, filling in defaults for anything the
-    /// caller left out and refusing anything outside the plan's bounds.
-    /// </summary>
-    private static List<SubscriptionQuantityItem>? BuildQuantities(
-        CreateSubscriptionRequest request,
-        Plan plan,
-        Price price)
-    {
-        var requested = request.Quantities.ToDictionary(
-            quantity => quantity.ItemKey,
-            quantity => quantity.Quantity,
-            StringComparer.Ordinal);
-
-        if (requested.Keys.Any(key =>
-                !plan.QuantityItems.Exists(item =>
-                    string.Equals(item.ItemKey, key, StringComparison.Ordinal))))
-        {
-            return null;
-        }
-
-        var items = new List<SubscriptionQuantityItem>(plan.QuantityItems.Count);
-
-        foreach (var item in plan.QuantityItems)
-        {
-            var quantity = requested.TryGetValue(item.ItemKey, out var supplied)
-                ? supplied
-                : item.DefaultQuantity;
-
-            if (quantity < item.MinQuantity ||
-                (item.MaxQuantity is { } maximum && quantity > maximum))
-            {
-                return null;
-            }
-
-            items.Add(new SubscriptionQuantityItem
-            {
-                ItemKey = item.ItemKey,
-                UnitLabel = item.UnitLabel,
-                Quantity = quantity,
-                // Snapshotted so a later catalogue edit cannot move what this subscriber pays.
-                UnitAmountMinor = string.Equals(
-                    item.ItemKey,
-                    price.QuantityItemKey,
-                    StringComparison.Ordinal)
-                    ? price.UnitAmountMinor
-                    : 0
-            });
-        }
-
-        return items;
     }
 
     private static SubscriptionDetail BuildSubscription(

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -1,0 +1,412 @@
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Turns a chosen plan and price into a stored subscription.
+/// </summary>
+public sealed class SubscriptionCreationService : ISubscriptionCreationService
+{
+    private const string StripeProvider = PaymentConstants.StripeProvider;
+
+    private readonly ISubscriptionCatalogueRepository _catalogue;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly IBillingAccountRepository _billingAccounts;
+    private readonly IValidator<CreateSubscriptionRequest> _validator;
+    private readonly ILogger<SubscriptionCreationService> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionCreationService(
+        ISubscriptionCatalogueRepository catalogue,
+        ISubscriptionRepository subscriptions,
+        IBillingAccountRepository billingAccounts,
+        IValidator<CreateSubscriptionRequest> validator,
+        ILogger<SubscriptionCreationService> logger,
+        TimeProvider? time = null)
+    {
+        _catalogue = catalogue;
+        _subscriptions = subscriptions;
+        _billingAccounts = billingAccounts;
+        _validator = validator;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionDetail>> CreateAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var invalid = await SubscriptionValidation
+            .CheckAsync<CreateSubscriptionRequest, SubscriptionDetail>(
+                _validator,
+                request,
+                "subscription_request_invalid",
+                "The subscription request is invalid.",
+                correlationId,
+                cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var terms = await ResolveTermsAsync(request, context, correlationId, cancellationToken);
+
+        if (!terms.IsSuccess)
+        {
+            return terms.ToFailure<SubscriptionDetail>();
+        }
+
+        var (plan, price) = terms.Value;
+        var quantities = BuildQuantities(request, plan, price);
+
+        if (quantities is null)
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_quantity_invalid",
+                "The quantities do not match the plan's items or fall outside their bounds.",
+                correlationId);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (!BillingPeriodCalculator.TryCreateSchedule(
+                price.Interval,
+                price.IntervalCount,
+                now,
+                request.TimeZoneId,
+                out var feeSchedule) ||
+            !BillingPeriodCalculator.TryCreateSchedule(
+                BillingInterval.Month,
+                1,
+                now,
+                request.TimeZoneId,
+                out var usageSchedule))
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_schedule_invalid",
+                "The billing schedule could not be derived from this time zone.",
+                correlationId);
+        }
+
+        var account = await _billingAccounts.GetOrCreateAsync(
+            new BillingAccount
+            {
+                TenantId = context.TenantId,
+                OrganizationId = context.OrganizationId,
+                ProviderName = StripeProvider,
+                BillingEmail = request.BillingEmail,
+                BillingName = request.BillingName
+            },
+            cancellationToken);
+
+        var subscription = BuildSubscription(
+            context,
+            plan,
+            price,
+            quantities,
+            account,
+            feeSchedule,
+            usageSchedule,
+            now,
+            correlationId);
+
+        if (!ApplyPeriods(subscription, now))
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_schedule_invalid",
+                "The billing periods could not be computed for this schedule.",
+                correlationId);
+        }
+
+        if (!await _subscriptions.TryCreateAsync(subscription, cancellationToken))
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_already_active",
+                "This organization already has a live subscription.",
+                correlationId);
+        }
+
+        _logger.LogInformation(
+            "Subscription created TenantHash={TenantHash} OrganizationHash={OrganizationHash} " +
+            "SubscriptionHash={SubscriptionHash} Plan={Plan} Status={Status} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(context.OrganizationId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Label(plan.Code),
+            PaymentLogValue.Label(subscription.Status.ToString()),
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionDetail>.Success(
+            subscription,
+            correlationId);
+    }
+
+    private async Task<SubscriptionOperationResult<(Plan Plan, Price Price)>> ResolveTermsAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var plan = await _catalogue.FindPlanByCodeAsync(
+            context.TenantId,
+            context.OrganizationId,
+            request.PlanCode,
+            cancellationToken);
+
+        if (plan is null)
+        {
+            return SubscriptionOperationResult<(Plan, Price)>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_plan_not_found",
+                "The plan does not exist or is not on sale.",
+                correlationId);
+        }
+
+        var price = await _catalogue.GetPriceAsync(
+            context.TenantId,
+            request.PriceId,
+            cancellationToken);
+
+        if (price is null ||
+            !string.Equals(price.PlanId, plan.ItemId, StringComparison.Ordinal) ||
+            price.Status != CatalogueStatus.Active)
+        {
+            return SubscriptionOperationResult<(Plan, Price)>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_price_not_found",
+                "The price does not exist for this plan.",
+                correlationId);
+        }
+
+        return SubscriptionOperationResult<(Plan, Price)>.Success(
+            (plan, price),
+            correlationId);
+    }
+
+    /// <summary>
+    /// Matches requested quantities to the plan's items, filling in defaults for anything the
+    /// caller left out and refusing anything outside the plan's bounds.
+    /// </summary>
+    private static List<SubscriptionQuantityItem>? BuildQuantities(
+        CreateSubscriptionRequest request,
+        Plan plan,
+        Price price)
+    {
+        var requested = request.Quantities.ToDictionary(
+            quantity => quantity.ItemKey,
+            quantity => quantity.Quantity,
+            StringComparer.Ordinal);
+
+        if (requested.Keys.Any(key =>
+                !plan.QuantityItems.Exists(item =>
+                    string.Equals(item.ItemKey, key, StringComparison.Ordinal))))
+        {
+            return null;
+        }
+
+        var items = new List<SubscriptionQuantityItem>(plan.QuantityItems.Count);
+
+        foreach (var item in plan.QuantityItems)
+        {
+            var quantity = requested.TryGetValue(item.ItemKey, out var supplied)
+                ? supplied
+                : item.DefaultQuantity;
+
+            if (quantity < item.MinQuantity ||
+                (item.MaxQuantity is { } maximum && quantity > maximum))
+            {
+                return null;
+            }
+
+            items.Add(new SubscriptionQuantityItem
+            {
+                ItemKey = item.ItemKey,
+                UnitLabel = item.UnitLabel,
+                Quantity = quantity,
+                // Snapshotted so a later catalogue edit cannot move what this subscriber pays.
+                UnitAmountMinor = string.Equals(
+                    item.ItemKey,
+                    price.QuantityItemKey,
+                    StringComparison.Ordinal)
+                    ? price.UnitAmountMinor
+                    : 0
+            });
+        }
+
+        return items;
+    }
+
+    private static SubscriptionDetail BuildSubscription(
+        SubscriptionContext context,
+        Plan plan,
+        Price price,
+        List<SubscriptionQuantityItem> quantities,
+        BillingAccount account,
+        BillingSchedule feeSchedule,
+        BillingSchedule usageSchedule,
+        DateTime now,
+        string correlationId)
+    {
+        var subscriptionId = Guid.NewGuid().ToString();
+
+        return new SubscriptionDetail
+        {
+            ItemId = subscriptionId,
+            TenantId = context.TenantId,
+            OrganizationId = context.OrganizationId,
+            BillingAccountId = account.ItemId,
+            Status = SubscriptionStatus.Incomplete,
+            CurrencyCode = price.CurrencyCode,
+            Plan = SnapshotOf(plan),
+            Price = SnapshotOf(price),
+            QuantityItems = quantities,
+            FeeSchedule = feeSchedule,
+            UsageSchedule = usageSchedule,
+            Trial = BuildTrial(plan, now),
+            OrderId = SubscriptionConstants.OrderIdFor(subscriptionId),
+            CorrelationId = correlationId,
+            CreatedAtUtc = now,
+            LastUpdatedDateUtc = now
+        };
+    }
+
+    private static TrialTerms? BuildTrial(Plan plan, DateTime now) =>
+        plan.TrialDays is not { } days
+            ? null
+            : new TrialTerms
+            {
+                StartsAtUtc = now,
+                EndsAtUtc = now.AddDays(days),
+                RequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
+                Grants = plan.TrialGrants
+                    .Select(grant => new TrialMeterGrant
+                    {
+                        MeterKey = grant.MeterKey,
+                        IncludedQuantity = grant.IncludedQuantity
+                    })
+                    .ToList()
+            };
+
+    private static bool ApplyPeriods(SubscriptionDetail subscription, DateTime now)
+    {
+        if (!BillingPeriodCalculator.TryGetPeriod(
+                subscription.FeeSchedule,
+                now,
+                out var feePeriod) ||
+            !BillingPeriodCalculator.TryGetPeriod(
+                subscription.UsageSchedule,
+                now,
+                out var usagePeriod))
+        {
+            return false;
+        }
+
+        subscription.CurrentPeriodStartUtc = feePeriod.StartUtc;
+        subscription.CurrentPeriodEndUtc = feePeriod.EndUtc;
+        subscription.NextFeeBillingAtUtc = subscription.Trial?.EndsAtUtc ?? feePeriod.EndUtc;
+        subscription.CurrentUsagePeriodStartUtc = usagePeriod.StartUtc;
+        subscription.CurrentUsagePeriodEndUtc = usagePeriod.EndUtc;
+        subscription.NextUsageBillingAtUtc = usagePeriod.EndUtc;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Copies the plan's terms onto the subscription. A copy, not a reference: editing the
+    /// catalogue afterwards must not change what an existing subscriber is entitled to or
+    /// charged.
+    /// </summary>
+    private static PlanSnapshot SnapshotOf(Plan plan) => new()
+    {
+        PlanId = plan.ItemId,
+        Code = plan.Code,
+        DisplayName = plan.DisplayName,
+        FeaturesJson = plan.FeaturesJson,
+        PlanVersion = plan.Version,
+        Entitlements = plan.Entitlements
+            .Select(entitlement => new PlanEntitlement
+            {
+                Key = entitlement.Key,
+                LimitKind = entitlement.LimitKind,
+                Limit = entitlement.Limit,
+                MeterKey = entitlement.MeterKey,
+                UnitLabel = entitlement.UnitLabel
+            })
+            .ToList(),
+        Meters = plan.Meters
+            .Select(meter => new PlanMeter
+            {
+                MeterKey = meter.MeterKey,
+                DisplayName = meter.DisplayName,
+                UnitLabel = meter.UnitLabel,
+                Aggregation = meter.Aggregation,
+                IncludedQuantity = meter.IncludedQuantity,
+                OverageAllowed = meter.OverageAllowed,
+                ThresholdPercents = [.. meter.ThresholdPercents],
+                RateTables = meter.RateTables
+                    .Select(table => new MeterRateTable
+                    {
+                        CurrencyCode = table.CurrencyCode,
+                        Tiers = table.Tiers
+                            .Select(tier => new MeterTier
+                            {
+                                UpToQuantity = tier.UpToQuantity,
+                                UnitAmountMinor = tier.UnitAmountMinor
+                            })
+                            .ToList()
+                    })
+                    .ToList()
+            })
+            .ToList(),
+        QuantityItems = plan.QuantityItems
+            .Select(item => new PlanQuantityItem
+            {
+                ItemKey = item.ItemKey,
+                UnitLabel = item.UnitLabel,
+                MinQuantity = item.MinQuantity,
+                MaxQuantity = item.MaxQuantity,
+                DefaultQuantity = item.DefaultQuantity
+            })
+            .ToList()
+    };
+
+    private static PriceSnapshot SnapshotOf(Price price) => new()
+    {
+        PriceId = price.ItemId,
+        CurrencyCode = price.CurrencyCode,
+        UnitAmountMinor = price.UnitAmountMinor,
+        Interval = price.Interval,
+        IntervalCount = price.IntervalCount,
+        QuantityItemKey = price.QuantityItemKey,
+        PriceVersion = price.Version
+    };
+
+    private static SubscriptionOperationResult<SubscriptionDetail> Failure(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId) =>
+        SubscriptionOperationResult<SubscriptionDetail>.Failure(
+            kind,
+            errorCode,
+            errorMessage,
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -222,8 +222,8 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             BillingAccountId = account.ItemId,
             Status = SubscriptionStatus.Incomplete,
             CurrencyCode = price.CurrencyCode,
-            Plan = SnapshotOf(plan),
-            Price = SnapshotOf(price),
+            Plan = SubscriptionSnapshotBuilder.SnapshotOf(plan),
+            Price = SubscriptionSnapshotBuilder.SnapshotOf(price),
             QuantityItems = quantities,
             FeeSchedule = feeSchedule,
             UsageSchedule = usageSchedule,
@@ -275,76 +275,6 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         return true;
     }
-
-    /// <summary>
-    /// Copies the plan's terms onto the subscription. A copy, not a reference: editing the
-    /// catalogue afterwards must not change what an existing subscriber is entitled to or
-    /// charged.
-    /// </summary>
-    private static PlanSnapshot SnapshotOf(Plan plan) => new()
-    {
-        PlanId = plan.ItemId,
-        Code = plan.Code,
-        DisplayName = plan.DisplayName,
-        FeaturesJson = plan.FeaturesJson,
-        PlanVersion = plan.Version,
-        Entitlements = plan.Entitlements
-            .Select(entitlement => new PlanEntitlement
-            {
-                Key = entitlement.Key,
-                LimitKind = entitlement.LimitKind,
-                Limit = entitlement.Limit,
-                MeterKey = entitlement.MeterKey,
-                UnitLabel = entitlement.UnitLabel
-            })
-            .ToList(),
-        Meters = plan.Meters
-            .Select(meter => new PlanMeter
-            {
-                MeterKey = meter.MeterKey,
-                DisplayName = meter.DisplayName,
-                UnitLabel = meter.UnitLabel,
-                Aggregation = meter.Aggregation,
-                IncludedQuantity = meter.IncludedQuantity,
-                OverageAllowed = meter.OverageAllowed,
-                ThresholdPercents = [.. meter.ThresholdPercents],
-                RateTables = meter.RateTables
-                    .Select(table => new MeterRateTable
-                    {
-                        CurrencyCode = table.CurrencyCode,
-                        Tiers = table.Tiers
-                            .Select(tier => new MeterTier
-                            {
-                                UpToQuantity = tier.UpToQuantity,
-                                UnitAmountMinor = tier.UnitAmountMinor
-                            })
-                            .ToList()
-                    })
-                    .ToList()
-            })
-            .ToList(),
-        QuantityItems = plan.QuantityItems
-            .Select(item => new PlanQuantityItem
-            {
-                ItemKey = item.ItemKey,
-                UnitLabel = item.UnitLabel,
-                MinQuantity = item.MinQuantity,
-                MaxQuantity = item.MaxQuantity,
-                DefaultQuantity = item.DefaultQuantity
-            })
-            .ToList()
-    };
-
-    private static PriceSnapshot SnapshotOf(Price price) => new()
-    {
-        PriceId = price.ItemId,
-        CurrencyCode = price.CurrencyCode,
-        UnitAmountMinor = price.UnitAmountMinor,
-        Interval = price.Interval,
-        IntervalCount = price.IntervalCount,
-        QuantityItemKey = price.QuantityItemKey,
-        PriceVersion = price.Version
-    };
 
     private static SubscriptionOperationResult<SubscriptionDetail> Failure(
         PaymentFailureKind kind,

--- a/server/Subscription.DomainService/Services/SubscriptionOperationResult.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionOperationResult.cs
@@ -1,0 +1,76 @@
+using Payment.DomainService.Enums;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// What a subscription operation returns, whether or not it worked.
+/// </summary>
+/// <remarks>
+/// Expected failures are values, not exceptions. A plan that does not exist, a version that has
+/// moved on, a quota that is used up — these are ordinary outcomes of a working system, and
+/// throwing for them turns control flow into stack traces and loses the error code the caller
+/// needs.
+/// <para>
+/// <see cref="PaymentFailureKind"/> is reused rather than duplicated. It is already
+/// domain-neutral, and sharing it means the subscription controllers map failures to status
+/// codes with exactly the same switch the payment controllers use.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionOperationResult<TValue>
+{
+    private SubscriptionOperationResult()
+    {
+    }
+
+    public bool IsSuccess { get; private init; }
+
+    public TValue? Value { get; private init; }
+
+    public PaymentFailureKind FailureKind { get; private init; }
+
+    public string? ErrorCode { get; private init; }
+
+    public string? ErrorMessage { get; private init; }
+
+    public IReadOnlyDictionary<string, string[]>? ValidationErrors { get; private init; }
+
+    public string CorrelationId { get; private init; } = string.Empty;
+
+    public static SubscriptionOperationResult<TValue> Success(
+        TValue value,
+        string correlationId) =>
+        new()
+        {
+            IsSuccess = true,
+            Value = value,
+            CorrelationId = correlationId
+        };
+
+    public static SubscriptionOperationResult<TValue> Failure(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId,
+        IReadOnlyDictionary<string, string[]>? validationErrors = null) =>
+        new()
+        {
+            IsSuccess = false,
+            FailureKind = kind,
+            ErrorCode = errorCode,
+            ErrorMessage = errorMessage,
+            CorrelationId = correlationId,
+            ValidationErrors = validationErrors
+        };
+
+    /// <summary>
+    /// Carries a failure across a change of payload type, so an orchestrating service can
+    /// return an inner failure without restating its code and message.
+    /// </summary>
+    public SubscriptionOperationResult<TOther> ToFailure<TOther>() =>
+        SubscriptionOperationResult<TOther>.Failure(
+            FailureKind,
+            ErrorCode ?? "subscription_failed",
+            ErrorMessage ?? "The subscription operation failed.",
+            CorrelationId,
+            ValidationErrors);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -1,0 +1,354 @@
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Moves a live subscription to a different price, mid-period.
+/// </summary>
+/// <remarks>
+/// A trial has paid nothing yet, so its plan simply swaps. Otherwise the change is priced by
+/// <see cref="SubscriptionProrationCalculator"/> and, if that leaves something owing, charged
+/// immediately through the same <see cref="ISubscriptionBillingGateway"/> a renewal uses — this
+/// is the seam's third caller, after the renewal service and (indirectly) the checkout service's
+/// sibling money path.
+/// <para>
+/// Restricted to a same-currency, same-billing-interval target price. A different interval would
+/// mean rebuilding the fee schedule and the current period boundaries mid-flight — a separate,
+/// harder problem this does not attempt.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeService
+{
+    private static readonly SubscriptionStatus[] EligibleStatuses =
+    [
+        SubscriptionStatus.Trialing,
+        SubscriptionStatus.Active
+    ];
+
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionCatalogueRepository _catalogue;
+    private readonly IBillingAccountRepository _billingAccounts;
+    private readonly ISubscriptionBillingGateway _gateway;
+    private readonly ISubscriptionOutboxEventFactory _events;
+    private readonly IEntitlementSnapshotCache _cache;
+    private readonly ISubscriptionResponseMapper _mapper;
+    private readonly IValidator<ChangeSubscriptionPlanRequest> _validator;
+    private readonly ILogger<SubscriptionPlanChangeService> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionPlanChangeService(
+        ISubscriptionContextResolver contextResolver,
+        ISubscriptionRepository subscriptions,
+        ISubscriptionCatalogueRepository catalogue,
+        IBillingAccountRepository billingAccounts,
+        ISubscriptionBillingGateway gateway,
+        ISubscriptionOutboxEventFactory events,
+        IEntitlementSnapshotCache cache,
+        ISubscriptionResponseMapper mapper,
+        IValidator<ChangeSubscriptionPlanRequest> validator,
+        ILogger<SubscriptionPlanChangeService> logger,
+        TimeProvider? time = null)
+    {
+        _contextResolver = contextResolver;
+        _subscriptions = subscriptions;
+        _catalogue = catalogue;
+        _billingAccounts = billingAccounts;
+        _gateway = gateway;
+        _events = events;
+        _cache = cache;
+        _mapper = mapper;
+        _validator = validator;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionResponse>> ChangePlanAsync(
+        string subscriptionId,
+        ChangeSubscriptionPlanRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var invalid = await SubscriptionValidation
+            .CheckAsync<ChangeSubscriptionPlanRequest, SubscriptionResponse>(
+                _validator,
+                request,
+                "subscription_plan_change_invalid",
+                "The plan change request is invalid.",
+                correlationId,
+                cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+
+        var subscription = await _subscriptions.GetAsync(
+            context.TenantId,
+            context.OrganizationId,
+            subscriptionId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "The subscription does not exist.",
+                correlationId);
+        }
+
+        if (!EligibleStatuses.Contains(subscription.Status))
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_change_not_eligible",
+                "This subscription cannot change plan in its current state.",
+                correlationId);
+        }
+
+        var terms = await ResolveTargetAsync(request, context, subscription, correlationId, cancellationToken);
+
+        if (!terms.IsSuccess)
+        {
+            return terms.ToFailure<SubscriptionResponse>();
+        }
+
+        var (plan, price) = terms.Value;
+        var quantities = SubscriptionQuantityBuilder.Build(request.Quantities, plan, price);
+
+        if (quantities is null)
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_quantity_invalid",
+                "The quantities do not match the plan's items or fall outside their bounds.",
+                correlationId);
+        }
+
+        var newPlan = SubscriptionSnapshotBuilder.SnapshotOf(plan);
+        var newPrice = SubscriptionSnapshotBuilder.SnapshotOf(price);
+
+        return subscription.Status == SubscriptionStatus.Trialing
+            ? await ApplyAsync(
+                subscription, newPlan, newPrice, quantities,
+                subscription.CreditBalanceMinor, null, correlationId, cancellationToken)
+            : await ChargeAndApplyAsync(
+                subscription, newPlan, newPrice, quantities, correlationId, cancellationToken);
+    }
+
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>> ChargeAndApplyAsync(
+        SubscriptionDetail subscription,
+        PlanSnapshot newPlan,
+        PriceSnapshot newPrice,
+        List<SubscriptionQuantityItem> quantities,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+        var outcome = SubscriptionProrationCalculator.Calculate(subscription, newPrice, quantities, now);
+
+        if (outcome.ChargeMinor <= 0)
+        {
+            return await ApplyAsync(
+                subscription, newPlan, newPrice, quantities,
+                outcome.NewCreditBalanceMinor, null, correlationId, cancellationToken);
+        }
+
+        var account = await _billingAccounts.GetAsync(
+            subscription.TenantId,
+            subscription.BillingAccountId,
+            cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(account?.DefaultPaymentMethodId))
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_change_no_payment_method",
+                "This upgrade cannot be charged without a saved payment method.",
+                correlationId);
+        }
+
+        var charge = await _gateway.ChargeAsync(
+            new SubscriptionChargeRequest
+            {
+                TenantId = subscription.TenantId,
+                OrganizationId = subscription.OrganizationId,
+                ProviderName = account.ProviderName,
+                StoredPaymentMethodId = account.DefaultPaymentMethodId,
+                ProviderCustomerId = account.ProviderCustomerId,
+                AmountMinor = outcome.ChargeMinor,
+                CurrencyCode = subscription.CurrencyCode,
+                OrderId = SubscriptionConstants.PlanChangeOrderIdFor(
+                    subscription.ItemId,
+                    subscription.Version),
+                Description = $"{newPlan.DisplayName} plan change"
+            },
+            SubscriptionConstants.PlanChangeKeyFor(subscription.ItemId, subscription.Version),
+            correlationId,
+            cancellationToken);
+
+        if (!charge.IsSuccess)
+        {
+            _logger.LogWarning(
+                "Subscription plan change declined TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} Reason={Reason}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(charge.ErrorCode ?? "unknown"));
+
+            return charge.ToFailure<SubscriptionResponse>();
+        }
+
+        return await ApplyAsync(
+            subscription, newPlan, newPrice, quantities,
+            outcome.NewCreditBalanceMinor, charge.Value, correlationId, cancellationToken);
+    }
+
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>> ApplyAsync(
+        SubscriptionDetail subscription,
+        PlanSnapshot newPlan,
+        PriceSnapshot newPrice,
+        List<SubscriptionQuantityItem> quantities,
+        long newCreditBalanceMinor,
+        string? paymentDetailId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var previousPlanCode = subscription.Plan.Code;
+        var expectedVersion = subscription.Version;
+
+        subscription.Plan = newPlan;
+        subscription.Price = newPrice;
+        subscription.QuantityItems = quantities;
+        subscription.CreditBalanceMinor = newCreditBalanceMinor;
+
+        var applied = await _subscriptions.TryChangePlanAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            expectedVersion,
+            newPlan,
+            newPrice,
+            quantities,
+            newCreditBalanceMinor,
+            paymentDetailId,
+            _events.CreatePlanChanged(subscription, previousPlanCode, correlationId),
+            cancellationToken);
+
+        if (!applied)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_change_conflict",
+                "The subscription changed while this plan change was being applied.",
+                correlationId);
+        }
+
+        _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);
+
+        _logger.LogInformation(
+            "Subscription plan changed TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
+            "PreviousPlan={PreviousPlan} NewPlan={NewPlan} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Label(previousPlanCode),
+            PaymentLogValue.Label(newPlan.Code),
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Success(
+            _mapper.ToResponse(subscription),
+            correlationId);
+    }
+
+    private async Task<SubscriptionOperationResult<(Plan Plan, Price Price)>> ResolveTargetAsync(
+        ChangeSubscriptionPlanRequest request,
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var plan = await _catalogue.FindPlanByCodeAsync(
+            context.TenantId,
+            context.OrganizationId,
+            request.PlanCode,
+            cancellationToken);
+
+        if (plan is null)
+        {
+            return SubscriptionOperationResult<(Plan, Price)>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_plan_not_found",
+                "The plan does not exist or is not on sale.",
+                correlationId);
+        }
+
+        var price = await _catalogue.GetPriceAsync(
+            context.TenantId,
+            request.PriceId,
+            cancellationToken);
+
+        if (price is null ||
+            !string.Equals(price.PlanId, plan.ItemId, StringComparison.Ordinal) ||
+            price.Status != CatalogueStatus.Active)
+        {
+            return SubscriptionOperationResult<(Plan, Price)>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_price_not_found",
+                "The price does not exist for this plan.",
+                correlationId);
+        }
+
+        if (!string.Equals(price.CurrencyCode, subscription.CurrencyCode, StringComparison.Ordinal))
+        {
+            return SubscriptionOperationResult<(Plan, Price)>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_plan_change_currency_mismatch",
+                "A subscription cannot change to a price in a different currency.",
+                correlationId);
+        }
+
+        if (price.Interval != subscription.Price.Interval ||
+            price.IntervalCount != subscription.Price.IntervalCount)
+        {
+            return SubscriptionOperationResult<(Plan, Price)>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_plan_change_interval_mismatch",
+                "A subscription cannot change to a price with a different billing interval.",
+                correlationId);
+        }
+
+        return SubscriptionOperationResult<(Plan, Price)>.Success((plan, price), correlationId);
+    }
+
+    private static SubscriptionOperationResult<SubscriptionResponse> Failure(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId) =>
+        SubscriptionOperationResult<SubscriptionResponse>.Failure(
+            kind,
+            errorCode,
+            errorMessage,
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -1,0 +1,88 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// What a mid-period plan change costs, or credits, right now.
+/// </summary>
+/// <remarks>
+/// Pure and static, like <see cref="SubscriptionAmountCalculator"/> — the instant is always a
+/// parameter. Both the old and new amounts go through the exact same gross-and-discount math a
+/// renewal uses (<see cref="SubscriptionAmountCalculator.GrossAmountMinor"/> and
+/// <see cref="SubscriptionAmountCalculator.ApplyDiscount"/>), just against two different
+/// price/quantity pairs — the subscriber's discount belongs to them, not the plan, so it applies
+/// to both sides identically.
+/// </remarks>
+public static class SubscriptionProrationCalculator
+{
+    public static ProrationOutcome Calculate(
+        SubscriptionDetail subscription,
+        PriceSnapshot targetPrice,
+        IReadOnlyList<SubscriptionQuantityItem> targetQuantityItems,
+        DateTime nowUtc)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+        ArgumentNullException.ThrowIfNull(targetPrice);
+        ArgumentNullException.ThrowIfNull(targetQuantityItems);
+
+        var totalTicks = (subscription.CurrentPeriodEndUtc - subscription.CurrentPeriodStartUtc).Ticks;
+
+        if (totalTicks <= 0)
+        {
+            // A malformed period grants nothing either way rather than dividing by zero or
+            // guessing — the caller should not have reached here with one.
+            return new ProrationOutcome(0, subscription.CreditBalanceMinor);
+        }
+
+        var remainingTicks = Math.Clamp(
+            (subscription.CurrentPeriodEndUtc - nowUtc).Ticks,
+            0,
+            totalTicks);
+
+        var oldGross = SubscriptionAmountCalculator.GrossAmountMinor(
+            subscription.Price,
+            subscription.QuantityItems);
+        var oldDiscounted = SubscriptionAmountCalculator.ApplyDiscount(
+            oldGross,
+            subscription.Discount,
+            subscription.DiscountPeriodsApplied,
+            nowUtc);
+
+        var newGross = SubscriptionAmountCalculator.GrossAmountMinor(targetPrice, targetQuantityItems);
+        var newDiscounted = SubscriptionAmountCalculator.ApplyDiscount(
+            newGross,
+            subscription.Discount,
+            subscription.DiscountPeriodsApplied,
+            nowUtc);
+
+        var oldRemainingValue = Prorate(oldDiscounted.AmountMinor, remainingTicks, totalTicks);
+        var newRemainingCost = Prorate(newDiscounted.AmountMinor, remainingTicks, totalTicks);
+
+        var rawDelta = newRemainingCost - oldRemainingValue;
+        var netAfterCredit = rawDelta - subscription.CreditBalanceMinor;
+
+        return netAfterCredit > 0
+            ? new ProrationOutcome(netAfterCredit, 0)
+            : new ProrationOutcome(0, -netAfterCredit);
+    }
+
+    /// <summary>
+    /// Scales an amount by the fraction of the period remaining, in exact integer arithmetic.
+    /// </summary>
+    /// <remarks>
+    /// <c>amount * remainingTicks</c> overflows a <see cref="long"/> long before the numbers
+    /// involved look unreasonable — a year-long period is already ~3×10^14 ticks. Widening to
+    /// <see cref="Int128"/> for the multiplication keeps this exact rather than reaching for a
+    /// floating-point ratio, which the rest of this module's money arithmetic deliberately never
+    /// does.
+    /// </remarks>
+    private static long Prorate(long amountMinor, long remainingTicks, long totalTicks) =>
+        (long)((Int128)amountMinor * remainingTicks / totalTicks);
+}
+
+/// <param name="ChargeMinor">What to charge now. Zero when the change is fully covered by credit.</param>
+/// <param name="NewCreditBalanceMinor">
+/// The credit balance to write back — either fully consumed (zero) or increased by an amount a
+/// downgrade could not immediately spend.
+/// </param>
+public readonly record struct ProrationOutcome(long ChargeMinor, long NewCreditBalanceMinor);

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -7,11 +7,13 @@ namespace Subscription.DomainService.Services;
 /// </summary>
 /// <remarks>
 /// Pure and static, like <see cref="SubscriptionAmountCalculator"/> — the instant is always a
-/// parameter. Both the old and new amounts go through the exact same gross-and-discount math a
-/// renewal uses (<see cref="SubscriptionAmountCalculator.GrossAmountMinor"/> and
-/// <see cref="SubscriptionAmountCalculator.ApplyDiscount"/>), just against two different
-/// price/quantity pairs — the subscriber's discount belongs to them, not the plan, so it applies
-/// to both sides identically.
+/// parameter. Both the old and new amounts go through the exact same gross, discount and tax math
+/// a renewal uses (<see cref="SubscriptionAmountCalculator.GrossAmountMinor"/>,
+/// <see cref="SubscriptionAmountCalculator.ApplyDiscount"/>,
+/// <see cref="SubscriptionAmountCalculator.TaxAmountMinor"/>), just against two different
+/// price/quantity pairs. The discount is the subscriber's, not the plan's, so it applies to both
+/// sides identically — but tax is each side's own price's rate, since a plan change can move the
+/// subscriber to a differently-taxed price.
 /// </remarks>
 public static class SubscriptionProrationCalculator
 {
@@ -55,8 +57,17 @@ public static class SubscriptionProrationCalculator
             subscription.DiscountPeriodsApplied,
             nowUtc);
 
-        var oldRemainingValue = Prorate(oldDiscounted.AmountMinor, remainingTicks, totalTicks);
-        var newRemainingCost = Prorate(newDiscounted.AmountMinor, remainingTicks, totalTicks);
+        // Each side taxed at its own price's rate — not necessarily the same rate, if the plan
+        // change also moves the subscriber to a differently-taxed price.
+        var oldTaxInclusive = oldDiscounted.AmountMinor + SubscriptionAmountCalculator.TaxAmountMinor(
+            oldDiscounted.AmountMinor,
+            subscription.Price.TaxRateBasisPoints);
+        var newTaxInclusive = newDiscounted.AmountMinor + SubscriptionAmountCalculator.TaxAmountMinor(
+            newDiscounted.AmountMinor,
+            targetPrice.TaxRateBasisPoints);
+
+        var oldRemainingValue = Prorate(oldTaxInclusive, remainingTicks, totalTicks);
+        var newRemainingCost = Prorate(newTaxInclusive, remainingTicks, totalTicks);
 
         var rawDelta = newRemainingCost - oldRemainingValue;
         var netAfterCredit = rawDelta - subscription.CreditBalanceMinor;

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityBuilder.cs
@@ -1,0 +1,70 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Matches requested quantities to a plan's items, snapshotting each at the price it was bought
+/// at. Shared by subscribing and by changing plan — both are "pick a plan and some quantities,"
+/// and the bounds-checking has to agree in both places or a plan change could grant what
+/// signing up would have refused.
+/// </summary>
+internal static class SubscriptionQuantityBuilder
+{
+    /// <summary>
+    /// Fills in defaults for anything the caller left out and refuses anything outside the
+    /// plan's bounds or naming an item the plan does not have.
+    /// </summary>
+    public static List<SubscriptionQuantityItem>? Build(
+        IReadOnlyList<SubscriptionQuantityRequest> requested,
+        Plan plan,
+        Price price)
+    {
+        ArgumentNullException.ThrowIfNull(requested);
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(price);
+
+        var requestedByKey = requested.ToDictionary(
+            quantity => quantity.ItemKey,
+            quantity => quantity.Quantity,
+            StringComparer.Ordinal);
+
+        if (requestedByKey.Keys.Any(key =>
+                !plan.QuantityItems.Exists(item =>
+                    string.Equals(item.ItemKey, key, StringComparison.Ordinal))))
+        {
+            return null;
+        }
+
+        var items = new List<SubscriptionQuantityItem>(plan.QuantityItems.Count);
+
+        foreach (var item in plan.QuantityItems)
+        {
+            var quantity = requestedByKey.TryGetValue(item.ItemKey, out var supplied)
+                ? supplied
+                : item.DefaultQuantity;
+
+            if (quantity < item.MinQuantity ||
+                (item.MaxQuantity is { } maximum && quantity > maximum))
+            {
+                return null;
+            }
+
+            items.Add(new SubscriptionQuantityItem
+            {
+                ItemKey = item.ItemKey,
+                UnitLabel = item.UnitLabel,
+                Quantity = quantity,
+                // Snapshotted so a later catalogue edit cannot move what this subscriber pays.
+                UnitAmountMinor = string.Equals(
+                    item.ItemKey,
+                    price.QuantityItemKey,
+                    StringComparison.Ordinal)
+                    ? price.UnitAmountMinor
+                    : 0
+            });
+        }
+
+        return items;
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -103,8 +103,11 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             : await _gateway.ChargeAsync(
                 new SubscriptionChargeRequest
                 {
+                    TenantId = subscription.TenantId,
+                    OrganizationId = subscription.OrganizationId,
                     ProviderName = account.ProviderName,
                     StoredPaymentMethodId = account.DefaultPaymentMethodId,
+                    ProviderCustomerId = account.ProviderCustomerId,
                     AmountMinor = charge.AmountMinor,
                     CurrencyCode = subscription.CurrencyCode,
                     OrderId = orderId,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -123,6 +123,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 subscription,
                 period,
                 charge.DiscountApplied,
+                charge.CreditConsumedMinor,
                 outcome.Value,
                 attemptNumber,
                 cancellationToken);
@@ -142,6 +143,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         SubscriptionDetail subscription,
         BillingPeriod period,
         bool discountApplied,
+        long creditConsumedMinor,
         string? paymentDetailId,
         int attemptNumber,
         CancellationToken cancellationToken)
@@ -159,6 +161,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 DunningAttemptCount = 0,
                 DiscountPeriodsApplied = subscription.DiscountPeriodsApplied +
                     (discountApplied ? 1 : 0),
+                CreditBalanceMinor = subscription.CreditBalanceMinor - creditConsumedMinor,
                 LastRenewalPaymentDetailId = string.IsNullOrEmpty(paymentDetailId)
                     ? null
                     : paymentDetailId,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -1,0 +1,316 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Charges a subscription's renewal, and drives dunning when it declines.
+/// </summary>
+/// <remarks>
+/// One method handles a normal renewal, a dunning retry, and a trial converting to paid — all
+/// three are "charge the stored card for the period that is due," and none needs to know which
+/// of the three it is. A trial with no stored card behaves the same as a dunning cycle with no
+/// card: there is nothing to retry, so it goes straight to <see cref="SubscriptionStatus.Unpaid"/>.
+/// </remarks>
+public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly IBillingAccountRepository _billingAccounts;
+    private readonly ISubscriptionBillingGateway _gateway;
+    private readonly ISubscriptionOutboxEventFactory _events;
+    private readonly IEntitlementSnapshotCache _cache;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionRenewalService> _logger;
+    private readonly TimeProvider _time;
+
+    public SubscriptionRenewalService(
+        ISubscriptionRepository subscriptions,
+        IBillingAccountRepository billingAccounts,
+        ISubscriptionBillingGateway gateway,
+        ISubscriptionOutboxEventFactory events,
+        IEntitlementSnapshotCache cache,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<SubscriptionRenewalService> logger,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _billingAccounts = billingAccounts;
+        _gateway = gateway;
+        _events = events;
+        _cache = cache;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task RenewAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["TenantHash"] = PaymentLogValue.Hash(subscription.TenantId),
+            ["SubscriptionHash"] = PaymentLogValue.Hash(subscription.ItemId)
+        });
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var account = await _billingAccounts.GetAsync(
+            subscription.TenantId,
+            subscription.BillingAccountId,
+            cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(account?.DefaultPaymentMethodId))
+        {
+            // Retrying without a card to charge is pointless — including a trial that never
+            // took one, which reaches this exact path at its end.
+            await MoveToUnpaidAsync(subscription, "no_payment_method", cancellationToken);
+
+            return;
+        }
+
+        if (!BillingPeriodCalculator.TryGetPeriod(subscription.FeeSchedule, now, out var period))
+        {
+            // A schedule that resolved at creation and stopped resolving is a configuration
+            // problem, not a billing outcome — leave the subscription as it is and let the next
+            // sweep try again rather than guessing at a period to write.
+            _logger.LogError(
+                "Subscription renewal could not resolve a billing period; the schedule's time " +
+                "zone may no longer be valid");
+
+            return;
+        }
+
+        var attemptNumber = subscription.DunningAttemptCount + 1;
+        var orderId = SubscriptionConstants.RenewalOrderIdFor(subscription.ItemId, period.Key);
+        var idempotencyKey = SubscriptionConstants.RenewalKeyFor(
+            subscription.ItemId,
+            period.Key,
+            attemptNumber);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, now);
+
+        var outcome = charge.AmountMinor <= 0
+            ? SubscriptionOperationResult<string>.Success(string.Empty, subscription.CorrelationId)
+            : await _gateway.ChargeAsync(
+                new SubscriptionChargeRequest
+                {
+                    ProviderName = account.ProviderName,
+                    StoredPaymentMethodId = account.DefaultPaymentMethodId,
+                    AmountMinor = charge.AmountMinor,
+                    CurrencyCode = subscription.CurrencyCode,
+                    OrderId = orderId,
+                    Description = $"{subscription.Plan.DisplayName} renewal"
+                },
+                idempotencyKey,
+                subscription.CorrelationId,
+                cancellationToken);
+
+        if (outcome.IsSuccess)
+        {
+            await ApplySuccessAsync(
+                subscription,
+                period,
+                charge.DiscountApplied,
+                outcome.Value,
+                attemptNumber,
+                cancellationToken);
+
+            return;
+        }
+
+        _logger.LogWarning(
+            "Subscription renewal declined AttemptNumber={AttemptNumber} Reason={Reason}",
+            attemptNumber,
+            PaymentLogValue.Label(outcome.ErrorCode ?? "unknown"));
+
+        await ApplyFailureAsync(subscription, period.Key, attemptNumber, now, cancellationToken);
+    }
+
+    private async Task ApplySuccessAsync(
+        SubscriptionDetail subscription,
+        BillingPeriod period,
+        bool discountApplied,
+        string? paymentDetailId,
+        int attemptNumber,
+        CancellationToken cancellationToken)
+    {
+        var applied = await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            new SubscriptionTransition(subscription.Status, SubscriptionStatus.Active)
+            {
+                ActivatedAtUtc = subscription.ActivatedAtUtc ?? _time.GetUtcNow().UtcDateTime,
+                CurrentPeriodStartUtc = period.StartUtc,
+                CurrentPeriodEndUtc = period.EndUtc,
+                NextFeeBillingAtUtc = period.EndUtc,
+                ClearPastDueSinceAt = true,
+                DunningAttemptCount = 0,
+                DiscountPeriodsApplied = subscription.DiscountPeriodsApplied +
+                    (discountApplied ? 1 : 0),
+                LastRenewalPaymentDetailId = string.IsNullOrEmpty(paymentDetailId)
+                    ? null
+                    : paymentDetailId,
+                Event = _events.CreateRenewalOutcome(
+                    subscription,
+                    SubscriptionConstants.SubscriptionRenewed,
+                    period.Key,
+                    attemptNumber,
+                    subscription.CorrelationId)
+            },
+            cancellationToken);
+
+        if (!applied)
+        {
+            // Another worker already settled this subscription's renewal. Its outcome stands.
+            return;
+        }
+
+        _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);
+
+        _logger.LogInformation(
+            "Subscription renewed AttemptNumber={AttemptNumber} PeriodKey={PeriodKey}",
+            attemptNumber,
+            PaymentLogValue.Label(period.Key));
+    }
+
+    private async Task ApplyFailureAsync(
+        SubscriptionDetail subscription,
+        string periodKey,
+        int attemptNumber,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var maxAttempts = Math.Max(1, _options.CurrentValue.DunningMaxAttempts);
+
+        if (subscription.Status != SubscriptionStatus.PastDue)
+        {
+            await ApplyTransitionAsync(
+                subscription,
+                subscription.Status,
+                SubscriptionStatus.PastDue,
+                periodKey,
+                attemptNumber,
+                new SubscriptionTransition(subscription.Status, SubscriptionStatus.PastDue)
+                {
+                    PastDueSinceUtc = now,
+                    DunningAttemptCount = attemptNumber,
+                    NextFeeBillingAtUtc = NextDunningAttemptAt(now),
+                    Event = _events.CreateRenewalOutcome(
+                        subscription,
+                        SubscriptionConstants.SubscriptionPastDue,
+                        periodKey,
+                        attemptNumber,
+                        subscription.CorrelationId)
+                },
+                cancellationToken);
+
+            return;
+        }
+
+        if (attemptNumber < maxAttempts)
+        {
+            await ApplyTransitionAsync(
+                subscription,
+                SubscriptionStatus.PastDue,
+                SubscriptionStatus.PastDue,
+                periodKey,
+                attemptNumber,
+                new SubscriptionTransition(SubscriptionStatus.PastDue, SubscriptionStatus.PastDue)
+                {
+                    DunningAttemptCount = attemptNumber,
+                    NextFeeBillingAtUtc = NextDunningAttemptAt(now),
+                    Event = _events.CreateRenewalOutcome(
+                        subscription,
+                        SubscriptionConstants.SubscriptionRenewalFailed,
+                        periodKey,
+                        attemptNumber,
+                        subscription.CorrelationId)
+                },
+                cancellationToken);
+
+            return;
+        }
+
+        await MoveToUnpaidAsync(subscription, "dunning_exhausted", cancellationToken);
+    }
+
+    private async Task MoveToUnpaidAsync(
+        SubscriptionDetail subscription,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        if (subscription.Status == SubscriptionStatus.Unpaid)
+        {
+            return;
+        }
+
+        var applied = await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            new SubscriptionTransition(subscription.Status, SubscriptionStatus.Unpaid)
+            {
+                ClearPastDueSinceAt = true,
+                ClearNextFeeBillingAt = true,
+                DunningAttemptCount = 0,
+                Event = _events.Create(
+                    subscription,
+                    SubscriptionConstants.SubscriptionUnpaid,
+                    subscription.CorrelationId)
+            },
+            cancellationToken);
+
+        if (!applied)
+        {
+            return;
+        }
+
+        _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);
+
+        _logger.LogInformation(
+            "Subscription moved to unpaid Reason={Reason}",
+            PaymentLogValue.Label(reason));
+    }
+
+    private async Task ApplyTransitionAsync(
+        SubscriptionDetail subscription,
+        SubscriptionStatus expected,
+        SubscriptionStatus target,
+        string periodKey,
+        int attemptNumber,
+        SubscriptionTransition transition,
+        CancellationToken cancellationToken)
+    {
+        var applied = await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            transition,
+            cancellationToken);
+
+        if (!applied)
+        {
+            return;
+        }
+
+        _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);
+
+        _logger.LogInformation(
+            "Subscription renewal outcome recorded FromStatus={FromStatus} ToStatus={ToStatus} " +
+            "AttemptNumber={AttemptNumber} PeriodKey={PeriodKey}",
+            PaymentLogValue.Label(expected.ToString()),
+            PaymentLogValue.Label(target.ToString()),
+            attemptNumber,
+            PaymentLogValue.Label(periodKey));
+    }
+
+    private DateTime NextDunningAttemptAt(DateTime now) =>
+        now.AddHours(Math.Max(1, _options.CurrentValue.DunningRetryIntervalHours));
+}

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -1,0 +1,42 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
+{
+    public SubscriptionResponse ToResponse(
+        SubscriptionDetail subscription,
+        string? checkoutUrl = null)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        return new SubscriptionResponse
+        {
+            SubscriptionId = subscription.ItemId,
+            Status = subscription.Status.ToString(),
+            PlanCode = subscription.Plan.Code,
+            PlanName = subscription.Plan.DisplayName,
+            CurrencyCode = subscription.CurrencyCode,
+            UnitAmountMinor = subscription.Price.UnitAmountMinor,
+            Interval = subscription.Price.Interval.ToString(),
+            IntervalCount = subscription.Price.IntervalCount,
+            Quantities = subscription.QuantityItems
+                .Select(item => new SubscriptionQuantityResponse
+                {
+                    ItemKey = item.ItemKey,
+                    UnitLabel = item.UnitLabel,
+                    Quantity = item.Quantity
+                })
+                .ToList(),
+            CurrentPeriodStartUtc = subscription.CurrentPeriodStartUtc,
+            CurrentPeriodEndUtc = subscription.CurrentPeriodEndUtc,
+            NextPaymentAtUtc = subscription.NextFeeBillingAtUtc,
+            TrialEndsAtUtc = subscription.Trial?.EndsAtUtc,
+            CancelAtPeriodEnd = subscription.CancelAtPeriodEnd,
+            CanceledAtUtc = subscription.CanceledAtUtc,
+            CheckoutUrl = checkoutUrl,
+            Version = subscription.Version
+        };
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -83,6 +83,7 @@ internal static class SubscriptionSnapshotBuilder
             Interval = price.Interval,
             IntervalCount = price.IntervalCount,
             QuantityItemKey = price.QuantityItemKey,
+            TaxRateBasisPoints = price.TaxRateBasisPoints,
             PriceVersion = price.Version
         };
     }

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -1,0 +1,89 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Copies a plan and price's terms into the immutable form a subscription carries.
+/// </summary>
+/// <remarks>
+/// A copy, not a reference: editing the catalogue afterwards must not change what an existing
+/// subscriber is entitled to or charged. Shared by subscribing and by changing plan — both need
+/// the identical snapshot, taken the identical way.
+/// </remarks>
+internal static class SubscriptionSnapshotBuilder
+{
+    public static PlanSnapshot SnapshotOf(Plan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        return new PlanSnapshot
+        {
+            PlanId = plan.ItemId,
+            Code = plan.Code,
+            DisplayName = plan.DisplayName,
+            FeaturesJson = plan.FeaturesJson,
+            PlanVersion = plan.Version,
+            Entitlements = plan.Entitlements
+                .Select(entitlement => new PlanEntitlement
+                {
+                    Key = entitlement.Key,
+                    LimitKind = entitlement.LimitKind,
+                    Limit = entitlement.Limit,
+                    MeterKey = entitlement.MeterKey,
+                    UnitLabel = entitlement.UnitLabel
+                })
+                .ToList(),
+            Meters = plan.Meters
+                .Select(meter => new PlanMeter
+                {
+                    MeterKey = meter.MeterKey,
+                    DisplayName = meter.DisplayName,
+                    UnitLabel = meter.UnitLabel,
+                    Aggregation = meter.Aggregation,
+                    IncludedQuantity = meter.IncludedQuantity,
+                    OverageAllowed = meter.OverageAllowed,
+                    ThresholdPercents = [.. meter.ThresholdPercents],
+                    RateTables = meter.RateTables
+                        .Select(table => new MeterRateTable
+                        {
+                            CurrencyCode = table.CurrencyCode,
+                            Tiers = table.Tiers
+                                .Select(tier => new MeterTier
+                                {
+                                    UpToQuantity = tier.UpToQuantity,
+                                    UnitAmountMinor = tier.UnitAmountMinor
+                                })
+                                .ToList()
+                        })
+                        .ToList()
+                })
+                .ToList(),
+            QuantityItems = plan.QuantityItems
+                .Select(item => new PlanQuantityItem
+                {
+                    ItemKey = item.ItemKey,
+                    UnitLabel = item.UnitLabel,
+                    MinQuantity = item.MinQuantity,
+                    MaxQuantity = item.MaxQuantity,
+                    DefaultQuantity = item.DefaultQuantity
+                })
+                .ToList()
+        };
+    }
+
+    public static PriceSnapshot SnapshotOf(Price price)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+
+        return new PriceSnapshot
+        {
+            PriceId = price.ItemId,
+            CurrencyCode = price.CurrencyCode,
+            UnitAmountMinor = price.UnitAmountMinor,
+            Interval = price.Interval,
+            IntervalCount = price.IntervalCount,
+            QuantityItemKey = price.QuantityItemKey,
+            PriceVersion = price.Version
+        };
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
@@ -1,0 +1,75 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// What a meter's usage costs beyond its included quantity, in minor units.
+/// </summary>
+/// <remarks>
+/// Pure and static, like the other calculators in this module. Only the *overage* is priced —
+/// <c>usage − IncludedQuantity</c> — so <see cref="PlanMeter.IncludedQuantity"/> stays the one
+/// place a plan's free allowance lives; a rate table never needs a zero-cost first tier to
+/// represent it.
+/// <para>
+/// Tier bounds are counted from the first overage unit, inclusive: a tier with
+/// <c>UpToQuantity = 400</c> covers overage units 1 through 400, and the next tier starts at
+/// overage unit 401. The final tier (<c>UpToQuantity = null</c>) absorbs whatever remains.
+/// </para>
+/// </remarks>
+public static class SubscriptionUsageRater
+{
+    public static long OverageAmountMinor(PlanMeter meter, long balance, string currencyCode)
+    {
+        ArgumentNullException.ThrowIfNull(meter);
+
+        if (!meter.OverageAllowed)
+        {
+            return 0;
+        }
+
+        var overageUnits = Math.Max(0, balance - meter.IncludedQuantity);
+
+        if (overageUnits == 0)
+        {
+            return 0;
+        }
+
+        var table = meter.RateTables.Find(table =>
+            string.Equals(table.CurrencyCode, currencyCode, StringComparison.OrdinalIgnoreCase));
+
+        // A meter with no rate table for this subscription's currency cannot be priced. Skipping
+        // it is a plan-authoring gap to fix, not a reason to fail every other meter's charge.
+        if (table is null)
+        {
+            return 0;
+        }
+
+        return WalkTiers(table.Tiers, overageUnits);
+    }
+
+    private static long WalkTiers(List<MeterTier> tiers, long overageUnits)
+    {
+        var previousBound = 0L;
+        var remaining = overageUnits;
+        Int128 total = 0;
+
+        foreach (var tier in tiers)
+        {
+            if (remaining <= 0)
+            {
+                break;
+            }
+
+            var bandWidth = tier.UpToQuantity is { } upTo
+                ? Math.Max(0, upTo - previousBound)
+                : remaining;
+            var bandUnits = Math.Min(remaining, bandWidth);
+
+            total += (Int128)bandUnits * tier.UnitAmountMinor;
+            remaining -= bandUnits;
+            previousBound = tier.UpToQuantity ?? previousBound;
+        }
+
+        return (long)total;
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionValidation.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionValidation.cs
@@ -1,0 +1,48 @@
+using FluentValidation;
+using FluentValidation.Results;
+using Payment.DomainService.Enums;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Turns a validation run into a result the caller can act on.
+/// </summary>
+/// <remarks>
+/// Written once. The payment module repeats this grouping in four preflight services, and each
+/// copy is a chance for one of them to report errors in a shape the client cannot parse.
+/// </remarks>
+public static class SubscriptionValidation
+{
+    public static async Task<SubscriptionOperationResult<TValue>?> CheckAsync<TRequest, TValue>(
+        IValidator<TRequest> validator,
+        TRequest request,
+        string errorCode,
+        string errorMessage,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(validator);
+
+        var validation = await validator.ValidateAsync(request, cancellationToken);
+
+        return validation.IsValid
+            ? null
+            : SubscriptionOperationResult<TValue>.Failure(
+                PaymentFailureKind.Validation,
+                errorCode,
+                errorMessage,
+                correlationId,
+                ToFieldErrors(validation));
+    }
+
+    private static Dictionary<string, string[]> ToFieldErrors(ValidationResult validation) =>
+        validation.Errors
+            .GroupBy(failure => failure.PropertyName, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .Select(failure => failure.ErrorMessage)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray(),
+                StringComparer.Ordinal);
+}

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -1,0 +1,467 @@
+using FluentValidation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Recording what an organization used.
+/// </summary>
+/// <remarks>
+/// The ledger is written before the counter, deliberately. A crash between the two leaves the
+/// counter under-counting, which the repair sweep can correct from the ledger; the other order
+/// would over-count with nothing left to prove it, and the customer would be billed for it.
+/// </remarks>
+public sealed class UsageRecordingService : IUsageRecordingService
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly IUsageThresholdEvaluator _thresholds;
+    private readonly IValidator<RecordUsageRequest> _validator;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<UsageRecordingService> _logger;
+    private readonly TimeProvider _time;
+
+    public UsageRecordingService(
+        ISubscriptionRepository subscriptions,
+        ISubscriptionUsageRepository usage,
+        ISubscriptionContextResolver contextResolver,
+        IUsageThresholdEvaluator thresholds,
+        IValidator<RecordUsageRequest> validator,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<UsageRecordingService> logger,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _usage = usage;
+        _contextResolver = contextResolver;
+        _thresholds = thresholds;
+        _validator = validator;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<UsageResponse>> RecordAsync(
+        RecordUsageRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<UsageResponse>(correlationId);
+        }
+
+        var invalid = await SubscriptionValidation.CheckAsync<RecordUsageRequest, UsageResponse>(
+            _validator,
+            request,
+            "subscription_usage_invalid",
+            "The usage record is invalid.",
+            correlationId,
+            cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var context = resolution.Context!;
+
+        var subscription = await _subscriptions.GetLiveAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "This organization has no active subscription.",
+                correlationId);
+        }
+
+        var meter = FindMeter(subscription, request.MeterKey);
+
+        if (meter is null)
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_meter_not_found",
+                "The plan does not define this meter.",
+                correlationId);
+        }
+
+        if (meter.Aggregation != MeterAggregation.Sum)
+        {
+            // Defined in the enum so it need not widen later, but refused explicitly rather
+            // than silently treated as a sum, which would bill the wrong figure.
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_meter_aggregation_unsupported",
+                "Only summed meters can be recorded in this release.",
+                correlationId);
+        }
+
+        var occurredAt = request.OccurredAtUtc ?? _time.GetUtcNow().UtcDateTime;
+
+        if (!BillingPeriodCalculator.TryGetPeriod(
+                subscription.UsageSchedule,
+                occurredAt,
+                out var period))
+        {
+            return Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_schedule_unavailable",
+                "The usage period could not be determined.",
+                correlationId);
+        }
+
+        return await ApplyAsync(
+            request,
+            context,
+            subscription,
+            meter,
+            period,
+            occurredAt,
+            correlationId,
+            cancellationToken);
+    }
+
+    public async Task<SubscriptionOperationResult<IReadOnlyList<UsageResponse>>> GetCurrentUsageAsync(
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = _contextResolver.Resolve(correlationId);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<IReadOnlyList<UsageResponse>>(correlationId);
+        }
+
+        var context = resolution.Context!;
+
+        var subscription = await _subscriptions.GetLiveAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "This organization has no active subscription.",
+                correlationId);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (!BillingPeriodCalculator.TryGetPeriod(
+                subscription.UsageSchedule,
+                now,
+                out var period))
+        {
+            return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_schedule_unavailable",
+                "The usage period could not be determined.",
+                correlationId);
+        }
+
+        var counters = await _usage.ListCountersAsync(
+            context.TenantId,
+            subscription.ItemId,
+            period.Key,
+            cancellationToken);
+
+        var responses = subscription.Plan.Meters
+            .Select(meter => Describe(
+                meter,
+                period,
+                counters.FirstOrDefault(counter => string.Equals(
+                    counter.MeterKey,
+                    meter.MeterKey,
+                    StringComparison.Ordinal))?.Balance ?? 0,
+                AllowanceFor(subscription, meter),
+                allowed: true,
+                replayed: false))
+            .ToList();
+
+        return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Success(
+            responses,
+            correlationId);
+    }
+
+    private async Task<SubscriptionOperationResult<UsageResponse>> ApplyAsync(
+        RecordUsageRequest request,
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        DateTime occurredAt,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var allowance = AllowanceFor(subscription, meter);
+
+        var record = new SubscriptionUsageRecord
+        {
+            TenantId = context.TenantId,
+            OrganizationId = context.OrganizationId,
+            SubscriptionId = subscription.ItemId,
+            MeterKey = meter.MeterKey,
+            PeriodKey = period.Key,
+            EntryType = UsageEntryType.Consumption,
+            Delta = request.Quantity,
+            IdempotencyKey = request.IdempotencyKey,
+            OccurredAtUtc = occurredAt,
+            Metadata = request.Metadata,
+            RecordedByUserId = context.UserId,
+            CorrelationId = correlationId
+        };
+
+        if (!await _usage.TryAppendRecordAsync(record, cancellationToken))
+        {
+            return await ReplayAsync(
+                subscription,
+                meter,
+                period,
+                allowance,
+                correlationId,
+                cancellationToken);
+        }
+
+        var counter = await _usage.ApplyDeltaAsync(
+            SeedFor(context, subscription, meter, period, allowance),
+            request.Quantity,
+            cancellationToken);
+
+        var withinAllowance = counter.Balance <= allowance;
+
+        if (request.Enforce && !withinAllowance && !meter.OverageAllowed)
+        {
+            return await RefuseAsync(
+                record,
+                context,
+                subscription,
+                meter,
+                period,
+                allowance,
+                correlationId,
+                cancellationToken);
+        }
+
+        await _thresholds.EvaluateAsync(
+            subscription,
+            counter,
+            correlationId,
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Usage recorded TenantHash={TenantHash} OrganizationHash={OrganizationHash} " +
+            "SubscriptionHash={SubscriptionHash} Meter={Meter} Balance={Balance} " +
+            "Included={Included} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(context.OrganizationId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Label(meter.MeterKey),
+            counter.Balance,
+            allowance,
+            correlationId);
+
+        return SubscriptionOperationResult<UsageResponse>.Success(
+            Describe(
+                meter,
+                period,
+                counter.Balance,
+                allowance,
+                allowed: withinAllowance || meter.OverageAllowed,
+                replayed: false),
+            correlationId);
+    }
+
+    /// <summary>
+    /// Undoes a recording that took an enforced meter past its allowance.
+    /// </summary>
+    /// <remarks>
+    /// A compensating entry rather than a deletion: the ledger is append-only, so the refusal
+    /// and what caused it both stay visible. The counter is decremented by the same amount, so
+    /// a refused call leaves the balance exactly where it was.
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<UsageResponse>> RefuseAsync(
+        SubscriptionUsageRecord record,
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        long allowance,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        await _usage.TryAppendRecordAsync(
+            new SubscriptionUsageRecord
+            {
+                TenantId = record.TenantId,
+                OrganizationId = record.OrganizationId,
+                SubscriptionId = record.SubscriptionId,
+                MeterKey = record.MeterKey,
+                PeriodKey = record.PeriodKey,
+                EntryType = UsageEntryType.Reversal,
+                Delta = -record.Delta,
+                IdempotencyKey = $"{record.IdempotencyKey}:reversal",
+                CompensatesRecordId = record.ItemId,
+                OccurredAtUtc = record.OccurredAtUtc,
+                CorrelationId = correlationId
+            },
+            cancellationToken);
+
+        var counter = await _usage.ApplyDeltaAsync(
+            SeedFor(context, subscription, meter, period, allowance),
+            -record.Delta,
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Usage refused because the allowance is exhausted TenantHash={TenantHash} " +
+            "SubscriptionHash={SubscriptionHash} Meter={Meter} Balance={Balance} " +
+            "Included={Included} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Label(meter.MeterKey),
+            counter.Balance,
+            allowance,
+            correlationId);
+
+        return SubscriptionOperationResult<UsageResponse>.Success(
+            Describe(meter, period, counter.Balance, allowance, allowed: false, replayed: false),
+            correlationId);
+    }
+
+    /// <summary>
+    /// Answers a repeated call with the same outcome as the first, without counting it again.
+    /// </summary>
+    private async Task<SubscriptionOperationResult<UsageResponse>> ReplayAsync(
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        long allowance,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var counter = await _usage.GetCounterAsync(
+            subscription.TenantId,
+            SubscriptionUsageCounter.CreateId(
+                subscription.ItemId,
+                meter.MeterKey,
+                period.Key),
+            cancellationToken);
+
+        var balance = counter?.Balance ?? 0;
+
+        return SubscriptionOperationResult<UsageResponse>.Success(
+            Describe(
+                meter,
+                period,
+                balance,
+                allowance,
+                allowed: balance <= allowance || meter.OverageAllowed,
+                replayed: true),
+            correlationId);
+    }
+
+    /// <summary>
+    /// How much of a meter this subscription may use before it is over.
+    /// </summary>
+    /// <remarks>
+    /// A trial's grant replaces the plan's allowance rather than adding to it. Where each unit
+    /// costs the seller money, a trial that hands out the full monthly quota is an open
+    /// invitation to sign up, consume and leave.
+    /// </remarks>
+    private static long AllowanceFor(SubscriptionDetail subscription, PlanMeter meter)
+    {
+        if (subscription.Status != SubscriptionStatus.Trialing ||
+            subscription.Trial is null)
+        {
+            return meter.IncludedQuantity;
+        }
+
+        var grant = subscription.Trial.Grants.Find(candidate =>
+            string.Equals(candidate.MeterKey, meter.MeterKey, StringComparison.Ordinal));
+
+        return grant?.IncludedQuantity ?? meter.IncludedQuantity;
+    }
+
+    private SubscriptionUsageCounter SeedFor(
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        long allowance) => new()
+    {
+        ItemId = SubscriptionUsageCounter.CreateId(
+            subscription.ItemId,
+            meter.MeterKey,
+            period.Key),
+        TenantId = context.TenantId,
+        OrganizationId = context.OrganizationId,
+        SubscriptionId = subscription.ItemId,
+        MeterKey = meter.MeterKey,
+        PeriodKey = period.Key,
+        // Captured when the period opens so a mid-period plan edit cannot re-fire thresholds
+        // that have already been reported.
+        LimitSnapshot = allowance,
+        PeriodStartUtc = period.StartUtc,
+        PeriodEndUtc = period.EndUtc,
+        ExpiresAtUtc = period.EndUtc.AddDays(
+            Math.Max(1, _options.CurrentValue.CounterRetentionDays))
+    };
+
+    private static PlanMeter? FindMeter(SubscriptionDetail subscription, string meterKey) =>
+        subscription.Plan.Meters.Find(meter =>
+            string.Equals(meter.MeterKey, meterKey, StringComparison.Ordinal));
+
+    private static UsageResponse Describe(
+        PlanMeter meter,
+        BillingPeriod period,
+        long balance,
+        long allowance,
+        bool allowed,
+        bool replayed) => new()
+    {
+        Allowed = allowed,
+        MeterKey = meter.MeterKey,
+        UnitLabel = meter.UnitLabel,
+        PeriodKey = period.Key,
+        PeriodStartUtc = period.StartUtc,
+        PeriodEndUtc = period.EndUtc,
+        Included = allowance,
+        Used = balance,
+        Remaining = Math.Max(0, allowance - balance),
+        Overage = Math.Max(0, balance - allowance),
+        Replayed = replayed
+    };
+
+    private static SubscriptionOperationResult<UsageResponse> Failure(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId) =>
+        SubscriptionOperationResult<UsageResponse>.Failure(
+            kind,
+            errorCode,
+            errorMessage,
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/UsageThresholdEvaluator.cs
+++ b/server/Subscription.DomainService/Services/UsageThresholdEvaluator.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Notices when consumption crosses a threshold, once.
+/// </summary>
+/// <remarks>
+/// Edge-triggered at the moment of the increment, not by a job that scans counters. A scanner
+/// would alert late and re-alert on every pass; checking here means the crossing is detected by
+/// whichever call caused it.
+/// <para>
+/// Which call that is gets settled by the database. Every process that sees the threshold
+/// crossed attempts to record it, and only the one whose update modifies a document raises the
+/// event — so a customer is told once rather than once per screening for the rest of the month.
+/// </para>
+/// </remarks>
+public sealed class UsageThresholdEvaluator : IUsageThresholdEvaluator
+{
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionOutboxEventFactory _events;
+    private readonly ILogger<UsageThresholdEvaluator> _logger;
+
+    public UsageThresholdEvaluator(
+        ISubscriptionUsageRepository usage,
+        ISubscriptionRepository subscriptions,
+        ISubscriptionOutboxEventFactory events,
+        ILogger<UsageThresholdEvaluator> logger)
+    {
+        _usage = usage;
+        _subscriptions = subscriptions;
+        _events = events;
+        _logger = logger;
+    }
+
+    public async Task<int> EvaluateAsync(
+        SubscriptionDetail subscription,
+        SubscriptionUsageCounter counter,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+        ArgumentNullException.ThrowIfNull(counter);
+
+        var meter = subscription.Plan.Meters.Find(candidate =>
+            string.Equals(candidate.MeterKey, counter.MeterKey, StringComparison.Ordinal));
+
+        if (meter is null ||
+            meter.ThresholdPercents.Count == 0 ||
+            counter.LimitSnapshot is not { } limit ||
+            limit <= 0)
+        {
+            return 0;
+        }
+
+        var reported = 0;
+
+        foreach (var threshold in Crossed(meter.ThresholdPercents, counter.Balance, limit))
+        {
+            if (!await _usage.TryMarkThresholdNotifiedAsync(
+                    counter.TenantId,
+                    counter.ItemId,
+                    threshold,
+                    cancellationToken))
+            {
+                // Someone else reported it. Raising it anyway is what would duplicate the alert.
+                continue;
+            }
+
+            await _subscriptions.TryAppendEventAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                _events.CreateUsageThreshold(
+                    subscription,
+                    counter,
+                    threshold,
+                    correlationId),
+                cancellationToken);
+
+            _logger.LogInformation(
+                "Usage threshold reached TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
+                "Meter={Meter} ThresholdPercent={ThresholdPercent} Balance={Balance} " +
+                "Included={Included} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(counter.MeterKey),
+                threshold,
+                counter.Balance,
+                limit,
+                correlationId);
+
+            reported++;
+        }
+
+        return reported;
+    }
+
+    /// <summary>
+    /// The thresholds this balance has reached, lowest first.
+    /// </summary>
+    /// <remarks>
+    /// Ascending order matters when a single large increment jumps several at once: reporting
+    /// 80 before 100 reads as a sequence to whoever receives them, rather than as two
+    /// simultaneous and apparently contradictory alerts.
+    /// <para>
+    /// Compared by multiplication rather than by computing a percentage, so integer division
+    /// cannot round a crossing away — at 79.6% nothing has been reached yet.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<int> Crossed(
+        IEnumerable<int> thresholds,
+        long balance,
+        long limit) =>
+        thresholds
+            .Where(threshold => balance * 100 >= limit * (long)threshold)
+            .Order();
+}

--- a/server/Subscription.DomainService/Subscription.DomainService.csproj
+++ b/server/Subscription.DomainService/Subscription.DomainService.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="SeliseBlocks.Genesis.OS" />
+  </ItemGroup>
+  <!--
+    Subscriptions build on the payment module: hosted checkout starts the first charge, and
+    payment state is what activation waits on. The dependency is one-directional and enforced
+    by XUnitTest/Subscription/SubscriptionBoundaryTests. The surface relied on is listed in
+    this project's README so payment authors can see what they cannot change freely.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Payment.DomainService\Payment.DomainService.csproj" />
+  </ItemGroup>
+</Project>

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -113,6 +113,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionRenewalProcessor,
             SubscriptionRenewalProcessor>();
+        services.AddScoped<
+            ISubscriptionUsageRatingProcessor,
+            SubscriptionUsageRatingProcessor>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Services;
@@ -44,6 +45,12 @@ public static class ApplicationServiceCollectionExtensions
             SubscriptionPaymentLinkRepository>();
 
         services.AddSingleton<IPlanResponseMapper, PlanResponseMapper>();
+        services.AddSingleton<
+            ISubscriptionResponseMapper,
+            SubscriptionResponseMapper>();
+        services.AddSingleton<
+            ISubscriptionOutboxEventFactory,
+            SubscriptionOutboxEventFactory>();
 
         services.AddTransient<
             IValidator<CreatePlanRequest>,
@@ -51,12 +58,18 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<
             IValidator<CreatePriceRequest>,
             CreatePriceRequestValidator>();
+        services.AddTransient<
+            IValidator<CreateSubscriptionRequest>,
+            CreateSubscriptionRequestValidator>();
 
         // Scoped: these read the caller's context, which belongs to one request.
         services.AddScoped<
             ISubscriptionContextResolver,
             SubscriptionContextResolver>();
         services.AddScoped<IPlanCatalogueService, PlanCatalogueService>();
+        services.AddScoped<
+            ISubscriptionCreationService,
+            SubscriptionCreationService>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Subscription.DomainService.Repositories;
 
 namespace Subscription.DomainService.Utilities;
 
@@ -18,6 +19,25 @@ public static class ApplicationServiceCollectionExtensions
 
         services.Configure<SubscriptionOptions>(
             configuration.GetSection(SubscriptionOptions.SectionName));
+
+        // Repositories are singletons and take the tenant as an argument, so the same instance
+        // serves a request and a background sweep. They hold no per-tenant state beyond the
+        // record of which tenants they have already indexed.
+        services.AddSingleton<
+            ISubscriptionCatalogueRepository,
+            SubscriptionCatalogueRepository>();
+        services.AddSingleton<
+            IBillingAccountRepository,
+            BillingAccountRepository>();
+        services.AddSingleton<
+            ISubscriptionRepository,
+            SubscriptionRepository>();
+        services.AddSingleton<
+            ISubscriptionUsageRepository,
+            SubscriptionUsageRepository>();
+        services.AddSingleton<
+            ISubscriptionPaymentLinkRepository,
+            SubscriptionPaymentLinkRepository>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -73,6 +73,12 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionCheckoutService,
             SubscriptionCheckoutService>();
+        services.AddScoped<
+            ISubscriptionActivationProcessor,
+            SubscriptionActivationProcessor>();
+        services.AddScoped<
+            ISubscriptionOutboxProcessor,
+            SubscriptionOutboxProcessor>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -94,6 +94,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionBillingGateway,
             RecurringChargeBillingGateway>();
+        services.AddScoped<
+            ISubscriptionRenewalService,
+            SubscriptionRenewalService>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -91,12 +91,13 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionOutboxProcessor,
             SubscriptionOutboxProcessor>();
+        // Registered as themselves — SubscriptionBillingGatewayResolver picks between them by
+        // provider name, so neither is the ISubscriptionBillingGateway DI entry on its own.
+        services.AddScoped<RecurringChargeBillingGateway>();
+        services.AddScoped<StripeInvoiceBillingGateway>();
         services.AddScoped<
             ISubscriptionBillingGateway,
-            RecurringChargeBillingGateway>();
-        // Registered as itself, not yet as ISubscriptionBillingGateway — a resolver picks
-        // between this and RecurringChargeBillingGateway by provider name.
-        services.AddScoped<StripeInvoiceBillingGateway>();
+            SubscriptionBillingGatewayResolver>();
         services.AddScoped<
             ISubscriptionRenewalService,
             SubscriptionRenewalService>();

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -97,6 +97,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionRenewalService,
             SubscriptionRenewalService>();
+        services.AddScoped<
+            ISubscriptionRenewalProcessor,
+            SubscriptionRenewalProcessor>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -79,6 +79,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionCheckoutService,
             SubscriptionCheckoutService>();
+        services.AddScoped<
+            ISubscriptionCancellationService,
+            SubscriptionCancellationService>();
         services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -61,6 +61,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<
             IValidator<CreateSubscriptionRequest>,
             CreateSubscriptionRequestValidator>();
+        services.AddTransient<
+            IValidator<RecordUsageRequest>,
+            RecordUsageRequestValidator>();
 
         // Scoped: these read the caller's context, which belongs to one request.
         services.AddScoped<
@@ -73,6 +76,8 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionCheckoutService,
             SubscriptionCheckoutService>();
+        services.AddScoped<IUsageRecordingService, UsageRecordingService>();
+        services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();
         services.AddScoped<
             ISubscriptionActivationProcessor,
             SubscriptionActivationProcessor>();

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -65,6 +65,9 @@ public static class ApplicationServiceCollectionExtensions
             IValidator<CreateSubscriptionRequest>,
             CreateSubscriptionRequestValidator>();
         services.AddTransient<
+            IValidator<ChangeSubscriptionPlanRequest>,
+            ChangeSubscriptionPlanRequestValidator>();
+        services.AddTransient<
             IValidator<RecordUsageRequest>,
             RecordUsageRequestValidator>();
 
@@ -82,6 +85,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionCancellationService,
             SubscriptionCancellationService>();
+        services.AddScoped<
+            ISubscriptionPlanChangeService,
+            SubscriptionPlanChangeService>();
         services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -44,6 +44,9 @@ public static class ApplicationServiceCollectionExtensions
             ISubscriptionPaymentLinkRepository,
             SubscriptionPaymentLinkRepository>();
 
+        // Singleton so the cache is actually shared. Scoped, every request would get an empty
+        // one and the hot path would read the database every time regardless.
+        services.AddSingleton<IEntitlementSnapshotCache, EntitlementSnapshotCache>();
         services.AddSingleton<IPlanResponseMapper, PlanResponseMapper>();
         services.AddSingleton<
             ISubscriptionResponseMapper,
@@ -76,6 +79,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionCheckoutService,
             SubscriptionCheckoutService>();
+        services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();
         services.AddScoped<

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -94,6 +94,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionBillingGateway,
             RecurringChargeBillingGateway>();
+        // Registered as itself, not yet as ISubscriptionBillingGateway — a resolver picks
+        // between this and RecurringChargeBillingGateway by provider name.
+        services.AddScoped<StripeInvoiceBillingGateway>();
         services.AddScoped<
             ISubscriptionRenewalService,
             SubscriptionRenewalService>();

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Subscription.DomainService.Utilities;
+
+public static class ApplicationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the subscription capability. Called by both the Api and the Worker, because
+    /// the same services back the request path and the background sweeps.
+    /// </summary>
+    public static IServiceCollection RegisterSubscriptionDomainServices(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.Configure<SubscriptionOptions>(
+            configuration.GetSection(SubscriptionOptions.SectionName));
+
+        return services;
+    }
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -43,6 +43,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             ISubscriptionPaymentLinkRepository,
             SubscriptionPaymentLinkRepository>();
+        services.AddSingleton<
+            ISubscriptionUsageInvoiceRepository,
+            SubscriptionUsageInvoiceRepository>();
 
         // Singleton so the cache is actually shared. Scoped, every request would get an empty
         // one and the hot path would read the database every time regardless.

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -70,6 +70,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionCreationService,
             SubscriptionCreationService>();
+        services.AddScoped<
+            ISubscriptionCheckoutService,
+            SubscriptionCheckoutService>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -1,6 +1,10 @@
+using FluentValidation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Validators;
 
 namespace Subscription.DomainService.Utilities;
 
@@ -38,6 +42,21 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             ISubscriptionPaymentLinkRepository,
             SubscriptionPaymentLinkRepository>();
+
+        services.AddSingleton<IPlanResponseMapper, PlanResponseMapper>();
+
+        services.AddTransient<
+            IValidator<CreatePlanRequest>,
+            CreatePlanRequestValidator>();
+        services.AddTransient<
+            IValidator<CreatePriceRequest>,
+            CreatePriceRequestValidator>();
+
+        // Scoped: these read the caller's context, which belongs to one request.
+        services.AddScoped<
+            ISubscriptionContextResolver,
+            SubscriptionContextResolver>();
+        services.AddScoped<IPlanCatalogueService, PlanCatalogueService>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -91,6 +91,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionOutboxProcessor,
             SubscriptionOutboxProcessor>();
+        services.AddScoped<
+            ISubscriptionBillingGateway,
+            RecurringChargeBillingGateway>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/BillingLocalTime.cs
+++ b/server/Subscription.DomainService/Utilities/BillingLocalTime.cs
@@ -1,0 +1,112 @@
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Converts a billing boundary expressed in a customer's local calendar into an instant.
+/// </summary>
+/// <remarks>
+/// Twice a year a local time either does not exist or exists twice, and a boundary that lands
+/// there has to resolve to exactly one instant. Left to the framework both cases throw, which
+/// would take out a renewal on precisely two nights a year and look like an unrelated outage.
+/// </remarks>
+public static class BillingLocalTime
+{
+    /// <summary>How far forward a boundary may be nudged to escape a spring-forward gap.</summary>
+    private static readonly TimeSpan MaximumGapSearch = TimeSpan.FromHours(4);
+
+    private static readonly TimeSpan GapStep = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Resolves an IANA identifier. Returns false rather than throwing, so a misconfigured
+    /// subscription fails closed at its own boundary instead of taking down the caller.
+    /// </summary>
+    /// <remarks>
+    /// The container images must carry <c>tzdata</c>; without it every identifier fails here,
+    /// on Alpine, in production only.
+    /// </remarks>
+    public static bool TryFindTimeZone(string? timeZoneId, out TimeZoneInfo timeZone)
+    {
+        timeZone = TimeZoneInfo.Utc;
+
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            return false;
+        }
+
+        try
+        {
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Turns a local billing boundary into the instant it happens at.
+    /// </summary>
+    /// <remarks>
+    /// A boundary inside a spring-forward gap moves to the first local time that exists, so the
+    /// period starts rather than being skipped. An autumn boundary that happens twice takes the
+    /// earlier of the two: which one matters far less than always picking the same one, since
+    /// an inconsistent choice would make a period overlap or gap by an hour.
+    /// </remarks>
+    public static DateTime ToUtc(DateTime local, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        var unspecified = DateTime.SpecifyKind(local, DateTimeKind.Unspecified);
+
+        if (timeZone.IsInvalidTime(unspecified))
+        {
+            unspecified = FirstValidTimeAtOrAfter(unspecified, timeZone);
+        }
+
+        if (timeZone.IsAmbiguousTime(unspecified))
+        {
+            // The larger offset is the pre-transition one, so subtracting it gives the earlier
+            // of the two instants that share this local time.
+            var earliest = timeZone
+                .GetAmbiguousTimeOffsets(unspecified)
+                .Max();
+
+            return DateTime.SpecifyKind(unspecified - earliest, DateTimeKind.Utc);
+        }
+
+        return TimeZoneInfo.ConvertTimeToUtc(unspecified, timeZone);
+    }
+
+    /// <summary>Turns an instant into the local calendar time it falls on.</summary>
+    public static DateTime ToLocal(DateTime instantUtc, TimeZoneInfo timeZone)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        return TimeZoneInfo.ConvertTimeFromUtc(
+            DateTime.SpecifyKind(instantUtc, DateTimeKind.Utc),
+            timeZone);
+    }
+
+    private static DateTime FirstValidTimeAtOrAfter(
+        DateTime local,
+        TimeZoneInfo timeZone)
+    {
+        var searched = TimeSpan.Zero;
+        var candidate = local;
+
+        while (timeZone.IsInvalidTime(candidate) && searched < MaximumGapSearch)
+        {
+            candidate = candidate.Add(GapStep);
+            searched = searched.Add(GapStep);
+        }
+
+        // Stepping rather than reading the adjustment rule keeps this correct for gaps of any
+        // size, including the half-hour ones some zones use.
+        return timeZone.IsInvalidTime(candidate) ? local : candidate;
+    }
+}

--- a/server/Subscription.DomainService/Utilities/BillingPeriod.cs
+++ b/server/Subscription.DomainService/Utilities/BillingPeriod.cs
@@ -1,0 +1,17 @@
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// One occurrence of a cadence: when it opened, when it closes, and what to call it.
+/// </summary>
+/// <param name="Index">
+/// How many whole cadences have elapsed since the anchor. Zero is the first period.
+/// </param>
+/// <param name="EndUtc">
+/// Also the next boundary — the two are the same instant, so a separate "next due" calculation
+/// cannot drift away from the period it belongs to.
+/// </param>
+public readonly record struct BillingPeriod(
+    int Index,
+    DateTime StartUtc,
+    DateTime EndUtc,
+    string Key);

--- a/server/Subscription.DomainService/Utilities/BillingPeriodCalculator.cs
+++ b/server/Subscription.DomainService/Utilities/BillingPeriodCalculator.cs
@@ -1,0 +1,238 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Works out which period an instant falls in, and when that period ends.
+/// </summary>
+/// <remarks>
+/// Pure and static: the instant is always a parameter, never read from the clock, so every
+/// boundary is reproducible and testable years either side of today.
+/// <para>
+/// Periods are <em>derived</em>, never advanced. Nothing has to notice a boundary passing —
+/// the moment it does, the same call simply returns the next period. That is what lets metered
+/// usage roll over without a scheduled job, and removes the class of bug where a rollover runs
+/// twice or not at all.
+/// </para>
+/// </remarks>
+public static class BillingPeriodCalculator
+{
+    /// <summary>
+    /// Guards the walk that corrects an estimated period index. The estimate is out by at most
+    /// one in normal use; anything further means the inputs are not what this assumes.
+    /// </summary>
+    private const int MaximumIndexCorrections = 8;
+
+    /// <summary>
+    /// Builds a schedule from a starting instant, preserving the day the subscriber chose.
+    /// </summary>
+    /// <remarks>
+    /// The anchor day is taken from the local calendar, not from UTC: a subscription created at
+    /// 00:30 in Zurich starts on the 1st there and on the 31st in UTC, and the customer's
+    /// calendar is the one their invoice follows.
+    /// </remarks>
+    public static bool TryCreateSchedule(
+        BillingInterval interval,
+        int intervalCount,
+        DateTime anchorInstantUtc,
+        string timeZoneId,
+        out BillingSchedule schedule)
+    {
+        schedule = new BillingSchedule();
+
+        if (intervalCount < 1 ||
+            !BillingLocalTime.TryFindTimeZone(timeZoneId, out var timeZone))
+        {
+            return false;
+        }
+
+        var anchorLocal = BillingLocalTime.ToLocal(anchorInstantUtc, timeZone);
+
+        schedule = new BillingSchedule
+        {
+            Interval = interval,
+            IntervalCount = intervalCount,
+            AnchorInstantUtc = DateTime.SpecifyKind(anchorInstantUtc, DateTimeKind.Utc),
+            TimeZoneId = timeZoneId,
+            AnchorDayOfMonth = anchorLocal.Day,
+            AnchorMinutesFromMidnight =
+                (anchorLocal.Hour * 60) + anchorLocal.Minute
+        };
+
+        return true;
+    }
+
+    /// <summary>
+    /// Finds the period containing <paramref name="instantUtc"/>.
+    /// </summary>
+    /// <returns>
+    /// False when the schedule cannot be resolved — an unknown time zone, or a cadence of less
+    /// than one. Failing closed here keeps a misconfigured subscription from throwing on a path
+    /// that is called on every gated action.
+    /// </returns>
+    public static bool TryGetPeriod(
+        BillingSchedule schedule,
+        DateTime instantUtc,
+        out BillingPeriod period)
+    {
+        period = default;
+
+        if (schedule is null ||
+            schedule.IntervalCount < 1 ||
+            !BillingLocalTime.TryFindTimeZone(schedule.TimeZoneId, out var timeZone))
+        {
+            return false;
+        }
+
+        var instant = DateTime.SpecifyKind(instantUtc, DateTimeKind.Utc);
+        var anchorLocal = BillingLocalTime.ToLocal(schedule.AnchorInstantUtc, timeZone);
+        var index = CorrectIndex(
+            schedule,
+            timeZone,
+            anchorLocal,
+            instant,
+            EstimateIndex(schedule, timeZone, anchorLocal, instant));
+
+        var startUtc = BoundaryOf(schedule, timeZone, anchorLocal, index);
+        var endUtc = BoundaryOf(schedule, timeZone, anchorLocal, index + 1);
+
+        period = new BillingPeriod(
+            index,
+            startUtc,
+            endUtc,
+            PeriodKey.Create(schedule.Interval, startUtc));
+
+        return true;
+    }
+
+    /// <summary>
+    /// The instant the given period boundary falls on.
+    /// </summary>
+    /// <remarks>
+    /// The month-end rule lives here, and it is the one worth stating: the chosen day is
+    /// clamped to the length of the target month on every read and never written back. A
+    /// subscription anchored on the 31st bills on the 28th in February and returns to the 31st
+    /// in March. Storing February's clamp instead would drag every later period earlier for the
+    /// life of the subscription — a drift nobody notices until a customer counts their invoices.
+    /// </remarks>
+    private static DateTime BoundaryOf(
+        BillingSchedule schedule,
+        TimeZoneInfo timeZone,
+        DateTime anchorLocal,
+        int index)
+    {
+        var offset = index * schedule.IntervalCount;
+
+        var local = schedule.Interval switch
+        {
+            BillingInterval.Day =>
+                anchorLocal.Date.AddDays(offset),
+            BillingInterval.Week =>
+                anchorLocal.Date.AddDays(offset * 7L),
+            BillingInterval.Month =>
+                MonthBoundary(schedule, anchorLocal, offset),
+            BillingInterval.Year =>
+                MonthBoundary(schedule, anchorLocal, offset * 12L),
+            _ => anchorLocal.Date
+        };
+
+        return BillingLocalTime.ToUtc(
+            local.AddMinutes(schedule.AnchorMinutesFromMidnight),
+            timeZone);
+    }
+
+    private static DateTime MonthBoundary(
+        BillingSchedule schedule,
+        DateTime anchorLocal,
+        long monthOffset)
+    {
+        var target = new DateTime(anchorLocal.Year, anchorLocal.Month, 1)
+            .AddMonths((int)monthOffset);
+
+        var day = Math.Min(
+            schedule.AnchorDayOfMonth,
+            DateTime.DaysInMonth(target.Year, target.Month));
+
+        return new DateTime(target.Year, target.Month, day);
+    }
+
+    /// <summary>
+    /// A cheap first guess at the period index, refined by <see cref="CorrectIndex"/>.
+    /// </summary>
+    /// <remarks>
+    /// Estimating in the local calendar and then correcting is deliberate: a clamped month end
+    /// and a daylight-saving shift both move a boundary by less than a whole period, so any
+    /// closed-form answer is occasionally out by one and always in a way that is hard to see.
+    /// </remarks>
+    private static int EstimateIndex(
+        BillingSchedule schedule,
+        TimeZoneInfo timeZone,
+        DateTime anchorLocal,
+        DateTime instantUtc)
+    {
+        var local = BillingLocalTime.ToLocal(instantUtc, timeZone);
+
+        var elapsed = schedule.Interval switch
+        {
+            BillingInterval.Day =>
+                (long)(local.Date - anchorLocal.Date).TotalDays,
+            BillingInterval.Week =>
+                (long)(local.Date - anchorLocal.Date).TotalDays / 7,
+            BillingInterval.Month =>
+                MonthsBetween(anchorLocal, local),
+            BillingInterval.Year =>
+                MonthsBetween(anchorLocal, local) / 12,
+            _ => 0
+        };
+
+        return (int)FloorDivide(elapsed, schedule.IntervalCount);
+    }
+
+    private static int CorrectIndex(
+        BillingSchedule schedule,
+        TimeZoneInfo timeZone,
+        DateTime anchorLocal,
+        DateTime instantUtc,
+        int estimate)
+    {
+        var index = estimate;
+
+        for (var correction = 0; correction < MaximumIndexCorrections; correction++)
+        {
+            if (BoundaryOf(schedule, timeZone, anchorLocal, index) > instantUtc)
+            {
+                index--;
+
+                continue;
+            }
+
+            if (BoundaryOf(schedule, timeZone, anchorLocal, index + 1) <= instantUtc)
+            {
+                index++;
+
+                continue;
+            }
+
+            break;
+        }
+
+        return index;
+    }
+
+    private static long MonthsBetween(DateTime from, DateTime to) =>
+        (((long)to.Year - from.Year) * 12) + (to.Month - from.Month);
+
+    /// <summary>
+    /// Division that rounds towards negative infinity, so an instant before the anchor lands in
+    /// a period rather than being rounded back into the first one.
+    /// </summary>
+    private static long FloorDivide(long dividend, long divisor)
+    {
+        var quotient = Math.DivRem(dividend, divisor, out var remainder);
+
+        return remainder != 0 && ((remainder < 0) != (divisor < 0))
+            ? quotient - 1
+            : quotient;
+    }
+}

--- a/server/Subscription.DomainService/Utilities/PeriodKey.cs
+++ b/server/Subscription.DomainService/Utilities/PeriodKey.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Names a usage period so a counter can be addressed without looking one up.
+/// </summary>
+/// <remarks>
+/// Built from the period's own start instant rather than from a calendar month, because a
+/// cadence of more than one month would otherwise give two different periods the same name and
+/// silently merge their counters.
+/// </remarks>
+public static class PeriodKey
+{
+    private const string InstantFormat = "yyyyMMdd'T'HHmmss";
+
+    public static string Create(BillingInterval interval, DateTime periodStartUtc) =>
+        string.Concat(
+            Code(interval),
+            periodStartUtc.ToString(InstantFormat, CultureInfo.InvariantCulture),
+            "Z");
+
+    private static string Code(BillingInterval interval) => interval switch
+    {
+        BillingInterval.Day => "D",
+        BillingInterval.Week => "W",
+        BillingInterval.Month => "M",
+        BillingInterval.Year => "Y",
+        _ => "U"
+    };
+}

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -31,4 +31,15 @@ public static class SubscriptionConstants
 
     public static string OrderIdFor(string subscriptionId) =>
         $"{OrderIdPrefix}{subscriptionId}";
+
+    /// <summary>
+    /// The idempotency key a subscription's first charge is raised under.
+    /// </summary>
+    /// <remarks>
+    /// Derived rather than random, and derived in one place so the checkout that writes it and
+    /// the recovery sweep that looks it up cannot disagree. It is what lets a charge be found
+    /// again after a crash between raising it and recording the link to it.
+    /// </remarks>
+    public static string InitialChargeKeyFor(string subscriptionId) =>
+        $"sub-init:{subscriptionId}";
 }

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -21,6 +21,10 @@ public static class SubscriptionConstants
         "SubscriptionCancellationRequested";
     public const string SubscriptionCanceled = "SubscriptionCanceled";
     public const string UsageThresholdReached = "UsageThresholdReached";
+    public const string SubscriptionRenewed = "SubscriptionRenewed";
+    public const string SubscriptionRenewalFailed = "SubscriptionRenewalFailed";
+    public const string SubscriptionPastDue = "SubscriptionPastDue";
+    public const string SubscriptionUnpaid = "SubscriptionUnpaid";
 
     /// <summary>
     /// Prefix for the order id a subscription's charges carry. Derived from the subscription id
@@ -42,4 +46,28 @@ public static class SubscriptionConstants
     /// </remarks>
     public static string InitialChargeKeyFor(string subscriptionId) =>
         $"sub-init:{subscriptionId}";
+
+    /// <summary>
+    /// A renewal's order id, scoped to the period it charges rather than to the subscription.
+    /// </summary>
+    /// <remarks>
+    /// The payment module allows only one recurring payment per order id, ever — so an order id
+    /// shared across every renewal would reject the second one outright. Scoping it to the
+    /// period keeps it stable across retries within that period (which is what lets a crash
+    /// between raising the charge and recording it be recovered by idempotency key) while
+    /// guaranteeing the next period's renewal never collides with an id already used.
+    /// </remarks>
+    public static string RenewalOrderIdFor(string subscriptionId, string periodKey) =>
+        $"{OrderIdPrefix}{subscriptionId}:{periodKey}";
+
+    /// <summary>
+    /// The idempotency key one renewal or dunning attempt is raised under.
+    /// </summary>
+    /// <remarks>
+    /// Includes the attempt number because, unlike the initial charge, a dunning retry is a
+    /// genuinely new charge attempt, not a replay of the last one — each must be free to
+    /// succeed or fail independently of the attempt before it.
+    /// </remarks>
+    public static string RenewalKeyFor(string subscriptionId, string periodKey, int attempt) =>
+        $"sub-renew:{subscriptionId}:{periodKey}:{attempt}";
 }

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -25,6 +25,7 @@ public static class SubscriptionConstants
     public const string SubscriptionRenewalFailed = "SubscriptionRenewalFailed";
     public const string SubscriptionPastDue = "SubscriptionPastDue";
     public const string SubscriptionUnpaid = "SubscriptionUnpaid";
+    public const string SubscriptionPlanChanged = "SubscriptionPlanChanged";
 
     /// <summary>
     /// Prefix for the order id a subscription's charges carry. Derived from the subscription id
@@ -70,4 +71,18 @@ public static class SubscriptionConstants
     /// </remarks>
     public static string RenewalKeyFor(string subscriptionId, string periodKey, int attempt) =>
         $"sub-renew:{subscriptionId}:{periodKey}:{attempt}";
+
+    /// <summary>
+    /// A plan change's order id, scoped to the version being changed from.
+    /// </summary>
+    /// <remarks>
+    /// A plan change has no period key to scope by — it is not a renewal — but <c>Version</c> is
+    /// already a monotonically increasing number unique to this exact attempt, which is all the
+    /// "one recurring payment per order id, ever" rule needs to stay satisfied.
+    /// </remarks>
+    public static string PlanChangeOrderIdFor(string subscriptionId, int version) =>
+        $"{OrderIdPrefix}{subscriptionId}:planchange:{version}";
+
+    public static string PlanChangeKeyFor(string subscriptionId, int version) =>
+        $"sub-planchange:{subscriptionId}:{version}";
 }

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -1,0 +1,34 @@
+namespace Subscription.DomainService.Utilities;
+
+public static class SubscriptionConstants
+{
+    /// <summary>
+    /// Where subscription domain events are published. Nothing in this repository consumes it:
+    /// the platform states what happened and each product decides what that means, which is why
+    /// a quota alert is an event here rather than an email.
+    /// </summary>
+    public const string LifecycleTopic =
+        "blocks_subscription_lifecycle_topic";
+
+    public const string SubscriptionCreated = "SubscriptionCreated";
+    public const string SubscriptionTrialStarted =
+        "SubscriptionTrialStarted";
+    public const string SubscriptionActivated =
+        "SubscriptionActivated";
+    public const string SubscriptionActivationFailed =
+        "SubscriptionActivationFailed";
+    public const string SubscriptionCancellationRequested =
+        "SubscriptionCancellationRequested";
+    public const string SubscriptionCanceled = "SubscriptionCanceled";
+    public const string UsageThresholdReached = "UsageThresholdReached";
+
+    /// <summary>
+    /// Prefix for the order id a subscription's charges carry. Derived from the subscription id
+    /// rather than stored separately, so a payment can be found again after a crash between
+    /// starting the charge and recording the link to it.
+    /// </summary>
+    public const string OrderIdPrefix = "sub:";
+
+    public static string OrderIdFor(string subscriptionId) =>
+        $"{OrderIdPrefix}{subscriptionId}";
+}

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -26,6 +26,8 @@ public static class SubscriptionConstants
     public const string SubscriptionPastDue = "SubscriptionPastDue";
     public const string SubscriptionUnpaid = "SubscriptionUnpaid";
     public const string SubscriptionPlanChanged = "SubscriptionPlanChanged";
+    public const string UsageRated = "UsageRated";
+    public const string UsageRatingFailed = "UsageRatingFailed";
 
     /// <summary>
     /// Prefix for the order id a subscription's charges carry. Derived from the subscription id
@@ -85,4 +87,21 @@ public static class SubscriptionConstants
 
     public static string PlanChangeKeyFor(string subscriptionId, int version) =>
         $"sub-planchange:{subscriptionId}:{version}";
+
+    /// <summary>
+    /// A usage invoice's order id, scoped to the period it charges and stable across every
+    /// retry — unlike the idempotency key below, this must never change: a fresh order id per
+    /// attempt would let the payment module's "one recurring payment per order id" rule be
+    /// satisfied by a second, duplicate charge for the same period.
+    /// </summary>
+    public static string UsageInvoiceOrderIdFor(string subscriptionId, string periodKey) =>
+        $"{OrderIdPrefix}{subscriptionId}:usage:{periodKey}";
+
+    /// <summary>
+    /// The idempotency key one overage-charge attempt is raised under. Carries the attempt
+    /// number for the same reason a renewal's dunning retry does — a retried charge must be
+    /// free to succeed where the last one declined, not replay its cached failure.
+    /// </summary>
+    public static string UsageInvoiceKeyFor(string subscriptionId, string periodKey, int attempt) =>
+        $"sub-usage:{subscriptionId}:{periodKey}:{attempt}";
 }

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -1,0 +1,57 @@
+namespace Subscription.DomainService.Utilities;
+
+public sealed class SubscriptionOptions
+{
+    public const string SectionName = "Subscription";
+
+    /// <summary>
+    /// How long a resolved subscription may be served from memory before it is read again.
+    /// Entitlement tolerates this staleness deliberately; usage counters never do and are
+    /// never cached.
+    /// </summary>
+    public int EntitlementCacheSeconds { get; set; } = 10;
+
+    /// <summary>
+    /// How long a finished usage period's counter is kept after it ends. The counter is a
+    /// derived read model and can always be rebuilt from the ledger, which is never expired.
+    /// </summary>
+    public int CounterRetentionDays { get; set; } = 400;
+
+    /// <summary>
+    /// How long a subscription may sit unpaid before the initial charge is considered
+    /// abandoned. Covers the shopper who opens checkout and closes the tab.
+    /// </summary>
+    public int InitialChargeGraceMinutes { get; set; } = 60;
+
+    /// <summary>
+    /// How often the worker sweeps for subscriptions whose activation never completed. Without
+    /// a tick, a subscription whose activation lost a compare-and-set stays unpaid-looking
+    /// forever while the shopper's money has already moved.
+    /// </summary>
+    public int ReconciliationPollSeconds { get; set; } = 120;
+
+    public int ActivationBatchSize { get; set; } = 50;
+    public int ActivationMaxAttempts { get; set; } = 10;
+    public int ActivationRetrySeconds { get; set; } = 30;
+
+    public int OutboxBatchSize { get; set; } = 50;
+    public int OutboxLeaseSeconds { get; set; } = 30;
+    public int OutboxMaxAttempts { get; set; } = 10;
+
+    public int UsageRequestsPerMinute { get; set; } = 600;
+    public int EntitlementRequestsPerMinute { get; set; } = 1_200;
+
+    /// <summary>
+    /// Caps on the free-form metadata a usage record may carry. Billing needs a count, not a
+    /// dossier: without a bound this field becomes an unversioned side-channel for whatever
+    /// the calling product happens to hold, including personal data it should not put here.
+    /// </summary>
+    public int MaximumUsageMetadataEntries { get; set; } = 10;
+    public int MaximumUsageMetadataValueLength { get; set; } = 256;
+
+    /// <summary>
+    /// Which tenants background sweeps run for. Nothing else discovers tenants, so a tenant
+    /// omitted here is silently skipped.
+    /// </summary>
+    public string[] TenantIds { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -52,6 +52,15 @@ public sealed class SubscriptionOptions
 
     public int UsageRatingBatchSize { get; set; } = 50;
 
+    /// <summary>
+    /// Overage-charge attempts, including the first decline, before an invoice is abandoned.
+    /// Independent of <see cref="DunningMaxAttempts"/>: a failed overage charge never affects
+    /// the subscription itself, so it is free to have its own, more relaxed cadence.
+    /// </summary>
+    public int UsageRatingMaxAttempts { get; set; } = 3;
+
+    public int UsageRatingRetryHours { get; set; } = 24;
+
     public int OutboxBatchSize { get; set; } = 50;
     public int OutboxLeaseSeconds { get; set; } = 30;
     public int OutboxMaxAttempts { get; set; } = 10;

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -50,6 +50,8 @@ public sealed class SubscriptionOptions
     /// </summary>
     public int DunningRetryIntervalHours { get; set; } = 24;
 
+    public int UsageRatingBatchSize { get; set; } = 50;
+
     public int OutboxBatchSize { get; set; } = 50;
     public int OutboxLeaseSeconds { get; set; } = 30;
     public int OutboxMaxAttempts { get; set; } = 10;

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -34,6 +34,22 @@ public sealed class SubscriptionOptions
     public int ActivationMaxAttempts { get; set; } = 10;
     public int ActivationRetrySeconds { get; set; } = 30;
 
+    public int RenewalBatchSize { get; set; } = 50;
+
+    /// <summary>
+    /// Renewal attempts, including the first decline, before a subscription moves to
+    /// <c>Unpaid</c>. Retrying beyond this is treated as certain to fail again rather than
+    /// eventually succeeding.
+    /// </summary>
+    public int DunningMaxAttempts { get; set; } = 4;
+
+    /// <summary>
+    /// A fixed interval between dunning attempts, not exponential backoff: this is a business
+    /// cadence for asking a customer to fix a card, not load-shedding against a failing
+    /// dependency.
+    /// </summary>
+    public int DunningRetryIntervalHours { get; set; } = 24;
+
     public int OutboxBatchSize { get; set; } = 50;
     public int OutboxLeaseSeconds { get; set; } = 30;
     public int OutboxMaxAttempts { get; set; } = 10;

--- a/server/Subscription.DomainService/Validators/ChangeSubscriptionPlanRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/ChangeSubscriptionPlanRequestValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Validators;
+
+public sealed class ChangeSubscriptionPlanRequestValidator
+    : AbstractValidator<ChangeSubscriptionPlanRequest>
+{
+    public ChangeSubscriptionPlanRequestValidator()
+    {
+        RuleFor(request => request.PlanCode).NotEmpty().MaximumLength(64);
+
+        RuleFor(request => request.PriceId).NotEmpty().MaximumLength(128);
+
+        RuleForEach(request => request.Quantities)
+            .ChildRules(quantity =>
+            {
+                quantity.RuleFor(item => item.ItemKey).NotEmpty().MaximumLength(64);
+                quantity.RuleFor(item => item.Quantity).GreaterThanOrEqualTo(0);
+            });
+
+        RuleFor(request => request.Quantities)
+            .Must(quantities => quantities
+                .Select(quantity => quantity.ItemKey)
+                .Distinct(StringComparer.Ordinal)
+                .Count() == quantities.Count)
+            .WithMessage("The same quantity item is listed more than once.")
+            .WithErrorCode("subscription_quantity_duplicated");
+    }
+}

--- a/server/Subscription.DomainService/Validators/CreatePlanRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePlanRequestValidator.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using FluentValidation;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Validators;
+
+public sealed class CreatePlanRequestValidator : AbstractValidator<CreatePlanRequest>
+{
+    private const int MaximumCodeLength = 64;
+    private const int MaximumFeaturesLength = 16_384;
+
+    public CreatePlanRequestValidator()
+    {
+        RuleFor(request => request.Code)
+            .NotEmpty()
+            .MaximumLength(MaximumCodeLength)
+            .Matches("^[a-z0-9_-]+$")
+            .WithMessage(
+                "A plan code may contain only lowercase letters, digits, hyphens and underscores.")
+            .WithErrorCode("subscription_plan_code_invalid");
+
+        RuleFor(request => request.DisplayName).NotEmpty().MaximumLength(200);
+
+        RuleFor(request => request.TrialDays)
+            .InclusiveBetween(1, 365)
+            .When(request => request.TrialDays.HasValue);
+
+        RuleFor(request => request.FeaturesJson)
+            .Must(BeAJsonObject)
+            .When(request => !string.IsNullOrWhiteSpace(request.FeaturesJson))
+            .WithMessage(
+                "Plan features must be a JSON object. It is stored verbatim and returned to " +
+                "callers, so it has to be something they can parse.")
+            .WithErrorCode("subscription_plan_features_invalid");
+
+        RuleForEach(request => request.QuantityItems)
+            .ChildRules(item =>
+            {
+                item.RuleFor(quantity => quantity.ItemKey).NotEmpty().MaximumLength(64);
+                item.RuleFor(quantity => quantity.UnitLabel).NotEmpty().MaximumLength(64);
+                item.RuleFor(quantity => quantity.MinQuantity).GreaterThanOrEqualTo(0);
+                item.RuleFor(quantity => quantity)
+                    .Must(quantity =>
+                        quantity.MaxQuantity is null ||
+                        quantity.MaxQuantity >= quantity.MinQuantity)
+                    .WithName(nameof(PlanQuantityItemRequest.MaxQuantity))
+                    .WithMessage("A maximum quantity cannot be below the minimum.");
+            });
+
+        RuleForEach(request => request.Meters)
+            .ChildRules(meter =>
+            {
+                meter.RuleFor(definition => definition.MeterKey).NotEmpty().MaximumLength(64);
+                meter.RuleFor(definition => definition.UnitLabel).NotEmpty().MaximumLength(64);
+                meter.RuleFor(definition => definition.IncludedQuantity)
+                    .GreaterThanOrEqualTo(0);
+                meter.RuleForEach(definition => definition.ThresholdPercents)
+                    .InclusiveBetween(1, 100);
+                meter.RuleFor(definition => definition.RateTables)
+                    .Must(HaveWellOrderedTiers)
+                    .WithMessage(
+                        "Rate tiers must ascend, and only the last may be unbounded — " +
+                        "otherwise a quantity falls into two bands and the bill depends on " +
+                        "which is read first.")
+                    .WithErrorCode("subscription_meter_tiers_invalid");
+            });
+
+        RuleForEach(request => request.Entitlements)
+            .ChildRules(entitlement =>
+            {
+                entitlement.RuleFor(definition => definition.Key).NotEmpty().MaximumLength(64);
+                entitlement.RuleFor(definition => definition)
+                    .Must(definition =>
+                        definition.LimitKind != EntitlementLimitKind.Count ||
+                        (definition.Limit.HasValue &&
+                         !string.IsNullOrWhiteSpace(definition.MeterKey)))
+                    .WithName(nameof(PlanEntitlementRequest.Limit))
+                    .WithMessage(
+                        "A counted entitlement needs both a limit and the meter that draws it down.");
+            });
+
+        RuleFor(request => request)
+            .Must(EveryEntitlementMeterExists)
+            .WithName(nameof(CreatePlanRequest.Entitlements))
+            .WithMessage(
+                "An entitlement names a meter the plan does not define, so nothing would ever " +
+                "draw it down.")
+            .WithErrorCode("subscription_entitlement_meter_unknown");
+
+        RuleFor(request => request)
+            .Must(EveryTrialGrantMeterExists)
+            .WithName(nameof(CreatePlanRequest.TrialGrants))
+            .WithMessage("A trial grant names a meter the plan does not define.")
+            .WithErrorCode("subscription_trial_grant_meter_unknown");
+    }
+
+    private static bool BeAJsonObject(string? featuresJson)
+    {
+        if (featuresJson is null || featuresJson.Length > MaximumFeaturesLength)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(featuresJson);
+
+            return document.RootElement.ValueKind == JsonValueKind.Object;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HaveWellOrderedTiers(List<MeterRateTableRequest> rateTables) =>
+        rateTables.TrueForAll(table =>
+        {
+            var tiers = table.Tiers;
+
+            if (tiers.Count == 0)
+            {
+                return true;
+            }
+
+            // Only the final tier may be open-ended; an unbounded band in the middle would
+            // swallow every band after it.
+            if (tiers.Take(tiers.Count - 1).Any(tier => tier.UpToQuantity is null))
+            {
+                return false;
+            }
+
+            // Every bound, including the last when it is closed — checking only the leading
+            // ones lets a final band sit below its predecessor and swallow the tier before it.
+            var bounds = tiers
+                .Where(tier => tier.UpToQuantity.HasValue)
+                .Select(tier => tier.UpToQuantity!.Value)
+                .ToArray();
+
+            return Array.TrueForAll(bounds, bound => bound > 0) &&
+                   bounds.Zip(bounds.Skip(1)).All(pair => pair.Second > pair.First);
+        });
+
+    private static bool EveryEntitlementMeterExists(CreatePlanRequest request)
+    {
+        var meterKeys = request.Meters
+            .Select(meter => meter.MeterKey)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return request.Entitlements.TrueForAll(entitlement =>
+            string.IsNullOrWhiteSpace(entitlement.MeterKey) ||
+            meterKeys.Contains(entitlement.MeterKey));
+    }
+
+    private static bool EveryTrialGrantMeterExists(CreatePlanRequest request)
+    {
+        var meterKeys = request.Meters
+            .Select(meter => meter.MeterKey)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return request.TrialGrants.TrueForAll(grant => meterKeys.Contains(grant.MeterKey));
+    }
+}

--- a/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
@@ -21,6 +21,10 @@ public sealed class CreatePriceRequestValidator : AbstractValidator<CreatePriceR
 
         RuleFor(request => request.IntervalCount).InclusiveBetween(1, 36);
 
+        RuleFor(request => request.TaxRateBasisPoints!.Value)
+            .InclusiveBetween(0, 10_000)
+            .When(request => request.TaxRateBasisPoints.HasValue);
+
         RuleFor(request => request)
             .Must(request => IsChargeable(currencyResolver, request))
             .WithName(nameof(CreatePriceRequest.CurrencyCode))

--- a/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
@@ -1,0 +1,46 @@
+using FluentValidation;
+using Payment.DomainService.Services;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Validators;
+
+public sealed class CreatePriceRequestValidator : AbstractValidator<CreatePriceRequest>
+{
+    public CreatePriceRequestValidator(ICurrencyMinorUnitResolver currencyResolver)
+    {
+        ArgumentNullException.ThrowIfNull(currencyResolver);
+
+        RuleFor(request => request.PlanId).NotEmpty();
+
+        RuleFor(request => request.CurrencyCode)
+            .NotEmpty()
+            .Length(3)
+            .Matches("^[A-Za-z]{3}$");
+
+        RuleFor(request => request.UnitAmountMinor).GreaterThanOrEqualTo(0);
+
+        RuleFor(request => request.IntervalCount).InclusiveBetween(1, 36);
+
+        RuleFor(request => request)
+            .Must(request => IsChargeable(currencyResolver, request))
+            .WithName(nameof(CreatePriceRequest.CurrencyCode))
+            .WithMessage(
+                "This currency is not configured for payments, so a subscription priced in it " +
+                "could never be charged.")
+            .WithErrorCode("subscription_currency_unsupported");
+    }
+
+    /// <summary>
+    /// Checks the currency here, where a person is authoring a price and can fix it, rather
+    /// than at checkout — where the same misconfiguration surfaces as an opaque payment error
+    /// to a customer who has already chosen a plan.
+    /// </summary>
+    private static bool IsChargeable(
+        ICurrencyMinorUnitResolver currencyResolver,
+        CreatePriceRequest request) =>
+        !string.IsNullOrWhiteSpace(request.CurrencyCode) &&
+        currencyResolver.TryConvertBack(
+            Math.Max(request.UnitAmountMinor, 1),
+            request.CurrencyCode.ToUpperInvariant(),
+            out _);
+}

--- a/server/Subscription.DomainService/Validators/CreateSubscriptionRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreateSubscriptionRequestValidator.cs
@@ -1,0 +1,44 @@
+using FluentValidation;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Validators;
+
+public sealed class CreateSubscriptionRequestValidator
+    : AbstractValidator<CreateSubscriptionRequest>
+{
+    public CreateSubscriptionRequestValidator()
+    {
+        RuleFor(request => request.PlanCode).NotEmpty().MaximumLength(64);
+
+        RuleFor(request => request.PriceId).NotEmpty().MaximumLength(128);
+
+        RuleFor(request => request.TimeZoneId)
+            .NotEmpty()
+            .Must(timeZoneId => BillingLocalTime.TryFindTimeZone(timeZoneId, out _))
+            .WithMessage(
+                "This time zone is not known to the server. Billing boundaries are computed in " +
+                "the customer's own calendar, so an unknown zone has to be refused here rather " +
+                "than surfacing at the first renewal.")
+            .WithErrorCode("subscription_time_zone_unknown");
+
+        RuleForEach(request => request.Quantities)
+            .ChildRules(quantity =>
+            {
+                quantity.RuleFor(item => item.ItemKey).NotEmpty().MaximumLength(64);
+                quantity.RuleFor(item => item.Quantity).GreaterThanOrEqualTo(0);
+            });
+
+        RuleFor(request => request.Quantities)
+            .Must(quantities => quantities
+                .Select(quantity => quantity.ItemKey)
+                .Distinct(StringComparer.Ordinal)
+                .Count() == quantities.Count)
+            .WithMessage("The same quantity item is listed more than once.")
+            .WithErrorCode("subscription_quantity_duplicated");
+
+        RuleFor(request => request.BillingEmail)
+            .EmailAddress()
+            .When(request => !string.IsNullOrWhiteSpace(request.BillingEmail));
+    }
+}

--- a/server/Subscription.DomainService/Validators/RecordUsageRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/RecordUsageRequestValidator.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+using Microsoft.Extensions.Options;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Validators;
+
+public sealed class RecordUsageRequestValidator : AbstractValidator<RecordUsageRequest>
+{
+    public RecordUsageRequestValidator(IOptionsMonitor<SubscriptionOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        RuleFor(request => request.MeterKey).NotEmpty().MaximumLength(64);
+
+        RuleFor(request => request.IdempotencyKey)
+            .NotEmpty()
+            .MaximumLength(128)
+            .WithMessage(
+                "An idempotency key is required. Without one a retried call becomes a second " +
+                "billable event, and callers do retry.")
+            .WithErrorCode("subscription_usage_idempotency_key_required");
+
+        RuleFor(request => request.Quantity)
+            .GreaterThan(0)
+            .WithMessage(
+                "Usage must be positive. A correction is recorded as its own reversal so the " +
+                "ledger can still explain the bill.");
+
+        RuleFor(request => request.Metadata)
+            .Must(metadata =>
+                metadata.Count <= options.CurrentValue.MaximumUsageMetadataEntries)
+            .WithMessage("Too many metadata entries.")
+            .WithErrorCode("subscription_usage_metadata_too_large");
+
+        RuleFor(request => request.Metadata)
+            .Must(metadata => metadata.Values.All(value =>
+                value.Length <= options.CurrentValue.MaximumUsageMetadataValueLength))
+            .WithMessage("A metadata value is too long.")
+            .WithErrorCode("subscription_usage_metadata_too_large");
+    }
+}

--- a/server/Worker/Consumers/Payment/PaymentWorkCommandConsumer.cs
+++ b/server/Worker/Consumers/Payment/PaymentWorkCommandConsumer.cs
@@ -4,6 +4,7 @@ using Payment.DomainService.Commands;
 using Payment.DomainService.Outbox;
 using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
+using Subscription.DomainService.Outbox;
 
 namespace Worker.Consumers.Payment;
 
@@ -100,10 +101,29 @@ public sealed class PaymentWorkCommandConsumer :
                     CancellationToken.None);
         }
 
+        // Subscriptions ride the payment tick rather than their own queue. Every inbound
+        // webhook already dispatches this command, so a paid subscription activates within
+        // milliseconds of the confirmation that paid for it — with no new bus plumbing and no
+        // change to how payments behave.
+        var subscriptionActivation = services.GetRequiredService<
+            ISubscriptionActivationProcessor>();
+        var subscriptionOutbox = services.GetRequiredService<
+            ISubscriptionOutboxProcessor>();
+        var activatedSubscriptions =
+            await subscriptionActivation.ProcessDueAsync(
+                command.TenantId,
+                CancellationToken.None);
+        var publishedSubscriptionEvents =
+            await subscriptionOutbox.PublishDueAsync(
+                command.TenantId,
+                CancellationToken.None);
+
         _logger.LogInformation(
-            "Payment work command processing completed ProcessedWebhookCount={ProcessedWebhookCount} PublishedPaymentEventCount={PublishedPaymentEventCount} PublishedRefundEventCount={PublishedRefundEventCount}",
+            "Payment work command processing completed ProcessedWebhookCount={ProcessedWebhookCount} PublishedPaymentEventCount={PublishedPaymentEventCount} PublishedRefundEventCount={PublishedRefundEventCount} ActivatedSubscriptionCount={ActivatedSubscriptionCount} PublishedSubscriptionEventCount={PublishedSubscriptionEventCount}",
             processedWebhooks,
             publishedPaymentEvents,
-            publishedRefundEvents);
+            publishedRefundEvents,
+            activatedSubscriptions,
+            publishedSubscriptionEvents);
     }
 }

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -8,6 +8,7 @@ using Utility.DomainService.Messaging;
 using Utility.DomainService.PdfGenerator.Utilities;
 using Utility.DomainService.TemplateEngine.Utilities;
 using SeliseBlocks.ConfigurationDriver;
+using Subscription.DomainService.Utilities;
 using Worker;
 using Worker.Configuration;
 using Worker.Consumers.Payment;
@@ -67,6 +68,7 @@ IHostBuilder CreateHostBuilder(string[] args) =>
             services.RegisterUtilityServices();
             services.AddSingleton<IVault>(_ => paymentVault);
             services.RegisterPaymentDomainServices(context.Configuration);
+            services.RegisterSubscriptionDomainServices(context.Configuration);
             services.AddHostedService<
                 PaymentReconciliationBackgroundService>();
             ApplicationConfigurations.ConfigureWorker(services, GetCombinedMessageConfiguration(secret.MessageConnectionString));

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -71,6 +71,8 @@ IHostBuilder CreateHostBuilder(string[] args) =>
             services.RegisterSubscriptionDomainServices(context.Configuration);
             services.AddHostedService<
                 PaymentReconciliationBackgroundService>();
+            services.AddHostedService<
+                SubscriptionReconciliationBackgroundService>();
             ApplicationConfigurations.ConfigureWorker(services, GetCombinedMessageConfiguration(secret.MessageConnectionString));
             //ApplicationConfigurations.ConfigureWorker(services, IdentifierConstants.GetMessageConfiguration(secret.MessageConnectionString));
             #endregion

--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -110,19 +110,23 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
             });
 
             var activation = services.GetRequiredService<ISubscriptionActivationProcessor>();
+            var renewals = services.GetRequiredService<ISubscriptionRenewalProcessor>();
             var outbox = services.GetRequiredService<ISubscriptionOutboxProcessor>();
 
             var settled = await activation.ProcessDueAsync(tenantId, stoppingToken);
             var recovered = await activation.RecoverStaleAsync(tenantId, stoppingToken);
+            var renewed = await renewals.ProcessDueAsync(tenantId, stoppingToken);
             var published = await outbox.PublishDueAsync(tenantId, stoppingToken);
 
-            if (settled + recovered + published > 0)
+            if (settled + recovered + renewed + published > 0)
             {
                 _logger.LogInformation(
                     "Subscription reconciliation pass completed SettledCount={SettledCount} " +
-                    "RecoveredCount={RecoveredCount} PublishedCount={PublishedCount}",
+                    "RecoveredCount={RecoveredCount} RenewedCount={RenewedCount} " +
+                    "PublishedCount={PublishedCount}",
                     settled,
                     recovered,
+                    renewed,
                     published);
             }
         }

--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -111,22 +111,29 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
 
             var activation = services.GetRequiredService<ISubscriptionActivationProcessor>();
             var renewals = services.GetRequiredService<ISubscriptionRenewalProcessor>();
+            var usageRating = services.GetRequiredService<ISubscriptionUsageRatingProcessor>();
             var outbox = services.GetRequiredService<ISubscriptionOutboxProcessor>();
 
             var settled = await activation.ProcessDueAsync(tenantId, stoppingToken);
             var recovered = await activation.RecoverStaleAsync(tenantId, stoppingToken);
             var renewed = await renewals.ProcessDueAsync(tenantId, stoppingToken);
+            var periodsClosed = await usageRating.CloseDuePeriodsAsync(tenantId, stoppingToken);
+            var invoicesCharged = await usageRating.ChargeDueInvoicesAsync(tenantId, stoppingToken);
             var published = await outbox.PublishDueAsync(tenantId, stoppingToken);
 
-            if (settled + recovered + renewed + published > 0)
+            if (settled + recovered + renewed + periodsClosed + invoicesCharged + published > 0)
             {
                 _logger.LogInformation(
                     "Subscription reconciliation pass completed SettledCount={SettledCount} " +
                     "RecoveredCount={RecoveredCount} RenewedCount={RenewedCount} " +
+                    "UsagePeriodsClosedCount={UsagePeriodsClosedCount} " +
+                    "UsageInvoicesChargedCount={UsageInvoicesChargedCount} " +
                     "PublishedCount={PublishedCount}",
                     settled,
                     recovered,
                     renewed,
+                    periodsClosed,
+                    invoicesCharged,
                     published);
             }
         }

--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Utilities;
+
+namespace Worker;
+
+/// <summary>
+/// The periodic sweep that finishes work no message could carry.
+/// </summary>
+/// <remarks>
+/// Activation normally happens within milliseconds of a webhook, driven by the payment work
+/// command. This exists for the cases nothing dispatches: a compare-and-set lost to another
+/// worker that then crashed, a charge raised but never recorded, a webhook that arrived while
+/// this service was restarting.
+/// <para>
+/// Without a tick, a subscription in any of those states stays unpaid-looking forever while the
+/// customer's money has already moved — the failure nobody reports because the customer assumes
+/// it is their own doing.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionReconciliationBackgroundService : BackgroundService
+{
+    private const int MinimumPollSeconds = 30;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionReconciliationBackgroundService> _logger;
+
+    public SubscriptionReconciliationBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<SubscriptionReconciliationBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var tenantIds = _options.CurrentValue.TenantIds;
+
+        if (tenantIds.Length == 0)
+        {
+            // Said plainly, because the alternative is a service that looks healthy and
+            // reconciles nothing. Nothing else discovers tenants.
+            _logger.LogWarning(
+                "Subscription reconciliation has no tenants configured and will do nothing. " +
+                "Set Subscription:TenantIds to enable it");
+
+            return;
+        }
+
+        _logger.LogInformation(
+            "Subscription reconciliation started TenantCount={TenantCount}",
+            tenantIds.Length);
+
+        using var timer = new PeriodicTimer(PollInterval());
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await timer.WaitForNextTickAsync(stoppingToken);
+                await SweepAsync(tenantIds, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception exception)
+            {
+                // One bad pass must not end the loop: the next tick is the recovery for
+                // whatever went wrong here.
+                _logger.LogError(
+                    exception,
+                    "Subscription reconciliation pass failed and will be retried");
+            }
+        }
+
+        _logger.LogInformation("Subscription reconciliation stopped");
+    }
+
+    private async Task SweepAsync(
+        IReadOnlyList<string> tenantIds,
+        CancellationToken stoppingToken)
+    {
+        foreach (var tenantId in tenantIds)
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            using var scope = _scopeFactory.CreateScope();
+            var services = scope.ServiceProvider;
+
+            // Background work has no request to read a tenant from, so one is established for
+            // the duration — the same discipline the payment work consumer follows.
+            using var context = services
+                .GetRequiredService<IPaymentTenantContextScopeFactory>()
+                .Establish(tenantId);
+
+            using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+            {
+                ["TenantHash"] = PaymentLogValue.Hash(tenantId),
+                ["SubscriptionSweepId"] = Guid.NewGuid().ToString("N")
+            });
+
+            var activation = services.GetRequiredService<ISubscriptionActivationProcessor>();
+            var outbox = services.GetRequiredService<ISubscriptionOutboxProcessor>();
+
+            var settled = await activation.ProcessDueAsync(tenantId, stoppingToken);
+            var recovered = await activation.RecoverStaleAsync(tenantId, stoppingToken);
+            var published = await outbox.PublishDueAsync(tenantId, stoppingToken);
+
+            if (settled + recovered + published > 0)
+            {
+                _logger.LogInformation(
+                    "Subscription reconciliation pass completed SettledCount={SettledCount} " +
+                    "RecoveredCount={RecoveredCount} PublishedCount={PublishedCount}",
+                    settled,
+                    recovered,
+                    published);
+            }
+        }
+    }
+
+    private TimeSpan PollInterval() =>
+        TimeSpan.FromSeconds(
+            Math.Max(MinimumPollSeconds, _options.CurrentValue.ReconciliationPollSeconds));
+}

--- a/server/Worker/Worker.csproj
+++ b/server/Worker/Worker.csproj
@@ -12,5 +12,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Utility.DomainService\Utility.DomainService.csproj" />
     <ProjectReference Include="..\Payment.DomainService\Payment.DomainService.csproj" />
+    <ProjectReference Include="..\Subscription.DomainService\Subscription.DomainService.csproj" />
   </ItemGroup>
 </Project>

--- a/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
@@ -1,0 +1,379 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// The guarantees this module leans on that only a real database can demonstrate.
+/// </summary>
+/// <remarks>
+/// Uniqueness, atomic increments and compare-and-set are all enforced by MongoDB, not by our
+/// code. Mocking them would test the mock: every one of these would pass against an in-memory
+/// stand-in while the real collection happily wrote a second live subscription or counted one
+/// screening twice.
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class SubscriptionRepositoryIntegrationTests
+{
+    private readonly MongoIntegrationFixture _fixture;
+    private readonly SubscriptionRepository _subscriptions;
+    private readonly SubscriptionUsageRepository _usage;
+    private readonly SubscriptionPaymentLinkRepository _links;
+    private readonly BillingAccountRepository _accounts;
+
+    public SubscriptionRepositoryIntegrationTests(MongoIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+        _subscriptions = new SubscriptionRepository(fixture.DbContextProvider);
+        _usage = new SubscriptionUsageRepository(fixture.DbContextProvider);
+        _links = new SubscriptionPaymentLinkRepository(fixture.DbContextProvider);
+        _accounts = new BillingAccountRepository(fixture.DbContextProvider);
+    }
+
+    [Fact]
+    public async Task An_organization_cannot_hold_two_live_subscriptions()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        (await _subscriptions.TryCreateAsync(
+            NewSubscription(tenantId, "org-1", SubscriptionStatus.Active),
+            CancellationToken.None)).Should().BeTrue();
+
+        (await _subscriptions.TryCreateAsync(
+                NewSubscription(tenantId, "org-1", SubscriptionStatus.Trialing),
+                CancellationToken.None))
+            .Should().BeFalse("the database refuses a second live subscription, so two " +
+                              "concurrent signups cannot both succeed");
+    }
+
+    [Fact]
+    public async Task An_ended_subscription_does_not_block_resubscribing()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _subscriptions.TryCreateAsync(
+            NewSubscription(tenantId, "org-2", SubscriptionStatus.Canceled),
+            CancellationToken.None);
+
+        (await _subscriptions.TryCreateAsync(
+                NewSubscription(tenantId, "org-2", SubscriptionStatus.Active),
+                CancellationToken.None))
+            .Should().BeTrue("the uniqueness rule covers only statuses that grant something");
+    }
+
+    [Fact]
+    public async Task Only_one_of_two_concurrent_transitions_wins()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var subscription = NewSubscription(tenantId, "org-3", SubscriptionStatus.Incomplete);
+
+        await _subscriptions.TryCreateAsync(
+            subscription,
+            CancellationToken.None);
+
+        var transition = new SubscriptionTransition(
+            SubscriptionStatus.Incomplete,
+            SubscriptionStatus.Active)
+        {
+            ActivatedAtUtc = DateTime.UtcNow
+        };
+
+        var first = _subscriptions.TryTransitionAsync(
+            tenantId,
+            subscription.ItemId,
+            transition,
+            CancellationToken.None);
+
+        var second = _subscriptions.TryTransitionAsync(
+            tenantId,
+            subscription.ItemId,
+            transition,
+            CancellationToken.None);
+
+        var outcomes = await Task.WhenAll(first, second);
+
+        outcomes.Count(succeeded => succeeded).Should().Be(1,
+            "activation must apply once even if two sweeps pick up the same payment");
+
+        var stored = await _subscriptions.GetByIdAsync(
+            tenantId,
+            subscription.ItemId,
+            CancellationToken.None);
+
+        stored!.Status.Should().Be(SubscriptionStatus.Active);
+        stored.Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task The_same_usage_key_can_only_be_recorded_once()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        (await _usage.TryAppendRecordAsync(
+            NewUsageRecord(tenantId, "sub-1", "key-1"),
+            CancellationToken.None)).Should().BeTrue();
+
+        (await _usage.TryAppendRecordAsync(
+                NewUsageRecord(tenantId, "sub-1", "key-1"),
+                CancellationToken.None))
+            .Should().BeFalse("a retried call must not become a second billable event");
+    }
+
+    [Fact]
+    public async Task A_counter_returns_the_balance_including_the_callers_own_delta()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var seed = NewCounter(tenantId, "sub-2", "screening", "M20260801T000000Z");
+
+        var first = await _usage.ApplyDeltaAsync(
+            seed,
+            1,
+            CancellationToken.None);
+
+        var second = await _usage.ApplyDeltaAsync(
+            seed,
+            1,
+            CancellationToken.None);
+
+        first.Balance.Should().Be(1);
+        second.Balance.Should().Be(2, "the post-increment balance is what makes recording an " +
+                                      "enforcement point rather than a check");
+        second.AppliedRecordCount.Should().Be(2);
+        second.LimitSnapshot.Should().Be(500, "the allowance is captured when the period opens");
+    }
+
+    [Fact]
+    public async Task Concurrent_increments_all_land()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var seed = NewCounter(tenantId, "sub-3", "screening", "M20260801T000000Z");
+
+        await Task.WhenAll(Enumerable.Range(0, 20).Select(_ =>
+            _usage.ApplyDeltaAsync(seed, 1, CancellationToken.None)));
+
+        var counter = await _usage.GetCounterAsync(
+            tenantId,
+            seed.ItemId,
+            CancellationToken.None);
+
+        counter!.Balance.Should().Be(20, "a read-modify-write would lose some of these");
+    }
+
+    [Fact]
+    public async Task Adjacent_periods_are_separate_counters()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _usage.ApplyDeltaAsync(
+            NewCounter(tenantId, "sub-4", "screening", "M20260801T000000Z"),
+            5,
+            CancellationToken.None);
+
+        var next = await _usage.ApplyDeltaAsync(
+            NewCounter(tenantId, "sub-4", "screening", "M20260901T000000Z"),
+            1,
+            CancellationToken.None);
+
+        next.Balance.Should().Be(1, "a new period starts at zero without any rollover job");
+    }
+
+    [Fact]
+    public async Task A_threshold_is_reported_by_exactly_one_caller()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var seed = NewCounter(tenantId, "sub-5", "screening", "M20260801T000000Z");
+
+        await _usage.ApplyDeltaAsync(seed, 400, CancellationToken.None);
+
+        var outcomes = await Task.WhenAll(
+            _usage.TryMarkThresholdNotifiedAsync(
+                tenantId, seed.ItemId, 80, CancellationToken.None),
+            _usage.TryMarkThresholdNotifiedAsync(
+                tenantId, seed.ItemId, 80, CancellationToken.None));
+
+        outcomes.Count(won => won).Should().Be(1,
+            "otherwise every screening past the threshold sends another email");
+    }
+
+    [Fact]
+    public async Task A_payment_can_be_linked_to_only_one_subscription()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        (await _links.TryCreateAsync(
+            NewLink(tenantId, "sub-6", "pay-1"),
+            CancellationToken.None)).Should().BeTrue();
+
+        (await _links.TryCreateAsync(
+                NewLink(tenantId, "sub-7", "pay-1"),
+                CancellationToken.None))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_link_settles_once_however_many_sweeps_see_it()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var link = NewLink(tenantId, "sub-8", "pay-2");
+
+        await _links.TryCreateAsync(link, CancellationToken.None);
+
+        var outcomes = await Task.WhenAll(
+            _links.TrySettleAsync(
+                tenantId,
+                link.ItemId,
+                SubscriptionPaymentLinkState.Applied,
+                CancellationToken.None),
+            _links.TrySettleAsync(
+                tenantId,
+                link.ItemId,
+                SubscriptionPaymentLinkState.Applied,
+                CancellationToken.None));
+
+        outcomes.Count(settled => settled).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_billing_account_is_created_once_per_organization_and_provider()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var first = await _accounts.GetOrCreateAsync(
+            NewAccount(tenantId, "org-9"),
+            CancellationToken.None);
+
+        var second = await _accounts.GetOrCreateAsync(
+            NewAccount(tenantId, "org-9"),
+            CancellationToken.None);
+
+        second.ItemId.Should().Be(first.ItemId);
+    }
+
+    [Fact]
+    public async Task A_provider_customer_is_recorded_once_and_never_replaced()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var account = await _accounts.GetOrCreateAsync(
+            NewAccount(tenantId, "org-10"),
+            CancellationToken.None);
+
+        (await _accounts.TrySetProviderCustomerAsync(
+            tenantId, account.ItemId, "cus_first", "pm_1",
+            CancellationToken.None)).Should().BeTrue();
+
+        (await _accounts.TrySetProviderCustomerAsync(
+                tenantId, account.ItemId, "cus_other", null,
+                CancellationToken.None))
+            .Should().BeFalse("adopting a second customer would strand every saved card on " +
+                              "the first");
+
+        var stored = await _accounts.GetAsync(
+            tenantId,
+            account.ItemId,
+            CancellationToken.None);
+
+        stored!.ProviderCustomerId.Should().Be("cus_first");
+    }
+
+    [Fact]
+    public async Task An_event_is_appended_once_per_deduplication_key()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var subscription = NewSubscription(tenantId, "org-11", SubscriptionStatus.Active);
+
+        await _subscriptions.TryCreateAsync(
+            subscription,
+            CancellationToken.None);
+
+        var outboxEvent = new SubscriptionOutboxEvent
+        {
+            EventType = "SubscriptionActivated",
+            DeduplicationKey = $"{subscription.ItemId}:SubscriptionActivated",
+            Payload = "{}",
+            CorrelationId = "corr-1"
+        };
+
+        (await _subscriptions.TryAppendEventAsync(
+            tenantId, subscription.ItemId, outboxEvent,
+            CancellationToken.None)).Should().BeTrue();
+
+        (await _subscriptions.TryAppendEventAsync(
+                tenantId, subscription.ItemId, outboxEvent,
+                CancellationToken.None))
+            .Should().BeFalse();
+    }
+
+    private static SubscriptionDetail NewSubscription(
+        string tenantId,
+        string organizationId,
+        SubscriptionStatus status)
+    {
+        var id = Guid.NewGuid().ToString();
+
+        return new SubscriptionDetail
+        {
+            ItemId = id,
+            TenantId = tenantId,
+            OrganizationId = organizationId,
+            BillingAccountId = "acct-1",
+            Status = status,
+            CurrencyCode = "CHF",
+            OrderId = $"sub:{id}"
+        };
+    }
+
+    private static SubscriptionUsageRecord NewUsageRecord(
+        string tenantId,
+        string subscriptionId,
+        string idempotencyKey) => new()
+    {
+        TenantId = tenantId,
+        OrganizationId = "org-1",
+        SubscriptionId = subscriptionId,
+        MeterKey = "screening",
+        PeriodKey = "M20260801T000000Z",
+        Delta = 1,
+        IdempotencyKey = idempotencyKey,
+        OccurredAtUtc = DateTime.UtcNow
+    };
+
+    private static SubscriptionUsageCounter NewCounter(
+        string tenantId,
+        string subscriptionId,
+        string meterKey,
+        string periodKey) => new()
+    {
+        ItemId = SubscriptionUsageCounter.CreateId(subscriptionId, meterKey, periodKey),
+        TenantId = tenantId,
+        OrganizationId = "org-1",
+        SubscriptionId = subscriptionId,
+        MeterKey = meterKey,
+        PeriodKey = periodKey,
+        LimitSnapshot = 500,
+        PeriodStartUtc = DateTime.UtcNow.AddDays(-1),
+        PeriodEndUtc = DateTime.UtcNow.AddDays(29),
+        ExpiresAtUtc = DateTime.UtcNow.AddDays(400)
+    };
+
+    private static SubscriptionPaymentLink NewLink(
+        string tenantId,
+        string subscriptionId,
+        string paymentDetailId) => new()
+    {
+        TenantId = tenantId,
+        OrganizationId = "org-1",
+        SubscriptionId = subscriptionId,
+        PaymentDetailId = paymentDetailId,
+        OrderId = $"sub:{subscriptionId}"
+    };
+
+    private static BillingAccount NewAccount(string tenantId, string organizationId) => new()
+    {
+        TenantId = tenantId,
+        OrganizationId = organizationId,
+        ProviderName = "STRIPE"
+    };
+}

--- a/server/XUnitTest/Payment/PaymentEncryptionScopeTests.cs
+++ b/server/XUnitTest/Payment/PaymentEncryptionScopeTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Utilities;
+
+namespace XUnitTest.Payment;
+
+/// <summary>
+/// Which key ring protects a saved card's token — the fix for the case where a caller's
+/// organization and the merchant account that issued the token are not the same thing.
+/// </summary>
+public sealed class PaymentEncryptionScopeTests
+{
+    [Fact]
+    public void A_record_with_a_resolved_scope_uses_the_encryption_organization()
+    {
+        var method = new StoredPaymentMethod
+        {
+            TenantId = "tenant-1",
+            OrganizationId = "caller-org",
+            EncryptionOrganizationId = "merchant-org",
+            EncryptionScopeResolvedAtUtc = DateTime.UtcNow
+        };
+
+        var scope = PaymentEncryptionScope.From(method);
+
+        scope.OrganizationId.Should().Be("merchant-org",
+            "the token is only usable at the merchant account that issued it, which need not " +
+            "be the organization that happened to save the card");
+    }
+
+    [Fact]
+    public void A_resolved_scope_can_be_the_tenant_level_ring_even_when_the_caller_has_an_organization()
+    {
+        var method = new StoredPaymentMethod
+        {
+            TenantId = "tenant-1",
+            OrganizationId = "caller-org",
+            EncryptionOrganizationId = null,
+            EncryptionScopeResolvedAtUtc = DateTime.UtcNow
+        };
+
+        var scope = PaymentEncryptionScope.From(method);
+
+        scope.OrganizationId.Should().BeNull(
+            "an organization that is a subscriber of a tenant-level merchant account has no " +
+            "ring of its own, and none should be inferred from its visibility scope");
+    }
+
+    [Fact]
+    public void A_legacy_record_with_no_resolved_scope_falls_back_to_the_visibility_organization()
+    {
+        var method = new StoredPaymentMethod
+        {
+            TenantId = "tenant-1",
+            OrganizationId = "caller-org",
+            EncryptionOrganizationId = null,
+            EncryptionScopeResolvedAtUtc = null
+        };
+
+        var scope = PaymentEncryptionScope.From(method);
+
+        scope.OrganizationId.Should().Be("caller-org",
+            "every organization was its own merchant when a record like this was written, so " +
+            "the two fields held the same value at the time");
+    }
+
+    [Fact]
+    public void The_encryption_organization_on_a_legacy_record_is_ignored()
+    {
+        // A record cannot actually be in this state today, but the derivation must not trust
+        // EncryptionOrganizationId until EncryptionScopeResolvedAtUtc says it was actually set.
+        var method = new StoredPaymentMethod
+        {
+            TenantId = "tenant-1",
+            OrganizationId = "caller-org",
+            EncryptionOrganizationId = "some-other-value",
+            EncryptionScopeResolvedAtUtc = null
+        };
+
+        PaymentEncryptionScope.From(method).OrganizationId.Should().Be("caller-org");
+    }
+}

--- a/server/XUnitTest/Payment/PaymentWorkCommandConsumerTests.cs
+++ b/server/XUnitTest/Payment/PaymentWorkCommandConsumerTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using Payment.DomainService.Commands;
 using Payment.DomainService.Outbox;
 using Payment.DomainService.Services;
+using Subscription.DomainService.Outbox;
 using Worker.Consumers.Payment;
 
 namespace XUnitTest.Payment;
@@ -60,6 +61,8 @@ public sealed class PaymentWorkCommandConsumerTests
             StoredMethodRecovery { get; } = new();
         public Mock<IPaymentRefundRecoveryProcessor> RefundRecovery { get; } = new();
         public Mock<IPaymentCaptureRecoveryProcessor> CaptureRecovery { get; } = new();
+        public Mock<ISubscriptionActivationProcessor> SubscriptionActivation { get; } = new();
+        public Mock<ISubscriptionOutboxProcessor> SubscriptionOutbox { get; } = new();
         public PaymentWorkCommandConsumer Consumer { get; }
 
         public Fixture()
@@ -106,6 +109,9 @@ public sealed class PaymentWorkCommandConsumerTests
             services.AddScoped(_ => StoredMethodRecovery.Object);
             services.AddScoped(_ => RefundRecovery.Object);
             services.AddScoped(_ => CaptureRecovery.Object);
+            // Subscriptions ride this same tick, so the consumer resolves their processors too.
+            services.AddScoped(_ => SubscriptionActivation.Object);
+            services.AddScoped(_ => SubscriptionOutbox.Object);
             var provider = services.BuildServiceProvider();
 
             Consumer = new PaymentWorkCommandConsumer(

--- a/server/XUnitTest/Payment/StoredPaymentMethodLifecycleServiceTests.cs
+++ b/server/XUnitTest/Payment/StoredPaymentMethodLifecycleServiceTests.cs
@@ -236,6 +236,94 @@ public sealed class StoredPaymentMethodLifecycleServiceTests
             Times.Once);
     }
 
+    /// <summary>
+    /// Organizations that are subscribers of one tenant-level account, not merchants in their
+    /// own right, must have their cards encrypted under the tenant's ring — never a ring named
+    /// for the organization, which does not exist and never will.
+    /// </summary>
+    [Fact]
+    public async Task A_card_saved_under_a_tenant_level_provider_is_encrypted_at_tenant_scope()
+    {
+        var fixture = new Fixture();
+        fixture.Providers
+            .Setup(cache => cache.GetAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<Task<PaymentProvider?>>>()))
+            .ReturnsAsync(new PaymentProvider
+            {
+                TenantId = "tenant-1",
+                OrganizationId = null
+            });
+
+        var payment = PaymentWith(rememberCard: true);
+        payment.OrganizationId = "caller-org";
+
+        await fixture.Service.ApplyAuthorisationTokenAsync(
+            fixture.TokenWebhook("AUTHORISATION"), payment, CancellationToken.None);
+
+        fixture.Methods.Verify(repository => repository.UpsertFromProviderAsync(
+                It.Is<StoredPaymentMethod>(method =>
+                    method.OrganizationId == "caller-org" &&
+                    method.EncryptionOrganizationId == null &&
+                    method.EncryptionScopeResolvedAtUtc != null),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "visibility stays with the caller; encryption follows the merchant account, which " +
+            "here is the tenant-level one");
+    }
+
+    /// <summary>
+    /// The other model this module supports: an organization with its own merchant account.
+    /// There the two fields agree, which is what made the bug easy to miss.
+    /// </summary>
+    [Fact]
+    public async Task A_card_saved_under_an_organization_scoped_provider_is_encrypted_at_that_scope()
+    {
+        var fixture = new Fixture();
+        fixture.Providers
+            .Setup(cache => cache.GetAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<Task<PaymentProvider?>>>()))
+            .ReturnsAsync(new PaymentProvider
+            {
+                TenantId = "tenant-1",
+                OrganizationId = "merchant-org"
+            });
+
+        var payment = PaymentWith(rememberCard: true);
+        payment.OrganizationId = "merchant-org";
+
+        await fixture.Service.ApplyAuthorisationTokenAsync(
+            fixture.TokenWebhook("AUTHORISATION"), payment, CancellationToken.None);
+
+        fixture.Methods.Verify(repository => repository.UpsertFromProviderAsync(
+                It.Is<StoredPaymentMethod>(method =>
+                    method.EncryptionOrganizationId == "merchant-org"),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task No_provider_configuration_fails_closed_rather_than_guessing_a_scope()
+    {
+        var fixture = new Fixture();
+        fixture.Providers
+            .Setup(cache => cache.GetAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<Task<PaymentProvider?>>>()))
+            .ReturnsAsync((PaymentProvider?)null);
+
+        var act = () => fixture.Service.ApplyAuthorisationTokenAsync(
+            fixture.TokenWebhook("AUTHORISATION"),
+            PaymentWith(rememberCard: true),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        fixture.VerifyNoUpsert();
+    }
+
     [Fact]
     public async Task Authorisation_for_inactive_method_without_fresh_consent_is_skipped()
     {
@@ -314,13 +402,18 @@ public sealed class StoredPaymentMethodLifecycleServiceTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(ProviderTokenProtectionResult.Failed);
+        var providers = new Mock<IPaymentProviderCache>();
+        providers.Setup(cache => cache.GetAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<Task<PaymentProvider?>>>()))
+            .ReturnsAsync(new PaymentProvider { TenantId = "tenant-1" });
         var service = new StoredPaymentMethodLifecycleService(
             methods.Object,
             Mock.Of<IPaymentRepository>(),
             protector.Object,
             Mock.Of<IStoredPaymentMethodDetailProviderGatewayResolver>(),
             Mock.Of<IStoredPaymentMethodProviderGatewayResolver>(),
-            Mock.Of<IPaymentProviderCache>(),
+            providers.Object,
             Mock.Of<ILogger<StoredPaymentMethodLifecycleService>>());
         var webhook = new PaymentWebhookInbox
         {
@@ -363,6 +456,16 @@ public sealed class StoredPaymentMethodLifecycleServiceTests
             get;
         } = new();
 
+        /// <summary>
+        /// The provider a token is encrypted under. Defaults to a tenant-level configuration,
+        /// which is the ordinary case; a test caring about organization-scoped encryption
+        /// arranges its own <see cref="PaymentProvider.OrganizationId"/> here.
+        /// </summary>
+        public Mock<IPaymentProviderCache> Providers
+        {
+            get;
+        } = new();
+
         public StoredPaymentMethodLifecycleService Service
         {
             get;
@@ -381,6 +484,18 @@ public sealed class StoredPaymentMethodLifecycleServiceTests
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     (StoredPaymentMethod?)null);
+
+            Providers
+                .Setup(cache => cache.GetAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Func<Task<PaymentProvider?>>>()))
+                .ReturnsAsync(new PaymentProvider
+                {
+                    TenantId = "tenant-1",
+                    ProviderName = PaymentConstants.AdyenOnlineProvider
+                });
 
             var keyRing =
                 new ProviderTokenEncryptionKeyRing(
@@ -402,7 +517,7 @@ public sealed class StoredPaymentMethodLifecycleServiceTests
                     new ProviderTokenProtector(new AesGcmSecretProtector(new FixedKeyRingProvider(keyRing))),
                     Mock.Of<IStoredPaymentMethodDetailProviderGatewayResolver>(),
                     Mock.Of<IStoredPaymentMethodProviderGatewayResolver>(),
-                    Mock.Of<IPaymentProviderCache>(),
+                    Providers.Object,
                     Mock.Of<
                         ILogger<
                             StoredPaymentMethodLifecycleService>>());
@@ -429,7 +544,7 @@ public sealed class StoredPaymentMethodLifecycleServiceTests
             providers.Setup(cache => cache.GetAsync(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                     It.IsAny<Func<Task<PaymentProvider?>>>()))
-                .ReturnsAsync(new PaymentProvider { ProviderName = "provider" });
+                .ReturnsAsync(new PaymentProvider { TenantId = "tenant-1", ProviderName = "provider" });
 
             Methods.Setup(repository => repository.GetByCardFingerprintAsync(
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),

--- a/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
+++ b/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
@@ -1,0 +1,218 @@
+using Blocks.Genesis;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Utilities;
+
+namespace XUnitTest.Payment;
+
+/// <summary>Raw Stripe Invoice API calls: one standalone invoice per attempt, no Subscription object.</summary>
+public sealed class StripeInvoiceClientTests
+{
+    [Fact]
+    public async Task Creating_an_invoice_item_sends_the_amount_in_minor_units()
+    {
+        var http = new Mock<IHttpService>(MockBehavior.Strict);
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                HttpMethod.Post,
+                It.Is<Dictionary<string, string>>(form =>
+                    form["customer"] == "cus_123" &&
+                    form["amount"] == "8900" &&
+                    form["currency"] == "chf" &&
+                    form["description"] == "Professional renewal"),
+                "https://api.stripe.com/v1/invoiceitems",
+                It.Is<Dictionary<string, string>>(headers => headers["Idempotency-Key"] == "idem-1"),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ReturnsAsync((new StripeInvoice { Id = "ii_1" }, (string?)null));
+
+        var result = await Client(http.Object).CreateInvoiceItemAsync(
+            Provider(), "cus_123", 8_900, "CHF", "Professional renewal", "idem-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.InvoiceOrItemId.Should().Be("ii_1");
+    }
+
+    [Fact]
+    public async Task Creating_an_invoice_never_lets_stripe_advance_it_on_its_own()
+    {
+        var http = new Mock<IHttpService>(MockBehavior.Strict);
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                HttpMethod.Post,
+                It.Is<Dictionary<string, string>>(form =>
+                    form["customer"] == "cus_123" &&
+                    form["collection_method"] == "charge_automatically" &&
+                    form["auto_advance"] == "false"),
+                "https://api.stripe.com/v1/invoices",
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ReturnsAsync((new StripeInvoice { Id = "in_1", Status = "draft" }, (string?)null));
+
+        var result = await Client(http.Object).CreateInvoiceAsync(
+            Provider(), "cus_123", "idem-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Paying_an_invoice_that_stays_open_is_a_rejection_not_a_transport_failure()
+    {
+        var http = new Mock<IHttpService>();
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                It.IsAny<HttpMethod>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ReturnsAsync((new StripeInvoice { Id = "in_1", Status = "open" }, (string?)null));
+
+        var result = await Client(http.Object).PayInvoiceAsync(
+            Provider(), "in_1", "pm_456", "idem-1:pay", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.InvoiceOrItemId.Should().Be("in_1");
+        result.SafeErrorCode.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Paying_an_invoice_that_lands_paid_is_a_success()
+    {
+        var http = new Mock<IHttpService>();
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                It.IsAny<HttpMethod>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ReturnsAsync((new StripeInvoice { Id = "in_1", Status = "paid" }, (string?)null));
+
+        var result = await Client(http.Object).PayInvoiceAsync(
+            Provider(), "in_1", "pm_456", "idem-1:pay", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_card_error_from_stripe_is_a_rejection()
+    {
+        var http = new Mock<IHttpService>();
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                It.IsAny<HttpMethod>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ReturnsAsync((
+                new StripeInvoice
+                {
+                    Error = new StripeError { Type = "card_error", DeclineCode = "insufficient_funds" }
+                },
+                (string?)null));
+
+        var result = await Client(http.Object).PayInvoiceAsync(
+            Provider(), "in_1", "pm_456", "idem-1:pay", CancellationToken.None);
+
+        result.Outcome.Should().Be(StripeInvoiceOutcome.Rejected);
+        result.SafeErrorCode.Should().Be("insufficient_funds");
+    }
+
+    [Fact]
+    public async Task A_stripe_side_error_stays_recoverable()
+    {
+        var http = new Mock<IHttpService>();
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                It.IsAny<HttpMethod>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ReturnsAsync((
+                new StripeInvoice { Error = new StripeError { Type = "api_error" } },
+                (string?)null));
+
+        var result = await Client(http.Object).FinalizeInvoiceAsync(
+            Provider(), "in_1", "idem-1:finalize", CancellationToken.None);
+
+        result.Outcome.Should().Be(StripeInvoiceOutcome.Unavailable);
+    }
+
+    [Fact]
+    public async Task An_unsafe_provider_endpoint_is_refused_without_calling_http()
+    {
+        var http = new Mock<IHttpService>(MockBehavior.Strict);
+        var provider = Provider();
+        provider.ApiBaseUrl = "https://127.0.0.1";
+
+        var result = await Client(http.Object).CreateInvoiceItemAsync(
+            provider, "cus_123", 1_000, "CHF", "x", "idem-1", CancellationToken.None);
+
+        result.Outcome.Should().Be(StripeInvoiceOutcome.Unavailable);
+        http.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task A_timeout_reports_an_unknown_outcome_rather_than_a_failure()
+    {
+        var http = new Mock<IHttpService>();
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                It.IsAny<HttpMethod>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var result = await Client(http.Object).PayInvoiceAsync(
+            Provider(), "in_1", "pm_456", "idem-1:pay", CancellationToken.None);
+
+        result.Outcome.Should().Be(StripeInvoiceOutcome.Timeout);
+    }
+
+    [Fact]
+    public async Task Voiding_swallows_its_own_failure()
+    {
+        var http = new Mock<IHttpService>();
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                It.IsAny<HttpMethod>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        await Client(http.Object)
+            .Invoking(client => client.VoidInvoiceAsync(Provider(), "in_1", CancellationToken.None))
+            .Should().NotThrowAsync("a void failing must never mask the decline that caused it");
+    }
+
+    private static StripeInvoiceClient Client(IHttpService http) =>
+        new(http, new StripeEndpointPolicy(), Options(), NullLogger<StripeInvoiceClient>.Instance);
+
+    private static IOptionsMonitor<PaymentOptions> Options()
+    {
+        var options = new Mock<IOptionsMonitor<PaymentOptions>>();
+        options.SetupGet(monitor => monitor.CurrentValue)
+            .Returns(new PaymentOptions { ProviderTimeoutSeconds = 15 });
+
+        return options.Object;
+    }
+
+    private static PaymentProvider Provider() =>
+        new()
+        {
+            ProviderName = PaymentConstants.StripeProvider,
+            ApiBaseUrl = StripeConstants.ApiBaseUrl,
+            ApiKey = "secret",
+            MerchantId = "merchant"
+        };
+}

--- a/server/XUnitTest/Subscription/BillingPeriodCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/BillingPeriodCalculatorTests.cs
@@ -1,0 +1,276 @@
+using System.Globalization;
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Billing boundaries, in the cases a calendar makes awkward.
+/// </summary>
+/// <remarks>
+/// Every failure here is one a customer counts: a renewal on the wrong day, a quota that resets
+/// twice, or a period that swallows an hour. None of them throw, so tests are the only place
+/// they surface.
+/// </remarks>
+public sealed class BillingPeriodCalculatorTests
+{
+    private const string Zurich = "Europe/Zurich";
+
+    [Fact]
+    public void A_monthly_anchor_on_the_31st_returns_to_the_31st_after_february()
+    {
+        var schedule = MonthlyOn(31, new DateTime(2026, 1, 31, 0, 0, 0, DateTimeKind.Utc));
+
+        StartOfPeriodContaining(schedule, new DateTime(2026, 2, 15, 12, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2026, 1, 31),
+                "mid-February is inside the period that opened on 31 January");
+
+        StartOfPeriodContaining(schedule, new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2026, 2, 28),
+                "February has no 31st, so the boundary clamps to the last day it has");
+
+        StartOfPeriodContaining(schedule, new DateTime(2026, 3, 31, 12, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2026, 3, 31),
+                "February's clamp must not be written back, or every later period drifts early");
+
+        StartOfPeriodContaining(schedule, new DateTime(2026, 4, 30, 12, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2026, 4, 30));
+
+        StartOfPeriodContaining(schedule, new DateTime(2026, 5, 31, 12, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2026, 5, 31));
+    }
+
+    [Fact]
+    public void A_february_29_anchor_falls_back_to_the_28th_in_a_non_leap_year()
+    {
+        var schedule = YearlyFrom(new DateTime(2024, 2, 29, 0, 0, 0, DateTimeKind.Utc));
+
+        StartOfPeriodContaining(schedule, new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2025, 2, 28));
+
+        StartOfPeriodContaining(schedule, new DateTime(2028, 6, 1, 0, 0, 0, DateTimeKind.Utc))
+            .Should().Be(new DateTime(2028, 2, 29), "the leap day returns when the year has one");
+    }
+
+    [Fact]
+    public void A_boundary_inside_the_spring_forward_gap_moves_to_the_first_valid_instant()
+    {
+        // Zurich loses 02:00–03:00 on 29 March 2026, so a 02:30 boundary does not exist.
+        var schedule = MonthlyAt(
+            29,
+            minutesFromMidnight: 150,
+            anchorUtc: new DateTime(2026, 1, 29, 1, 30, 0, DateTimeKind.Utc));
+
+        var boundary = StartOfPeriodContainingUtc(
+            schedule,
+            new DateTime(2026, 3, 30, 12, 0, 0, DateTimeKind.Utc));
+
+        // 03:00 local on the transition day is 01:00 UTC.
+        boundary.Should().Be(new DateTime(2026, 3, 29, 1, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void An_ambiguous_autumn_boundary_resolves_to_the_earlier_instant()
+    {
+        // Zurich repeats 02:00–03:00 on 25 October 2026, so 02:30 happens twice.
+        var schedule = MonthlyAt(
+            25,
+            minutesFromMidnight: 150,
+            anchorUtc: new DateTime(2026, 8, 25, 0, 30, 0, DateTimeKind.Utc));
+
+        var boundary = StartOfPeriodContainingUtc(
+            schedule,
+            new DateTime(2026, 10, 26, 12, 0, 0, DateTimeKind.Utc));
+
+        // The first 02:30 is still on summer time, UTC+2.
+        boundary.Should().Be(new DateTime(2026, 10, 25, 0, 30, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void A_period_runs_from_one_boundary_to_the_next_without_gap_or_overlap()
+    {
+        var schedule = MonthlyOn(15, new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc));
+
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc), out var first)
+            .Should().BeTrue();
+
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, first.EndUtc, out var second)
+            .Should().BeTrue();
+
+        second.StartUtc.Should().Be(first.EndUtc, "the end of one period is the start of the next");
+        second.Index.Should().Be(first.Index + 1);
+    }
+
+    [Fact]
+    public void An_instant_on_a_boundary_belongs_to_the_period_it_opens()
+    {
+        var schedule = MonthlyOn(1, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), out var period)
+            .Should().BeTrue();
+
+        period.Index.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(BillingInterval.Month, 3, "2026-01-01", "2026-02-15", "2026-01-01")]
+    [InlineData(BillingInterval.Month, 3, "2026-01-01", "2026-04-02", "2026-04-01")]
+    [InlineData(BillingInterval.Week, 2, "2026-01-01", "2026-01-10", "2026-01-01")]
+    [InlineData(BillingInterval.Week, 2, "2026-01-01", "2026-01-16", "2026-01-15")]
+    [InlineData(BillingInterval.Day, 10, "2026-01-01", "2026-01-09", "2026-01-01")]
+    [InlineData(BillingInterval.Day, 10, "2026-01-01", "2026-01-11", "2026-01-11")]
+    public void A_cadence_of_more_than_one_lands_on_the_right_boundary(
+        BillingInterval interval,
+        int intervalCount,
+        string anchor,
+        string instant,
+        string expectedStart)
+    {
+        BillingPeriodCalculator.TryCreateSchedule(
+            interval,
+            intervalCount,
+            Utc(anchor),
+            "UTC",
+            out var schedule).Should().BeTrue();
+
+        StartOfPeriodContaining(schedule, Utc(instant))
+            .Should().Be(Utc(expectedStart).Date);
+    }
+
+    /// <summary>
+    /// Parses a date as an instant. <c>DateTime.Parse</c> alone yields a local kind, and
+    /// converting that to UTC shifts the calendar day on any machine east or west of Greenwich —
+    /// which would make these cases pass or fail depending on where they are run.
+    /// </summary>
+    private static DateTime Utc(string date) =>
+        DateTime.SpecifyKind(
+            DateTime.ParseExact(date, "yyyy-MM-dd", CultureInfo.InvariantCulture),
+            DateTimeKind.Utc);
+
+    [Fact]
+    public void Adjacent_periods_of_a_multi_month_cadence_get_different_keys()
+    {
+        var schedule = QuarterlyFrom(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc), out var first)
+            .Should().BeTrue();
+
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc), out var second)
+            .Should().BeTrue();
+
+        second.Key.Should().NotBe(first.Key,
+            "a key built from the calendar month rather than the period start would merge " +
+            "two quarters into one counter");
+    }
+
+    [Fact]
+    public void An_unknown_time_zone_is_reported_rather_than_thrown()
+    {
+        var schedule = MonthlyOn(1, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        schedule.TimeZoneId = "Middle/Earth";
+
+        var resolved = BillingPeriodCalculator.TryGetPeriod(
+            schedule,
+            new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+            out _);
+
+        resolved.Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_cadence_of_less_than_one_is_refused()
+    {
+        var schedule = MonthlyOn(1, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        schedule.IntervalCount = 0;
+
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, DateTime.UtcNow, out _)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_schedule_takes_its_anchor_day_from_the_customers_calendar()
+    {
+        // Zurich is UTC+1 in January, so 23:30 on the 31st is 00:30 on the 1st there.
+        BillingPeriodCalculator.TryCreateSchedule(
+            BillingInterval.Month,
+            1,
+            new DateTime(2026, 1, 31, 23, 30, 0, DateTimeKind.Utc),
+            Zurich,
+            out var schedule).Should().BeTrue();
+
+        schedule.AnchorDayOfMonth.Should().Be(1);
+        schedule.AnchorMinutesFromMidnight.Should().Be(30);
+    }
+
+    private static DateTime StartOfPeriodContaining(BillingSchedule schedule, DateTime instantUtc)
+    {
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, instantUtc, out var period)
+            .Should().BeTrue();
+
+        BillingLocalTime.TryFindTimeZone(schedule.TimeZoneId, out var timeZone)
+            .Should().BeTrue();
+
+        return BillingLocalTime.ToLocal(period.StartUtc, timeZone).Date;
+    }
+
+    private static DateTime StartOfPeriodContainingUtc(BillingSchedule schedule, DateTime instantUtc)
+    {
+        BillingPeriodCalculator
+            .TryGetPeriod(schedule, instantUtc, out var period)
+            .Should().BeTrue();
+
+        return period.StartUtc;
+    }
+
+    private static BillingSchedule MonthlyOn(int day, DateTime anchorUtc) => new()
+    {
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        AnchorInstantUtc = anchorUtc,
+        TimeZoneId = "UTC",
+        AnchorDayOfMonth = day,
+        AnchorMinutesFromMidnight = 0
+    };
+
+    private static BillingSchedule MonthlyAt(
+        int day,
+        int minutesFromMidnight,
+        DateTime anchorUtc) => new()
+    {
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        AnchorInstantUtc = anchorUtc,
+        TimeZoneId = Zurich,
+        AnchorDayOfMonth = day,
+        AnchorMinutesFromMidnight = minutesFromMidnight
+    };
+
+    private static BillingSchedule YearlyFrom(DateTime anchorUtc) => new()
+    {
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        AnchorInstantUtc = anchorUtc,
+        TimeZoneId = "UTC",
+        AnchorDayOfMonth = anchorUtc.Day,
+        AnchorMinutesFromMidnight = 0
+    };
+
+    private static BillingSchedule QuarterlyFrom(DateTime anchorUtc) => new()
+    {
+        Interval = BillingInterval.Month,
+        IntervalCount = 3,
+        AnchorInstantUtc = anchorUtc,
+        TimeZoneId = "UTC",
+        AnchorDayOfMonth = anchorUtc.Day,
+        AnchorMinutesFromMidnight = 0
+    };
+}

--- a/server/XUnitTest/Subscription/EntitlementServiceTests.cs
+++ b/server/XUnitTest/Subscription/EntitlementServiceTests.cs
@@ -1,0 +1,320 @@
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The question asked on every gated action.
+/// </summary>
+public sealed class EntitlementServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail? _subscription = NewSubscription();
+    private long _balance;
+    private int _reads;
+
+    public EntitlementServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                _reads++;
+
+                return _subscription;
+            });
+
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new SubscriptionUsageCounter { Balance = _balance });
+    }
+
+    /// <summary>
+    /// The guarantee this module exists to make, checked where it cannot be argued with.
+    /// </summary>
+    /// <remarks>
+    /// If the provider is unreachable, every existing customer must keep working. The way that
+    /// is enforced is that entitlement has no way to call one — so this asserts the dependency
+    /// list rather than any behaviour, because behaviour can be added back by accident.
+    /// </remarks>
+    [Fact]
+    public void Entitlement_cannot_call_a_payment_provider()
+    {
+        var dependencies = typeof(EntitlementService)
+            .GetConstructors()
+            .Single()
+            .GetParameters()
+            .Select(parameter => parameter.ParameterType.Name)
+            .ToArray();
+
+        dependencies.Should().NotContain(name =>
+            name.Contains("Gateway", StringComparison.Ordinal) ||
+            name.Contains("HttpClient", StringComparison.Ordinal) ||
+            name.Contains("PaymentService", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task An_organization_with_no_subscription_is_granted_nothing()
+    {
+        _subscription = null;
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.Value!.HasSubscription.Should().BeFalse();
+        result.Value.Entitlements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task A_canceled_subscription_grants_nothing()
+    {
+        _subscription!.Status = SubscriptionStatus.Canceled;
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.Value!.Entitlements.Should().BeEmpty();
+        result.Value.Status.Should().Be(nameof(SubscriptionStatus.Canceled));
+    }
+
+    [Fact]
+    public async Task A_past_due_subscription_still_grants_during_the_grace_period()
+    {
+        _subscription!.Status = SubscriptionStatus.PastDue;
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.Value!.Entitlements.Should().NotBeEmpty(
+            "cutting a customer off the moment a renewal fails punishes an expired card");
+    }
+
+    [Fact]
+    public async Task A_counted_entitlement_reports_what_is_left()
+    {
+        _balance = 487;
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        var entitlement = result.Value!.Entitlements.Single();
+        entitlement.Allowed.Should().BeTrue();
+        entitlement.Used.Should().Be(487);
+        entitlement.Remaining.Should().Be(13);
+    }
+
+    [Fact]
+    public async Task A_counted_entitlement_at_its_limit_reports_the_reason()
+    {
+        _balance = 500;
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        var entitlement = result.Value!.Entitlements.Single();
+        entitlement.Allowed.Should().BeFalse();
+        entitlement.Reason.Should().Be(nameof(EntitlementReason.LimitReached));
+        entitlement.Remaining.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task An_unlimited_entitlement_never_reports_a_limit_reached()
+    {
+        _subscription!.Plan.Entitlements =
+        [
+            new PlanEntitlement
+            {
+                Key = "api_access",
+                LimitKind = EntitlementLimitKind.Unlimited
+            }
+        ];
+        _balance = long.MaxValue / 2;
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.Value!.Entitlements.Single().Allowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task The_decision_carries_the_products_own_unit_label()
+    {
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.Value!.Entitlements.Single().UnitLabel.Should().Be("screening");
+        result.Value.Quantities.Single().UnitLabel.Should().Be("seat");
+    }
+
+    [Fact]
+    public async Task Plan_features_pass_through_untouched()
+    {
+        _subscription!.Plan.FeaturesJson = """{"qualified_signature":true}""";
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.Value!.FeaturesJson.Should().Be("""{"qualified_signature":true}""");
+    }
+
+    [Fact]
+    public async Task A_trials_grant_replaces_the_plans_limit()
+    {
+        _subscription!.Status = SubscriptionStatus.Trialing;
+        _subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = DateTime.UtcNow,
+            EndsAtUtc = DateTime.UtcNow.AddDays(14),
+            Grants = [new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 25 }]
+        };
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.Value!.Entitlements.Single().Limit.Should().Be(25,
+            "entitlement and usage recording must measure the same allowance, or a caller is " +
+            "told it may act and then refused");
+    }
+
+    [Fact]
+    public async Task An_unknown_key_says_it_is_not_on_the_plan()
+    {
+        var result = await Service().GetAsync(
+            "not_a_feature", false, "corr-1", CancellationToken.None);
+
+        result.Value!.Allowed.Should().BeFalse();
+        result.Value.Reason.Should().Be(nameof(EntitlementReason.NotInPlan));
+    }
+
+    [Fact]
+    public async Task An_unknown_key_without_a_subscription_says_so_instead()
+    {
+        _subscription = null;
+
+        var result = await Service().GetAsync(
+            "pep_screening", false, "corr-1", CancellationToken.None);
+
+        result.Value!.Reason.Should().Be(nameof(EntitlementReason.NoSubscription),
+            "the reason sends a support engineer to a different place than 'not on this plan'");
+    }
+
+    [Fact]
+    public async Task Repeated_reads_are_served_from_the_cache()
+    {
+        var service = Service();
+
+        await service.GetAsync(false, "corr-1", CancellationToken.None);
+        await service.GetAsync(false, "corr-2", CancellationToken.None);
+
+        _reads.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_fresh_read_bypasses_the_cache()
+    {
+        var service = Service();
+
+        await service.GetAsync(false, "corr-1", CancellationToken.None);
+        await service.GetAsync(true, "corr-2", CancellationToken.None);
+
+        _reads.Should().Be(2, "a caller about to do something irreversible can insist");
+    }
+
+    [Fact]
+    public async Task A_caller_without_an_organization_is_refused()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Unavailable,
+                "subscription_organization_missing",
+                "An organization is required."));
+
+        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.Unavailable);
+    }
+
+    private EntitlementService Service() => new(
+        _subscriptions.Object,
+        _usage.Object,
+        _contextResolver.Object,
+        new EntitlementSnapshotCache(new OptionsStub(), _time),
+        _time);
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        CurrentPeriodEndUtc = new DateTime(2026, 8, 31, 21, 59, 59, DateTimeKind.Utc),
+        QuantityItems =
+        [
+            new SubscriptionQuantityItem
+            {
+                ItemKey = "seat",
+                UnitLabel = "seat",
+                Quantity = 12
+            }
+        ],
+        Plan = new PlanSnapshot
+        {
+            Code = "professional",
+            Entitlements =
+            [
+                new PlanEntitlement
+                {
+                    Key = "pep_screening",
+                    LimitKind = EntitlementLimitKind.Count,
+                    Limit = 500,
+                    MeterKey = "screening",
+                    UnitLabel = "screening"
+                }
+            ],
+            Meters =
+            [
+                new PlanMeter
+                {
+                    MeterKey = "screening",
+                    UnitLabel = "screening",
+                    IncludedQuantity = 500
+                }
+            ]
+        },
+        UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new();
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -1,0 +1,341 @@
+using FluentAssertions;
+using FluentValidation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Services;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Validators;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Authoring a plan, and the rules that stop an unusable one being sold.
+/// </summary>
+public sealed class PlanCatalogueServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<ICurrencyMinorUnitResolver> _currencyResolver = new();
+    private Plan? _created;
+
+    public PlanCatalogueServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _catalogue
+            .Setup(repository => repository.TryCreatePlanAsync(
+                It.IsAny<Plan>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Plan, CancellationToken>((plan, _) => _created = plan)
+            .ReturnsAsync(true);
+
+        _currencyResolver
+            .Setup(resolver => resolver.TryConvertBack(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                out It.Ref<decimal>.IsAny))
+            .Returns(true);
+    }
+
+    [Fact]
+    public async Task A_plan_keeps_the_products_own_vocabulary()
+    {
+        var request = NewPlan();
+        request.QuantityItems[0].UnitLabel = "workspace";
+        request.Meters[0].MeterKey = "envelope";
+        request.Entitlements[0].MeterKey = "envelope";
+
+        var result = await Service().CreatePlanAsync(
+            request,
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.QuantityItems[0].UnitLabel.Should().Be("workspace");
+        _created.Meters[0].MeterKey.Should().Be("envelope",
+            "the platform stores the product's word and never substitutes its own");
+    }
+
+    [Fact]
+    public async Task Plan_features_are_stored_verbatim()
+    {
+        var request = NewPlan();
+        request.FeaturesJson = """{"qualified_signature":true,"max_templates":50}""";
+
+        await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        _created!.FeaturesJson.Should().Be(request.FeaturesJson,
+            "nothing here interprets a feature, so nothing may reshape one either");
+    }
+
+    [Fact]
+    public async Task A_plan_scoped_to_no_organization_serves_the_whole_tenant()
+    {
+        await Service().CreatePlanAsync(NewPlan(), "corr-1", CancellationToken.None);
+
+        _created!.OrganizationId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_duplicate_plan_code_is_a_conflict()
+    {
+        _catalogue
+            .Setup(repository => repository.TryCreatePlanAsync(
+                It.IsAny<Plan>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().CreatePlanAsync(
+            NewPlan(),
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be("subscription_plan_exists");
+    }
+
+    [Fact]
+    public async Task An_entitlement_naming_an_unknown_meter_is_rejected()
+    {
+        var request = NewPlan();
+        request.Entitlements[0].MeterKey = "not-a-meter";
+
+        var result = await Service().CreatePlanAsync(
+            request,
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        _catalogue.Verify(
+            repository => repository.TryCreatePlanAsync(
+                It.IsAny<Plan>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "nothing is written when the plan could never work");
+    }
+
+    [Fact]
+    public async Task Malformed_plan_features_are_rejected()
+    {
+        var request = NewPlan();
+        request.FeaturesJson = "not json";
+
+        var result = await Service().CreatePlanAsync(
+            request,
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ValidationErrors.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Overlapping_rate_tiers_are_rejected()
+    {
+        var request = NewPlan();
+        request.Meters[0].RateTables =
+        [
+            new MeterRateTableRequest
+            {
+                CurrencyCode = "CHF",
+                Tiers =
+                [
+                    new MeterTierRequest { UpToQuantity = 500, UnitAmountMinor = 100 },
+                    new MeterTierRequest { UpToQuantity = 200, UnitAmountMinor = 90 }
+                ]
+            }
+        ];
+
+        var result = await Service().CreatePlanAsync(
+            request,
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+    }
+
+    [Fact]
+    public async Task An_unbounded_tier_anywhere_but_last_is_rejected()
+    {
+        var request = NewPlan();
+        request.Meters[0].RateTables =
+        [
+            new MeterRateTableRequest
+            {
+                CurrencyCode = "CHF",
+                Tiers =
+                [
+                    new MeterTierRequest { UpToQuantity = null, UnitAmountMinor = 100 },
+                    new MeterTierRequest { UpToQuantity = 500, UnitAmountMinor = 90 }
+                ]
+            }
+        ];
+
+        var result = await Service().CreatePlanAsync(
+            request,
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+    }
+
+    [Fact]
+    public async Task A_price_in_a_currency_payments_cannot_charge_is_refused()
+    {
+        _currencyResolver
+            .Setup(resolver => resolver.TryConvertBack(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                out It.Ref<decimal>.IsAny))
+            .Returns(false);
+
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId,
+                "plan-1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StoredPlan());
+
+        var result = await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                CurrencyCode = "XYZ",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "seat"
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_price_invalid");
+        _catalogue.Verify(
+            repository => repository.TryCreatePriceAsync(
+                It.IsAny<Price>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "catching this at authoring time is the point — at checkout it reaches a customer");
+    }
+
+    [Fact]
+    public async Task A_price_for_an_unknown_quantity_item_is_rejected()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId,
+                "plan-1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StoredPlan());
+
+        var result = await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "not-an-item"
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_quantity_item_unknown");
+    }
+
+    [Fact]
+    public async Task Another_organizations_plan_reports_as_missing()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId,
+                "plan-2",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Plan
+            {
+                ItemId = "plan-2",
+                TenantId = TenantId,
+                OrganizationId = "somebody-else"
+            });
+
+        var result = await Service().GetPlanAsync(
+            "plan-2",
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound,
+            "a forbidden response would confirm the identifier exists somewhere else");
+    }
+
+    [Fact]
+    public async Task A_caller_without_an_organization_is_refused()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Unavailable,
+                "subscription_organization_missing",
+                "An organization is required."));
+
+        var result = await Service().ListPlansAsync("corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_organization_missing");
+    }
+
+    private PlanCatalogueService Service() => new(
+        _catalogue.Object,
+        _contextResolver.Object,
+        new CreatePlanRequestValidator(),
+        new CreatePriceRequestValidator(_currencyResolver.Object),
+        new PlanResponseMapper(),
+        NullLogger<PlanCatalogueService>.Instance);
+
+    private static Plan StoredPlan() => new()
+    {
+        ItemId = "plan-1",
+        TenantId = TenantId,
+        Code = "professional",
+        QuantityItems = [new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat" }]
+    };
+
+    private static CreatePlanRequest NewPlan() => new()
+    {
+        Code = "professional",
+        DisplayName = "Professional",
+        QuantityItems =
+        [
+            new PlanQuantityItemRequest { ItemKey = "seat", UnitLabel = "seat" }
+        ],
+        Meters =
+        [
+            new PlanMeterRequest
+            {
+                MeterKey = "screening",
+                DisplayName = "Screenings",
+                UnitLabel = "screening",
+                IncludedQuantity = 500,
+                ThresholdPercents = [80, 100]
+            }
+        ],
+        Entitlements =
+        [
+            new PlanEntitlementRequest
+            {
+                Key = "pep_screening",
+                LimitKind = EntitlementLimitKind.Count,
+                Limit = 500,
+                MeterKey = "screening"
+            }
+        ]
+    };
+}

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -253,6 +253,36 @@ public sealed class PlanCatalogueServiceTests
     }
 
     [Fact]
+    public async Task An_out_of_range_tax_rate_is_rejected()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId,
+                "plan-1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StoredPlan());
+
+        var result = await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "seat",
+                TaxRateBasisPoints = 10_001
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_price_invalid");
+        _catalogue.Verify(
+            repository => repository.TryCreatePriceAsync(
+                It.IsAny<Price>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task Another_organizations_plan_reports_as_missing()
     {
         _catalogue

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -1,0 +1,218 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Services;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>Charging a renewal as a standalone Stripe Invoice.</summary>
+public sealed class StripeInvoiceBillingGatewayTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<IPaymentProviderCache> _providers = new();
+    private readonly Mock<IPaymentRepository> _payments = new();
+    private readonly Mock<IStoredPaymentMethodRepository> _storedMethods = new();
+    private readonly Mock<IProviderTokenProtector> _tokenProtector = new();
+    private readonly Mock<IStripeInvoiceClient> _invoices = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 31, 22, 0, 0, TimeSpan.Zero));
+
+    public StripeInvoiceBillingGatewayTests()
+    {
+        _providers
+            .Setup(cache => cache.GetAsync(
+                TenantId,
+                OrganizationId,
+                PaymentConstants.StripeProvider,
+                It.IsAny<Func<Task<PaymentProvider?>>>()))
+            .ReturnsAsync(Provider());
+
+        _storedMethods
+            .Setup(repository => repository.GetAsync(
+                TenantId, "method-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewMethod());
+
+        _storedMethods
+            .Setup(repository => repository.TryClaimForPaymentAsync(
+                TenantId,
+                "method-1",
+                "shopper-1",
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewMethod());
+
+        _tokenProtector
+            .Setup(protector => protector.UnprotectAsync(
+                It.IsAny<StoredPaymentMethod>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProviderTokenReadResult(true, "pm_456"));
+
+        _invoices
+            .Setup(client => client.CreateInvoiceItemAsync(
+                It.IsAny<PaymentProvider>(),
+                "cus_123",
+                8_900,
+                "CHF",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "ii_1"));
+
+        _invoices
+            .Setup(client => client.CreateInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "cus_123", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "draft"));
+
+        _invoices
+            .Setup(client => client.FinalizeInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "in_1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "open"));
+
+        _invoices
+            .Setup(client => client.PayInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "in_1", "pm_456", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "paid"));
+    }
+
+    [Fact]
+    public async Task A_full_success_returns_the_invoice_id()
+    {
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("in_1");
+    }
+
+    [Fact]
+    public async Task Each_stripe_call_gets_its_own_suffixed_idempotency_key()
+    {
+        await Gateway().ChargeAsync(Request(), "sub-renew:sub-1:M20260901T000000Z:1", "corr-1", CancellationToken.None);
+
+        _invoices.Verify(client => client.CreateInvoiceItemAsync(
+            It.IsAny<PaymentProvider>(), "cus_123", 8_900, "CHF", It.IsAny<string>(),
+            "sub-renew:sub-1:M20260901T000000Z:1:item", It.IsAny<CancellationToken>()));
+        _invoices.Verify(client => client.PayInvoiceAsync(
+            It.IsAny<PaymentProvider>(), "in_1", "pm_456",
+            "sub-renew:sub-1:M20260901T000000Z:1:pay", It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task A_declined_payment_voids_the_invoice_and_is_reported_as_provider_rejected()
+    {
+        _invoices
+            .Setup(client => client.PayInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "in_1", "pm_456", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(
+                StripeInvoiceOutcome.Rejected, "in_1", "open", "card_declined"));
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.ProviderRejected);
+        result.ErrorCode.Should().Be("card_declined");
+        _invoices.Verify(
+            client => client.VoidInvoiceAsync(It.IsAny<PaymentProvider>(), "in_1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task No_provider_customer_id_fails_closed_without_calling_stripe()
+    {
+        var request = Request();
+        request.ProviderCustomerId = null;
+
+        var result = await Gateway().ChargeAsync(request, "idem-1", "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Unavailable);
+        result.ErrorCode.Should().Be("subscription_customer_unresolved");
+        _invoices.Verify(
+            client => client.CreateInvoiceItemAsync(
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_claim_conflict_is_a_conflict_failure()
+    {
+        _storedMethods
+            .Setup(repository => repository.TryClaimForPaymentAsync(
+                TenantId, "method-1", "shopper-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StoredPaymentMethod?)null);
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+    }
+
+    [Fact]
+    public async Task An_unreadable_token_is_unavailable()
+    {
+        _tokenProtector
+            .Setup(protector => protector.UnprotectAsync(
+                It.IsAny<StoredPaymentMethod>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProviderTokenReadResult.Failed);
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Unavailable);
+        result.ErrorCode.Should().Be("stored_payment_method_token_unavailable");
+    }
+
+    [Fact]
+    public async Task The_claim_is_always_released()
+    {
+        await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        _storedMethods.Verify(
+            repository => repository.ReleasePaymentClaimAsync(
+                TenantId, "method-1", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private StripeInvoiceBillingGateway Gateway() => new(
+        _providers.Object,
+        _payments.Object,
+        _storedMethods.Object,
+        _tokenProtector.Object,
+        _invoices.Object,
+        NullLogger<StripeInvoiceBillingGateway>.Instance,
+        _time);
+
+    private static SubscriptionChargeRequest Request() => new()
+    {
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        ProviderName = PaymentConstants.StripeProvider,
+        StoredPaymentMethodId = "method-1",
+        ProviderCustomerId = "cus_123",
+        AmountMinor = 8_900,
+        CurrencyCode = "CHF",
+        OrderId = "sub:sub-1:M20260901T000000Z",
+        Description = "Professional renewal"
+    };
+
+    private static PaymentProvider Provider() => new()
+    {
+        ProviderName = PaymentConstants.StripeProvider,
+        ApiBaseUrl = StripeConstants.ApiBaseUrl,
+        ApiKey = "secret",
+        IsEnabled = true
+    };
+
+    private static StoredPaymentMethod NewMethod() => new()
+    {
+        ItemId = "method-1",
+        TenantId = TenantId,
+        ShopperReference = "shopper-1"
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -1,0 +1,381 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Carrying a payment outcome into the subscription waiting on it.
+/// </summary>
+/// <remarks>
+/// The rule under test throughout: only a webhook activates. Anything else — an optimistic
+/// status, a shopper returning from a redirect — can be produced without money having moved.
+/// </remarks>
+public sealed class SubscriptionActivationProcessorTests
+{
+    private const string TenantId = "tenant-1";
+
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+    private readonly Mock<IPaymentRepository> _payments = new();
+    private readonly Mock<IStoredPaymentMethodRepository> _storedMethods = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionTransition? _transition;
+
+    public SubscriptionActivationProcessorTests()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewSubscription);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId,
+                "sub-1",
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+
+        _links
+            .Setup(repository => repository.TrySettleAsync(
+                TenantId,
+                "link-1",
+                It.IsAny<SubscriptionPaymentLinkState>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task An_authorized_payment_without_a_webhook_does_not_activate()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: false);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(0);
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a status without a webhook behind it is not evidence that money moved");
+    }
+
+    [Fact]
+    public async Task A_confirmed_payment_activates_the_subscription()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Incomplete);
+        _transition.NewStatus.Should().Be(SubscriptionStatus.Active);
+        _transition.Event!.EventType.Should().Be(SubscriptionConstants.SubscriptionActivated);
+    }
+
+    [Fact]
+    public async Task A_confirmed_payment_on_a_trial_starts_the_trial_instead()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Captured, webhookConfirmed: true);
+
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var subscription = NewSubscription();
+                subscription.Trial = new TrialTerms
+                {
+                    StartsAtUtc = DateTime.UtcNow,
+                    EndsAtUtc = DateTime.UtcNow.AddDays(14)
+                };
+
+                return subscription;
+            });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Trialing);
+    }
+
+    [Fact]
+    public async Task A_refused_payment_ends_the_subscription()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Refused, webhookConfirmed: true);
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.IncompleteExpired);
+        _transition.ClearNextFeeBillingAt.Should().BeTrue();
+
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                TenantId,
+                "link-1",
+                SubscriptionPaymentLinkState.Abandoned,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_subscription_already_carried_across_settles_without_transitioning_again()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var subscription = NewSubscription();
+                subscription.Status = SubscriptionStatus.Active;
+
+                return subscription;
+            });
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Losing_the_transition_race_leaves_the_link_for_the_winner()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId,
+                "sub-1",
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(0);
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                SubscriptionPaymentLinkState.Applied,
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_pending_payment_is_rescheduled_rather_than_abandoned()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Processing, webhookConfirmed: false);
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _links.Verify(
+            repository => repository.RescheduleAsync(
+                TenantId,
+                "link-1",
+                1,
+                It.IsAny<DateTime>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task The_provider_customer_is_taken_from_the_saved_card()
+    {
+        GivenDueLink();
+        GivenPayment(
+            PaymentStatuses.Authorized,
+            webhookConfirmed: true,
+            storedMethodId: "method-1");
+
+        _storedMethods
+            .Setup(repository => repository.GetAsync(
+                TenantId, "method-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StoredPaymentMethod
+            {
+                ItemId = "method-1",
+                ProviderPayerReference = "cus_123"
+            });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _accounts.Verify(
+            repository => repository.TrySetProviderCustomerAsync(
+                TenantId,
+                "acct-1",
+                "cus_123",
+                "method-1",
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the renewal needs this identifier, and checkout is the only place it appears");
+    }
+
+    [Fact]
+    public async Task A_charge_raised_but_never_recorded_is_recovered_by_its_derived_key()
+    {
+        _subscriptions
+            .Setup(repository => repository.ListStaleAsync(
+                TenantId,
+                SubscriptionStatus.Incomplete,
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewSubscription()]);
+
+        _links
+            .Setup(repository => repository.FindBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionPaymentLink?)null);
+
+        _payments
+            .Setup(repository => repository.GetByIdempotencyKeyAsync(
+                TenantId,
+                SubscriptionConstants.InitialChargeKeyFor("sub-1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail { ItemId = "pay-1" });
+
+        var recovered = await Processor().RecoverStaleAsync(TenantId, CancellationToken.None);
+
+        recovered.Should().Be(1);
+        _links.Verify(
+            repository => repository.TryCreateAsync(
+                It.Is<SubscriptionPaymentLink>(link => link.PaymentDetailId == "pay-1"),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "otherwise the customer has paid and the subscription grants nothing, with " +
+            "nothing scanning for it");
+    }
+
+    [Fact]
+    public async Task A_stale_subscription_with_no_charge_at_all_is_expired()
+    {
+        _subscriptions
+            .Setup(repository => repository.ListStaleAsync(
+                TenantId,
+                SubscriptionStatus.Incomplete,
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewSubscription()]);
+
+        _links
+            .Setup(repository => repository.FindBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionPaymentLink?)null);
+
+        _payments
+            .Setup(repository => repository.GetByIdempotencyKeyAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PaymentDetail?)null);
+
+        await Processor().RecoverStaleAsync(TenantId, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.IncompleteExpired);
+    }
+
+    private void GivenDueLink() =>
+        _links
+            .Setup(repository => repository.ListDueAsync(
+                TenantId,
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new SubscriptionPaymentLink
+                {
+                    ItemId = "link-1",
+                    TenantId = TenantId,
+                    OrganizationId = "org-1",
+                    SubscriptionId = "sub-1",
+                    PaymentDetailId = "pay-1",
+                    CorrelationId = "corr-1"
+                }
+            ]);
+
+    private void GivenPayment(
+        string status,
+        bool webhookConfirmed,
+        string? storedMethodId = null) =>
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "pay-1",
+                TenantId = TenantId,
+                PaymentStatus = status,
+                WebhookConfirmedAtUtc = webhookConfirmed ? DateTime.UtcNow : null,
+                StoredPaymentMethodPublicId = storedMethodId
+            });
+
+    private SubscriptionActivationProcessor Processor() => new(
+        _links.Object,
+        _subscriptions.Object,
+        _accounts.Object,
+        new SubscriptionOutboxEventFactory(),
+        _payments.Object,
+        _storedMethods.Object,
+        new OptionsMonitorStub(new SubscriptionOptions()),
+        NullLogger<SubscriptionActivationProcessor>.Instance,
+        _time);
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = "org-1",
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Incomplete,
+        CurrencyCode = "CHF",
+        OrderId = "sub:sub-1",
+        CorrelationId = "corr-1",
+        Plan = new PlanSnapshot { Code = "professional" }
+    };
+
+    private sealed class OptionsMonitorStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public OptionsMonitorStub(SubscriptionOptions value) => CurrentValue = value;
+
+        public SubscriptionOptions CurrentValue { get; }
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
@@ -120,6 +120,57 @@ public sealed class SubscriptionAmountCalculatorTests
             "only what the period actually costs is consumed, the rest stays banked");
     }
 
+    [Fact]
+    public void Tax_is_added_after_the_discount_not_before()
+    {
+        var subscription = NewSubscription(discount: new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_500
+        });
+        subscription.Price.TaxRateBasisPoints = 1_000; // 10%
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        // Discounted to 750, then 10% tax on 750 = 75. Not 10% of the original 1,000.
+        charge.TaxAmountMinor.Should().Be(75);
+        charge.AmountMinor.Should().Be(825);
+    }
+
+    [Fact]
+    public void No_tax_rate_changes_nothing()
+    {
+        var subscription = NewSubscription(discount: null);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.TaxAmountMinor.Should().Be(0);
+        charge.AmountMinor.Should().Be(1_000);
+    }
+
+    [Fact]
+    public void Credit_is_consumed_against_the_tax_inclusive_total()
+    {
+        var subscription = NewSubscription(discount: null);
+        subscription.Price.TaxRateBasisPoints = 1_000; // 10% of 1,000 = 100, total owed 1,100
+        subscription.CreditBalanceMinor = 1_050;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.TaxAmountMinor.Should().Be(100);
+        charge.CreditConsumedMinor.Should().Be(1_050);
+        charge.AmountMinor.Should().Be(50);
+    }
+
+    [Fact]
+    public void The_first_charge_is_also_taxed()
+    {
+        var subscription = NewSubscription(discount: null);
+        subscription.Price.TaxRateBasisPoints = 1_000;
+
+        SubscriptionAmountCalculator.PeriodAmountMinor(subscription).Should().Be(1_100);
+    }
+
     private static SubscriptionDetail NewSubscription(DiscountTerms? discount) => new()
     {
         Price = new PriceSnapshot { UnitAmountMinor = 1_000 },

--- a/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// What a period costs, and whether a discount is still the reason it costs less.
+/// </summary>
+public sealed class SubscriptionAmountCalculatorTests
+{
+    private static readonly DateTime Now = new(2026, 8, 14, 10, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void A_discount_with_no_bound_never_expires()
+    {
+        var subscription = NewSubscription(discount: new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_500
+        });
+
+        subscription.DiscountPeriodsApplied = 50;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.DiscountApplied.Should().BeTrue();
+        charge.AmountMinor.Should().Be(750);
+    }
+
+    [Fact]
+    public void A_discount_stops_after_its_duration_in_periods()
+    {
+        var subscription = NewSubscription(discount: new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_500,
+            DurationPeriods = 3
+        });
+
+        subscription.DiscountPeriodsApplied = 3;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.DiscountApplied.Should().BeFalse();
+        charge.AmountMinor.Should().Be(1_000);
+    }
+
+    [Fact]
+    public void A_discount_still_applies_on_its_last_eligible_period()
+    {
+        var subscription = NewSubscription(discount: new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_500,
+            DurationPeriods = 3
+        });
+
+        subscription.DiscountPeriodsApplied = 2;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.DiscountApplied.Should().BeTrue();
+        charge.AmountMinor.Should().Be(750);
+    }
+
+    [Fact]
+    public void A_discount_stops_after_its_expiry_even_with_periods_remaining()
+    {
+        var subscription = NewSubscription(discount: new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_500,
+            DurationPeriods = 12,
+            ExpiresAtUtc = Now.AddDays(-1)
+        });
+
+        subscription.DiscountPeriodsApplied = 1;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.DiscountApplied.Should().BeFalse();
+        charge.AmountMinor.Should().Be(1_000);
+    }
+
+    [Fact]
+    public void No_discount_is_a_full_charge()
+    {
+        var subscription = NewSubscription(discount: null);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.DiscountApplied.Should().BeFalse();
+        charge.AmountMinor.Should().Be(1_000);
+    }
+
+    private static SubscriptionDetail NewSubscription(DiscountTerms? discount) => new()
+    {
+        Price = new PriceSnapshot { UnitAmountMinor = 1_000 },
+        Discount = discount
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
@@ -95,6 +95,31 @@ public sealed class SubscriptionAmountCalculatorTests
         charge.AmountMinor.Should().Be(1_000);
     }
 
+    [Fact]
+    public void A_credit_balance_reduces_the_charge_and_reports_what_it_consumed()
+    {
+        var subscription = NewSubscription(discount: null);
+        subscription.CreditBalanceMinor = 400;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.AmountMinor.Should().Be(600);
+        charge.CreditConsumedMinor.Should().Be(400);
+    }
+
+    [Fact]
+    public void A_credit_larger_than_the_period_amount_never_produces_a_negative_charge()
+    {
+        var subscription = NewSubscription(discount: null);
+        subscription.CreditBalanceMinor = 5_000;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.AmountMinor.Should().Be(0);
+        charge.CreditConsumedMinor.Should().Be(1_000,
+            "only what the period actually costs is consumed, the rest stays banked");
+    }
+
     private static SubscriptionDetail NewSubscription(DiscountTerms? discount) => new()
     {
         Price = new PriceSnapshot { UnitAmountMinor = 1_000 },

--- a/server/XUnitTest/Subscription/SubscriptionBillingGatewayResolverTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionBillingGatewayResolverTests.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Responses;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>Which billing gateway a renewal actually goes through, by provider name.</summary>
+public sealed class SubscriptionBillingGatewayResolverTests
+{
+    [Fact]
+    public async Task Stripe_routes_to_the_stripe_invoice_gateway()
+    {
+        var recurring = new Mock<IRecurringPaymentService>();
+        var currency = new Mock<ICurrencyMinorUnitResolver>();
+        var stripeInvoices = new Mock<IStripeInvoiceClient>();
+
+        var providers = new Mock<IPaymentProviderCache>();
+        providers
+            .Setup(cache => cache.GetAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<Func<Task<PaymentProvider?>>>()))
+            .ReturnsAsync((PaymentProvider?)null);
+
+        var recurringGateway = new RecurringChargeBillingGateway(recurring.Object, currency.Object);
+        var stripeGateway = new StripeInvoiceBillingGateway(
+            providers.Object,
+            Mock.Of<IPaymentRepository>(),
+            Mock.Of<IStoredPaymentMethodRepository>(),
+            Mock.Of<IProviderTokenProtector>(),
+            stripeInvoices.Object,
+            NullLogger<StripeInvoiceBillingGateway>.Instance);
+
+        var resolver = new SubscriptionBillingGatewayResolver(stripeGateway, recurringGateway);
+
+        await resolver.ChargeAsync(
+            new SubscriptionChargeRequest
+            {
+                ProviderName = PaymentConstants.StripeProvider,
+                ProviderCustomerId = "cus_123"
+            },
+            "idem-1",
+            "corr-1",
+            CancellationToken.None);
+
+        // Reaching StripeInvoiceBillingGateway's own provider resolution (and getting nothing
+        // back, since it was stubbed to null) is the proof it was the one actually called.
+        recurring.Verify(
+            service => service.CreateRecurringPaymentAsync(
+                It.IsAny<CreateRecurringPaymentRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Anything_other_than_stripe_falls_through_to_the_recurring_charge_gateway()
+    {
+        var recurring = new Mock<IRecurringPaymentService>();
+        recurring
+            .Setup(service => service.CreateRecurringPaymentAsync(
+                It.IsAny<CreateRecurringPaymentRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PaymentOperationResult.Failure(
+                PaymentFailureKind.Unavailable,
+                "x", "x", "corr-1"));
+        var currency = new Mock<ICurrencyMinorUnitResolver>();
+        currency
+            .Setup(resolver => resolver.TryConvertBack(
+                It.IsAny<long>(), It.IsAny<string>(), out It.Ref<decimal>.IsAny))
+            .Returns(true);
+
+        var recurringGateway = new RecurringChargeBillingGateway(recurring.Object, currency.Object);
+        var stripeInvoices = new Mock<IStripeInvoiceClient>(MockBehavior.Strict);
+        var stripeGateway = new StripeInvoiceBillingGateway(
+            Mock.Of<IPaymentProviderCache>(),
+            Mock.Of<IPaymentRepository>(),
+            Mock.Of<IStoredPaymentMethodRepository>(),
+            Mock.Of<IProviderTokenProtector>(),
+            stripeInvoices.Object,
+            NullLogger<StripeInvoiceBillingGateway>.Instance);
+
+        var resolver = new SubscriptionBillingGatewayResolver(stripeGateway, recurringGateway);
+
+        await resolver.ChargeAsync(
+            new SubscriptionChargeRequest
+            {
+                ProviderName = PaymentConstants.AdyenOnlineProvider,
+                AmountMinor = 1_000,
+                CurrencyCode = "CHF"
+            },
+            "idem-1",
+            "corr-1",
+            CancellationToken.None);
+
+        recurring.Verify(
+            service => service.CreateRecurringPaymentAsync(
+                It.IsAny<CreateRecurringPaymentRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        stripeInvoices.VerifyNoOtherCalls();
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionBoundaryTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionBoundaryTests.cs
@@ -1,0 +1,120 @@
+using System.Reflection;
+using FluentAssertions;
+using Payment.DomainService.Entities;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Subscriptions depend on payments; payments must never depend on subscriptions.
+/// </summary>
+/// <remarks>
+/// The direction is what keeps the payment module able to change. Once payment code reaches
+/// back into subscriptions the two stop being separable, and a cycle between two projects in
+/// one solution is caught by the compiler only when the reference is added — not when a type
+/// quietly starts flowing the wrong way through an interface both already share.
+/// </remarks>
+public sealed class SubscriptionBoundaryTests
+{
+    private const string SubscriptionRoot = "Subscription.DomainService";
+
+    private static readonly Assembly PaymentAssembly =
+        typeof(PaymentDetail).Assembly;
+
+    private static readonly Assembly SubscriptionAssembly =
+        typeof(SubscriptionOptions).Assembly;
+
+    [Fact]
+    public void The_two_modules_are_separate_assemblies()
+    {
+        SubscriptionAssembly.Should().NotBeSameAs(PaymentAssembly);
+    }
+
+    [Fact]
+    public void No_payment_type_names_a_subscription_type_in_its_signatures()
+    {
+        var offenders = PaymentAssembly
+            .GetTypes()
+            .SelectMany(SignatureTypesOf)
+            .Where(IsSubscriptionType)
+            .Select(type => type.FullName!)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        offenders.Should().BeEmpty(
+            "payment must not depend on subscriptions; every collaboration in this codebase " +
+            "is constructor-injected, so a type appearing in a signature is a real dependency");
+    }
+
+    [Fact]
+    public void The_payment_assembly_does_not_reference_the_subscription_assembly()
+    {
+        var referenced = PaymentAssembly
+            .GetReferencedAssemblies()
+            .Select(name => name.Name)
+            .ToArray();
+
+        referenced.Should().NotContain(SubscriptionRoot);
+    }
+
+    private static IEnumerable<Type> SignatureTypesOf(Type type)
+    {
+        const BindingFlags members =
+            BindingFlags.Public |
+            BindingFlags.NonPublic |
+            BindingFlags.Instance |
+            BindingFlags.Static |
+            BindingFlags.DeclaredOnly;
+
+        foreach (var field in type.GetFields(members))
+        {
+            yield return field.FieldType;
+        }
+
+        foreach (var property in type.GetProperties(members))
+        {
+            yield return property.PropertyType;
+        }
+
+        foreach (var constructor in type.GetConstructors(members))
+        {
+            foreach (var parameter in constructor.GetParameters())
+            {
+                yield return parameter.ParameterType;
+            }
+        }
+
+        foreach (var method in type.GetMethods(members))
+        {
+            yield return method.ReturnType;
+
+            foreach (var parameter in method.GetParameters())
+            {
+                yield return parameter.ParameterType;
+            }
+        }
+    }
+
+    private static bool IsSubscriptionType(Type type)
+    {
+        var candidate = type.IsByRef || type.IsArray || type.IsPointer
+            ? type.GetElementType() ?? type
+            : type;
+
+        if (candidate.IsGenericType)
+        {
+            return candidate
+                .GetGenericArguments()
+                .Append(candidate.GetGenericTypeDefinition())
+                .Any(NamespaceIsSubscription);
+        }
+
+        return NamespaceIsSubscription(candidate);
+    }
+
+    private static bool NamespaceIsSubscription(Type type) =>
+        type.Namespace is not null &&
+        (type.Namespace.Equals(SubscriptionRoot, StringComparison.Ordinal) ||
+         type.Namespace.StartsWith($"{SubscriptionRoot}.", StringComparison.Ordinal));
+}

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -103,6 +103,26 @@ public sealed class SubscriptionCancellationServiceTests
     }
 
     [Fact]
+    public async Task An_immediate_cancellation_stops_the_usage_rating_sweep()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: true, null, "corr-1", CancellationToken.None);
+
+        _transition!.ClearNextUsageBillingAt.Should().BeTrue(
+            "nothing more will be metered once entitlement stops immediately");
+    }
+
+    [Fact]
+    public async Task An_at_period_end_cancellation_leaves_usage_rating_untouched()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        _transition!.ClearNextUsageBillingAt.Should().BeFalse(
+            "the subscription keeps granting and metering until the period actually ends");
+    }
+
+    [Fact]
     public async Task Cancelling_drops_the_cached_entitlement_immediately()
     {
         await Service().CancelAsync(

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Ending a subscription, and how little that changes today.
+/// </summary>
+public sealed class SubscriptionCancellationServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail? _subscription = NewSubscription();
+    private SubscriptionTransition? _transition;
+
+    public SubscriptionCancellationServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetAsync(
+                TenantId, OrganizationId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId,
+                "sub-1",
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task Cancelling_keeps_the_period_that_was_paid_for()
+    {
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Active,
+            "taking access away on the day someone cancels is charging for a month and " +
+            "delivering part of one");
+        _transition.CancelAtPeriodEnd.Should().BeTrue();
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Active));
+    }
+
+    [Fact]
+    public async Task Cancelling_stops_the_next_payment()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        _transition!.ClearNextFeeBillingAt.Should().BeTrue();
+        _transition.CanceledAtUtc.Should().Be(
+            new DateTime(2026, 8, 14, 12, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task When_it_was_asked_for_is_separate_from_when_it_takes_effect()
+    {
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        result.Value!.CanceledAtUtc.Should().NotBeNull();
+        _transition!.EndedAtUtc.Should().BeNull(
+            "it has not ended yet, and conflating the two loses the answer to most support " +
+            "questions about cancellation");
+    }
+
+    [Fact]
+    public async Task An_immediate_cancellation_ends_it_now()
+    {
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: true, "fraud", "corr-1", CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Canceled);
+        _transition.EndedAtUtc.Should().NotBeNull();
+        _transition.CancellationReason.Should().Be("fraud");
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Canceled));
+    }
+
+    [Fact]
+    public async Task Cancelling_drops_the_cached_entitlement_immediately()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: true, null, "corr-1", CancellationToken.None);
+
+        _cache.Verify(
+            cache => cache.Invalidate(TenantId, OrganizationId),
+            Times.Once,
+            "the cached snapshot decides what the customer may do");
+    }
+
+    [Fact]
+    public async Task Cancelling_raises_an_event()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        _transition!.Event!.EventType.Should()
+            .Be(SubscriptionConstants.SubscriptionCancellationRequested);
+        _transition.Event.CorrelationId.Should().Be("corr-1");
+    }
+
+    [Fact]
+    public async Task Another_organizations_subscription_reports_as_missing()
+    {
+        _subscription = null;
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound,
+            "a forbidden response would confirm the identifier exists somewhere else");
+    }
+
+    [Fact]
+    public async Task Cancelling_an_ended_subscription_is_a_conflict()
+    {
+        _subscription!.Status = SubscriptionStatus.Canceled;
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_already_ended");
+    }
+
+    [Fact]
+    public async Task Losing_the_transition_race_is_reported_as_a_conflict()
+    {
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId,
+                "sub-1",
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        _cache.Verify(
+            cache => cache.Invalidate(It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_trialing_subscription_can_be_cancelled_too()
+    {
+        _subscription!.Status = SubscriptionStatus.Trialing;
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Trialing);
+    }
+
+    private SubscriptionCancellationService Service() => new(
+        _subscriptions.Object,
+        _contextResolver.Object,
+        new SubscriptionOutboxEventFactory(),
+        new SubscriptionResponseMapper(),
+        _cache.Object,
+        NullLogger<SubscriptionCancellationService>.Instance,
+        _time);
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        CurrentPeriodEndUtc = new DateTime(2026, 8, 31, 21, 59, 59, DateTimeKind.Utc),
+        NextFeeBillingAtUtc = new DateTime(2026, 8, 31, 21, 59, 59, DateTimeKind.Utc),
+        Plan = new PlanSnapshot { Code = "professional" },
+        Price = new PriceSnapshot { CurrencyCode = "CHF", UnitAmountMinor = 8900 }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -1,0 +1,317 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Responses;
+using Payment.DomainService.Services;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Raising the first charge, and what happens when there is nothing to charge or the charge
+/// declines.
+/// </summary>
+public sealed class SubscriptionCheckoutServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionCreationService> _creation = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<IPaymentService> _payments = new();
+    private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
+
+    private SubscriptionDetail _subscription = NewSubscription();
+    private MakePaymentRequest? _paymentRequest;
+    private string? _idempotencyKey;
+    private SubscriptionPaymentLink? _link;
+
+    public SubscriptionCheckoutServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _creation
+            .Setup(service => service.CreateAsync(
+                It.IsAny<CreateSubscriptionRequest>(),
+                It.IsAny<SubscriptionContext>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => SubscriptionOperationResult<SubscriptionDetail>.Success(
+                _subscription,
+                "corr-1"));
+
+        _currency
+            .Setup(resolver => resolver.TryConvertBack(
+                It.IsAny<long>(), It.IsAny<string>(), out It.Ref<decimal>.IsAny))
+            .Returns((long minor, string _, out decimal amount) =>
+            {
+                amount = minor / 100m;
+
+                return true;
+            });
+
+        _payments
+            .Setup(service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<MakePaymentRequest, string, string, CancellationToken>(
+                (request, key, _, _) =>
+                {
+                    _paymentRequest = request;
+                    _idempotencyKey = key;
+                })
+            .ReturnsAsync(PaymentOperationResult.Success(
+                new PaymentResponse
+                {
+                    PaymentDetailId = "pay-1",
+                    RedirectUrl = "https://checkout.stripe.com/session"
+                },
+                "corr-1"));
+
+        _links
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionPaymentLink>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionPaymentLink, CancellationToken>((link, _) => _link = link)
+            .ReturnsAsync(true);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task The_charge_saves_the_payment_method_for_the_renewal()
+    {
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        _paymentRequest!.SavePaymentMethod.Should().BeTrue(
+            "the renewal charges this card with nobody present, which the provider only " +
+            "permits if the mandate was taken when it was saved");
+    }
+
+    [Fact]
+    public async Task The_charge_carries_the_subscriptions_own_order_id_and_idempotency_key()
+    {
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        _paymentRequest!.OrderId.Should().Be($"sub:{_subscription.ItemId}");
+        _idempotencyKey.Should().Be($"sub-init:{_subscription.ItemId}",
+            "a retried request must find the same payment, not raise a second one");
+    }
+
+    [Fact]
+    public async Task The_charge_does_not_name_an_organization()
+    {
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        _paymentRequest!.OrganizationId.Should().BeNull(
+            "organizations here are subscribers, not merchants: naming one would look for a " +
+            "merchant account the customer does not have");
+    }
+
+    [Fact]
+    public async Task The_amount_is_the_quantity_times_the_snapshotted_price()
+    {
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        _paymentRequest!.Amount.Should().Be(1068.00m);
+    }
+
+    [Fact]
+    public async Task A_pending_link_records_which_payment_to_wait_for()
+    {
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        _link!.PaymentDetailId.Should().Be("pay-1");
+        _link.State.Should().Be(SubscriptionPaymentLinkState.Pending);
+        _link.CorrelationId.Should().Be("corr-1",
+            "the sweep that settles this runs later and elsewhere, so the trace has to travel " +
+            "with the record");
+    }
+
+    [Fact]
+    public async Task The_checkout_url_is_returned_to_the_caller()
+    {
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.Value!.CheckoutUrl.Should().Be("https://checkout.stripe.com/session");
+        result.Value.Status.Should().Be(nameof(SubscriptionStatus.Incomplete));
+    }
+
+    [Fact]
+    public async Task A_declined_charge_leaves_the_subscription_granting_nothing()
+    {
+        _payments
+            .Setup(service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PaymentOperationResult.Failure(
+                PaymentFailureKind.ProviderRejected,
+                "payment_refused",
+                "The card was declined.",
+                "corr-1"));
+
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.ProviderRejected);
+
+        _links.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionPaymentLink>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "there is no payment to wait for");
+
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "nothing was granted, so nothing needs revoking");
+    }
+
+    [Fact]
+    public async Task A_card_free_trial_starts_without_touching_the_money_path()
+    {
+        _subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = DateTime.UtcNow,
+            EndsAtUtc = DateTime.UtcNow.AddDays(14),
+            RequiresPaymentMethod = false
+        };
+
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Trialing));
+
+        _payments.Verify(
+            service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a zero-amount charge is refused by the money path, so it must never be attempted");
+    }
+
+    [Fact]
+    public async Task A_fully_discounted_period_starts_without_a_charge()
+    {
+        _subscription.Discount = new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 10_000
+        };
+
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Active));
+
+        _payments.Verify(
+            service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_caller_without_an_organization_never_reaches_creation()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Unavailable,
+                "subscription_organization_missing",
+                "An organization is required."));
+
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_organization_missing");
+        _creation.Verify(
+            service => service.CreateAsync(
+                It.IsAny<CreateSubscriptionRequest>(),
+                It.IsAny<SubscriptionContext>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private SubscriptionCheckoutService Service() => new(
+        _creation.Object,
+        _subscriptions.Object,
+        _links.Object,
+        _contextResolver.Object,
+        new SubscriptionOutboxEventFactory(),
+        new SubscriptionResponseMapper(),
+        _payments.Object,
+        _currency.Object,
+        NullLogger<SubscriptionCheckoutService>.Instance);
+
+    private static SubscriptionDetail NewSubscription()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        return new SubscriptionDetail
+        {
+            ItemId = id,
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            Status = SubscriptionStatus.Incomplete,
+            CurrencyCode = "CHF",
+            OrderId = $"sub:{id}",
+            Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "seat"
+            },
+            QuantityItems =
+            [
+                new SubscriptionQuantityItem
+                {
+                    ItemKey = "seat",
+                    UnitLabel = "seat",
+                    Quantity = 12,
+                    UnitAmountMinor = 8900
+                }
+            ]
+        };
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -1,0 +1,353 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Turning a chosen plan into a subscription, and the things that must be true of the result
+/// years later.
+/// </summary>
+public sealed class SubscriptionCreationServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero));
+
+    private Plan _plan = NewPlan();
+    private SubscriptionDetail? _created;
+
+    public SubscriptionCreationServiceTests()
+    {
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "professional", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _plan);
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice);
+
+        _accounts
+            .Setup(repository => repository.GetOrCreateAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionDetail, CancellationToken>(
+                (subscription, _) => _created = subscription)
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task The_currency_comes_from_the_price_and_is_fixed()
+    {
+        var result = await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.CurrencyCode.Should().Be("CHF");
+    }
+
+    [Fact]
+    public async Task The_organization_comes_from_the_caller_not_the_request()
+    {
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.OrganizationId.Should().Be(OrganizationId,
+            "accepting an organization from the body would let anyone subscribe on another " +
+            "organization's behalf");
+    }
+
+    [Fact]
+    public async Task The_plan_snapshot_is_a_copy_not_a_reference()
+    {
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _plan.Entitlements[0].Limit = 1;
+        _plan.Meters[0].IncludedQuantity = 1;
+
+        _created!.Plan.Entitlements[0].Limit.Should().Be(500);
+        _created.Plan.Meters[0].IncludedQuantity.Should().Be(500,
+            "editing the catalogue must not change what an existing subscriber holds");
+    }
+
+    [Fact]
+    public async Task A_subscription_starts_granting_nothing()
+    {
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.Status.Should().Be(SubscriptionStatus.Incomplete,
+            "nobody has paid yet, so walking away must leave nothing granted");
+        _created.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task The_order_id_is_derived_from_the_subscription()
+    {
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.OrderId.Should().Be($"sub:{_created.ItemId}",
+            "a crash between raising a charge and recording it leaves this as the only way " +
+            "back to the payment");
+    }
+
+    [Fact]
+    public async Task Usage_is_metered_monthly_even_on_a_yearly_plan()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var price = NewPrice();
+                price.Interval = BillingInterval.Year;
+
+                return price;
+            });
+
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.FeeSchedule.Interval.Should().Be(BillingInterval.Year);
+        _created.UsageSchedule.Interval.Should().Be(BillingInterval.Month,
+            "waiting a year to settle metered usage is a year of unsecured credit");
+    }
+
+    [Fact]
+    public async Task A_missing_quantity_takes_the_plans_default()
+    {
+        var request = NewRequest();
+        request.Quantities.Clear();
+
+        await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        _created!.QuantityItems.Should().ContainSingle()
+            .Which.Quantity.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_quantity_beyond_the_plans_maximum_is_refused()
+    {
+        _plan.QuantityItems[0].MaxQuantity = 10;
+
+        var request = NewRequest();
+        request.Quantities[0].Quantity = 11;
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        _subscriptions.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_quantity_for_an_unknown_item_is_refused()
+    {
+        var request = NewRequest();
+        request.Quantities[0].ItemKey = "not-an-item";
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_quantity_invalid");
+    }
+
+    [Fact]
+    public async Task An_unknown_time_zone_is_refused_before_anything_is_written()
+    {
+        var request = NewRequest();
+        request.TimeZoneId = "Middle/Earth";
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        _subscriptions.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "an unusable schedule must not become a stored subscription");
+    }
+
+    [Fact]
+    public async Task A_trial_carries_its_own_capped_grants()
+    {
+        _plan.TrialDays = 14;
+        _plan.TrialGrants =
+        [
+            new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 25 }
+        ];
+
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.Trial!.EndsAtUtc.Should().Be(new DateTime(2026, 8, 28, 10, 0, 0, DateTimeKind.Utc));
+        _created.Trial.Grants.Should().ContainSingle()
+            .Which.IncludedQuantity.Should().Be(25,
+                "each unit costs the seller real money, so an uncapped trial is a direct loss");
+    }
+
+    [Fact]
+    public async Task A_second_live_subscription_is_a_conflict()
+    {
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be("subscription_already_active");
+    }
+
+    [Fact]
+    public async Task A_price_belonging_to_another_plan_is_not_found()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var price = NewPrice();
+                price.PlanId = "another-plan";
+
+                return price;
+            });
+
+        var result = await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+    }
+
+    [Fact]
+    public void The_period_amount_multiplies_quantity_by_the_snapshotted_unit_price()
+    {
+        var subscription = new SubscriptionDetail
+        {
+            Price = new PriceSnapshot { QuantityItemKey = "seat", UnitAmountMinor = 8900 },
+            QuantityItems =
+            [
+                new SubscriptionQuantityItem
+                {
+                    ItemKey = "seat",
+                    Quantity = 12,
+                    UnitAmountMinor = 8900
+                }
+            ]
+        };
+
+        SubscriptionAmountCalculator.PeriodAmountMinor(subscription)
+            .Should().Be(106_800);
+    }
+
+    [Fact]
+    public void A_discount_can_reach_zero_but_never_go_below_it()
+    {
+        var subscription = new SubscriptionDetail
+        {
+            Price = new PriceSnapshot { UnitAmountMinor = 1_000 },
+            Discount = new DiscountTerms
+            {
+                Kind = DiscountKind.FixedAmount,
+                AmountMinor = 5_000
+            }
+        };
+
+        SubscriptionAmountCalculator.PeriodAmountMinor(subscription)
+            .Should().Be(0, "a negative charge is a refund, and one must never arrive by " +
+                            "arithmetic");
+    }
+
+    private SubscriptionCreationService Service() => new(
+        _catalogue.Object,
+        _subscriptions.Object,
+        _accounts.Object,
+        new CreateSubscriptionRequestValidator(),
+        NullLogger<SubscriptionCreationService>.Instance,
+        _time);
+
+    private static SubscriptionContext Context() =>
+        new(TenantId, OrganizationId, "actor-1", "user-1");
+
+    private static CreateSubscriptionRequest NewRequest() => new()
+    {
+        PlanCode = "professional",
+        PriceId = "price-1",
+        TimeZoneId = "Europe/Zurich",
+        Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 12 }]
+    };
+
+    private static Plan NewPlan() => new()
+    {
+        ItemId = "plan-1",
+        TenantId = TenantId,
+        Code = "professional",
+        DisplayName = "Professional",
+        Status = CatalogueStatus.Active,
+        Version = 3,
+        QuantityItems =
+        [
+            new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat", DefaultQuantity = 1 }
+        ],
+        Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                UnitLabel = "screening",
+                IncludedQuantity = 500,
+                ThresholdPercents = [80, 100]
+            }
+        ],
+        Entitlements =
+        [
+            new PlanEntitlement
+            {
+                Key = "pep_screening",
+                LimitKind = EntitlementLimitKind.Count,
+                Limit = 500,
+                MeterKey = "screening"
+            }
+        ]
+    };
+
+    private static Price NewPrice() => new()
+    {
+        ItemId = "price-1",
+        TenantId = TenantId,
+        PlanId = "plan-1",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 8900,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        QuantityItemKey = "seat",
+        Status = CatalogueStatus.Active
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionEntitySerializationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionEntitySerializationTests.cs
@@ -1,0 +1,199 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The stored shape survives a round trip, and a document written by a newer build still loads.
+/// </summary>
+/// <remarks>
+/// Rolling deployments mean an old process reads documents a new one wrote. Without
+/// <c>BsonIgnoreExtraElements</c> an added field makes the old process throw on every read of
+/// that document, which turns a routine deploy into an outage that only appears once traffic
+/// reaches the older instances.
+/// </remarks>
+public sealed class SubscriptionEntitySerializationTests
+{
+    [Fact]
+    public void A_subscription_survives_a_round_trip()
+    {
+        var original = NewSubscription();
+
+        var restored = BsonSerializer.Deserialize<SubscriptionDetail>(
+            original.ToBsonDocument());
+
+        restored.ItemId.Should().Be(original.ItemId);
+        restored.Status.Should().Be(SubscriptionStatus.Trialing);
+        restored.CurrencyCode.Should().Be("CHF");
+        restored.Plan.Entitlements.Should().ContainSingle()
+            .Which.Key.Should().Be("pep_screening");
+        restored.Price.UnitAmountMinor.Should().Be(8900);
+        restored.QuantityItems.Should().ContainSingle()
+            .Which.UnitLabel.Should().Be("seat");
+        restored.FeeSchedule.AnchorDayOfMonth.Should().Be(31);
+        restored.UsageSchedule.TimeZoneId.Should().Be("Europe/Zurich");
+        restored.Trial!.Grants.Should().ContainSingle()
+            .Which.IncludedQuantity.Should().Be(25);
+    }
+
+    [Fact]
+    public void A_subscription_written_by_a_newer_build_still_loads()
+    {
+        var document = NewSubscription().ToBsonDocument();
+        document.Add("SomeFieldAddedLater", "value");
+        document["Plan"].AsBsonDocument.Add("AlsoAddedLater", 42);
+
+        var restored = () =>
+            BsonSerializer.Deserialize<SubscriptionDetail>(document);
+
+        restored.Should().NotThrow();
+    }
+
+    [Fact]
+    public void A_usage_counter_id_is_composed_from_its_scope()
+    {
+        SubscriptionUsageCounter
+            .CreateId("sub-1", "screening", "M20260801T000000Z")
+            .Should()
+            .Be("sub-1:screening:M20260801T000000Z");
+    }
+
+    [Fact]
+    public void A_usage_record_survives_a_round_trip()
+    {
+        var original = new SubscriptionUsageRecord
+        {
+            TenantId = "tenant-1",
+            OrganizationId = "org-1",
+            SubscriptionId = "sub-1",
+            MeterKey = "screening",
+            PeriodKey = "M20260801T000000Z",
+            EntryType = UsageEntryType.Reversal,
+            Delta = -1,
+            IdempotencyKey = "usage-1",
+            OccurredAtUtc = new DateTime(2026, 8, 14, 9, 0, 0, DateTimeKind.Utc),
+            Metadata = new Dictionary<string, string> { ["caseRef"] = "opaque-1" },
+            CorrelationId = "corr-1"
+        };
+
+        var restored = BsonSerializer.Deserialize<SubscriptionUsageRecord>(
+            original.ToBsonDocument());
+
+        restored.Delta.Should().Be(-1);
+        restored.EntryType.Should().Be(UsageEntryType.Reversal);
+        restored.Metadata.Should().ContainKey("caseRef");
+        restored.CorrelationId.Should().Be("corr-1");
+    }
+
+    [Fact]
+    public void Aggregates_start_at_version_one()
+    {
+        new SubscriptionDetail().Version.Should().Be(1);
+        new Plan().Version.Should().Be(1);
+        new Price().Version.Should().Be(1);
+        new BillingAccount().Version.Should().Be(1);
+    }
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        TenantId = "tenant-1",
+        OrganizationId = "org-1",
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Trialing,
+        CurrencyCode = "CHF",
+        OrderId = "sub:sub-1",
+        Plan = new PlanSnapshot
+        {
+            PlanId = "plan-1",
+            Code = "professional",
+            DisplayName = "Professional",
+            FeaturesJson = """{"pep_screening":true}""",
+            PlanVersion = 3,
+            Entitlements =
+            [
+                new PlanEntitlement
+                {
+                    Key = "pep_screening",
+                    LimitKind = EntitlementLimitKind.Count,
+                    Limit = 500,
+                    MeterKey = "screening",
+                    UnitLabel = "screening"
+                }
+            ],
+            Meters =
+            [
+                new PlanMeter
+                {
+                    MeterKey = "screening",
+                    UnitLabel = "screening",
+                    IncludedQuantity = 500,
+                    ThresholdPercents = [80, 100],
+                    RateTables =
+                    [
+                        new MeterRateTable
+                        {
+                            CurrencyCode = "CHF",
+                            Tiers =
+                            [
+                                new MeterTier { UpToQuantity = 500, UnitAmountMinor = 100 },
+                                new MeterTier { UpToQuantity = null, UnitAmountMinor = 85 }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            QuantityItems =
+            [
+                new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat" }
+            ]
+        },
+        Price = new PriceSnapshot
+        {
+            PriceId = "price-1",
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 8900,
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            QuantityItemKey = "seat",
+            PriceVersion = 1
+        },
+        QuantityItems =
+        [
+            new SubscriptionQuantityItem
+            {
+                ItemKey = "seat",
+                UnitLabel = "seat",
+                Quantity = 12,
+                UnitAmountMinor = 8900
+            }
+        ],
+        FeeSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorDayOfMonth = 31,
+            TimeZoneId = "Europe/Zurich",
+            AnchorInstantUtc = new DateTime(2026, 1, 31, 23, 0, 0, DateTimeKind.Utc)
+        },
+        UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorDayOfMonth = 1,
+            TimeZoneId = "Europe/Zurich",
+            AnchorInstantUtc = new DateTime(2026, 1, 31, 23, 0, 0, DateTimeKind.Utc)
+        },
+        Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Utc),
+            Grants =
+            [
+                new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 25 }
+            ]
+        }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionEnumStabilityTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionEnumStabilityTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Subscription.DomainService.Enums;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Enum values are persisted, so their numbers are part of the storage format.
+/// </summary>
+/// <remarks>
+/// Inserting a member without an explicit value renumbers everything after it, and every
+/// document already written then means something else. Nothing throws — a canceled subscription
+/// simply reads back as active. These tests pin the numbers so that change cannot pass review
+/// silently.
+/// </remarks>
+public sealed class SubscriptionEnumStabilityTests
+{
+    [Fact]
+    public void Subscription_status_numbers_are_fixed()
+    {
+        ((int)SubscriptionStatus.Incomplete).Should().Be(0);
+        ((int)SubscriptionStatus.IncompleteExpired).Should().Be(1);
+        ((int)SubscriptionStatus.Trialing).Should().Be(2);
+        ((int)SubscriptionStatus.Active).Should().Be(3);
+        ((int)SubscriptionStatus.PastDue).Should().Be(4);
+        ((int)SubscriptionStatus.Unpaid).Should().Be(5);
+        ((int)SubscriptionStatus.Canceled).Should().Be(6);
+    }
+
+    [Fact]
+    public void Billing_interval_numbers_are_fixed()
+    {
+        ((int)BillingInterval.Day).Should().Be(0);
+        ((int)BillingInterval.Week).Should().Be(1);
+        ((int)BillingInterval.Month).Should().Be(2);
+        ((int)BillingInterval.Year).Should().Be(3);
+    }
+
+    [Fact]
+    public void Usage_entry_type_numbers_are_fixed()
+    {
+        ((int)UsageEntryType.Consumption).Should().Be(0);
+        ((int)UsageEntryType.Reversal).Should().Be(1);
+        ((int)UsageEntryType.Grant).Should().Be(2);
+    }
+
+    [Fact]
+    public void Payment_link_state_numbers_are_fixed()
+    {
+        ((int)SubscriptionPaymentLinkState.Pending).Should().Be(0);
+        ((int)SubscriptionPaymentLinkState.Applied).Should().Be(1);
+        ((int)SubscriptionPaymentLinkState.Abandoned).Should().Be(2);
+    }
+
+    [Theory]
+    [InlineData(typeof(SubscriptionStatus))]
+    [InlineData(typeof(BillingInterval))]
+    [InlineData(typeof(CatalogueStatus))]
+    [InlineData(typeof(MeterAggregation))]
+    [InlineData(typeof(EntitlementLimitKind))]
+    [InlineData(typeof(EntitlementReason))]
+    [InlineData(typeof(UsageEntryType))]
+    [InlineData(typeof(SubscriptionPaymentPurpose))]
+    [InlineData(typeof(SubscriptionPaymentLinkState))]
+    [InlineData(typeof(SubscriptionOutboxStatus))]
+    [InlineData(typeof(DiscountKind))]
+    public void Every_persisted_enum_starts_at_zero_and_has_no_gaps(Type enumType)
+    {
+        var values = Enum.GetValues(enumType)
+            .Cast<object>()
+            .Select(value => (int)value)
+            .Order()
+            .ToArray();
+
+        values.Should().Equal(
+            Enumerable.Range(0, values.Length).ToArray(),
+            "a gap or a non-zero start usually means a member was removed rather than " +
+            "retired, and its number is now free to be reused by a later addition");
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -1,0 +1,313 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>Moving a live subscription to a different price, mid-period, with proration.</summary>
+public sealed class SubscriptionPlanChangeServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail _subscription = NewSubscription(SubscriptionStatus.Active, 1_000);
+    private BillingAccount? _account = new()
+    {
+        ItemId = "acct-1",
+        ProviderName = "STRIPE",
+        DefaultPaymentMethodId = "pm-1",
+        ProviderCustomerId = "cus_123"
+    };
+
+    public SubscriptionPlanChangeServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetAsync(
+                TenantId, OrganizationId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+
+        _subscriptions
+            .Setup(repository => repository.TryChangePlanAsync(
+                TenantId,
+                "sub-1",
+                It.IsAny<int>(),
+                It.IsAny<PlanSnapshot>(),
+                It.IsAny<PriceSnapshot>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(),
+                It.IsAny<long>(),
+                It.IsAny<string?>(),
+                It.IsAny<SubscriptionOutboxEvent>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "premium", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPlan());
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice(2_000));
+
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _account);
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("in_1", "corr-1"));
+    }
+
+    [Fact]
+    public async Task An_upgrade_charges_the_prorated_difference_through_the_gateway()
+    {
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.Is<SubscriptionChargeRequest>(request => request.AmountMinor == 1_000),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_declined_charge_leaves_the_subscription_unchanged()
+    {
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.ProviderRejected, "card_declined", "declined", "corr-1"));
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        _subscriptions.Verify(
+            repository => repository.TryChangePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<long>(),
+                It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_downgrade_never_calls_the_gateway()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Active, 2_000);
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice(1_000));
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_trial_swap_never_calls_the_gateway_or_touches_credit()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Trialing, 1_000);
+        _subscription.CreditBalanceMinor = 0;
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _subscriptions.Verify(
+            repository => repository.TryChangePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(),
+                0L,
+                It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_different_currency_is_refused()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice(2_000, currencyCode: "EUR"));
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_plan_change_currency_mismatch");
+    }
+
+    [Fact]
+    public async Task A_different_billing_interval_is_refused()
+    {
+        var price = NewPrice(2_000);
+        price.Interval = BillingInterval.Year;
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(price);
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_plan_change_interval_mismatch");
+    }
+
+    [Theory]
+    [InlineData(SubscriptionStatus.PastDue)]
+    [InlineData(SubscriptionStatus.Unpaid)]
+    [InlineData(SubscriptionStatus.Canceled)]
+    public async Task An_ineligible_status_is_a_conflict(SubscriptionStatus status)
+    {
+        _subscription = NewSubscription(status, 1_000);
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+    }
+
+    [Fact]
+    public async Task A_lost_compare_and_set_is_reported_as_a_conflict()
+    {
+        _subscriptions
+            .Setup(repository => repository.TryChangePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<long>(),
+                It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_plan_change_conflict");
+    }
+
+    [Fact]
+    public async Task No_payment_method_refuses_an_upgrade()
+    {
+        _account = new BillingAccount
+        {
+            ItemId = "acct-1",
+            ProviderName = "STRIPE",
+            DefaultPaymentMethodId = null
+        };
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_plan_change_no_payment_method");
+    }
+
+    private SubscriptionPlanChangeService Service() => new(
+        _contextResolver.Object,
+        _subscriptions.Object,
+        _catalogue.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new SubscriptionResponseMapper(),
+        new ChangeSubscriptionPlanRequestValidator(),
+        NullLogger<SubscriptionPlanChangeService>.Instance,
+        _time);
+
+    private static ChangeSubscriptionPlanRequest Request() => new()
+    {
+        PlanCode = "premium",
+        PriceId = "price-2"
+    };
+
+    private static SubscriptionDetail NewSubscription(
+        SubscriptionStatus status, long currentAmountMinor) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = status,
+        CurrencyCode = "CHF",
+        Version = 3,
+        Plan = new PlanSnapshot { Code = "basic", DisplayName = "Basic" },
+        Price = NewPriceSnapshot(currentAmountMinor),
+        QuantityItems = [],
+        CurrentPeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentPeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static PriceSnapshot NewPriceSnapshot(long unitAmountMinor) => new()
+    {
+        CurrencyCode = "CHF",
+        UnitAmountMinor = unitAmountMinor,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1
+    };
+
+    private static Plan NewPlan() => new()
+    {
+        ItemId = "plan-2",
+        TenantId = TenantId,
+        Code = "premium",
+        DisplayName = "Premium",
+        Status = CatalogueStatus.Active
+    };
+
+    private static Price NewPrice(long unitAmountMinor, string currencyCode = "CHF") => new()
+    {
+        ItemId = "price-2",
+        TenantId = TenantId,
+        PlanId = "plan-2",
+        CurrencyCode = currencyCode,
+        UnitAmountMinor = unitAmountMinor,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        Status = CatalogueStatus.Active
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>What a mid-period plan change costs, or credits, right now.</summary>
+public sealed class SubscriptionProrationCalculatorTests
+{
+    private static readonly DateTime PeriodStart = new(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime PeriodEnd = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void An_upgrade_right_at_period_start_charges_almost_the_full_difference()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000);
+        var targetPrice = NewPrice(2_000);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodStart);
+
+        outcome.ChargeMinor.Should().Be(1_000);
+        outcome.NewCreditBalanceMinor.Should().Be(0);
+    }
+
+    [Fact]
+    public void An_upgrade_right_at_period_end_charges_almost_nothing()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000);
+        var targetPrice = NewPrice(2_000);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodEnd);
+
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.NewCreditBalanceMinor.Should().Be(0);
+    }
+
+    [Fact]
+    public void A_downgrade_halfway_through_the_period_banks_a_credit_instead_of_charging()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 2_000);
+        var targetPrice = NewPrice(1_000);
+        var halfway = PeriodStart.AddDays(15);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], halfway);
+
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.NewCreditBalanceMinor.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void An_existing_credit_balance_is_applied_before_any_new_charge()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000, creditBalanceMinor: 1_000);
+        var targetPrice = NewPrice(2_000);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodStart);
+
+        // The full 1,000 difference is covered by the existing 1,000 credit.
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.NewCreditBalanceMinor.Should().Be(0);
+    }
+
+    [Fact]
+    public void A_credit_larger_than_the_upgrade_leaves_the_remainder_banked()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000, creditBalanceMinor: 5_000);
+        var targetPrice = NewPrice(2_000);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodStart);
+
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.NewCreditBalanceMinor.Should().Be(4_000);
+    }
+
+    [Fact]
+    public void A_discount_reduces_both_sides_of_the_comparison_identically()
+    {
+        var subscription = NewSubscription(
+            oldAmountMinor: 1_000,
+            discount: new DiscountTerms { Kind = DiscountKind.Percent, PercentBasisPoints = 5_000 });
+        var targetPrice = NewPrice(2_000);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodStart);
+
+        // Without the discount this would be 1,000 (2,000 - 1,000); halved on both sides it is
+        // still exactly half the undiscounted difference.
+        outcome.ChargeMinor.Should().Be(500);
+    }
+
+    [Fact]
+    public void No_change_in_price_neither_charges_nor_credits()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000);
+        var targetPrice = NewPrice(1_000);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodStart.AddDays(10));
+
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.NewCreditBalanceMinor.Should().Be(0);
+    }
+
+    private static SubscriptionDetail NewSubscription(
+        long oldAmountMinor,
+        long creditBalanceMinor = 0,
+        DiscountTerms? discount = null) => new()
+    {
+        CurrentPeriodStartUtc = PeriodStart,
+        CurrentPeriodEndUtc = PeriodEnd,
+        Price = NewPrice(oldAmountMinor),
+        QuantityItems = [],
+        Discount = discount,
+        CreditBalanceMinor = creditBalanceMinor
+    };
+
+    private static PriceSnapshot NewPrice(long unitAmountMinor) =>
+        new() { UnitAmountMinor = unitAmountMinor };
+}

--- a/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
@@ -107,6 +107,36 @@ public sealed class SubscriptionProrationCalculatorTests
         outcome.NewCreditBalanceMinor.Should().Be(0);
     }
 
+    [Fact]
+    public void A_taxed_upgrade_nets_the_tax_inclusive_amounts()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000);
+        subscription.Price.TaxRateBasisPoints = 1_000; // 10%
+        var targetPrice = NewPrice(2_000);
+        targetPrice.TaxRateBasisPoints = 1_000;
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodStart);
+
+        // Old side: 1,000 + 10% = 1,100. New side: 2,000 + 10% = 2,200. Delta = 1,100.
+        outcome.ChargeMinor.Should().Be(1_100);
+    }
+
+    [Fact]
+    public void A_plan_change_between_differently_taxed_prices_taxes_each_side_at_its_own_rate()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000);
+        subscription.Price.TaxRateBasisPoints = null; // old price is untaxed
+        var targetPrice = NewPrice(1_000);
+        targetPrice.TaxRateBasisPoints = 2_000; // new price carries 20% tax
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription, targetPrice, [], PeriodStart);
+
+        // Old side stays 1,000 (no tax). New side is 1,000 + 20% = 1,200. Delta = 200.
+        outcome.ChargeMinor.Should().Be(200);
+    }
+
     private static SubscriptionDetail NewSubscription(
         long oldAmountMinor,
         long creditBalanceMinor = 0,

--- a/server/XUnitTest/Subscription/SubscriptionRenewalProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalProcessorTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>The periodic sweep that finds subscriptions due for a renewal or a dunning retry.</summary>
+public sealed class SubscriptionRenewalProcessorTests
+{
+    private const string TenantId = "tenant-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionRenewalService> _renewals = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private IReadOnlyList<SubscriptionDetail> _due = [];
+
+    public SubscriptionRenewalProcessorTests() =>
+        _subscriptions
+            .Setup(repository => repository.ListDueForRenewalAsync(
+                TenantId,
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _due);
+
+    [Fact]
+    public async Task Every_due_subscription_is_handed_to_the_renewal_service()
+    {
+        _due =
+        [
+            NewSubscription("sub-1"),
+            NewSubscription("sub-2")
+        ];
+
+        var processed = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        processed.Should().Be(2);
+        _renewals.Verify(
+            renewals => renewals.RenewAsync(
+                It.Is<SubscriptionDetail>(subscription => subscription.ItemId == "sub-1"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _renewals.Verify(
+            renewals => renewals.RenewAsync(
+                It.Is<SubscriptionDetail>(subscription => subscription.ItemId == "sub-2"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Nothing_due_processes_nothing()
+    {
+        _due = [];
+
+        var processed = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        processed.Should().Be(0);
+        _renewals.Verify(
+            renewals => renewals.RenewAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task The_batch_size_setting_bounds_the_query()
+    {
+        _due = [NewSubscription("sub-1")];
+
+        await Processor(batchSize: 5).ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _subscriptions.Verify(
+            repository => repository.ListDueForRenewalAsync(
+                TenantId,
+                It.IsAny<DateTime>(),
+                5,
+                It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task A_lost_compare_and_set_inside_the_renewal_service_is_not_treated_as_an_error()
+    {
+        _due = [NewSubscription("sub-1")];
+
+        _renewals
+            .Setup(renewals => renewals.RenewAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var processed = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        processed.Should().Be(1, "the sweep counts what it attempted, not what changed");
+    }
+
+    private SubscriptionRenewalProcessor Processor(int batchSize = 50) => new(
+        _subscriptions.Object,
+        _renewals.Object,
+        new OptionsStub(batchSize),
+        NullLogger<SubscriptionRenewalProcessor>.Instance,
+        _time);
+
+    private static SubscriptionDetail NewSubscription(string id) => new()
+    {
+        ItemId = id,
+        TenantId = TenantId,
+        Status = SubscriptionStatus.Active
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public OptionsStub(int batchSize) =>
+            CurrentValue = new SubscriptionOptions { RenewalBatchSize = batchSize };
+
+        public SubscriptionOptions CurrentValue { get; }
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
@@ -89,6 +89,19 @@ public sealed class SubscriptionRenewalServiceTests
     }
 
     [Fact]
+    public async Task A_successful_renewal_writes_the_credit_balance_decremented_by_what_it_consumed()
+    {
+        var subscription = NewSubscription(SubscriptionStatus.Active);
+        subscription.CreditBalanceMinor = 3_000;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        // The period costs 8,900; the full 3,000 credit is consumed and the transition banks
+        // what remains — nothing, in this case, since the credit is smaller than the charge.
+        _transition!.CreditBalanceMinor.Should().Be(0);
+    }
+
+    [Fact]
     public async Task A_first_decline_moves_active_to_past_due()
     {
         Decline();

--- a/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
@@ -1,0 +1,290 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Charging a renewal, and the dunning state machine that follows a decline.
+/// </summary>
+public sealed class SubscriptionRenewalServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 31, 22, 0, 0, TimeSpan.Zero));
+
+    private BillingAccount? _account = new()
+    {
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        ProviderName = "STRIPE",
+        DefaultPaymentMethodId = "pm-1"
+    };
+
+    private SubscriptionTransition? _transition;
+
+    public SubscriptionRenewalServiceTests()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _account);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId,
+                "sub-1",
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+    }
+
+    [Fact]
+    public async Task A_successful_renewal_advances_the_period_and_clears_dunning()
+    {
+        var subscription = NewSubscription(SubscriptionStatus.Active);
+        subscription.DunningAttemptCount = 2;
+        subscription.PastDueSinceUtc = _time.GetUtcNow().UtcDateTime.AddDays(-3);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Active);
+        _transition.DunningAttemptCount.Should().Be(0);
+        _transition.ClearPastDueSinceAt.Should().BeTrue();
+        _transition.LastRenewalPaymentDetailId.Should().Be("pay-1");
+        _transition.Event!.EventType.Should().Be(SubscriptionConstants.SubscriptionRenewed);
+    }
+
+    [Fact]
+    public async Task A_successful_renewal_drops_the_cached_entitlement()
+    {
+        await Service().RenewAsync(NewSubscription(SubscriptionStatus.Active), CancellationToken.None);
+
+        _cache.Verify(cache => cache.Invalidate(TenantId, OrganizationId), Times.Once);
+    }
+
+    [Fact]
+    public async Task A_first_decline_moves_active_to_past_due()
+    {
+        Decline();
+
+        var subscription = NewSubscription(SubscriptionStatus.Active);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Active);
+        _transition.NewStatus.Should().Be(SubscriptionStatus.PastDue);
+        _transition.DunningAttemptCount.Should().Be(1);
+        _transition.PastDueSinceUtc.Should().NotBeNull();
+        _transition.Event!.EventType.Should().Be(SubscriptionConstants.SubscriptionPastDue);
+    }
+
+    [Fact]
+    public async Task A_retry_short_of_the_ceiling_stays_past_due()
+    {
+        Decline();
+
+        var subscription = NewSubscription(SubscriptionStatus.PastDue);
+        subscription.DunningAttemptCount = 1;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.PastDue);
+        _transition.DunningAttemptCount.Should().Be(2);
+        _transition.Event!.EventType.Should().Be(SubscriptionConstants.SubscriptionRenewalFailed);
+    }
+
+    [Fact]
+    public async Task A_decline_at_the_attempt_ceiling_moves_to_unpaid()
+    {
+        Decline();
+
+        var subscription = NewSubscription(SubscriptionStatus.PastDue);
+        subscription.DunningAttemptCount = 3;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Unpaid);
+        _transition.ClearPastDueSinceAt.Should().BeTrue();
+        _transition.ClearNextFeeBillingAt.Should().BeTrue();
+        _transition.Event!.EventType.Should().Be(SubscriptionConstants.SubscriptionUnpaid);
+    }
+
+    [Fact]
+    public async Task No_stored_payment_method_skips_straight_to_unpaid_with_no_attempts()
+    {
+        _account = new BillingAccount
+        {
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            ProviderName = "STRIPE",
+            DefaultPaymentMethodId = null
+        };
+
+        var subscription = NewSubscription(SubscriptionStatus.Active);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Unpaid);
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "retrying without a card to charge is pointless");
+    }
+
+    [Fact]
+    public async Task A_trial_with_a_card_converts_to_active_on_success()
+    {
+        var subscription = NewSubscription(SubscriptionStatus.Trialing);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Trialing);
+        _transition.NewStatus.Should().Be(SubscriptionStatus.Active);
+    }
+
+    [Fact]
+    public async Task A_trial_with_no_card_converts_straight_to_unpaid()
+    {
+        _account = new BillingAccount
+        {
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            ProviderName = "STRIPE",
+            DefaultPaymentMethodId = null
+        };
+
+        var subscription = NewSubscription(SubscriptionStatus.Trialing);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Unpaid);
+    }
+
+    [Fact]
+    public async Task Already_unpaid_is_left_alone()
+    {
+        _account = new BillingAccount
+        {
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            ProviderName = "STRIPE",
+            DefaultPaymentMethodId = null
+        };
+
+        var subscription = NewSubscription(SubscriptionStatus.Unpaid);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_fully_discounted_period_renews_without_charging_anything()
+    {
+        var subscription = NewSubscription(SubscriptionStatus.Active);
+        subscription.Discount = new DiscountTerms
+        {
+            Kind = DiscountKind.FixedAmount,
+            AmountMinor = 100_000
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Active);
+    }
+
+    private void Decline() =>
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.ProviderRejected,
+                "card_declined",
+                "The card was declined.",
+                "corr-1"));
+
+    private SubscriptionRenewalService Service() => new(
+        _subscriptions.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new OptionsStub(),
+        NullLogger<SubscriptionRenewalService>.Instance,
+        _time);
+
+    private static SubscriptionDetail NewSubscription(SubscriptionStatus status) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = status,
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+        Price = new PriceSnapshot { CurrencyCode = "CHF", UnitAmountMinor = 8_900 },
+        FeeSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new() { DunningMaxAttempts = 4 };
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// What the running service actually gets from the container.
+/// </summary>
+/// <remarks>
+/// A missing registration or a wrong lifetime compiles perfectly and fails on the first
+/// request. Repositories in particular must stay singleton: their record of which tenants they
+/// have already indexed is per instance, so a scoped one would re-issue index commands on every
+/// call.
+/// </remarks>
+public sealed class SubscriptionServiceRegistrationTests
+{
+    [Fact]
+    public void The_registration_returns_the_same_collection_for_chaining()
+    {
+        var services = new ServiceCollection();
+
+        services.RegisterSubscriptionDomainServices(Configuration())
+            .Should().BeSameAs(services);
+    }
+
+    [Theory]
+    [InlineData(typeof(ISubscriptionCatalogueRepository))]
+    [InlineData(typeof(IBillingAccountRepository))]
+    [InlineData(typeof(ISubscriptionRepository))]
+    [InlineData(typeof(ISubscriptionUsageRepository))]
+    [InlineData(typeof(ISubscriptionPaymentLinkRepository))]
+    public void Repositories_are_singletons(Type serviceType)
+    {
+        var descriptor = Subscriptions()
+            .Single(candidate => candidate.ServiceType == serviceType);
+
+        descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void Options_bind_from_the_subscription_section()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterSubscriptionDomainServices(Configuration(new Dictionary<string, string?>
+        {
+            ["Subscription:EntitlementCacheSeconds"] = "42",
+            ["Subscription:CounterRetentionDays"] = "7"
+        }));
+
+        var options = services
+            .BuildServiceProvider()
+            .GetRequiredService<IOptions<SubscriptionOptions>>()
+            .Value;
+
+        options.EntitlementCacheSeconds.Should().Be(42);
+        options.CounterRetentionDays.Should().Be(7);
+    }
+
+    [Fact]
+    public void Options_keep_their_defaults_when_nothing_is_configured()
+    {
+        var options = new SubscriptionOptions();
+
+        options.EntitlementCacheSeconds.Should().Be(10);
+        options.ReconciliationPollSeconds.Should().Be(120);
+        options.TenantIds.Should().BeEmpty(
+            "nothing else discovers tenants, so an omitted tenant is silently skipped by " +
+            "every background sweep");
+    }
+
+    private static IServiceCollection Subscriptions()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterSubscriptionDomainServices(Configuration());
+
+        return services;
+    }
+
+    private static IConfiguration Configuration(
+        Dictionary<string, string?>? overrides = null) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(overrides ?? [])
+            .Build();
+}

--- a/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>What a meter's usage costs beyond its included quantity.</summary>
+public sealed class SubscriptionUsageRaterTests
+{
+    [Fact]
+    public void Usage_under_the_included_quantity_rates_to_zero()
+    {
+        var meter = NewMeter(includedQuantity: 500, tiers: [Tier(null, 10)]);
+
+        SubscriptionUsageRater.OverageAmountMinor(meter, 300, "CHF").Should().Be(0);
+    }
+
+    [Fact]
+    public void Usage_exactly_at_the_included_quantity_rates_to_zero()
+    {
+        var meter = NewMeter(includedQuantity: 500, tiers: [Tier(null, 10)]);
+
+        SubscriptionUsageRater.OverageAmountMinor(meter, 500, "CHF").Should().Be(0);
+    }
+
+    [Fact]
+    public void Overage_entirely_within_the_first_tier_never_reaches_the_second_rate()
+    {
+        var meter = NewMeter(
+            includedQuantity: 500,
+            tiers: [Tier(400, 10), Tier(null, 5)]);
+
+        // 100 overage units, all inside the first 400-unit band.
+        SubscriptionUsageRater.OverageAmountMinor(meter, 600, "CHF").Should().Be(1_000);
+    }
+
+    [Fact]
+    public void Overage_split_across_two_tiers_charges_each_slice_at_its_own_rate()
+    {
+        var meter = NewMeter(
+            includedQuantity: 500,
+            tiers: [Tier(400, 10), Tier(null, 5)]);
+
+        // 700 overage units: 400 at 10 (=4,000) + 300 at 5 (=1,500) = 5,500.
+        SubscriptionUsageRater.OverageAmountMinor(meter, 1_200, "CHF").Should().Be(5_500);
+    }
+
+    [Fact]
+    public void The_final_unbounded_tier_absorbs_whatever_remains()
+    {
+        var meter = NewMeter(
+            includedQuantity: 0,
+            tiers: [Tier(10, 100), Tier(20, 50), Tier(null, 1)]);
+
+        // 10 at 100 (=1,000) + 10 at 50 (=500) + 980 at 1 (=980) = 2,480.
+        SubscriptionUsageRater.OverageAmountMinor(meter, 1_000, "CHF").Should().Be(2_480);
+    }
+
+    [Fact]
+    public void Overage_allowed_false_always_rates_to_zero()
+    {
+        var meter = NewMeter(includedQuantity: 0, tiers: [Tier(null, 10)]);
+        meter.OverageAllowed = false;
+
+        SubscriptionUsageRater.OverageAmountMinor(meter, 1_000, "CHF").Should().Be(0);
+    }
+
+    [Fact]
+    public void No_matching_currency_rates_to_zero_rather_than_throwing()
+    {
+        var meter = NewMeter(includedQuantity: 0, tiers: [Tier(null, 10)]);
+
+        SubscriptionUsageRater.OverageAmountMinor(meter, 1_000, "EUR").Should().Be(0);
+    }
+
+    [Fact]
+    public void Currency_matching_is_case_insensitive()
+    {
+        var meter = NewMeter(includedQuantity: 0, tiers: [Tier(null, 10)]);
+        meter.RateTables[0].CurrencyCode = "chf";
+
+        SubscriptionUsageRater.OverageAmountMinor(meter, 100, "CHF").Should().Be(1_000);
+    }
+
+    private static MeterTier Tier(long? upTo, long unitAmountMinor) =>
+        new() { UpToQuantity = upTo, UnitAmountMinor = unitAmountMinor };
+
+    private static PlanMeter NewMeter(long includedQuantity, List<MeterTier> tiers) => new()
+    {
+        MeterKey = "screening",
+        IncludedQuantity = includedQuantity,
+        RateTables = [new MeterRateTable { CurrencyCode = "CHF", Tiers = tiers }]
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -135,6 +135,26 @@ public sealed class SubscriptionUsageRatingProcessorTests
     }
 
     [Fact]
+    public async Task Tax_is_applied_once_to_the_aggregate_not_per_meter_line()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.Price.TaxRateBasisPoints = 1_000; // 10%
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 700), NewCounter("envelope", 300)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        // screening: 200 * 10 = 2,000. envelope: 200 * 20 = 4,000. Subtotal 6,000, +10% tax = 6,600.
+        _createdInvoice!.TaxAmountMinor.Should().Be(600);
+        _createdInvoice.TotalAmountMinor.Should().Be(6_600);
+        _createdInvoice.Lines.Sum(line => line.AmountMinor).Should().Be(6_000,
+            "tax is on the aggregate, never split back across individual meter lines");
+    }
+
+    [Fact]
     public async Task An_existing_invoice_is_not_recreated()
     {
         _due = [NewSubscription("sub-1")];

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -2,16 +2,18 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Payment.DomainService.Enums;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 using XUnitTest.Payment;
 
 namespace XUnitTest.Subscription;
 
-/// <summary>Closing a usage period and pricing its overage into an invoice.</summary>
+/// <summary>Closing a usage period, pricing its overage, and charging the resulting invoice.</summary>
 public sealed class SubscriptionUsageRatingProcessorTests
 {
     private const string TenantId = "tenant-1";
@@ -20,10 +22,13 @@ public sealed class SubscriptionUsageRatingProcessorTests
     private readonly Mock<ISubscriptionRepository> _subscriptions = new();
     private readonly Mock<ISubscriptionUsageRepository> _usage = new();
     private readonly Mock<ISubscriptionUsageInvoiceRepository> _usageInvoices = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 9, 1, 0, 30, 0, TimeSpan.Zero));
 
     private IReadOnlyList<SubscriptionDetail> _due = [];
+    private IReadOnlyList<SubscriptionUsageInvoice> _dueInvoices = [];
     private SubscriptionUsageInvoice? _createdInvoice;
 
     public SubscriptionUsageRatingProcessorTests()
@@ -41,6 +46,12 @@ public sealed class SubscriptionUsageRatingProcessorTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string tenantId, string subscriptionId, CancellationToken _) =>
+                NewSubscription(subscriptionId));
+
         _usageInvoices
             .Setup(repository => repository.GetAsync(
                 TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -52,10 +63,41 @@ public sealed class SubscriptionUsageRatingProcessorTests
             .Callback<SubscriptionUsageInvoice, CancellationToken>((invoice, _) => _createdInvoice = invoice)
             .ReturnsAsync(true);
 
+        _usageInvoices
+            .Setup(repository => repository.ListDueAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _dueInvoices);
+
+        _usageInvoices
+            .Setup(repository => repository.TryMarkChargedAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _usageInvoices
+            .Setup(repository => repository.TryMarkAbandonedAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         _usage
             .Setup(repository => repository.ListCountersAsync(
                 TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
+
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                ProviderName = "STRIPE",
+                DefaultPaymentMethodId = "pm-1",
+                ProviderCustomerId = "cus_123"
+            });
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("in_1", "corr-1"));
     }
 
     [Fact]
@@ -160,10 +202,138 @@ public sealed class SubscriptionUsageRatingProcessorTests
         closed.Should().Be(0);
     }
 
+    [Fact]
+    public async Task A_successful_charge_marks_the_invoice_charged_and_emits_an_event()
+    {
+        _dueInvoices = [NewInvoice()];
+
+        await Processor().ChargeDueInvoicesAsync(TenantId, CancellationToken.None);
+
+        _usageInvoices.Verify(
+            repository => repository.TryMarkChargedAsync(
+                TenantId, "inv-1", "in_1", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _subscriptions.Verify(
+            repository => repository.TryAppendEventAsync(
+                TenantId,
+                "sub-1",
+                It.Is<SubscriptionOutboxEvent>(e => e.EventType == SubscriptionConstants.UsageRated),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_declined_charge_reschedules_short_of_the_attempt_ceiling()
+    {
+        _dueInvoices = [NewInvoice()];
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.ProviderRejected, "card_declined", "declined", "corr-1"));
+
+        await Processor().ChargeDueInvoicesAsync(TenantId, CancellationToken.None);
+
+        _usageInvoices.Verify(
+            repository => repository.RescheduleAsync(
+                TenantId, "inv-1", 1, It.IsAny<DateTime>(), "card_declined", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _usageInvoices.Verify(
+            repository => repository.TryMarkAbandonedAsync(
+                TenantId, "inv-1", It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_decline_at_the_attempt_ceiling_abandons_and_emits_a_failure_event()
+    {
+        _dueInvoices = [NewInvoice(attemptCount: 2)];
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.ProviderRejected, "card_declined", "declined", "corr-1"));
+
+        await Processor().ChargeDueInvoicesAsync(TenantId, CancellationToken.None);
+
+        _usageInvoices.Verify(
+            repository => repository.TryMarkAbandonedAsync(
+                TenantId, "inv-1", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _subscriptions.Verify(
+            repository => repository.TryAppendEventAsync(
+                TenantId,
+                "sub-1",
+                It.Is<SubscriptionOutboxEvent>(e => e.EventType == SubscriptionConstants.UsageRatingFailed),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task No_payment_method_reschedules_without_calling_the_gateway()
+    {
+        _dueInvoices = [NewInvoice()];
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount { ProviderName = "STRIPE", DefaultPaymentMethodId = null });
+
+        await Processor().ChargeDueInvoicesAsync(TenantId, CancellationToken.None);
+
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _usageInvoices.Verify(
+            repository => repository.RescheduleAsync(
+                TenantId, "inv-1", 1, It.IsAny<DateTime>(), "no_payment_method", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_failed_overage_charge_never_touches_the_subscription_status()
+    {
+        _dueInvoices = [NewInvoice(attemptCount: 2)];
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.ProviderRejected, "card_declined", "declined", "corr-1"));
+
+        await Processor().ChargeDueInvoicesAsync(TenantId, CancellationToken.None);
+
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static SubscriptionUsageInvoice NewInvoice(int attemptCount = 0) => new()
+    {
+        ItemId = "inv-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        SubscriptionId = "sub-1",
+        PeriodKey = "M20260801T000000Z",
+        CurrencyCode = "CHF",
+        TotalAmountMinor = 2_000,
+        AttemptCount = attemptCount,
+        State = SubscriptionUsageInvoiceState.Pending,
+        CorrelationId = "corr-1"
+    };
+
     private SubscriptionUsageRatingProcessor Processor() => new(
         _subscriptions.Object,
         _usage.Object,
         _usageInvoices.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
         new OptionsStub(),
         NullLogger<SubscriptionUsageRatingProcessor>.Instance,
         _time);

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -1,0 +1,238 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>Closing a usage period and pricing its overage into an invoice.</summary>
+public sealed class SubscriptionUsageRatingProcessorTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionUsageInvoiceRepository> _usageInvoices = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 9, 1, 0, 30, 0, TimeSpan.Zero));
+
+    private IReadOnlyList<SubscriptionDetail> _due = [];
+    private SubscriptionUsageInvoice? _createdInvoice;
+
+    public SubscriptionUsageRatingProcessorTests()
+    {
+        _subscriptions
+            .Setup(repository => repository.ListDueForUsageRatingAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _due);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId,
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _usageInvoices
+            .Setup(repository => repository.GetAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageInvoice?)null);
+
+        _usageInvoices
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionUsageInvoice, CancellationToken>((invoice, _) => _createdInvoice = invoice)
+            .ReturnsAsync(true);
+
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+    }
+
+    [Fact]
+    public async Task A_period_with_no_overage_creates_a_no_charge_invoice()
+    {
+        _due = [NewSubscription("sub-1")];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 100)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        _createdInvoice!.State.Should().Be(SubscriptionUsageInvoiceState.NoCharge);
+        _createdInvoice.TotalAmountMinor.Should().Be(0);
+        _createdInvoice.NextAttemptAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_period_with_overage_creates_a_pending_invoice_priced_across_meters()
+    {
+        _due = [NewSubscription("sub-1")];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 700), NewCounter("envelope", 50)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        // screening: 200 overage * 10 = 2,000. envelope has no counter overage (under included).
+        _createdInvoice!.State.Should().Be(SubscriptionUsageInvoiceState.Pending);
+        _createdInvoice.TotalAmountMinor.Should().Be(2_000);
+        _createdInvoice.Lines.Should().ContainSingle(line => line.MeterKey == "screening");
+        _createdInvoice.NextAttemptAtUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task An_existing_invoice_is_not_recreated()
+    {
+        _due = [NewSubscription("sub-1")];
+        _usageInvoices
+            .Setup(repository => repository.GetAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageInvoice());
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        _usageInvoices.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        // The period still advances even though the invoice already existed.
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_worker_outage_spanning_three_periods_rates_all_three()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.CurrentUsagePeriodStartUtc = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        subscription.CurrentUsagePeriodEndUtc = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        _due = [subscription];
+
+        var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        // June, July and August all close before the September "now" is reached.
+        closed.Should().Be(3);
+        _usageInvoices.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task Nothing_due_closes_nothing()
+    {
+        _due = [];
+
+        var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        closed.Should().Be(0);
+        _usageInvoices.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_lost_compare_and_set_stops_advancing_that_subscription()
+    {
+        _due = [NewSubscription("sub-1")];
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        closed.Should().Be(0);
+    }
+
+    private SubscriptionUsageRatingProcessor Processor() => new(
+        _subscriptions.Object,
+        _usage.Object,
+        _usageInvoices.Object,
+        new OptionsStub(),
+        NullLogger<SubscriptionUsageRatingProcessor>.Instance,
+        _time);
+
+    private static SubscriptionDetail NewSubscription(string id) => new()
+    {
+        ItemId = id,
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        CurrentUsagePeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentUsagePeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        },
+        Plan = new PlanSnapshot
+        {
+            Meters =
+            [
+                new PlanMeter
+                {
+                    MeterKey = "screening",
+                    IncludedQuantity = 500,
+                    OverageAllowed = true,
+                    RateTables =
+                    [
+                        new MeterRateTable
+                        {
+                            CurrencyCode = "CHF",
+                            Tiers = [new MeterTier { UpToQuantity = null, UnitAmountMinor = 10 }]
+                        }
+                    ]
+                },
+                new PlanMeter
+                {
+                    MeterKey = "envelope",
+                    IncludedQuantity = 100,
+                    OverageAllowed = true,
+                    RateTables =
+                    [
+                        new MeterRateTable
+                        {
+                            CurrencyCode = "CHF",
+                            Tiers = [new MeterTier { UpToQuantity = null, UnitAmountMinor = 20 }]
+                        }
+                    ]
+                }
+            ]
+        }
+    };
+
+    private static SubscriptionUsageCounter NewCounter(string meterKey, long balance) => new()
+    {
+        MeterKey = meterKey,
+        Balance = balance
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new();
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -1,0 +1,307 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Recording usage, and the guarantees a bill depends on.
+/// </summary>
+public sealed class UsageRecordingServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<IUsageThresholdEvaluator> _thresholds = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail _subscription = NewSubscription();
+    private long _balance;
+    private readonly List<SubscriptionUsageRecord> _ledger = [];
+
+    public UsageRecordingServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+
+        _usage
+            .Setup(repository => repository.TryAppendRecordAsync(
+                It.IsAny<SubscriptionUsageRecord>(), It.IsAny<CancellationToken>()))
+            .Returns<SubscriptionUsageRecord, CancellationToken>((record, _) =>
+            {
+                // Stands in for the unique index: the same key never lands twice.
+                if (_ledger.Exists(existing => string.Equals(
+                        existing.IdempotencyKey,
+                        record.IdempotencyKey,
+                        StringComparison.Ordinal)))
+                {
+                    return Task.FromResult(false);
+                }
+
+                _ledger.Add(record);
+
+                return Task.FromResult(true);
+            });
+
+        _usage
+            .Setup(repository => repository.ApplyDeltaAsync(
+                It.IsAny<SubscriptionUsageCounter>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<SubscriptionUsageCounter, long, CancellationToken>((seed, delta, _) =>
+            {
+                _balance += delta;
+                seed.Balance = _balance;
+
+                return Task.FromResult(seed);
+            });
+
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new SubscriptionUsageCounter { Balance = _balance });
+    }
+
+    [Fact]
+    public async Task Recording_reports_the_balance_including_this_call()
+    {
+        var result = await Service().RecordAsync(
+            NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Used.Should().Be(1);
+        result.Value.Remaining.Should().Be(499);
+        result.Value.Allowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task The_ledger_is_written_before_the_counter()
+    {
+        await Service().RecordAsync(NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        _ledger.Should().ContainSingle();
+        _usage.Verify(
+            repository => repository.ApplyDeltaAsync(
+                It.IsAny<SubscriptionUsageCounter>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_repeated_key_changes_nothing_and_says_so()
+    {
+        await Service().RecordAsync(NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        var replay = await Service().RecordAsync(
+            NewRequest("usage-1"), "corr-2", CancellationToken.None);
+
+        replay.Value!.Replayed.Should().BeTrue();
+        replay.Value.Used.Should().Be(1, "a retry must not become a second billable event");
+        _ledger.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task A_usage_record_carries_its_correlation_id()
+    {
+        await Service().RecordAsync(NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        _ledger[0].CorrelationId.Should().Be("corr-1",
+            "billing questions are answered months later, from this row alone");
+        _ledger[0].PeriodKey.Should().NotBeEmpty(
+            "stamping the period on write is what stops a record drifting into another month");
+    }
+
+    [Fact]
+    public async Task Usage_past_the_allowance_is_recorded_as_overage_when_it_is_allowed()
+    {
+        _balance = 500;
+
+        var result = await Service().RecordAsync(
+            NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        result.Value!.Allowed.Should().BeTrue();
+        result.Value.Overage.Should().Be(1);
+        result.Value.Remaining.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task An_enforced_meter_past_its_allowance_refuses_and_rolls_back()
+    {
+        _subscription.Plan.Meters[0].OverageAllowed = false;
+        _balance = 500;
+
+        var request = NewRequest("usage-1");
+        request.Enforce = true;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.Value!.Allowed.Should().BeFalse();
+        result.Value.Used.Should().Be(500, "a refused call must leave the balance where it was");
+
+        _ledger.Should().HaveCount(2);
+        _ledger[1].EntryType.Should().Be(UsageEntryType.Reversal,
+            "the ledger is append-only, so a refusal is recorded rather than erased");
+        _ledger[1].Delta.Should().Be(-1);
+        _ledger[1].CompensatesRecordId.Should().Be(_ledger[0].ItemId);
+    }
+
+    [Fact]
+    public async Task A_trial_uses_its_own_grant_rather_than_the_plans_allowance()
+    {
+        _subscription.Status = SubscriptionStatus.Trialing;
+        _subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = DateTime.UtcNow,
+            EndsAtUtc = DateTime.UtcNow.AddDays(14),
+            Grants = [new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 25 }]
+        };
+
+        var result = await Service().RecordAsync(
+            NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        result.Value!.Included.Should().Be(25,
+            "a trial that hands out the full monthly quota is an open invitation");
+    }
+
+    [Fact]
+    public async Task A_meter_the_plan_does_not_define_is_not_found()
+    {
+        var request = NewRequest("usage-1");
+        request.MeterKey = "not-a-meter";
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+    }
+
+    [Fact]
+    public async Task Usage_without_a_subscription_is_not_found()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var result = await Service().RecordAsync(
+            NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_not_found");
+    }
+
+    [Fact]
+    public async Task A_missing_idempotency_key_is_refused()
+    {
+        var request = NewRequest("usage-1");
+        request.IdempotencyKey = string.Empty;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        _ledger.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task An_unsupported_aggregation_is_refused_rather_than_summed()
+    {
+        _subscription.Plan.Meters[0].Aggregation = MeterAggregation.Max;
+
+        var result = await Service().RecordAsync(
+            NewRequest("usage-1"), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_meter_aggregation_unsupported");
+        _ledger.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Late_reported_usage_lands_in_the_period_it_happened_in()
+    {
+        var request = NewRequest("usage-1");
+        request.OccurredAtUtc = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc);
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.Value!.PeriodStartUtc.Should().BeBefore(
+            new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    private UsageRecordingService Service() => new(
+        _subscriptions.Object,
+        _usage.Object,
+        _contextResolver.Object,
+        _thresholds.Object,
+        new RecordUsageRequestValidator(new OptionsStub()),
+        new OptionsStub(),
+        NullLogger<UsageRecordingService>.Instance,
+        _time);
+
+    private static RecordUsageRequest NewRequest(string idempotencyKey) => new()
+    {
+        MeterKey = "screening",
+        Quantity = 1,
+        IdempotencyKey = idempotencyKey
+    };
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot
+        {
+            Code = "professional",
+            Meters =
+            [
+                new PlanMeter
+                {
+                    MeterKey = "screening",
+                    UnitLabel = "screening",
+                    IncludedQuantity = 500,
+                    OverageAllowed = true,
+                    ThresholdPercents = [80, 100]
+                }
+            ]
+        },
+        UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new();
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/UsageThresholdEvaluatorTests.cs
+++ b/server/XUnitTest/Subscription/UsageThresholdEvaluatorTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Noticing a threshold, once.
+/// </summary>
+public sealed class UsageThresholdEvaluatorTests
+{
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly List<SubscriptionOutboxEvent> _events = [];
+    private readonly HashSet<int> _alreadyNotified = [];
+
+    public UsageThresholdEvaluatorTests()
+    {
+        _usage
+            .Setup(repository => repository.TryMarkThresholdNotifiedAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, string, int, CancellationToken>((_, _, threshold, _) =>
+                // Stands in for the conditional update: only the first caller modifies it.
+                Task.FromResult(_alreadyNotified.Add(threshold)));
+
+        _subscriptions
+            .Setup(repository => repository.TryAppendEventAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionOutboxEvent>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionOutboxEvent, CancellationToken>(
+                (_, _, outboxEvent, _) => _events.Add(outboxEvent))
+            .ReturnsAsync(true);
+    }
+
+    [Theory]
+    [InlineData(399, 0)]
+    [InlineData(400, 1)]
+    [InlineData(499, 1)]
+    [InlineData(500, 2)]
+    public async Task A_threshold_fires_exactly_when_it_is_reached(long balance, int expected)
+    {
+        var reported = await Evaluator().EvaluateAsync(
+            NewSubscription(),
+            NewCounter(balance),
+            "corr-1",
+            CancellationToken.None);
+
+        reported.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task A_threshold_is_reported_once_however_often_it_is_evaluated()
+    {
+        var subscription = NewSubscription();
+
+        await Evaluator().EvaluateAsync(
+            subscription, NewCounter(400), "corr-1", CancellationToken.None);
+
+        var second = await Evaluator().EvaluateAsync(
+            subscription, NewCounter(410), "corr-2", CancellationToken.None);
+
+        second.Should().Be(0, "otherwise every unit past the threshold sends another alert");
+        _events.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Several_thresholds_crossed_at_once_are_reported_in_order()
+    {
+        await Evaluator().EvaluateAsync(
+            NewSubscription(), NewCounter(500), "corr-1", CancellationToken.None);
+
+        _events.Should().HaveCount(2);
+        _events[0].Payload.Should().Contain("\"thresholdPercent\":80");
+        _events[1].Payload.Should().Contain("\"thresholdPercent\":100");
+    }
+
+    [Fact]
+    public async Task Each_threshold_gets_its_own_deduplication_key_per_period()
+    {
+        await Evaluator().EvaluateAsync(
+            NewSubscription(), NewCounter(500), "corr-1", CancellationToken.None);
+
+        _events.Select(outboxEvent => outboxEvent.DeduplicationKey)
+            .Should().OnlyHaveUniqueItems()
+            .And.AllSatisfy(key => key.Should().Contain("M20260801T000000Z",
+                "crossing 80% in September is a different event from crossing it in August"));
+    }
+
+    [Fact]
+    public async Task A_meter_with_no_thresholds_reports_nothing()
+    {
+        var subscription = NewSubscription();
+        subscription.Plan.Meters[0].ThresholdPercents = [];
+
+        var reported = await Evaluator().EvaluateAsync(
+            subscription, NewCounter(500), "corr-1", CancellationToken.None);
+
+        reported.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task A_counter_with_no_allowance_reports_nothing()
+    {
+        var counter = NewCounter(500);
+        counter.LimitSnapshot = null;
+
+        var reported = await Evaluator().EvaluateAsync(
+            NewSubscription(), counter, "corr-1", CancellationToken.None);
+
+        reported.Should().Be(0, "a percentage of nothing is not a crossing");
+    }
+
+    [Fact]
+    public async Task Losing_the_race_to_report_raises_nothing()
+    {
+        _usage
+            .Setup(repository => repository.TryMarkThresholdNotifiedAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var reported = await Evaluator().EvaluateAsync(
+            NewSubscription(), NewCounter(500), "corr-1", CancellationToken.None);
+
+        reported.Should().Be(0);
+        _events.Should().BeEmpty("the winner has already told the customer");
+    }
+
+    private UsageThresholdEvaluator Evaluator() => new(
+        _usage.Object,
+        _subscriptions.Object,
+        new SubscriptionOutboxEventFactory(),
+        NullLogger<UsageThresholdEvaluator>.Instance);
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = "tenant-1",
+        OrganizationId = "org-1",
+        Plan = new PlanSnapshot
+        {
+            Code = "professional",
+            Meters =
+            [
+                new PlanMeter
+                {
+                    MeterKey = "screening",
+                    UnitLabel = "screening",
+                    IncludedQuantity = 500,
+                    ThresholdPercents = [80, 100]
+                }
+            ]
+        }
+    };
+
+    private static SubscriptionUsageCounter NewCounter(long balance) => new()
+    {
+        ItemId = SubscriptionUsageCounter.CreateId(
+            "sub-1", "screening", "M20260801T000000Z"),
+        TenantId = "tenant-1",
+        OrganizationId = "org-1",
+        SubscriptionId = "sub-1",
+        MeterKey = "screening",
+        PeriodKey = "M20260801T000000Z",
+        Balance = balance,
+        LimitSnapshot = 500
+    };
+}

--- a/server/XUnitTest/XUnitTest.csproj
+++ b/server/XUnitTest/XUnitTest.csproj
@@ -17,6 +17,7 @@
 	<ProjectReference Include="..\Api\Api.csproj" />
 	<ProjectReference Include="..\Worker\Worker.csproj" />
 	<ProjectReference Include="..\Payment.DomainService\Payment.DomainService.csproj" />
+	<ProjectReference Include="..\Subscription.DomainService\Subscription.DomainService.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Adds a reusable Subscription module: plan/price catalogue, subscription lifecycle (create, activate, renew, cancel, plan-change), billing-gateway abstraction (Stripe Invoice + Adyen recurring charge), metered usage rating, mid-period proration, and per-price tax.
- All money movement (first charge, renewal, plan-change proration, usage overage) flows through one shared amount-calculation pipeline: gross → discount → tax → credit.
- Transactional outbox publishes subscription lifecycle events; CAS/optimistic concurrency guards status transitions and plan/quantity changes separately.

## Test plan
- [x] `dotnet test` (non-integration) passes: 2025 passed, 1 skipped, 0 failed
- [ ] Mongo integration tests (`XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs`) — not run, no local mongod/Docker available in this environment
- [ ] Live Stripe/Adyen test-mode traffic — not exercised
- [ ] SCA recovery — not yet implemented (tracked as follow-up)