### PR TITLE
feat(subscription): console organization override

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -515,11 +515,13 @@
             An organization's own subscription. Served under <c>/api/subscriptions</c>.
             </summary>
             <remarks>
-            No endpoint here takes an organization. Every one resolves it from the authenticated
-            caller, because an identifier in a URL is something anyone can change.
+            Every endpoint resolves its organization from the authenticated caller. A caller may also
+            name one explicitly, but it is honored only for the platform console — see the module
+            README's "Console organization override" section — so an identifier here is not simply
+            something anyone can change.
             </remarks>
         </member>
-        <member name="M:Api.Controllers.SubscriptionsController.GetCurrent(System.Threading.CancellationToken)">
+        <member name="M:Api.Controllers.SubscriptionsController.GetCurrent(System.String,System.Threading.CancellationToken)">
             <summary>
             The caller's own subscription.
             </summary>
@@ -530,7 +532,7 @@
             something failed.
             </remarks>
         </member>
-        <member name="M:Api.Controllers.SubscriptionsController.Cancel(System.String,System.Boolean,System.String,System.Threading.CancellationToken)">
+        <member name="M:Api.Controllers.SubscriptionsController.Cancel(System.String,System.Boolean,System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Cancels a subscription.
             </summary>

--- a/server/Api/Controllers/EntitlementsController.cs
+++ b/server/Api/Controllers/EntitlementsController.cs
@@ -35,11 +35,16 @@ public sealed class EntitlementsController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<EntitlementSnapshotResponse>), StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> GetAll(
         [FromQuery] bool fresh,
+        [FromQuery] string? organizationId,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
 
-        var result = await _entitlements.GetAsync(fresh, correlationId, cancellationToken);
+        var result = await _entitlements.GetAsync(
+            fresh,
+            organizationId,
+            correlationId,
+            cancellationToken);
 
         return result.ToActionResult(correlationId);
     }
@@ -50,6 +55,7 @@ public sealed class EntitlementsController : ControllerBase
     public async Task<IActionResult> Get(
         string entitlementKey,
         [FromQuery] bool fresh,
+        [FromQuery] string? organizationId,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
@@ -57,6 +63,7 @@ public sealed class EntitlementsController : ControllerBase
         var result = await _entitlements.GetAsync(
             entitlementKey,
             fresh,
+            organizationId,
             correlationId,
             cancellationToken);
 

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -26,11 +26,16 @@ public sealed class SubscriptionPlansController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<PlanResponse>>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<PlanResponse>>), StatusCodes.Status503ServiceUnavailable)]
-    public async Task<IActionResult> ListPlans(CancellationToken cancellationToken)
+    public async Task<IActionResult> ListPlans(
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
 
-        var result = await _catalogue.ListPlansAsync(correlationId, cancellationToken);
+        var result = await _catalogue.ListPlansAsync(
+            organizationId,
+            correlationId,
+            cancellationToken);
 
         return result.ToActionResult(correlationId);
     }
@@ -41,12 +46,14 @@ public sealed class SubscriptionPlansController : ControllerBase
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetPlan(
         string planId,
+        [FromQuery] string? organizationId,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
 
         var result = await _catalogue.GetPlanAsync(
             planId,
+            organizationId,
             correlationId,
             cancellationToken);
 

--- a/server/Api/Controllers/SubscriptionUsageController.cs
+++ b/server/Api/Controllers/SubscriptionUsageController.cs
@@ -49,11 +49,16 @@ public sealed class SubscriptionUsageController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<UsageResponse>>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<UsageResponse>>), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetCurrent(CancellationToken cancellationToken)
+    public async Task<IActionResult> GetCurrent(
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
 
-        var result = await _usage.GetCurrentUsageAsync(correlationId, cancellationToken);
+        var result = await _usage.GetCurrentUsageAsync(
+            organizationId,
+            correlationId,
+            cancellationToken);
 
         return result.ToActionResult(correlationId);
     }

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -68,11 +68,16 @@ public sealed class SubscriptionsController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetCurrent(CancellationToken cancellationToken)
+    public async Task<IActionResult> GetCurrent(
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
 
-        var result = await _checkout.GetCurrentAsync(correlationId, cancellationToken);
+        var result = await _checkout.GetCurrentAsync(
+            organizationId,
+            correlationId,
+            cancellationToken);
 
         return result.ToActionResult(correlationId);
     }
@@ -94,6 +99,7 @@ public sealed class SubscriptionsController : ControllerBase
         string subscriptionId,
         [FromQuery] bool immediately,
         [FromQuery] string? reason,
+        [FromQuery] string? organizationId,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
@@ -102,6 +108,7 @@ public sealed class SubscriptionsController : ControllerBase
             subscriptionId,
             immediately,
             reason,
+            organizationId,
             correlationId,
             cancellationToken);
 

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -13,8 +13,10 @@ namespace Api.Controllers;
 /// An organization's own subscription. Served under <c>/api/subscriptions</c>.
 /// </summary>
 /// <remarks>
