### PR TITLE
fix(payment): register IPaymentReservationService as scoped, not singleton

### DIFF
--- a/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -114,7 +114,11 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<IPaymentFundReturnStrategyResolver, PaymentFundReturnStrategyResolver>();
         services.AddSingleton<IPaymentCaptureRequestFactory, PaymentCaptureRequestFactory>();
         services.AddSingleton<IPaymentCaptureResponseMapper, PaymentCaptureResponseMapper>();
-        services.AddSingleton<IPaymentReservationService, PaymentReservationService>();
+        // Scoped, not Singleton: it depends on IPaymentOrganizationResolver and (through it)
+        // IOrganizationDirectory, both scoped per request. A singleton cannot hold a scoped
+        // dependency without pinning one instance for the app's entire lifetime — the DI
+        // container refuses to build the graph at all rather than let that happen silently.
+        services.AddScoped<IPaymentReservationService, PaymentReservationService>();
         services.AddSingleton<IPaymentStateTransitionService, PaymentStateTransitionService>();
         services.AddSingleton<IPaymentInitiationService, HostedCheckoutInitiationService>();
         services.AddSingleton<


### PR DESCRIPTION
## Summary
- `IPaymentReservationService` was registered as `Singleton` while its constructor depends on `IPaymentOrganizationResolver` and (through it) `IOrganizationDirectory`, both registered `Scoped`.
- ASP.NET Core's own container validation refuses to build the service graph when a singleton would capture a scoped dependency, so the API failed to start at all with `InvalidOperationException: Cannot consume scoped service ... from singleton 'IPaymentReservationService'`.
- Only consumer is `PaymentService`, already registered `Scoped`, so bumping this one registration resolves the whole chain with no further ripple.

## Test plan
- [x] `dotnet test` (non-integration) passes: 2062 passed, 1 skipped, 0 failed
- [x] `dotnet run` on `server/Api` starts cleanly and reaches "Application started" — previously failed at the DI-validation step before any host code ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)