### PR TITLE
fix(subscription): say what an unpriced overage does, not that it is free

### DIFF
--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
@@ -118,7 +118,7 @@ describe("formatMeterAllowance", () => {
       overageAllowed: true,
     });
 
-    expect(description).toContain("unlimited free");
+    expect(description).toContain("unlimited at no charge");
     expect(description).not.toContain("billed");
   });
 
@@ -131,7 +131,7 @@ describe("formatMeterAllowance", () => {
       rateTables: [],
     });
 
-    expect(description).toContain("unlimited free");
+    expect(description).toContain("unlimited at no charge");
   });
 
   it("says usage is blocked once the meter does not allow overage", () => {

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
@@ -72,10 +72,12 @@ export const formatMeterAllowance = (meter: {
   }
 
   // Saying "then overage billed" with no rate table would promise revenue that is never
-  // charged: the rater cannot price a meter it has no tiers for, so it bills nothing.
+  // charged: the rater cannot price a meter it has no tiers for, so it bills nothing. Worded
+  // as a plain statement of what happens rather than "unlimited free", which read as a feature
+  // being advertised instead of an allowance that caps nothing.
   return meter.rateTables?.length
     ? `${included}, then overage billed`
-    : `${included}, then unlimited free`;
+    : `${included}, then unlimited at no charge`;
 };
 
 export const formatEntitlementLimit = (entitlement: {


### PR DESCRIPTION
`"150 signatures included, then unlimited free"` reads as a feature being advertised. It is meant to warn the author that the allowance caps nothing and the excess earns nothing — the rater prices a meter with no rate table at zero.

The first person to read it asked what it meant, which is the answer. Now: **"150 signatures included, then unlimited at no charge"**.

Wording only — no behaviour change. 53 client tests pass, `tsc -b` clean.