-/// No endpoint here takes an organization. Every one resolves it from the authenticated
-/// caller, because an identifier in a URL is something anyone can change.
+/// Every endpoint resolves its organization from the authenticated caller. A caller may also
+/// name one explicitly, but it is honored only for the platform console — see the module
+/// README's "Console organization override" section — so an identifier here is not simply
+/// something anyone can change.
 /// </remarks>
 [ApiController]
 [Authorize]

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -62,6 +62,41 @@ not be confused, and a charge raised from here deliberately names no organizatio
 > merchant. `Payment:FallBackToSharedEncryptionKeyRing` remains the safety net for those records
 > until they are backfilled or re-saved; don't set it to `false` until they are.
 
+## Console organization override
+
+Every request DTO in this module has an optional `organizationId` field (a body field on writes,
+an `?organizationId=` query parameter on reads), and every endpoint resolves the caller's
+organization through `IPaymentOrganizationResolver` — the same policy `POST /api/payments/create`
+and provider registration already use, reused rather than duplicated. **Whether naming one has any
+effect depends on who is asking**, exactly as in the payment module:
+
+| Caller | Its own organization | What `organizationId` in the request does |
+| --- | --- | --- |
+| The platform console | fixed, `Payment:ConsoleOrganizationId` (default `default`) | decides the organization |
+| An application using the API | its own, from its token | nothing — ignored, and the caller's own is used |
+
+This exists because the Blocks Utilities portal simulates every action as the console, and the
+console's token always carries the same fixed organization for every tenant. Before this, every
+subscription action performed from the portal landed on whatever `default` resolved to, with no
+way to act on behalf of a real organization while testing. `x-blocks-key` and the bearer token
+still decide the tenant exactly as before — this only widens who the *organization* may be, and
+only for the console.
+
+`SubscriptionContextResolver` is the single place this is applied: it resolves the tenant and
+actor from `BlocksContext` as before, then hands the request's `organizationId` (if any) to
+`IPaymentOrganizationResolver.ResolveAsync` alongside that context, exactly the way
+`PaymentReservationService` already does for a payment. One exception remains, unchanged from
+before this existed: if the *resolved* organization is still blank — a caller with no organization
+at all, console or not — the request fails closed as `subscription_organization_missing` rather
+than falling back to a tenant-wide, unscoped answer. A subscription belongs to an organization or
+it belongs to nothing; there is no in-between reading to fall back to.
+
+No new configuration: `Payment:ConsoleOrganizationId`, `Payment:IamBaseUrl` and
+`Payment:VerifyOrganizationWithIam` govern this exactly as they already govern payments. Moving
+the console, or turning the override off entirely, is a single change that affects both modules
+at once — see the payment module's own README section on `ConsoleOrganizationId` for the full
+detail on the magic-value trade-off and the IAM verification it goes through.
+
 ## Status
 
 `Incomplete → IncompleteExpired`, `Incomplete → Trialing | Active`, cancellation, renewal, and

--- a/server/Subscription.DomainService/Requests/ChangeSubscriptionPlanRequest.cs
+++ b/server/Subscription.DomainService/Requests/ChangeSubscriptionPlanRequest.cs
@@ -8,4 +8,14 @@ public sealed class ChangeSubscriptionPlanRequest
 
     /// <summary>Defaults to the target plan's own defaults for anything left out, same as signup.</summary>
     public List<SubscriptionQuantityRequest> Quantities { get; set; } = [];
+
+    /// <summary>
+    /// Which organization's subscription to change. Omit it to use the caller's own
+    /// organization.
+    /// </summary>
+    /// <remarks>
+    /// Ignored unless the caller is the platform console — see
+    /// <see cref="CreateSubscriptionRequest.OrganizationId"/> for the full rule.
+    /// </remarks>
+    public string? OrganizationId { get; set; }
 }

--- a/server/Subscription.DomainService/Requests/CreateSubscriptionRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreateSubscriptionRequest.cs
@@ -21,10 +21,18 @@ public sealed class CreateSubscriptionRequest
     public string? DiscountCode { get; set; }
 
     /// <summary>
-    /// Notably absent: the organization. It comes from the authenticated caller, because
-    /// accepting it here would let anyone subscribe — or read — on another organization's
-    /// behalf by naming it.
+    /// Which organization within the tenant this subscribes. Omit it to use the caller's own
+    /// organization.
     /// </summary>
+    /// <remarks>
+    /// Ignored unless the caller is the platform console (<c>Payment:ConsoleOrganizationId</c>)
+    /// — everyone else's own token organization is used regardless of what this carries, the
+    /// same rule <see cref="Payment.DomainService.Requests.MakePaymentRequest.OrganizationId"/>
+    /// already follows. Without this the console — which is fixed to one organization for every
+    /// tenant — could only ever simulate a subscription for that one organization.
+    /// </remarks>
+    public string? OrganizationId { get; set; }
+
     public string? BillingEmail { get; set; }
 
     public string? BillingName { get; set; }

--- a/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
+++ b/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
@@ -39,4 +39,14 @@ public sealed class RecordUsageRequest
     /// and exported for invoicing.
     /// </remarks>
     public Dictionary<string, string> Metadata { get; set; } = [];
