### PR TITLE
fix(subscription): stop the plan summary duplicating a half-filled row

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PlanSummaryCard, type PlanSummaryData } from "./plan-summary-card";
+
+const plan = (overrides: Partial<PlanSummaryData> = {}): PlanSummaryData => ({
+  displayName: "Personal",
+  code: "personal",
+  organizationLabel: "AmLora Test Org",
+  trialDays: null,
+  trialRequiresPaymentMethod: true,
+  quantityItems: [],
+  meters: [],
+  entitlements: [],
+  prices: [],
+  ...overrides,
+});
+
+const meter = (overrides: Partial<PlanSummaryData["meters"][number]> = {}) => ({
+  meterKey: "ses-signatures",
+  displayName: "Simple Signatures (SES)",
+  unitLabel: "signature",
+  includedQuantity: 150,
+  overageAllowed: true,
+  ...overrides,
+});
+
+describe("PlanSummaryCard", () => {
+  /**
+   * The regression this guards. Keying these rows by a field the author is still typing left
+   * duplicate/empty keys in the list, and React stranded the half-filled row: the card showed
+   * both the abandoned "0 s included" version and the finished one for a single meter.
+   */
+  it("shows one row per meter after a half-filled row is completed", () => {
+    const { rerender } = render(
+      <PlanSummaryCard
+        plan={plan({
+          // Mid-typing: display name entered, meter key still blank.
+          meters: [meter({ meterKey: "", unitLabel: "", includedQuantity: 0 })],
+        })}
+      />,
+    );
+
+    rerender(<PlanSummaryCard plan={plan({ meters: [meter()] })} />);
+
+    expect(screen.getAllByText(/Simple Signatures \(SES\)/)).toHaveLength(1);
+    expect(screen.queryByText(/0 s included/)).not.toBeInTheDocument();
+  });
+
+  /**
+   * The exact sequence from the builder: two meters added before either key is typed, then
+   * filled in one at a time. This card stays mounted across all of it, unlike the Review step
+   * which mounts once at the end — which is why the two disagreed.
+   */
+  it("shows two rows after two blank-keyed meters are filled in one at a time", () => {
+    const blank = (displayName: string) =>
+      meter({ meterKey: "", displayName, unitLabel: "", includedQuantity: 0 });
+
+    const { rerender } = render(
+      <PlanSummaryCard
+        plan={plan({ meters: [blank("Simple Signatures (SES)"), blank("Advanced Signatures (AES)")] })}
+      />,
+    );
+
+    rerender(
+      <PlanSummaryCard
+        plan={plan({
+          meters: [
+            meter({ meterKey: "ses-signatures", displayName: "Simple Signatures (SES)" }),
+            blank("Advanced Signatures (AES)"),
+          ],
+        })}
+      />,
+    );
+
+    rerender(
+      <PlanSummaryCard
+        plan={plan({
+          meters: [
+            meter({ meterKey: "ses-signatures", displayName: "Simple Signatures (SES)" }),
+            meter({
+              meterKey: "aes-signatures",
+              displayName: "Advanced Signatures (AES)",
+              includedQuantity: 2,
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getAllByText(/Simple Signatures \(SES\)/)).toHaveLength(1);
+    expect(screen.getAllByText(/Advanced Signatures \(AES\)/)).toHaveLength(1);
+    expect(screen.queryByText(/0 s included/)).not.toBeInTheDocument();
+  });
+
+  it("keeps two meters distinct while both keys are still blank", () => {
+    render(
+      <PlanSummaryCard
+        plan={plan({
+          meters: [
+            meter({ meterKey: "", displayName: "Simple Signatures (SES)" }),
+            meter({ meterKey: "", displayName: "Advanced Signatures (AES)" }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Simple Signatures \(SES\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Advanced Signatures \(AES\)/)).toBeInTheDocument();
+  });
+
+  it("renders quantity items and entitlements that have no key yet", () => {
+    render(
+      <PlanSummaryCard
+        plan={plan({
+          quantityItems: [
+            { itemKey: "", unitLabel: "user", defaultQuantity: 1 },
+            { itemKey: "", unitLabel: "workspace", defaultQuantity: 3 },
+          ],
+          entitlements: [
+            { key: "", limitKind: "Boolean", limit: null, unitLabel: null },
+            { key: "shared-templates", limitKind: "Boolean", limit: null, unitLabel: null },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/1 user included by default/)).toBeInTheDocument();
+    expect(screen.getByText(/3 workspaces included by default/)).toBeInTheDocument();
+    expect(screen.getByText("shared-templates:")).toBeInTheDocument();
+  });
+
+  it("describes a meter's allowance and what happens past it", () => {
+    render(<PlanSummaryCard plan={plan({ meters: [meter()] })} />);
+
+    expect(
+      screen.getByText(/150 signatures included, then overage billed/),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -36,6 +36,14 @@ export interface PlanSummaryData {
  * builder's Review step and the plan detail page so the two never drift into describing the same
  * plan two different ways.
  */
+/*
+ * Every list below is keyed by index on purpose. The obvious keys — meterKey, itemKey,
+ * entitlement.key — are fields the author is still typing, so they are empty on a freshly added
+ * row and collide across rows the moment there are two. Duplicate keys leave React's
+ * reconciliation of the list undefined, which stranded a half-filled row in this card while the
+ * Review step, mounted later from the same data, rendered correctly. These rows hold no state,
+ * never reorder, and are pure projections of the array, so the index is both stable and unique.
+ */
 export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
   const hasPricing = plan.quantityItems.length > 0 || plan.prices.length > 0;
   const hasUsage = plan.meters.length > 0;
@@ -78,8 +86,8 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
           <div className="flex items-start gap-2 text-sm">
             <Layers className="mt-0.5 h-4 w-4 shrink-0 text-blocks-primary-600" />
             <div className="space-y-0.5">
-              {plan.quantityItems.map((item) => (
-                <p key={item.itemKey}>
+              {plan.quantityItems.map((item, index) => (
+                <p key={index}>
                   {item.defaultQuantity.toLocaleString()} {item.unitLabel}
                   {item.defaultQuantity === 1 ? "" : "s"} included by default
                 </p>
@@ -92,8 +100,8 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
           <div className="flex items-start gap-2 text-sm">
             <Gauge className="mt-0.5 h-4 w-4 shrink-0 text-blocks-primary-600" />
             <div className="space-y-0.5">
-              {plan.meters.map((meter) => (
-                <p key={meter.meterKey}>
+              {plan.meters.map((meter, index) => (
+                <p key={index}>
                   <span className="font-medium">{meter.displayName}:</span>{" "}
                   {formatMeterAllowance(meter)}
                 </p>
@@ -106,8 +114,8 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
           <div className="flex items-start gap-2 text-sm">
             <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-blocks-primary-600" />
             <div className="space-y-0.5">
-              {plan.entitlements.map((entitlement) => (
-                <p key={entitlement.key}>
+              {plan.entitlements.map((entitlement, index) => (
+                <p key={index}>
                   <span className="font-medium">{entitlement.key}:</span>{" "}
                   {formatEntitlementLimit(entitlement)}
                 </p>


### PR DESCRIPTION
A plan with one meter rendered it **twice** in the builder's sidebar summary — once as the abandoned `"Simple Signatures (SES): 0 s included"` from before the meter key was typed, once correctly.

## Cause

The summary keyed its meter, quantity-item and entitlement rows by fields the author is still typing (`meterKey`, `itemKey`, `entitlement.key`). A freshly added row starts with a blank key, so two of them collide, and React's reconciliation of a list with duplicate keys is undefined — it stranded the abandoned version of the row alongside the finished one.

Only the sidebar showed it. The Review step renders the same component from the same data, but mounts once at the end, so it never passed through the duplicate-key window — which is why the two cards disagreed on screen.

## Fix

Keys by index. Normally the weaker choice, but the correct one here: these rows hold no state, never reorder, and are a pure projection of the array, so the index is both stable and unique. A comment on the component records why, so it doesn't get "improved" back.

## Verification

The regression test walks the real sequence — two meters added before either key is typed, then filled in one at a time. I confirmed it **fails** against the previous keying (`expected [ …(2) ] to have a length of 1 but got 2`, reproducing the screenshot exactly) and passes with the fix.

An earlier draft of the test — a simple two-render rerender — passed against the buggy code and would have been worthless as a guard; it took the full add-both-then-fill-in sequence to reproduce.

- `tsc -b` clean
- 43/43 subscription tests pass
- `npm run lint` — no findings in the subscription module

Not clicked through in the running app: the preview browser here isn't authenticated. The component test covers the interaction directly instead.