### PR TITLE
fix(subscription): keep added overage bands ascending, and show when they are not

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/meter-rate-table-fields.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/meter-rate-table-fields.test.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  createSubscriptionPlanSchema,
+  defaultSubscriptionPlanFormValues,
+  type CreateSubscriptionPlanFormValues,
+} from "../../schemas/subscription-plan.schema";
+import { MeterRateTableFields } from "./meter-rate-table-fields";
+
+const meter = {
+  meterKey: "api-calls",
+  displayName: "API calls",
+  unitLabel: "call",
+  aggregation: 0,
+  includedQuantity: 150,
+  overageAllowed: true,
+  thresholdPercents: [],
+  rateTables: [],
+};
+
+const Harness = () => {
+  const form = useForm<CreateSubscriptionPlanFormValues>({
+    resolver: zodResolver(createSubscriptionPlanSchema),
+    defaultValues: { ...defaultSubscriptionPlanFormValues, meters: [meter] },
+  });
+
+  return (
+    <FormProvider {...form}>
+      <MeterRateTableFields meterIndex={0} />
+    </FormProvider>
+  );
+};
+
+/**
+ * Read off the rendered inputs rather than the form object: it is what an author actually sees,
+ * and capturing the form would mean assigning to an outer variable during render.
+ */
+const bounds = () =>
+  Array.from(
+    document.querySelectorAll<HTMLInputElement>('input[name$=".upToQuantity"]'),
+  ).map((input) => input.value);
+
+describe("MeterRateTableFields", () => {
+  it("starts a table with a single unbounded band", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("Price the overage"));
+
+    expect(bounds()).toEqual([""]);
+  });
+
+  /**
+   * The regression this guards: the band being closed is the open-ended one, so it has no
+   * bound of its own to reuse. Defaulting to a constant put two bands on the same bound the
+   * moment this was clicked twice, which the server rejects outright.
+   */
+  it("gives each added band a bound above the one before it", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("Price the overage"));
+    fireEvent.click(screen.getByText("Add another band"));
+    fireEvent.click(screen.getByText("Add another band"));
+
+    const [first, second, last] = bounds();
+
+    expect(first).toBe("1000");
+    expect(second).toBe("2000");
+    expect(Number(second)).toBeGreaterThan(Number(first));
+    expect(last).toBe("");
+  });
+
+  it("keeps the last band open however many are added", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByText("Price the overage"));
+    fireEvent.click(screen.getByText("Add another band"));
+    fireEvent.click(screen.getByText("Add another band"));
+
+    const all = bounds();
+
+    expect(all.at(-1)).toBe("");
+    expect(all.slice(0, -1).every((bound) => bound !== "")).toBe(true);
+  });
+});
+
+describe("the schema behind it", () => {
+  const withTiers = (tiers: { upToQuantity?: number; unitAmountMinor: number }[]) =>
+    createSubscriptionPlanSchema.safeParse({
+      ...defaultSubscriptionPlanFormValues,
+      code: "metered",
+      displayName: "Metered",
+      organizationId: "__tenant_wide__",
+      meters: [{ ...meter, rateTables: [{ currencyCode: "CHF", tiers }] }],
+    });
+
+  it("rejects two bands ending on the same quantity", () => {
+    expect(
+      withTiers([
+        { upToQuantity: 1_000, unitAmountMinor: 100 },
+        { upToQuantity: 1_000, unitAmountMinor: 50 },
+        { unitAmountMinor: 0 },
+      ]).success,
+    ).toBe(false);
+  });
+
+  it("rejects bands that descend", () => {
+    expect(
+      withTiers([
+        { upToQuantity: 2_000, unitAmountMinor: 100 },
+        { upToQuantity: 1_000, unitAmountMinor: 50 },
+        { unitAmountMinor: 0 },
+      ]).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unbounded band that is not the last", () => {
+    expect(
+      withTiers([
+        { unitAmountMinor: 100 },
+        { upToQuantity: 1_000, unitAmountMinor: 50 },
+      ]).success,
+    ).toBe(false);
+  });
+
+  it("accepts ascending bands ending in an open one", () => {
+    expect(
+      withTiers([
+        { upToQuantity: 1_000, unitAmountMinor: 100 },
+        { upToQuantity: 2_000, unitAmountMinor: 50 },
+        { unitAmountMinor: 25 },
+      ]).success,
+    ).toBe(true);
+  });
+});
+
+describe("the ordering error", () => {
+  it("is shown against the table rather than failing silently", async () => {
+    const Invalid = () => {
+      const form = useForm<CreateSubscriptionPlanFormValues>({
+        resolver: zodResolver(createSubscriptionPlanSchema),
+        defaultValues: {
+          ...defaultSubscriptionPlanFormValues,
+          code: "metered",
+          displayName: "Metered",
+          meters: [
+            {
+              ...meter,
+              rateTables: [
+                {
+                  currencyCode: "CHF",
+                  tiers: [
+                    { upToQuantity: 1_000, unitAmountMinor: 100 },
+                    { upToQuantity: 1_000, unitAmountMinor: 50 },
+                    { unitAmountMinor: 0 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      return (
+        <FormProvider {...form}>
+          <button type="button" onClick={() => form.trigger()}>
+            validate
+          </button>
+          <MeterRateTableFields meterIndex={0} />
+        </FormProvider>
+      );
+    };
+
+    render(<Invalid />);
+    fireEvent.click(screen.getByText("validate"));
+
+    await waitFor(() =>
+      expect(screen.getByText(/must end above the one before it/)).toBeInTheDocument(),
+    );
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/meter-rate-table-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/meter-rate-table-fields.tsx
@@ -65,6 +65,23 @@ export const MeterRateTableFields = ({ meterIndex }: { meterIndex: number }) => 
   );
 };
 
+/**
+ * The message for a rule that belongs to the tier list as a whole rather than to any one input.
+ * Read off the error tree because there is no field to hang a FormMessage on, and tolerant of
+ * both shapes a field-array error arrives in.
+ */
+const useTiersError = (meterIndex: number, tableIndex: number): string | undefined => {
+  const {
+    formState: { errors },
+  } = useFormContext<CreateSubscriptionPlanFormValues>();
+
+  const tiers = errors.meters?.[meterIndex]?.rateTables?.[tableIndex]?.tiers as
+    | { message?: string; root?: { message?: string } }
+    | undefined;
+
+  return tiers?.message ?? tiers?.root?.message;
+};
+
 const RateTable = ({
   meterIndex,
   tableIndex,
@@ -83,6 +100,8 @@ const RateTable = ({
     control,
     name: `meters.${meterIndex}.rateTables.${tableIndex}.tiers`,
   });
+
+  const tiersError = useTiersError(meterIndex, tableIndex);
 
   return (
     <div className="space-y-3">
@@ -180,24 +199,38 @@ const RateTable = ({
         );
       })}
 
+      {/* The ordering rule is checked on the whole table, not on any one input, so it has no
+          field of its own to render under — read straight off the error tree instead. Without
+          this an invalid table looked fine right up until the server rejected it. A field-array
+          error can land on the array or under its root depending on how it was raised, so both
+          are checked. */}
+      {tiersError ? (
+        <p className="text-sm font-medium text-destructive">{tiersError}</p>
+      ) : null}
+
       <Button
         type="button"
         variant="ghost"
         size="sm"
         onClick={() => {
-          // The band that was unbounded gains a bound, and the new one becomes the open end,
-          // so the table always ends somewhere that prices the rest.
-          const last = tierValues?.[tiers.fields.length - 1];
+          const lastIndex = tiers.fields.length - 1;
+          const last = tierValues?.[lastIndex];
 
-          tiers.update(tiers.fields.length - 1, {
-            upToQuantity: last?.upToQuantity ?? 1_000,
+          // The band being closed is the open-ended one, so it never has a bound of its own to
+          // reuse. Deriving the suggestion from the band before it is what keeps the table
+          // ascending — defaulting to a constant put two bands on the same bound as soon as
+          // this was clicked twice, which the server rejects.
+          const previousBound = tierValues?.[lastIndex - 1]?.upToQuantity;
+
+          tiers.update(lastIndex, {
+            upToQuantity: previousBound ? previousBound * 2 : 1_000,
             unitAmountMinor: last?.unitAmountMinor ?? 0,
           });
           tiers.append({ unitAmountMinor: 0 });
         }}
       >
         <Plus className="mr-2 h-4 w-4" />
-        Add a cheaper band above
+        Add another band
       </Button>
 
       <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Clicking **"Add a cheaper band above"** twice produced two bands ending on the same quantity:

| | |
|---|---|
| Up to **1000** | 100 per unit |
| Up to **1000** | 50 per unit |
| Everything above | 0 |

The server rejects that — bands must strictly ascend, or a quantity falls into two of them and the bill depends on which is read first.

## Two causes

**The bound always defaulted to 1000.** The band being closed is the open-ended one, so it has no `upToQuantity` of its own to reuse, and `last?.upToQuantity ?? 1_000` therefore fell back to the constant every single time. Now derived from the band *before* it, so each addition lands above its predecessor.

**The error had nowhere to appear.** The ordering rule is checked on the tier list as a whole, not on any one input, so there was no field for `FormMessage` to hang on. The table validated as invalid and showed nothing — right up until submit, which then reported "check the highlighted fields" while highlighting none. Now read off the error tree and rendered against the table.

Also renamed the button to **"Add another band"**: the new band isn't necessarily cheaper, and the old label implied the mechanic ran the other way.

## Why the last row is disabled

That's deliberate and unchanged — the final band must stay unbounded, or usage past it has no price at all. Same rule the server's validator enforces.

## Verification

Both fixes confirmed by reverting each in turn and watching the matching test fail (`expected 1000 to be 2000`, and the error assertion). 8 new tests covering the add-band behaviour, the schema's ordering rules, and the error actually rendering.

- 61 client subscription tests pass
- `tsc -b` clean
- `npm run lint` — no findings in the subscription module