### PR TITLE
fix(subscription): plan builder usage-limit fields and validation copy

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+import type { ReactNode } from "react";
+import {
+  defaultSubscriptionPlanFormValues,
+  type CreateSubscriptionPlanFormValues,
+} from "../../schemas/subscription-plan.schema";
+import { StepUsageLimits } from "./step-usage-limits";
+
+const Harness = ({
+  children,
+  defaults,
+}: {
+  children: ReactNode;
+  defaults?: Partial<CreateSubscriptionPlanFormValues>;
+}) => {
+  const form = useForm<CreateSubscriptionPlanFormValues>({
+    defaultValues: { ...defaultSubscriptionPlanFormValues, ...defaults },
+  });
+
+  return <FormProvider {...form}>{children}</FormProvider>;
+};
+
+const meter = {
+  meterKey: "ses-signatures",
+  displayName: "Simple Signatures (SES)",
+  unitLabel: "signature",
+  aggregation: 0,
+  includedQuantity: 150,
+  overageAllowed: true,
+  thresholdPercents: [],
+  rateTables: [],
+};
+
+const renderStep = () =>
+  render(
+    <Harness defaults={{ meters: [meter] }}>
+      <StepUsageLimits />
+    </Harness>,
+  );
+
+const addLimit = () => fireEvent.click(screen.getByText("Add usage limit"));
+
+const selectKind = (card: HTMLElement, optionLabel: string | RegExp) => {
+  // Radix Select renders a button, not a native <select>, so the option list has to be opened
+  // before the choice exists in the DOM.
+  fireEvent.click(card.querySelector("[role='combobox']")!);
+  fireEvent.click(screen.getByText(optionLabel));
+};
+
+const cards = () => screen.getAllByLabelText("Remove").map((button) => button.closest("div")!);
+
+describe("StepUsageLimits", () => {
+  it("reveals the meter and limit fields when a card's own kind becomes Count", async () => {
+    renderStep();
+    addLimit();
+
+    expect(screen.queryByText("Limit")).not.toBeInTheDocument();
+
+    selectKind(cards()[0], /^Count/);
+
+    await waitFor(() => {
+      expect(screen.getByText("Draws down which meter")).toBeInTheDocument();
+      expect(screen.getByText("Limit")).toBeInTheDocument();
+    });
+  });
+
+  /**
+   * The regression this guards: useFieldArray's `fields` is a snapshot refreshed only when the
+   * array itself changes, so reading the kind from it left a second card's dependent fields
+   * hidden forever — the first card looked fine purely because appending the second one happened
+   * to re-snapshot it.
+   */
+  it("reveals them on a later card too, not just the first", async () => {
+    renderStep();
+    addLimit();
+    addLimit();
+
+    selectKind(cards()[1], /^Count/);
+
+    await waitFor(() => {
+      expect(screen.getByText("Draws down which meter")).toBeInTheDocument();
+      expect(screen.getByText("Limit")).toBeInTheDocument();
+    });
+  });
+
+  it("hides them again when the kind moves away from Count", async () => {
+    renderStep();
+    addLimit();
+
+    selectKind(cards()[0], /^Count/);
+    await waitFor(() => expect(screen.getByText("Limit")).toBeInTheDocument());
+
+    selectKind(cards()[0], /^Unlimited/);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Draws down which meter")).not.toBeInTheDocument();
+      expect(screen.queryByText("Limit")).not.toBeInTheDocument();
+    });
+  });
+
+  it("offers the plan's own meters as the drawdown source", async () => {
+    renderStep();
+    addLimit();
+
+    selectKind(cards()[0], /^Count/);
+    await waitFor(() => expect(screen.getByText("Draws down which meter")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Choose a meter"));
+
+    expect(await screen.findByText("Simple Signatures (SES)")).toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
@@ -19,9 +19,13 @@ import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscriptio
 import { CardListItem, CardListShell } from "./card-list-shell";
 
 export const StepUsageLimits = () => {
-  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
   const entitlements = useFieldArray({ control, name: "entitlements" });
   const meters = useWatch({ control, name: "meters" });
+  // Watched rather than read off useFieldArray's `fields`: that array is a snapshot taken when
+  // the list itself changes, so editing a card's own Kind would never reveal the fields that
+  // depend on it.
+  const entitlementValues = useWatch({ control, name: "entitlements" });
 
   return (
     <div className="space-y-5">
@@ -43,7 +47,7 @@ export const StepUsageLimits = () => {
         }
       >
         {entitlements.fields.map((field, index) => {
-          const limitKind = field.limitKind;
+          const limitKind = entitlementValues?.[index]?.limitKind ?? field.limitKind;
 
           return (
             <CardListItem key={field.id} onRemove={() => entitlements.remove(index)}>
@@ -68,7 +72,18 @@ export const StepUsageLimits = () => {
                     <FormLabel className="text-xs">Kind</FormLabel>
                     <Select
                       value={String(inputField.value)}
-                      onValueChange={(value) => inputField.onChange(Number(value))}
+                      onValueChange={(value) => {
+                        const kind = Number(value);
+                        inputField.onChange(kind);
+
+                        // Only a counted entitlement carries these. Leaving them behind on a
+                        // switch would submit a meter reference the plan may no longer define,
+                        // which the server rejects outright.
+                        if (kind !== 1) {
+                          setValue(`entitlements.${index}.meterKey`, undefined);
+                          setValue(`entitlements.${index}.limit`, undefined);
+                        }
+                      }}
                     >
                       <FormControl>
                         <SelectTrigger>

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -7,8 +7,19 @@ import {
   TENANT_WIDE_ORGANIZATION,
 } from "../constants/subscription.constants";
 
+// "unit" starts with a consonant sound ("you-nit") despite its spelling, so a plain vowel-letter
+// check would wrongly produce "an unit label" — the one exception among today's labels.
+const CONSONANT_SOUNDING = new Set(["unit label"]);
+
+const article = (label: string) =>
+  !CONSONANT_SOUNDING.has(label) && /^[aeiou]/i.test(label) ? "an" : "a";
+
 const key = (label: string) =>
-  z.string().trim().min(1, `Enter a ${label}.`).max(SUBSCRIPTION_KEY_MAX_LENGTH);
+  z
+    .string()
+    .trim()
+    .min(1, `Enter ${article(label)} ${label}.`)
+    .max(SUBSCRIPTION_KEY_MAX_LENGTH);
 
 const isJsonObject = (value: string): boolean => {
   try {


### PR DESCRIPTION
Two fixes for the plan builder merged in #215. Both were pushed to that PR's branch after it had already merged, so they never reached `dev` — this carries them over.

## The real bug: counted usage limits couldn't be configured

On Step 3, switching a usage-limit card's Kind to **Count** did not reveal the "Draws down which meter" and "Limit" fields, so the entitlement submitted with no meter and a limit of `0`.

`useFieldArray`'s `fields` is a snapshot refreshed only when the array itself changes (append/remove), not when a value inside a card is edited — so reading `limitKind` from it never saw the change. The *first* card appeared to work purely by accident: clicking "Add usage limit" re-snapshotted the array and happened to pick up the value already set. Every later card stayed broken.

Reads the live value via `useWatch` instead. Also clears `meterKey`/`limit` when the kind moves away from Count, so a stale meter reference can't be submitted against a plan that no longer defines it (the server rejects that with `subscription_entitlement_meter_unknown`).

Adds four regression tests. I verified they're genuine guards by reverting the fix and confirming all four fail, then pass again with it restored.

## Minor: validation copy

"Enter a item key." → "Enter an item key." A plain vowel-letter check would have overcorrected "unit label" to "an unit label", so the exception is handled explicitly.

## Verification
- `tsc -b` clean
- `npm run test` — 38/38 subscription tests pass
- `npm run lint` — no findings in the subscription module

Not verified by clicking through the running app: the preview browser here isn't authenticated against a backend. The component tests cover the interaction directly instead.