+
+    /// <summary>
+    /// Which organization's subscription this usage counts against. Omit it to use the
+    /// caller's own organization.
+    /// </summary>
+    /// <remarks>
+    /// Ignored unless the caller is the platform console — see
+    /// <see cref="CreateSubscriptionRequest.OrganizationId"/> for the full rule.
+    /// </remarks>
+    public string? OrganizationId { get; set; }
 }

--- a/server/Subscription.DomainService/Services/EntitlementService.cs
+++ b/server/Subscription.DomainService/Services/EntitlementService.cs
@@ -47,12 +47,13 @@ public sealed class EntitlementService : IEntitlementService
 
     public async Task<SubscriptionOperationResult<EntitlementSnapshotResponse>> GetAsync(
         bool fresh,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            organizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)
@@ -80,10 +81,11 @@ public sealed class EntitlementService : IEntitlementService
     public async Task<SubscriptionOperationResult<EntitlementResponse>> GetAsync(
         string entitlementKey,
         bool fresh,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var snapshot = await GetAsync(fresh, correlationId, cancellationToken);
+        var snapshot = await GetAsync(fresh, organizationId, correlationId, cancellationToken);
 
         if (!snapshot.IsSuccess)
         {

--- a/server/Subscription.DomainService/Services/EntitlementService.cs
+++ b/server/Subscription.DomainService/Services/EntitlementService.cs
@@ -50,7 +50,10 @@ public sealed class EntitlementService : IEntitlementService
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {

--- a/server/Subscription.DomainService/Services/IEntitlementService.cs
+++ b/server/Subscription.DomainService/Services/IEntitlementService.cs
@@ -10,14 +10,21 @@ public interface IEntitlementService
     /// <param name="fresh">
     /// Bypass the short-lived cache. Worth setting before something irreversible.
     /// </param>
+    /// <param name="organizationId">
+    /// An organization named by the caller, if any. Trusted only for the platform console — see
+    /// <see cref="Subscription.DomainService.Requests.CreateSubscriptionRequest.OrganizationId"/>
+    /// for the full rule.
+    /// </param>
     Task<SubscriptionOperationResult<EntitlementSnapshotResponse>> GetAsync(
         bool fresh,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
 
     Task<SubscriptionOperationResult<EntitlementResponse>> GetAsync(
         string entitlementKey,
         bool fresh,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
@@ -15,12 +15,19 @@ public interface IPlanCatalogueService
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <param name="organizationId">
+    /// An organization named by the caller, if any. Trusted only for the platform console — see
+    /// <see cref="Subscription.DomainService.Requests.CreateSubscriptionRequest.OrganizationId"/>
+    /// for the full rule.
+    /// </param>
     Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
 
     Task<SubscriptionOperationResult<PlanResponse>> GetPlanAsync(
         string planId,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/ISubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCancellationService.cs
@@ -11,10 +11,16 @@ public interface ISubscriptionCancellationService
     /// End now rather than at the end of the period already paid for. Reserved for cases where
     /// the customer is entitled to stop at once; the ordinary answer is false.
     /// </param>
+    /// <param name="organizationId">
+    /// An organization named by the caller, if any. Trusted only for the platform console — see
+    /// <see cref="Subscription.DomainService.Requests.CreateSubscriptionRequest.OrganizationId"/>
+    /// for the full rule.
+    /// </param>
     Task<SubscriptionOperationResult<SubscriptionResponse>> CancelAsync(
         string subscriptionId,
         bool immediately,
         string? reason,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/ISubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCheckoutService.cs
@@ -13,7 +13,13 @@ public interface ISubscriptionCheckoutService
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <param name="organizationId">
+    /// An organization named by the caller, if any. Trusted only for the platform console — see
+    /// <see cref="Subscription.DomainService.Requests.CreateSubscriptionRequest.OrganizationId"/>
+    /// for the full rule.
+    /// </param>
     Task<SubscriptionOperationResult<SubscriptionResponse>> GetCurrentAsync(
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/ISubscriptionContextResolver.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionContextResolver.cs
@@ -1,3 +1,5 @@
+using Payment.DomainService.Services;
+
 namespace Subscription.DomainService.Services;
 
 /// <summary>
@@ -8,11 +10,21 @@ public interface ISubscriptionContextResolver
     /// <summary>
     /// Resolves the caller's tenant, organization and actor.
     /// </summary>
+    /// <param name="requestedOrganizationId">
+    /// An organization named by the request, if any. Trusted only for the platform console —
+    /// see <see cref="IPaymentOrganizationResolver"/>, the same policy payment writes and reads
+    /// already use. Every other caller's own token organization wins regardless of what this
+    /// carries.
+    /// </param>
     /// <remarks>
-    /// Unlike the payment resolver this wraps, a blank organization is refused rather than
-    /// treated as "sees everything in the tenant". Entitlement without an organization has no
-    /// meaning, and a machine-to-machine caller with no organization would otherwise receive an
-    /// unscoped answer — which is the shape of an access-control failure, not a convenience.
+    /// Unlike the payment resolver this wraps, a blank <em>resolved</em> organization is refused
+    /// rather than treated as "sees everything in the tenant". Entitlement without an
+    /// organization has no meaning, and a machine-to-machine caller with no organization would
+    /// otherwise receive an unscoped answer — which is the shape of an access-control failure,
+    /// not a convenience.
     /// </remarks>
-    SubscriptionContextResolution Resolve(string correlationId);
+    Task<SubscriptionContextResolution> ResolveAsync(
+        string correlationId,
+        string? requestedOrganizationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/IUsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/IUsageRecordingService.cs
@@ -18,7 +18,13 @@ public interface IUsageRecordingService
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <param name="organizationId">
+    /// An organization named by the caller, if any. Trusted only for the platform console — see
+    /// <see cref="Subscription.DomainService.Requests.CreateSubscriptionRequest.OrganizationId"/>
+    /// for the full rule.
+    /// </param>
     Task<SubscriptionOperationResult<IReadOnlyList<UsageResponse>>> GetCurrentUsageAsync(
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -45,7 +45,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {
@@ -96,7 +99,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {
@@ -172,7 +178,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {
@@ -207,7 +216,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -171,16 +171,21 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             PaymentLogValue.Label(price.CurrencyCode),
             correlationId);
 
-        return await GetPlanAsync(plan.ItemId, correlationId, cancellationToken);
+        return await GetPlanAsync(
+            plan.ItemId,
+            context.OrganizationId,
+            correlationId,
+            cancellationToken);
     }
 
     public async Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            organizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)
@@ -213,12 +218,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
 
     public async Task<SubscriptionOperationResult<PlanResponse>> GetPlanAsync(
         string planId,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            organizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -58,7 +58,10 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -55,12 +55,13 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         string subscriptionId,
         bool immediately,
         string? reason,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            organizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -60,7 +60,10 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {
@@ -92,7 +95,10 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -62,7 +62,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            request.OrganizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -92,12 +92,13 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionResponse>> GetCurrentAsync(
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            organizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)

--- a/server/Subscription.DomainService/Services/SubscriptionContext.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionContext.cs
@@ -1,11 +1,13 @@
 namespace Subscription.DomainService.Services;
 
 /// <summary>
-/// The caller, resolved. Every value comes from the authenticated context, never the request.
+/// The caller, resolved.
 /// </summary>
 /// <remarks>
-/// Taking the organization from the request instead would let anyone read or change another
-/// organization's subscription by naming it, which no amount of filtering downstream can undo.
+/// Every value comes from the authenticated context — except <see cref="OrganizationId"/>,
+/// which the platform console alone may override by naming one in the request. Everyone else's
+/// organization is exactly the one their token carries, no amount of filtering downstream can
+/// undo a wider rule than that. See <see cref="ISubscriptionContextResolver.ResolveAsync"/>.
 /// </remarks>
 public sealed record SubscriptionContext(
     string TenantId,

--- a/server/Subscription.DomainService/Services/SubscriptionContextResolver.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionContextResolver.cs
@@ -6,12 +6,20 @@ namespace Subscription.DomainService.Services;
 public sealed class SubscriptionContextResolver : ISubscriptionContextResolver
 {
     private readonly IPaymentExecutionContextResolver _paymentContextResolver;
+    private readonly IPaymentOrganizationResolver _organizationResolver;
 
     public SubscriptionContextResolver(
-        IPaymentExecutionContextResolver paymentContextResolver) =>
+        IPaymentExecutionContextResolver paymentContextResolver,
+        IPaymentOrganizationResolver organizationResolver)
+    {
         _paymentContextResolver = paymentContextResolver;
+        _organizationResolver = organizationResolver;
+    }
 
-    public SubscriptionContextResolution Resolve(string correlationId)
+    public async Task<SubscriptionContextResolution> ResolveAsync(
+        string correlationId,
+        string? requestedOrganizationId,
+        CancellationToken cancellationToken)
     {
         var resolution = _paymentContextResolver.Resolve(correlationId);
 
@@ -25,11 +33,29 @@ public sealed class SubscriptionContextResolver : ISubscriptionContextResolver
 
         var context = resolution.Context;
 
-        if (string.IsNullOrWhiteSpace(context.OrganizationId))
+        // The same rule payment writes and reads already apply: trusted only for the platform
+        // console (Payment:ConsoleOrganizationId), ignored for everyone else. One policy, shared
+        // rather than duplicated — see IPaymentOrganizationResolver's own remarks.
+        var organization = await _organizationResolver.ResolveAsync(
+            requestedOrganizationId,
+            context,
+            correlationId,
+            cancellationToken);
+
+        if (organization.Failure is { } failure)
+        {
+            return SubscriptionContextResolution.Unresolved(
+                failure.FailureKind,
+                failure.ErrorCode,
+                failure.ErrorMessage);
+        }
+
+        if (string.IsNullOrWhiteSpace(organization.OrganizationId))
         {
             // Fails closed rather than falling back to tenant-wide scope. A subscription
             // belongs to an organization, so a caller without one has nothing to be told about
-            // — and answering anyway would mean answering for somebody else.
+            // — and answering anyway would mean answering for somebody else. Stricter than the
+            // payment resolver it wraps, which is content to leave this blank.
             return SubscriptionContextResolution.Unresolved(
                 PaymentFailureKind.Unavailable,
                 "subscription_organization_missing",
@@ -39,7 +65,7 @@ public sealed class SubscriptionContextResolver : ISubscriptionContextResolver
         return SubscriptionContextResolution.Resolved(
             new SubscriptionContext(
                 context.TenantId,
-                context.OrganizationId,
+                organization.OrganizationId,
                 context.ActorId,
                 context.UserId));
     }

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -97,7 +97,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            request.OrganizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -95,7 +95,10 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             return invalid;
         }
 
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -58,7 +58,10 @@ public sealed class UsageRecordingService : IUsageRecordingService
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {
@@ -145,7 +148,10 @@ public sealed class UsageRecordingService : IUsageRecordingService
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var resolution = _contextResolver.Resolve(correlationId);
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            null,
+            cancellationToken);
 
         if (!resolution.IsSuccess)
         {

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -60,7 +60,7 @@ public sealed class UsageRecordingService : IUsageRecordingService
 
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            request.OrganizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -145,12 +145,13 @@ public sealed class UsageRecordingService : IUsageRecordingService
     }
 
     public async Task<SubscriptionOperationResult<IReadOnlyList<UsageResponse>>> GetCurrentUsageAsync(
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            organizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)

--- a/server/XUnitTest/Subscription/EntitlementServiceTests.cs
+++ b/server/XUnitTest/Subscription/EntitlementServiceTests.cs
@@ -33,8 +33,11 @@ public sealed class EntitlementServiceTests
     public EntitlementServiceTests()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Resolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
                 new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
 
         _subscriptions
@@ -239,8 +242,11 @@ public sealed class EntitlementServiceTests
     public async Task A_caller_without_an_organization_is_refused()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Unresolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Unresolved(
                 PaymentFailureKind.Unavailable,
                 "subscription_organization_missing",
                 "An organization is required."));

--- a/server/XUnitTest/Subscription/EntitlementServiceTests.cs
+++ b/server/XUnitTest/Subscription/EntitlementServiceTests.cs
@@ -85,7 +85,7 @@ public sealed class EntitlementServiceTests
     {
         _subscription = null;
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.Value!.HasSubscription.Should().BeFalse();
         result.Value.Entitlements.Should().BeEmpty();
@@ -96,7 +96,7 @@ public sealed class EntitlementServiceTests
     {
         _subscription!.Status = SubscriptionStatus.Canceled;
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.Value!.Entitlements.Should().BeEmpty();
         result.Value.Status.Should().Be(nameof(SubscriptionStatus.Canceled));
@@ -107,7 +107,7 @@ public sealed class EntitlementServiceTests
     {
         _subscription!.Status = SubscriptionStatus.PastDue;
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.Value!.Entitlements.Should().NotBeEmpty(
             "cutting a customer off the moment a renewal fails punishes an expired card");
@@ -118,7 +118,7 @@ public sealed class EntitlementServiceTests
     {
         _balance = 487;
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         var entitlement = result.Value!.Entitlements.Single();
         entitlement.Allowed.Should().BeTrue();
@@ -131,7 +131,7 @@ public sealed class EntitlementServiceTests
     {
         _balance = 500;
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         var entitlement = result.Value!.Entitlements.Single();
         entitlement.Allowed.Should().BeFalse();
@@ -152,7 +152,7 @@ public sealed class EntitlementServiceTests
         ];
         _balance = long.MaxValue / 2;
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.Value!.Entitlements.Single().Allowed.Should().BeTrue();
     }
@@ -160,7 +160,7 @@ public sealed class EntitlementServiceTests
     [Fact]
     public async Task The_decision_carries_the_products_own_unit_label()
     {
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.Value!.Entitlements.Single().UnitLabel.Should().Be("screening");
         result.Value.Quantities.Single().UnitLabel.Should().Be("seat");
@@ -171,7 +171,7 @@ public sealed class EntitlementServiceTests
     {
         _subscription!.Plan.FeaturesJson = """{"qualified_signature":true}""";
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.Value!.FeaturesJson.Should().Be("""{"qualified_signature":true}""");
     }
@@ -187,7 +187,7 @@ public sealed class EntitlementServiceTests
             Grants = [new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 25 }]
         };
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.Value!.Entitlements.Single().Limit.Should().Be(25,
             "entitlement and usage recording must measure the same allowance, or a caller is " +
@@ -198,7 +198,7 @@ public sealed class EntitlementServiceTests
     public async Task An_unknown_key_says_it_is_not_on_the_plan()
     {
         var result = await Service().GetAsync(
-            "not_a_feature", false, "corr-1", CancellationToken.None);
+            "not_a_feature", false, null, "corr-1", CancellationToken.None);
 
         result.Value!.Allowed.Should().BeFalse();
         result.Value.Reason.Should().Be(nameof(EntitlementReason.NotInPlan));
@@ -210,7 +210,7 @@ public sealed class EntitlementServiceTests
         _subscription = null;
 
         var result = await Service().GetAsync(
-            "pep_screening", false, "corr-1", CancellationToken.None);
+            "pep_screening", false, null, "corr-1", CancellationToken.None);
 
         result.Value!.Reason.Should().Be(nameof(EntitlementReason.NoSubscription),
             "the reason sends a support engineer to a different place than 'not on this plan'");
@@ -221,8 +221,8 @@ public sealed class EntitlementServiceTests
     {
         var service = Service();
 
-        await service.GetAsync(false, "corr-1", CancellationToken.None);
-        await service.GetAsync(false, "corr-2", CancellationToken.None);
+        await service.GetAsync(false, null, "corr-1", CancellationToken.None);
+        await service.GetAsync(false, null, "corr-2", CancellationToken.None);
 
         _reads.Should().Be(1);
     }
@@ -232,8 +232,8 @@ public sealed class EntitlementServiceTests
     {
         var service = Service();
 
-        await service.GetAsync(false, "corr-1", CancellationToken.None);
-        await service.GetAsync(true, "corr-2", CancellationToken.None);
+        await service.GetAsync(false, null, "corr-1", CancellationToken.None);
+        await service.GetAsync(true, null, "corr-2", CancellationToken.None);
 
         _reads.Should().Be(2, "a caller about to do something irreversible can insist");
     }
@@ -251,10 +251,22 @@ public sealed class EntitlementServiceTests
                 "subscription_organization_missing",
                 "An organization is required."));
 
-        var result = await Service().GetAsync(false, "corr-1", CancellationToken.None);
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
         result.FailureKind.Should().Be(PaymentFailureKind.Unavailable);
+    }
+
+    [Fact]
+    public async Task A_requested_organization_is_forwarded_to_context_resolution()
+    {
+        await Service().GetAsync(false, "org-9", "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
     private EntitlementService Service() => new(

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -29,8 +29,11 @@ public sealed class PlanCatalogueServiceTests
     public PlanCatalogueServiceTests()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Resolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
                 new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
 
         _catalogue
@@ -310,8 +313,11 @@ public sealed class PlanCatalogueServiceTests
     public async Task A_caller_without_an_organization_is_refused()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Unresolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Unresolved(
                 PaymentFailureKind.Unavailable,
                 "subscription_organization_missing",
                 "An organization is required."));

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -302,6 +302,7 @@ public sealed class PlanCatalogueServiceTests
 
         var result = await Service().GetPlanAsync(
             "plan-2",
+            null,
             "corr-1",
             CancellationToken.None);
 
@@ -322,10 +323,39 @@ public sealed class PlanCatalogueServiceTests
                 "subscription_organization_missing",
                 "An organization is required."));
 
-        var result = await Service().ListPlansAsync("corr-1", CancellationToken.None);
+        var result = await Service().ListPlansAsync(null, "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("subscription_organization_missing");
+    }
+
+    [Fact]
+    public async Task A_requested_organization_on_list_plans_is_forwarded_to_context_resolution()
+    {
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Plan>());
+
+        await Service().ListPlansAsync("org-9", "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
+    }
+
+    [Fact]
+    public async Task A_requested_organization_on_get_plan_is_forwarded_to_context_resolution()
+    {
+        await Service().GetPlanAsync("plan-1", "org-9", "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
     private PlanCatalogueService Service() => new(

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -60,7 +60,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task Cancelling_keeps_the_period_that_was_paid_for()
     {
         var result = await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
         _transition!.NewStatus.Should().Be(SubscriptionStatus.Active,
@@ -74,7 +74,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task Cancelling_stops_the_next_payment()
     {
         await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         _transition!.ClearNextFeeBillingAt.Should().BeTrue();
         _transition.CanceledAtUtc.Should().Be(
@@ -85,7 +85,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task When_it_was_asked_for_is_separate_from_when_it_takes_effect()
     {
         var result = await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         result.Value!.CanceledAtUtc.Should().NotBeNull();
         _transition!.EndedAtUtc.Should().BeNull(
@@ -97,7 +97,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task An_immediate_cancellation_ends_it_now()
     {
         var result = await Service().CancelAsync(
-            "sub-1", immediately: true, "fraud", "corr-1", CancellationToken.None);
+            "sub-1", immediately: true, "fraud", null, "corr-1", CancellationToken.None);
 
         _transition!.NewStatus.Should().Be(SubscriptionStatus.Canceled);
         _transition.EndedAtUtc.Should().NotBeNull();
@@ -109,7 +109,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task An_immediate_cancellation_stops_the_usage_rating_sweep()
     {
         await Service().CancelAsync(
-            "sub-1", immediately: true, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: true, null, null, "corr-1", CancellationToken.None);
 
         _transition!.ClearNextUsageBillingAt.Should().BeTrue(
             "nothing more will be metered once entitlement stops immediately");
@@ -119,7 +119,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task An_at_period_end_cancellation_leaves_usage_rating_untouched()
     {
         await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         _transition!.ClearNextUsageBillingAt.Should().BeFalse(
             "the subscription keeps granting and metering until the period actually ends");
@@ -129,7 +129,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task Cancelling_drops_the_cached_entitlement_immediately()
     {
         await Service().CancelAsync(
-            "sub-1", immediately: true, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: true, null, null, "corr-1", CancellationToken.None);
 
         _cache.Verify(
             cache => cache.Invalidate(TenantId, OrganizationId),
@@ -141,7 +141,7 @@ public sealed class SubscriptionCancellationServiceTests
     public async Task Cancelling_raises_an_event()
     {
         await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         _transition!.Event!.EventType.Should()
             .Be(SubscriptionConstants.SubscriptionCancellationRequested);
@@ -154,7 +154,7 @@ public sealed class SubscriptionCancellationServiceTests
         _subscription = null;
 
         var result = await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         result.FailureKind.Should().Be(PaymentFailureKind.NotFound,
             "a forbidden response would confirm the identifier exists somewhere else");
@@ -166,7 +166,7 @@ public sealed class SubscriptionCancellationServiceTests
         _subscription!.Status = SubscriptionStatus.Canceled;
 
         var result = await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         result.ErrorCode.Should().Be("subscription_already_ended");
     }
@@ -183,7 +183,7 @@ public sealed class SubscriptionCancellationServiceTests
             .ReturnsAsync(false);
 
         var result = await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
         _cache.Verify(
@@ -197,10 +197,23 @@ public sealed class SubscriptionCancellationServiceTests
         _subscription!.Status = SubscriptionStatus.Trialing;
 
         var result = await Service().CancelAsync(
-            "sub-1", immediately: false, null, "corr-1", CancellationToken.None);
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
         _transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Trialing);
+    }
+
+    [Fact]
+    public async Task A_requested_organization_is_forwarded_to_context_resolution()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, "org-9", "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
     private SubscriptionCancellationService Service() => new(

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -33,8 +33,11 @@ public sealed class SubscriptionCancellationServiceTests
     public SubscriptionCancellationServiceTests()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Resolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
                 new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
 
         _subscriptions

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -38,8 +38,11 @@ public sealed class SubscriptionCheckoutServiceTests
     public SubscriptionCheckoutServiceTests()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Resolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
                 new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
 
         _creation
@@ -253,8 +256,11 @@ public sealed class SubscriptionCheckoutServiceTests
     public async Task A_caller_without_an_organization_never_reaches_creation()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Unresolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Unresolved(
                 PaymentFailureKind.Unavailable,
                 "subscription_organization_missing",
                 "An organization is required."));

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -293,6 +293,18 @@ public sealed class SubscriptionCheckoutServiceTests
             "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
+    [Fact]
+    public async Task A_requested_organization_on_get_current_is_forwarded_to_context_resolution()
+    {
+        await Service().GetCurrentAsync("org-9", "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
+    }
+
     private SubscriptionCheckoutService Service() => new(
         _creation.Object,
         _subscriptions.Object,

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -278,6 +278,21 @@ public sealed class SubscriptionCheckoutServiceTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task A_requested_organization_is_forwarded_to_context_resolution()
+    {
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest { OrganizationId = "org-9" },
+            "corr-1",
+            CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
+    }
+
     private SubscriptionCheckoutService Service() => new(
         _creation.Object,
         _subscriptions.Object,

--- a/server/XUnitTest/Subscription/SubscriptionContextResolverTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionContextResolverTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Moq;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Responses;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Services;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Who the subscription module trusts as the caller's organization.
+/// </summary>
+/// <remarks>
+/// Thin by design: the actual policy — which caller may name an organization other than their
+/// own — lives once in <see cref="IPaymentOrganizationResolver"/> and is exercised directly by
+/// <see cref="XUnitTest.Payment.PaymentOrganizationResolverTests"/>. These tests exist to prove
+/// the adapter wires that policy in correctly and keeps subscription's own, stricter rule: a
+/// blank resolved organization is refused rather than left as an unscoped read.
+/// </remarks>
+public sealed class SubscriptionContextResolverTests
+{
+    private readonly Mock<IPaymentExecutionContextResolver> _paymentContext = new();
+
+    [Fact]
+    public async Task The_console_may_name_another_organization()
+    {
+        Configure(TestPaymentOptions.ConsoleOrganizationId);
+
+        var resolution = await ResolveAsync(requestedOrganizationId: "org-2");
+
+        resolution.IsSuccess.Should().BeTrue();
+        resolution.Context!.OrganizationId.Should().Be("org-2");
+    }
+
+    [Fact]
+    public async Task An_applications_own_organization_wins_over_its_request()
+    {
+        Configure("org-1");
+
+        var resolution = await ResolveAsync(requestedOrganizationId: "org-2");
+
+        resolution.IsSuccess.Should().BeTrue();
+        resolution.Context!.OrganizationId.Should().Be("org-1");
+    }
+
+    [Fact]
+    public async Task Naming_nothing_takes_the_callers_own_organization()
+    {
+        Configure("org-1");
+
+        var resolution = await ResolveAsync(requestedOrganizationId: null);
+
+        resolution.IsSuccess.Should().BeTrue();
+        resolution.Context!.OrganizationId.Should().Be("org-1");
+    }
+
+    [Fact]
+    public async Task Missing_tenant_context_fails_closed()
+    {
+        _paymentContext
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(new PaymentContextResolution(
+                null,
+                PaymentOperationResult.Failure(
+                    PaymentFailureKind.Unavailable,
+                    "payment_context_missing",
+                    "Authenticated tenant context is unavailable.",
+                    "corr")));
+
+        var resolution = await ResolveAsync(requestedOrganizationId: null);
+
+        resolution.IsSuccess.Should().BeFalse();
+        resolution.ErrorCode.Should().Be("subscription_context_missing");
+    }
+
+    /// <summary>
+    /// Unlike the payment resolver it wraps, a blank resolved organization is not a valid
+    /// outcome here — a caller scoped to the whole tenant has nothing a subscription answer
+    /// could mean.
+    /// </summary>
+    [Fact]
+    public async Task A_caller_without_an_organization_is_refused()
+    {
+        Configure(organizationId: null);
+
+        var resolution = await ResolveAsync(requestedOrganizationId: null);
+
+        resolution.IsSuccess.Should().BeFalse();
+        resolution.ErrorCode.Should().Be("subscription_organization_missing");
+    }
+
+    private void Configure(string? organizationId) =>
+        _paymentContext
+            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
+            .Returns(new PaymentContextResolution(
+                new PaymentExecutionContext("tenant-1", "actor-1", organizationId, "user-1"),
+                null));
+
+    private Task<SubscriptionContextResolution> ResolveAsync(string? requestedOrganizationId) =>
+        new SubscriptionContextResolver(
+                _paymentContext.Object,
+                new PaymentOrganizationResolver(
+                    Mock.Of<IOrganizationDirectory>(),
+                    TestPaymentOptions.Monitor(),
+                    Microsoft.Extensions.Logging.Abstractions.NullLogger<PaymentOrganizationResolver>.Instance))
+            .ResolveAsync("corr", requestedOrganizationId, CancellationToken.None);
+}

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -40,8 +40,11 @@ public sealed class SubscriptionPlanChangeServiceTests
     public SubscriptionPlanChangeServiceTests()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Resolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
                 new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
 
         _subscriptions

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -249,6 +249,21 @@ public sealed class SubscriptionPlanChangeServiceTests
         result.ErrorCode.Should().Be("subscription_plan_change_no_payment_method");
     }
 
+    [Fact]
+    public async Task A_requested_organization_is_forwarded_to_context_resolution()
+    {
+        var request = Request();
+        request.OrganizationId = "org-9";
+
+        await Service().ChangePlanAsync("sub-1", request, "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
+    }
+
     private SubscriptionPlanChangeService Service() => new(
         _contextResolver.Object,
         _subscriptions.Object,

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -37,8 +37,11 @@ public sealed class UsageRecordingServiceTests
     public UsageRecordingServiceTests()
     {
         _contextResolver
-            .Setup(resolver => resolver.Resolve(It.IsAny<string>()))
-            .Returns(SubscriptionContextResolution.Resolved(
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
                 new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
 
         _subscriptions

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -250,6 +250,21 @@ public sealed class UsageRecordingServiceTests
             new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
     }
 
+    [Fact]
+    public async Task A_requested_organization_is_forwarded_to_context_resolution()
+    {
+        var request = NewRequest("usage-1");
+        request.OrganizationId = "org-9";
+
+        await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
+    }
+
     private UsageRecordingService Service() => new(
         _subscriptions.Object,
         _usage.Object,

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -85,6 +85,11 @@ public sealed class UsageRecordingServiceTests
             .Setup(repository => repository.GetCounterAsync(
                 TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => new SubscriptionUsageCounter { Balance = _balance });
+
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => []);
     }
 
     [Fact]
@@ -257,6 +262,18 @@ public sealed class UsageRecordingServiceTests
         request.OrganizationId = "org-9";
 
         await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches it");
+    }
+
+    [Fact]
+    public async Task A_requested_organization_on_get_current_usage_is_forwarded_to_context_resolution()
+    {
+        await Service().GetCurrentUsageAsync("org-9", "corr-1", CancellationToken.None);
 
         _contextResolver.Verify(
             resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),


### PR DESCRIPTION
## Summary
- Every subscription endpoint now resolves its organization through `IPaymentOrganizationResolver`, the same policy `POST /api/payments/create` already uses, instead of trusting `BlocksContext` unconditionally.
- The platform console (`Payment:ConsoleOrganizationId`, default `default`) may now name an organization — in the body on writes, `?organizationId=` on reads — and have it trusted; every other caller's own token organization wins regardless of what's sent.
- Fixes simulating subscription actions from the Blocks Utilities portal always landing on whatever `default` resolves to, with no way to act on behalf of a real organization.
- No new configuration: reuses `Payment:ConsoleOrganizationId`, `Payment:IamBaseUrl`, `Payment:VerifyOrganizationWithIam` verbatim.

## Test plan
- [x] `dotnet test` (non-integration) passes: 2062 passed, 1 skipped, 0 failed
- [ ] End-to-end: subscribe as org X via console token + `organizationId` in body, then read it back via `GET /subscriptions/current?organizationId=org-x` — not run in this environment (no live token minting available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)