### PR TITLE
fix(subscription): make organization-scoped plans usable from the portal

### DIFF
--- a/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
+++ b/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
@@ -48,4 +48,11 @@ export const SUBSCRIPTION_CURRENCY_OPTIONS = [
  */
 export const TENANT_WIDE_ORGANIZATION = "__tenant_wide__";
 
+/**
+ * Which organization's catalogue the portal is looking at, carried in the URL so a plan scoped
+ * to one organization stays reachable across navigation, refreshes and shared links. The server
+ * honours it for the console only.
+ */
+export const ORGANIZATION_QUERY_PARAM = "organizationId";
+
 export const ORGANIZATION_PAGE_SIZE = 200;

--- a/client/app/cross-modules/utilities/subscription/hooks/use-organization-scope.test.ts
+++ b/client/app/cross-modules/utilities/subscription/hooks/use-organization-scope.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { withOrganizationScope } from "./use-organization-scope";
+
+describe("withOrganizationScope", () => {
+  it("leaves a tenant-wide link alone", () => {
+    expect(withOrganizationScope("/app/t/subscription/plans", null)).toBe(
+      "/app/t/subscription/plans",
+    );
+    expect(withOrganizationScope("/app/t/subscription/plans", undefined)).toBe(
+      "/app/t/subscription/plans",
+    );
+  });
+
+  /**
+   * The whole point: a plan scoped to an organization is invisible to the console without this,
+   * because the portal's own context resolves to the console organization instead.
+   */
+  it("names the organization so a scoped plan stays reachable", () => {
+    expect(withOrganizationScope("/app/t/subscription/plans/plan-1", "org-1")).toBe(
+      "/app/t/subscription/plans/plan-1?organizationId=org-1",
+    );
+  });
+
+  it("escapes an organization id that would otherwise break the query string", () => {
+    expect(withOrganizationScope("/plans", "org 1&x=2")).toBe(
+      "/plans?organizationId=org%201%26x%3D2",
+    );
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/hooks/use-organization-scope.ts
+++ b/client/app/cross-modules/utilities/subscription/hooks/use-organization-scope.ts
@@ -1,0 +1,25 @@
+import { useSearchParams } from "react-router";
+import { ORGANIZATION_QUERY_PARAM } from "../constants/subscription.constants";
+
+/**
+ * The organization whose catalogue the portal is currently showing, or undefined for tenant-wide.
+ *
+ * Lives in the URL rather than component state because a plan scoped to an organization is
+ * invisible without it: the server resolves the portal's own context to the console
+ * organization, so reading such a plan needs this named explicitly. Keeping it in the URL means
+ * a refresh, a back button or a pasted link all still land on a plan that exists.
+ */
+export const useOrganizationScope = (): string | undefined => {
+  const [searchParams] = useSearchParams();
+
+  return searchParams.get(ORGANIZATION_QUERY_PARAM) ?? undefined;
+};
+
+/** Carries the current organization scope onto another link within the portal. */
+export const withOrganizationScope = (
+  path: string,
+  organizationId: string | null | undefined,
+): string =>
+  organizationId
+    ? `${path}?${ORGANIZATION_QUERY_PARAM}=${encodeURIComponent(organizationId)}`
+    : path;

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -55,7 +55,12 @@ export interface PlanMeter {
   includedQuantity: number;
   overageAllowed: boolean;
   thresholdPercents: number[];
-  rateTables: MeterRateTable[];
+  /**
+   * Absent from the response: tiered overage pricing can be stored but is not yet returned, and
+   * the builder does not offer a way to author it. Declared optional rather than required so
+   * reading it cannot throw on a payload that never carries it.
+   */
+  rateTables?: MeterRateTable[];
 }
 
 export interface PlanEntitlement {

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
@@ -28,6 +28,7 @@ import { StepPricingModel } from "../components/plan-builder/step-pricing-model"
 import { StepReview } from "../components/plan-builder/step-review";
 import { StepTrial } from "../components/plan-builder/step-trial";
 import { StepUsageLimits } from "../components/plan-builder/step-usage-limits";
+import { withOrganizationScope } from "../hooks/use-organization-scope";
 import { useCreateSubscriptionPlan } from "../hooks/use-create-subscription-plan";
 import {
   createSubscriptionPlanSchema,
@@ -180,7 +181,15 @@ const CreateSubscriptionPlanWizard = () => {
         description: `${plan.displayName} is ready.`,
       });
 
-      navigate(`${listPath}/${encodeURIComponent(plan.planId)}`);
+      // Carries the organization the plan was just scoped to. Without it the detail page
+      // resolves as the console organization, and a plan belonging to someone else reads as
+      // missing — the plan is created and then immediately unreachable.
+      navigate(
+        withOrganizationScope(
+          `${listPath}/${encodeURIComponent(plan.planId)}`,
+          plan.organizationId,
+        ),
+      );
     } catch (error) {
       setSubmissionError(
         error instanceof Error ? error.message : "The plan could not be created.",

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-price-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-price-page.tsx
@@ -30,6 +30,7 @@ import {
 } from "../constants/subscription.constants";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
 import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-price";
+import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
 import type { CreateSubscriptionPriceRequest } from "../models/subscription-plan.model";
 import {
@@ -43,9 +44,13 @@ import { toMinorUnits } from "../utilities/subscription-format";
 export const CreateSubscriptionPricePage = () => {
   const { itemId, planId } = useParams();
   const navigate = useNavigate();
-  const detailPath = `/app/${itemId ?? ""}/subscription/plans/${encodeURIComponent(planId ?? "")}`;
+  const organizationScope = useOrganizationScope();
+  const detailPath = withOrganizationScope(
+    `/app/${itemId ?? ""}/subscription/plans/${encodeURIComponent(planId ?? "")}`,
+    organizationScope,
+  );
 
-  const { data: plan, isLoading } = useSubscriptionPlan(planId);
+  const { data: plan, isLoading } = useSubscriptionPlan(planId, organizationScope);
   const { mutateAsync, isPending } = useCreateSubscriptionPrice();
   const [submissionError, setSubmissionError] = useState<string | null>(null);
 

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -10,14 +10,20 @@ import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { ORGANIZATION_PAGE_SIZE } from "../constants/subscription.constants";
 import { PlanSummaryCard, type PlanSummaryData } from "../components/plan-summary-card";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
 import { formatEntitlementLimit, formatMeterAllowance, formatPrice } from "../utilities/subscription-format";
 
 export const SubscriptionPlanDetailPage = () => {
   const { itemId, planId } = useParams();
+  const organizationScope = useOrganizationScope();
   const basePath = `/app/${itemId ?? ""}/subscription/plans`;
+  const listPath = withOrganizationScope(basePath, organizationScope);
 
-  const { data: plan, error, isError, isLoading } = useSubscriptionPlan(planId);
+  const { data: plan, error, isError, isLoading } = useSubscriptionPlan(
+    planId,
+    organizationScope,
+  );
 
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData } = useGetOrganizations({
@@ -55,7 +61,7 @@ export const SubscriptionPlanDetailPage = () => {
         <SubscriptionPlanPageHeader
           title="Plan"
           description="This plan could not be loaded."
-          backTo={basePath}
+          backTo={listPath}
         />
         <Card className="flex min-h-56 flex-col items-center justify-center text-center">
           <span className="rounded-full bg-destructive/10 p-4 text-destructive">
@@ -93,10 +99,10 @@ export const SubscriptionPlanDetailPage = () => {
       <SubscriptionPlanPageHeader
         title={plan.displayName}
         description={plan.description || "No description provided."}
-        backTo={basePath}
+        backTo={listPath}
         actions={
           <Button asChild>
-            <Link to={`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`}>
+            <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`, plan.organizationId)}>
               <Plus className="mr-2 h-4 w-4" />
               Add price
             </Link>
@@ -133,17 +139,14 @@ export const SubscriptionPlanDetailPage = () => {
                     <p className="text-sm text-muted-foreground">
                       {formatMeterAllowance(meter)}
                     </p>
-                    {meter.thresholdPercents.length > 0 && (
+                    {/* Optional-chained deliberately: a plan stored before the response
+                        carried thresholds has no array here at all, and reading length off
+                        that took the whole page down rather than hiding one line. */}
+                    {meter.thresholdPercents?.length ? (
                       <p className="mt-2 text-xs text-muted-foreground">
                         Notifies at {meter.thresholdPercents.join("%, ")}% of allowance
                       </p>
-                    )}
-                    {meter.rateTables.length > 0 && (
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        Tiered overage pricing configured for{" "}
-                        {meter.rateTables.map((table) => table.currencyCode).join(", ")}
-                      </p>
-                    )}
+                    ) : null}
                   </Card>
                 ))}
               </div>
@@ -173,7 +176,7 @@ export const SubscriptionPlanDetailPage = () => {
                   No price yet — subscribers cannot check out until one exists.
                 </p>
                 <Button asChild size="sm">
-                  <Link to={`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`}>
+                  <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`, plan.organizationId)}>
                     <Plus className="mr-2 h-4 w-4" />
                     Add price
                   </Link>

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
@@ -1,20 +1,34 @@
 import { useMemo, useState } from "react";
 import { AlertCircle, Layers, Plus, RefreshCw, Search } from "lucide-react";
-import { Link, useParams } from "react-router";
+import { Link, useParams, useSearchParams } from "react-router";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import { Input } from "@/components/ui-kits/input/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
-import { ORGANIZATION_PAGE_SIZE } from "../constants/subscription.constants";
+import {
+  ORGANIZATION_PAGE_SIZE,
+  ORGANIZATION_QUERY_PARAM,
+  TENANT_WIDE_ORGANIZATION,
+} from "../constants/subscription.constants";
 import { PlanCard } from "../components/plan-card";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlans } from "../hooks/use-subscription-plans";
 
 export const SubscriptionPlanListPage = () => {
   const { itemId } = useParams();
   const [search, setSearch] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const organizationScope = searchParams.get(ORGANIZATION_QUERY_PARAM) ?? undefined;
   const {
     data: plans,
     error,
@@ -22,7 +36,7 @@ export const SubscriptionPlanListPage = () => {
     isFetching,
     isLoading,
     refetch,
-  } = useSubscriptionPlans();
+  } = useSubscriptionPlans(organizationScope);
 
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData } = useGetOrganizations({
@@ -30,6 +44,8 @@ export const SubscriptionPlanListPage = () => {
     page: 0,
     pageSize: ORGANIZATION_PAGE_SIZE,
   });
+
+  const organizations = organizationsData?.organizations ?? [];
 
   const organizationName = useMemo(() => {
     const names = new Map(
@@ -76,7 +92,7 @@ export const SubscriptionPlanListPage = () => {
               Refresh
             </Button>
             <Button asChild>
-              <Link to={`${basePath}/create`}>
+              <Link to={withOrganizationScope(`${basePath}/create`, organizationScope)}>
                 <Plus className="mr-2 h-4 w-4" />
                 Create plan
               </Link>
@@ -90,20 +106,46 @@ export const SubscriptionPlanListPage = () => {
           <div>
             <h2 className="font-semibold">Plan catalogue</h2>
             <p className="text-xs text-muted-foreground">
-              Plans created for a specific organization are only visible from here, not from that
-              organization&apos;s own view of the catalogue.
+              {organizationScope
+                ? "Showing this organization's own plans alongside the tenant-wide ones."
+                : "Showing tenant-wide plans. Choose an organization to see plans scoped to it."}
             </p>
           </div>
 
-          <div className="relative min-w-0 sm:w-64">
-            <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-            <Input
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-              placeholder="Search plan name or code"
-              className="pl-9"
-              aria-label="Search subscription plans"
-            />
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+            <Select
+              value={organizationScope ?? TENANT_WIDE_ORGANIZATION}
+              onValueChange={(value) =>
+                setSearchParams(
+                  value === TENANT_WIDE_ORGANIZATION
+                    ? {}
+                    : { [ORGANIZATION_QUERY_PARAM]: value },
+                )
+              }
+            >
+              <SelectTrigger className="sm:w-56" aria-label="Organization">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={TENANT_WIDE_ORGANIZATION}>Tenant-wide only</SelectItem>
+                {organizations.map((organization) => (
+                  <SelectItem key={organization.itemId} value={organization.itemId}>
+                    {organization.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <div className="relative min-w-0 sm:w-64">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search plan name or code"
+                className="pl-9"
+                aria-label="Search subscription plans"
+              />
+            </div>
           </div>
         </div>
 
@@ -145,7 +187,7 @@ export const SubscriptionPlanListPage = () => {
               </p>
               {!plans?.length && (
                 <Button asChild className="mt-5">
-                  <Link to={`${basePath}/create`}>
+                  <Link to={withOrganizationScope(`${basePath}/create`, organizationScope)}>
                     <Plus className="mr-2 h-4 w-4" />
                     Create plan
                   </Link>
@@ -159,7 +201,13 @@ export const SubscriptionPlanListPage = () => {
                   key={plan.planId}
                   plan={plan}
                   organizationLabel={organizationName(plan.organizationId)}
-                  detailPath={`${basePath}/${encodeURIComponent(plan.planId)}`}
+                  // The plan's own organization, not the current filter: a tenant-wide plan
+                  // needs no scope, and an organization's plan stays reachable however it
+                  // was reached.
+                  detailPath={withOrganizationScope(
+                    `${basePath}/${encodeURIComponent(plan.planId)}`,
+                    plan.organizationId,
+                  )}
                 />
               ))}
             </div>

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.test.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.fn();
+const postMock = vi.fn();
+
+vi.mock("@/lib/http-client", () => ({
+  serviceInstances: {
+    utitlitiesService: {
+      get: (...args: unknown[]) => getMock(...args),
+      post: (...args: unknown[]) => postMock(...args),
+    },
+  },
+}));
+
+import { subscriptionService } from "./subscription.service";
+
+const ok = (data: unknown) => ({ success: true, data, error: null });
+
+describe("subscriptionService", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    postMock.mockReset();
+  });
+
+  it("asks for tenant-wide plans when no organization is named", async () => {
+    getMock.mockResolvedValue(ok([]));
+
+    await subscriptionService.listPlans();
+
+    expect(getMock).toHaveBeenCalledWith("/api/subscription-plans");
+  });
+
+  /**
+   * The server resolves the portal's own context to the console organization, so a plan scoped
+   * elsewhere is only visible when the request names that organization explicitly.
+   */
+  it("names the organization when listing a scoped catalogue", async () => {
+    getMock.mockResolvedValue(ok([]));
+
+    await subscriptionService.listPlans("org-1");
+
+    expect(getMock).toHaveBeenCalledWith("/api/subscription-plans?organizationId=org-1");
+  });
+
+  it("names the organization when reading one scoped plan", async () => {
+    getMock.mockResolvedValue(ok({ planId: "plan-1" }));
+
+    await subscriptionService.getPlan("plan-1", "org-1");
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/api/subscription-plans/plan-1?organizationId=org-1",
+    );
+  });
+
+  it("escapes ids rather than pasting them into the path", async () => {
+    getMock.mockResolvedValue(ok({ planId: "a/b" }));
+
+    await subscriptionService.getPlan("a/b", "org 1");
+
+    expect(getMock).toHaveBeenCalledWith(
+      "/api/subscription-plans/a%2Fb?organizationId=org%201",
+    );
+  });
+
+  it("surfaces the server's own message when a plan cannot be read", async () => {
+    getMock.mockResolvedValue({
+      success: false,
+      data: null,
+      error: { code: "subscription_plan_not_found", message: "The plan does not exist." },
+    });
+
+    await expect(subscriptionService.getPlan("plan-1")).rejects.toThrow(
+      "The plan does not exist.",
+    );
+  });
+});

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -18,6 +18,13 @@ public sealed class PlanResponse
 
     public string? Description { get; init; }
 
+    /// <summary>
+    /// The organization this plan is scoped to, or null when the tenant sells it to everyone.
+    /// Returned so a caller that can see plans from more than one organization — the console —
+    /// can tell them apart; a plan only reaches a caller who was already entitled to see it.
+    /// </summary>
+    public string? OrganizationId { get; init; }
+
     /// <summary>The plan's own feature bag, exactly as it was authored.</summary>
     public string? FeaturesJson { get; init; }
 
@@ -57,9 +64,18 @@ public sealed class PlanMeterResponse
 
     public string UnitLabel { get; init; } = string.Empty;
 
+    /// <summary>How recordings combine, as its name — see <c>MeterAggregation</c>.</summary>
+    public string Aggregation { get; init; } = string.Empty;
+
     public long IncludedQuantity { get; init; }
 
     public bool OverageAllowed { get; init; }
+
+    /// <summary>
+    /// Percentages of the allowance that raise an event the first time they are crossed.
+    /// Returned so whoever authored the plan can see what it will actually notify on.
+    /// </summary>
+    public List<int> ThresholdPercents { get; init; } = [];
 }
 
 public sealed class PlanEntitlementResponse

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -24,6 +24,7 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
             Code = plan.Code,
             DisplayName = plan.DisplayName,
             Description = plan.Description,
+            OrganizationId = plan.OrganizationId,
             FeaturesJson = plan.FeaturesJson,
             TrialDays = plan.TrialDays,
             TrialRequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
@@ -44,8 +45,10 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     MeterKey = meter.MeterKey,
                     DisplayName = meter.DisplayName,
                     UnitLabel = meter.UnitLabel,
+                    Aggregation = meter.Aggregation.ToString(),
                     IncludedQuantity = meter.IncludedQuantity,
-                    OverageAllowed = meter.OverageAllowed
+                    OverageAllowed = meter.OverageAllowed,
+                    ThresholdPercents = [.. meter.ThresholdPercents]
                 })
                 .ToList(),
             Entitlements = plan.Entitlements

--- a/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// What a plan looks like to whoever authored it.
+/// </summary>
+/// <remarks>
+/// The console configures a plan and then has to read it back to show what it built. Anything
+/// authorable that the response drops is invisible from that moment on — a field the portal
+/// offers to set and then never displays again reads as data loss, whether or not it was stored.
+/// </remarks>
+public sealed class PlanResponseMapperTests
+{
+    private readonly PlanResponseMapper _mapper = new();
+
+    [Fact]
+    public void An_organization_scoped_plan_reports_its_organization()
+    {
+        var response = _mapper.ToResponse(Plan("organization-1"), []);
+
+        response.OrganizationId.Should().Be("organization-1",
+            "a caller seeing plans from several organizations cannot otherwise tell them apart");
+    }
+
+    [Fact]
+    public void A_tenant_wide_plan_reports_no_organization()
+    {
+        var response = _mapper.ToResponse(Plan(organizationId: null), []);
+
+        response.OrganizationId.Should().BeNull();
+    }
+
+    [Fact]
+    public void A_meter_carries_the_thresholds_it_will_notify_on()
+    {
+        var response = _mapper.ToResponse(Plan("organization-1"), []);
+
+        response.Meters[0].ThresholdPercents.Should().Equal(80, 100);
+    }
+
+    [Fact]
+    public void A_meter_reports_its_aggregation_by_name()
+    {
+        var response = _mapper.ToResponse(Plan("organization-1"), []);
+
+        response.Meters[0].Aggregation.Should().Be(nameof(MeterAggregation.Sum),
+            "a client that has to know 0 means summed is coupled to our storage format");
+    }
+
+    /// <summary>
+    /// Copied rather than shared, so a caller mutating the list it was handed cannot reach back
+    /// into the stored plan.
+    /// </summary>
+    [Fact]
+    public void A_meters_thresholds_are_not_the_stored_list()
+    {
+        var plan = Plan("organization-1");
+
+        var response = _mapper.ToResponse(plan, []);
+        response.Meters[0].ThresholdPercents.Add(999);
+
+        plan.Meters[0].ThresholdPercents.Should().Equal(80, 100);
+    }
+
+    private static Plan Plan(string? organizationId) => new()
+    {
+        ItemId = "plan-1",
+        TenantId = "tenant-1",
+        OrganizationId = organizationId,
+        Code = "professional",
+        DisplayName = "Professional",
+        Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                DisplayName = "Screenings",
+                UnitLabel = "screening",
+                Aggregation = MeterAggregation.Sum,
+                IncludedQuantity = 500,
+                OverageAllowed = true,
+                ThresholdPercents = [80, 100]
+            }
+        ]
+    };
+}


### PR DESCRIPTION
Creating a plan for a specific organization succeeded, then the plan vanished — the redirect showed `subscription_plan_not_found`, and it never appeared in the list either. Tenant-wide plans were fine, which is why this held up until an organization was picked in the builder.

## Cause

The portal's own context resolves to the console organization, so the server's visibility rule — a plan is visible when it is tenant-wide **or** belongs to your organization — excluded it.

The console override exists for exactly this case and works. It was simply never sent: `subscriptionService` and the hooks both accept an `organizationId`, but no screen ever passed one. Plumbing built, never connected.

## Fix

The organization now travels in the URL, so it survives a refresh, the back button and a shared link:

- **List page** — organization selector, which also surfaces the scoped plans it was silently hiding
- **Links** — plan and add-price links carry the plan's own organization
- **Detail / add-price** — read it back and name it when fetching
- **After create** — redirects including the organization just used, so this exact flow works

## Two response gaps found while wiring it up

**`OrganizationId` is now returned.** Without it, every plan card in the portal read "Tenant-wide" — including organization-scoped ones. Actively misleading, and it made the plan's own organization unavailable for building links.

**A meter now returns `Aggregation` and `ThresholdPercents`.** The detail page already read `meter.thresholdPercents.length`, which would have thrown on `undefined` the moment a plan with a meter loaded — the 404 was masking a crash. Rate tables stay absent since nothing can author them yet, and the dead rendering of them is removed rather than left to fail. The client type now marks `rateTables` optional so reading it cannot throw.

Both additions are additive to the DTO; no existing field changed shape.

## Verification

- `dotnet build` — 0 errors; backend subscription tests **247 passing**, including new mapper tests
- `tsc -b` clean
- client subscription tests **46 passing**, including new coverage that the service actually names the organization in the request URL
- `npm run lint` — no findings in the subscription module

Not clicked through end to end: the preview browser here isn't authenticated against a backend. Worth confirming manually that creating a plan under an organization now lands on a working detail page.