### PR TITLE
fix(subscription): stop double-charging a trial and let overage be priced

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/meter-rate-table-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/meter-rate-table-fields.tsx
@@ -1,0 +1,208 @@
+import { Plus, X } from "lucide-react";
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui-kits/form/form";
+import { Input } from "@/components/ui-kits/input/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { SUBSCRIPTION_CURRENCY_OPTIONS } from "../../constants/subscription.constants";
+import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+
+/**
+ * What usage past the allowance costs.
+ *
+ * Without a table for the subscription's currency the rater prices overage at zero — it is
+ * recorded, permitted, and billed nothing — so a meter that allows overage and has no table
+ * here is giving that usage away.
+ */
+export const MeterRateTableFields = ({ meterIndex }: { meterIndex: number }) => {
+  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const tables = useFieldArray({
+    control,
+    name: `meters.${meterIndex}.rateTables`,
+  });
+
+  return (
+    <div className="space-y-3 rounded-md border border-dashed p-3">
+      {tables.fields.map((table, tableIndex) => (
+        <RateTable
+          key={table.id}
+          meterIndex={meterIndex}
+          tableIndex={tableIndex}
+          onRemove={() => tables.remove(tableIndex)}
+        />
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={() =>
+          tables.append({
+            currencyCode: SUBSCRIPTION_CURRENCY_OPTIONS[0].code,
+            // One unbounded band is the smallest table that prices anything: every unit past
+            // the allowance costs the same.
+            tiers: [{ unitAmountMinor: 0 }],
+          })
+        }
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        {tables.fields.length === 0 ? "Price the overage" : "Add another currency"}
+      </Button>
+    </div>
+  );
+};
+
+const RateTable = ({
+  meterIndex,
+  tableIndex,
+  onRemove,
+}: {
+  meterIndex: number;
+  tableIndex: number;
+  onRemove: () => void;
+}) => {
+  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const tiers = useFieldArray({
+    control,
+    name: `meters.${meterIndex}.rateTables.${tableIndex}.tiers`,
+  });
+  const tierValues = useWatch({
+    control,
+    name: `meters.${meterIndex}.rateTables.${tableIndex}.tiers`,
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-end gap-2">
+        <FormField
+          control={control}
+          name={`meters.${meterIndex}.rateTables.${tableIndex}.currencyCode`}
+          render={({ field }) => (
+            <FormItem className="flex-1">
+              <FormLabel className="text-xs">Currency</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {SUBSCRIPTION_CURRENCY_OPTIONS.map((currency) => (
+                    <SelectItem key={currency.code} value={currency.code}>
+                      {currency.code}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={onRemove}
+          aria-label="Remove currency"
+          className="text-muted-foreground hover:text-destructive"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {tiers.fields.map((tier, tierIndex) => {
+        const isLast = tierIndex === tiers.fields.length - 1;
+
+        return (
+          <div key={tier.id} className="flex items-end gap-2">
+            <FormField
+              control={control}
+              name={`meters.${meterIndex}.rateTables.${tableIndex}.tiers.${tierIndex}.upToQuantity`}
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel className="text-xs">
+                    {isLast ? "Everything above" : "Up to"}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ""}
+                      type="number"
+                      min={1}
+                      // The final band has no upper bound — one that did would leave usage
+                      // past it unpriced.
+                      disabled={isLast}
+                      placeholder={isLast ? "no limit" : "1000"}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={control}
+              name={`meters.${meterIndex}.rateTables.${tableIndex}.tiers.${tierIndex}.unitAmountMinor`}
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel className="text-xs">Per unit (minor)</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="number" min={0} placeholder="5" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => tiers.remove(tierIndex)}
+              disabled={tiers.fields.length === 1}
+              aria-label="Remove tier"
+              className="text-muted-foreground hover:text-destructive"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        );
+      })}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => {
+          // The band that was unbounded gains a bound, and the new one becomes the open end,
+          // so the table always ends somewhere that prices the rest.
+          const last = tierValues?.[tiers.fields.length - 1];
+
+          tiers.update(tiers.fields.length - 1, {
+            upToQuantity: last?.upToQuantity ?? 1_000,
+            unitAmountMinor: last?.unitAmountMinor ?? 0,
+          });
+          tiers.append({ unitAmountMinor: 0 });
+        }}
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        Add a cheaper band above
+      </Button>
+
+      <p className="text-xs text-muted-foreground">
+        Amounts are in minor units — 5 means 5 cents per extra unit.
+      </p>
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -20,6 +20,7 @@ import {
 import { METER_AGGREGATION_OPTIONS } from "../../constants/subscription.constants";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 import { CardListItem, CardListShell } from "./card-list-shell";
+import { MeterRateTableFields } from "./meter-rate-table-fields";
 import { ThresholdChipInput } from "./threshold-chip-input";
 
 const PRICING_SHAPES = [
@@ -49,6 +50,9 @@ export const StepPricingModel = () => {
 
   const quantityItems = useFieldArray({ control, name: "quantityItems" });
   const meters = useFieldArray({ control, name: "meters" });
+  // Watched, not read from useFieldArray's snapshot, which only refreshes when the list
+  // itself changes — see step-usage-limits for the same trap.
+  const meterValues = useWatch({ control, name: "meters" });
 
   const showSeats = pricingShape === "seats" || pricingShape === "both";
   const showUsage = pricingShape === "usage" || pricingShape === "both";
@@ -290,6 +294,20 @@ export const StepPricingModel = () => {
                     </FormItem>
                   )}
                 />
+
+                {/* Only meaningful where overage is permitted: a blocked meter never produces
+                    billable units, so there is nothing to price. */}
+                {meterValues?.[index]?.overageAllowed ? (
+                  <FormItem>
+                    <FormLabel className="text-xs">Overage pricing</FormLabel>
+                    {meterValues[index]?.rateTables?.length ? null : (
+                      <p className="text-xs text-muted-foreground">
+                        No price set, so usage past the allowance is billed nothing.
+                      </p>
+                    )}
+                    <MeterRateTableFields meterIndex={index} />
+                  </FormItem>
+                ) : null}
               </CardListItem>
             ))}
           </CardListShell>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -65,8 +65,8 @@ export const StepTrial = () => {
               </div>
               <p className="text-xs text-muted-foreground">
                 {trialRequiresPaymentMethod
-                  ? "A card is required up front; nothing is charged until the trial ends."
-                  : "Subscribers get full access with no card on file until the trial ends."}
+                  ? "The first period is charged at signup — the payment path cannot hold a card without charging it. The trial then only governs the allowances below."
+                  : "Genuinely free until the trial ends, when the first charge is taken. Your product must collect a card before then, or that charge has nothing to bill."}
               </p>
             </FormItem>
           )}

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
@@ -21,6 +21,7 @@ const meter = (overrides: Partial<PlanSummaryData["meters"][number]> = {}) => ({
   unitLabel: "signature",
   includedQuantity: 150,
   overageAllowed: true,
+  rateTables: [{ currencyCode: "CHF" }],
   ...overrides,
 });
 

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -20,6 +20,8 @@ export interface PlanSummaryData {
     unitLabel: string;
     includedQuantity: number;
     overageAllowed: boolean;
+    /** Drives whether overage is described as billed or given away. */
+    rateTables?: { currencyCode: string }[];
   }[];
   entitlements: { key: string; limitKind: string; limit: number | null; unitLabel: string | null }[];
   prices: {
@@ -77,8 +79,8 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
         {plan.trialDays ? (
           <p className="text-sm text-muted-foreground">
             {plan.trialRequiresPaymentMethod
-              ? `A card is required up front; nothing is charged until the ${plan.trialDays}-day trial ends.`
-              : `Subscribers get full access for ${plan.trialDays} days with no card on file.`}
+              ? `Charged at signup; the ${plan.trialDays}-day trial governs the allowances, not the price.`
+              : `Free for ${plan.trialDays} days, then the first charge is taken.`}
           </p>
         ) : null}
 

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -56,9 +56,9 @@ export interface PlanMeter {
   overageAllowed: boolean;
   thresholdPercents: number[];
   /**
-   * Absent from the response: tiered overage pricing can be stored but is not yet returned, and
-   * the builder does not offer a way to author it. Declared optional rather than required so
-   * reading it cannot throw on a payload that never carries it.
+   * Empty when overage cannot be priced. Optional rather than required because a plan stored
+   * before the response carried this field has no array at all, and reading length off that
+   * took the whole detail page down.
    */
   rateTables?: MeterRateTable[];
 }

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
@@ -102,6 +102,12 @@ const CreateSubscriptionPlanWizard = () => {
       unitLabel: meter?.unitLabel ?? "",
       includedQuantity: meter?.includedQuantity ?? 0,
       overageAllowed: meter?.overageAllowed ?? false,
+      // Only the currency matters to the summary — its presence is what decides whether
+      // overage reads as billed or given away.
+      rateTables: (meter?.rateTables ?? [])
+        .map((table) => table?.currencyCode)
+        .filter((currencyCode): currencyCode is string => Boolean(currencyCode))
+        .map((currencyCode) => ({ currencyCode })),
     })),
     entitlements: (draft.entitlements ?? []).map((entitlement) => ({
       key: entitlement?.key ?? "",

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -34,14 +34,40 @@ const meterTierSchema = z.object({
   unitAmountMinor: z.coerce.number().int().min(0),
 });
 
-const meterRateTableSchema = z.object({
-  currencyCode: z
-    .string()
-    .trim()
-    .length(3, "Use a three-letter currency code.")
-    .toUpperCase(),
-  tiers: z.array(meterTierSchema).min(1, "Add at least one tier."),
-});
+const meterRateTableSchema = z
+  .object({
+    currencyCode: z
+      .string()
+      .trim()
+      .length(3, "Use a three-letter currency code.")
+      .toUpperCase(),
+    tiers: z.array(meterTierSchema).min(1, "Add at least one tier."),
+  })
+  .superRefine((table, context) => {
+    // Mirrors the server's rule. Bands must ascend and only the last may be open-ended,
+    // otherwise a quantity falls into two of them and the bill depends on which is read first.
+    const bounded = table.tiers.slice(0, -1);
+
+    if (bounded.some((tier) => tier.upToQuantity === undefined)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tiers"],
+        message: "Only the last band may be unbounded.",
+      });
+    }
+
+    const bounds = table.tiers
+      .map((tier) => tier.upToQuantity)
+      .filter((bound): bound is number => bound !== undefined);
+
+    if (bounds.some((bound, index) => index > 0 && bound <= bounds[index - 1])) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tiers"],
+        message: "Each band must end above the one before it.",
+      });
+    }
+  });
 
 const meterSchema = z.object({
   meterKey: key("meter key"),

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
@@ -93,7 +93,24 @@ describe("formatPrice", () => {
 });
 
 describe("formatMeterAllowance", () => {
-  it("says what happens after the included amount when overage is allowed", () => {
+  it("says overage is billed only when there is a table to price it against", () => {
+    const description = formatMeterAllowance({
+      displayName: "API calls",
+      unitLabel: "call",
+      includedQuantity: 1000,
+      overageAllowed: true,
+      rateTables: [{ currencyCode: "CHF" }],
+    });
+
+    expect(description).toContain("1,000 calls included");
+    expect(description).toContain("overage billed");
+  });
+
+  /**
+   * The rater prices a meter it has no tiers for at zero, so calling this "overage billed"
+   * promised revenue that is never charged.
+   */
+  it("says overage is free when the meter has no rate table", () => {
     const description = formatMeterAllowance({
       displayName: "API calls",
       unitLabel: "call",
@@ -101,8 +118,20 @@ describe("formatMeterAllowance", () => {
       overageAllowed: true,
     });
 
-    expect(description).toContain("1,000 calls included");
-    expect(description).toContain("overage billed");
+    expect(description).toContain("unlimited free");
+    expect(description).not.toContain("billed");
+  });
+
+  it("treats an empty rate table list the same as none at all", () => {
+    const description = formatMeterAllowance({
+      displayName: "API calls",
+      unitLabel: "call",
+      includedQuantity: 1000,
+      overageAllowed: true,
+      rateTables: [],
+    });
+
+    expect(description).toContain("unlimited free");
   });
 
   it("says usage is blocked once the meter does not allow overage", () => {

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
@@ -62,10 +62,20 @@ export const formatMeterAllowance = (meter: {
   unitLabel: string;
   includedQuantity: number;
   overageAllowed: boolean;
+  /** Empty or absent means the rater prices overage at zero. */
+  rateTables?: { currencyCode: string }[];
 }): string => {
   const included = `${meter.includedQuantity.toLocaleString()} ${meter.unitLabel}${meter.includedQuantity === 1 ? "" : "s"} included`;
 
-  return meter.overageAllowed ? `${included}, then overage billed` : `${included}, then blocked`;
+  if (!meter.overageAllowed) {
+    return `${included}, then blocked`;
+  }
+
+  // Saying "then overage billed" with no rate table would promise revenue that is never
+  // charged: the rater cannot price a meter it has no tiers for, so it bills nothing.
+  return meter.rateTables?.length
+    ? `${included}, then overage billed`
+    : `${included}, then unlimited free`;
 };
 
 export const formatEntitlementLimit = (entitlement: {

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -76,6 +76,28 @@ public sealed class PlanMeterResponse
     /// Returned so whoever authored the plan can see what it will actually notify on.
     /// </summary>
     public List<int> ThresholdPercents { get; init; } = [];
+
+    /// <summary>
+    /// What usage past the allowance costs, per currency. Empty means overage cannot be priced
+    /// — it is recorded and permitted but charged nothing, so the portal has to be able to show
+    /// that a meter allowing overage has no table behind it.
+    /// </summary>
+    public List<PlanMeterRateTableResponse> RateTables { get; init; } = [];
+}
+
+public sealed class PlanMeterRateTableResponse
+{
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public List<PlanMeterTierResponse> Tiers { get; init; } = [];
+}
+
+public sealed class PlanMeterTierResponse
+{
+    /// <summary>Upper bound of the band. Null is the final, unbounded one.</summary>
+    public long? UpToQuantity { get; init; }
+
+    public long UnitAmountMinor { get; init; }
 }
 
 public sealed class PlanEntitlementResponse

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -48,7 +48,20 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     Aggregation = meter.Aggregation.ToString(),
                     IncludedQuantity = meter.IncludedQuantity,
                     OverageAllowed = meter.OverageAllowed,
-                    ThresholdPercents = [.. meter.ThresholdPercents]
+                    ThresholdPercents = [.. meter.ThresholdPercents],
+                    RateTables = meter.RateTables
+                        .Select(table => new PlanMeterRateTableResponse
+                        {
+                            CurrencyCode = table.CurrencyCode,
+                            Tiers = table.Tiers
+                                .Select(tier => new PlanMeterTierResponse
+                                {
+                                    UpToQuantity = tier.UpToQuantity,
+                                    UnitAmountMinor = tier.UnitAmountMinor
+                                })
+                                .ToList()
+                        })
+                        .ToList()
                 })
                 .ToList(),
             Entitlements = plan.Entitlements

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -268,7 +268,17 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         subscription.CurrentPeriodStartUtc = feePeriod.StartUtc;
         subscription.CurrentPeriodEndUtc = feePeriod.EndUtc;
-        subscription.NextFeeBillingAtUtc = subscription.Trial?.EndsAtUtc ?? feePeriod.EndUtc;
+
+        // Only a card-free trial defers the first fee to the day it ends, because only that
+        // one starts without taking payment. A trial that demands a card is charged for its
+        // first period up front — the money path has no way to hold a card without charging it
+        // — so that period is already paid, and billing again on the trial's last day would
+        // take the same money twice. This condition deliberately mirrors the one
+        // SubscriptionCheckoutService uses to decide whether to charge at all.
+        subscription.NextFeeBillingAtUtc =
+            subscription.Trial is { RequiresPaymentMethod: false } trial
+                ? trial.EndsAtUtc
+                : feePeriod.EndUtc;
         subscription.CurrentUsagePeriodStartUtc = usagePeriod.StartUtc;
         subscription.CurrentUsagePeriodEndUtc = usagePeriod.EndUtc;
         subscription.NextUsageBillingAtUtc = usagePeriod.EndUtc;

--- a/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
@@ -52,6 +52,24 @@ public sealed class PlanResponseMapperTests
     }
 
     /// <summary>
+    /// Overage that cannot be priced is charged nothing, so an author has to be able to see
+    /// whether a meter permitting overage actually has a table behind it.
+    /// </summary>
+    [Fact]
+    public void A_meter_carries_the_tiers_its_overage_is_priced_against()
+    {
+        var response = _mapper.ToResponse(Plan("organization-1"), []);
+
+        var table = response.Meters[0].RateTables.Should().ContainSingle().Subject;
+        table.CurrencyCode.Should().Be("CHF");
+        table.Tiers.Should().HaveCount(2);
+        table.Tiers[0].UpToQuantity.Should().Be(1_000);
+        table.Tiers[0].UnitAmountMinor.Should().Be(5);
+        table.Tiers[1].UpToQuantity.Should().BeNull("the last band is the unbounded one");
+        table.Tiers[1].UnitAmountMinor.Should().Be(3);
+    }
+
+    /// <summary>
     /// Copied rather than shared, so a caller mutating the list it was handed cannot reach back
     /// into the stored plan.
     /// </summary>
@@ -83,7 +101,19 @@ public sealed class PlanResponseMapperTests
                 Aggregation = MeterAggregation.Sum,
                 IncludedQuantity = 500,
                 OverageAllowed = true,
-                ThresholdPercents = [80, 100]
+                ThresholdPercents = [80, 100],
+                RateTables =
+                [
+                    new MeterRateTable
+                    {
+                        CurrencyCode = "CHF",
+                        Tiers =
+                        [
+                            new MeterTier { UpToQuantity = 1_000, UnitAmountMinor = 5 },
+                            new MeterTier { UpToQuantity = null, UnitAmountMinor = 3 }
+                        ]
+                    }
+                ]
             }
         ]
     };

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -193,6 +193,50 @@ public sealed class SubscriptionCreationServiceTests
             "an unusable schedule must not become a stored subscription");
     }
 
+    /// <summary>
+    /// A card-free trial takes no money at signup, so the first fee is the day it ends.
+    /// </summary>
+    [Fact]
+    public async Task A_card_free_trial_bills_for_the_first_time_when_it_ends()
+    {
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.NextFeeBillingAtUtc.Should().Be(_created.Trial!.EndsAtUtc);
+    }
+
+    /// <summary>
+    /// The regression this guards: a trial demanding a card is charged for its first period up
+    /// front, because the money path cannot hold a card without charging it. Billing again on
+    /// the trial's last day took the same money twice.
+    /// </summary>
+    [Fact]
+    public async Task A_trial_that_demands_a_card_is_not_billed_again_when_it_ends()
+    {
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = true;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.NextFeeBillingAtUtc.Should().NotBe(_created.Trial!.EndsAtUtc,
+            "the first period was already paid at signup");
+        _created.NextFeeBillingAtUtc.Should().Be(_created.CurrentPeriodEndUtc,
+            "the next fee falls when the period that was paid for runs out");
+    }
+
+    [Fact]
+    public async Task A_subscription_without_a_trial_bills_at_the_period_end()
+    {
+        _plan.TrialDays = null;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.Trial.Should().BeNull();
+        _created.NextFeeBillingAtUtc.Should().Be(_created.CurrentPeriodEndUtc);
+    }
+
     [Fact]
     public async Task A_trial_carries_its_own_capped_grants()
     {


### PR DESCRIPTION
Three defects found while walking a real plan through the builder. They compounded: the money bug was hidden by copy asserting the opposite, and the pricing gap made a headline feature unbuildable.

## A — A trial could charge twice

A trial demanding a card is charged for its first period **at signup**, because the money path has no way to hold a card without charging it (the currency resolver refuses any amount ≤ 0, and no setup-intent/zero-auth flow exists in the payment module). But the first fee was scheduled for the trial's last day regardless:

```csharp
NextFeeBillingAtUtc = subscription.Trial?.EndsAtUtc ?? feePeriod.EndUtc;
```

So a 14-day trial with a €3/month price charged €3 at signup, then €3 again when the trial ended — `Trialing` is a live status the renewal sweep bills.

Now defers to the trial end **only for a card-free trial**, mirroring the condition `SubscriptionCheckoutService` already uses to decide whether to charge at all. Verified by reverting the fix and confirming the new test fails.

## B — Overage could not be priced from the portal

```csharp
// A meter with no rate table for this subscription's currency cannot be priced.
if (table is null) return 0;
```

The builder offered no way to author a rate table, so **every plan it produced gave overage away** — recorded, permitted, billed nothing. `overageAllowed` was decorative.

- The meter card gains a tier editor, shown only where overage is permitted
- The schema enforces the server's ordering rule (ascending bands, only the last unbounded), so a table that would be rejected is caught while authoring
- `PlanMeterResponse` returns the tables, so the detail page can show what a plan actually charges

## C — The copy asserted the opposite of both

- *"A card is required up front; nothing is charged until the trial ends"* — false for the only trial shape that collects a card
- *"then overage billed"* — false for every plan the builder could create

Both now describe what happens, including the honest caveat that a card-free trial has nothing saved to bill when it ends, so the product must collect a card during it.

## Still missing

A genuine free trial *with* a card on file needs a setup-intent / zero-amount authorization the payment module does not have. Until that exists, the two trial shapes are: charge at signup (card collected), or free and nothing saved to charge later. The UI now says so rather than implying a third option exists.

## Verification

- backend **251 tests passing**; the double-charge test confirmed failing against the old scheduling
- client **53 tests passing**
- `tsc -b` clean, `npm run lint` clean in the subscription module

Not exercised against a live backend — the preview browser here isn't authenticated. Worth confirming a card-required trial now produces exactly one charge.