### PR TITLE
fix(subscription): price an organization's plan without reporting it missing

### DIFF
--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -150,6 +150,8 @@ export interface CreateSubscriptionPlanRequest {
 
 export interface CreateSubscriptionPriceRequest {
   planId: string;
+  /** Omitted for a tenant-wide plan; honoured for the console only. */
+  organizationId?: string;
   currencyCode: string;
   unitAmountMinor: number;
   interval: number;

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-price-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-price-page.tsx
@@ -69,6 +69,9 @@ export const CreateSubscriptionPricePage = () => {
 
     const request: CreateSubscriptionPriceRequest = {
       planId,
+      // The plan may belong to an organization the console is not itself in, and the server
+      // resolves this request on its own — without naming it, the plan reads as missing.
+      organizationId: organizationScope,
       currencyCode: values.currencyCode,
       unitAmountMinor: toMinorUnits(values.amount, values.currencyCode),
       interval: values.interval,

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -6,6 +6,13 @@ public sealed class CreatePriceRequest
 {
     public string PlanId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The organization whose plan this price belongs to. Ignored unless the caller is the
+    /// console (<c>Payment:ConsoleOrganizationId</c>) — everyone else prices their own
+    /// organization's plans, whatever this says.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+
     public string CurrencyCode { get; set; } = string.Empty;
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -101,7 +101,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
 
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            request.OrganizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)
@@ -109,7 +109,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             return resolution.ToFailure<PlanResponse>(correlationId);
         }
 
-        var invalid = await SubscriptionValidation.CheckAsync<CreatePriceRequest, PlanResponse>(
+        var priceInvalid = await SubscriptionValidation.CheckAsync<CreatePriceRequest, PlanResponse>(
             _priceValidator,
             request,
             "subscription_price_invalid",
@@ -117,9 +117,9 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             correlationId,
             cancellationToken);
 
-        if (invalid is not null)
+        if (priceInvalid is not null)
         {
-            return invalid;
+            return priceInvalid;
         }
 
         var context = resolution.Context!;
@@ -128,7 +128,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             request.PlanId,
             cancellationToken);
 
-        if (plan is null)
+        // Visibility is checked here as it is on a read: the lookup above is keyed only by
+        // tenant and plan, so without this any caller in the tenant could put a price on
+        // another organization's plan.
+        if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
         {
             return NotFound(correlationId);
         }
@@ -171,6 +174,9 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             PaymentLogValue.Label(price.CurrencyCode),
             correlationId);
 
+        // The resolved organization, which is the plan's own once the request named it. Reading
+        // back under the caller's unresolved scope reported the plan as missing — after the
+        // price had already been committed, so the caller saw a failure for work that landed.
         return await GetPlanAsync(
             plan.ItemId,
             context.OrganizationId,

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -43,12 +43,154 @@ public sealed class PlanCatalogueServiceTests
             .Callback<Plan, CancellationToken>((plan, _) => _created = plan)
             .ReturnsAsync(true);
 
+        // A plan with no prices yet is the ordinary state right after it is authored, and every
+        // path that maps a plan to a response reads this.
+        _catalogue
+            .Setup(repository => repository.ListPricesAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
         _currencyResolver
             .Setup(resolver => resolver.TryConvertBack(
                 It.IsAny<long>(),
                 It.IsAny<string>(),
                 out It.Ref<decimal>.IsAny))
             .Returns(true);
+    }
+
+    /// <summary>
+    /// The regression this guards: the price was written and then the plan read back without
+    /// naming the organization it belongs to. The console writes under its own fixed
+    /// organization, so the read reported the plan as missing — after the price had already
+    /// been committed. The caller saw a failure for work that had actually succeeded.
+    /// </summary>
+    [Fact]
+    public async Task Pricing_another_organizations_plan_returns_that_plan_rather_than_missing()
+    {
+        var plan = StoredPlan();
+        plan.OrganizationId = "org-9";
+
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plan);
+        _catalogue
+            .Setup(repository => repository.TryCreatePriceAsync(
+                It.IsAny<Price>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // The console only reaches org-9 by naming it. Resolving without the name leaves it in
+        // its own fixed organization, which is exactly what the price path used to do — so the
+        // default setup from the constructor stands in for that.
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), "org-9", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, "org-9", "actor-1", "user-1")));
+
+        var result = await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                OrganizationId = "org-9",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "seat"
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "the price was created, so reporting it as missing is a lie about work that landed");
+        result.Value!.PlanId.Should().Be("plan-1");
+    }
+
+    /// <summary>
+    /// The lookup is keyed by tenant and plan alone, so without this any caller in the tenant
+    /// could put a price on another organization's plan.
+    /// </summary>
+    [Fact]
+    public async Task Pricing_a_plan_belonging_to_someone_else_is_refused()
+    {
+        var plan = StoredPlan();
+        plan.OrganizationId = "somebody-else";
+
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plan);
+
+        var result = await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "seat"
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        _catalogue.Verify(
+            repository => repository.TryCreatePriceAsync(
+                It.IsAny<Price>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a refused price must not reach the store");
+    }
+
+    [Fact]
+    public async Task A_tenant_wide_plan_can_still_be_priced()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StoredPlan());
+        _catalogue
+            .Setup(repository => repository.TryCreatePriceAsync(
+                It.IsAny<Price>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "seat"
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_price_forwards_its_requested_organization_to_context_resolution()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StoredPlan());
+
+        await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                OrganizationId = "org-9",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8900,
+                QuantityItemKey = "seat"
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce,
+            "only the console gets to act on this, and that is decided downstream");
     }
 
     [Fact]


### PR DESCRIPTION
Adding a price to an organization-scoped plan **wrote the price and then answered `subscription_plan_not_found`** — a failure reported for work that had already landed. Observed live on `dev-utilities`.

## Cause

`CreatePriceAsync` resolved the caller with **no requested organization**:

```csharp
var resolution = await _contextResolver.ResolveAsync(correlationId, null, cancellationToken);
```

So the console stayed in its own fixed organization. The plan lookup is keyed by tenant and plan alone, so it still found the plan and the price was committed — but reading the plan back afterwards goes through the ordinary visibility rule, which cannot see a plan belonging to a different organization.

`CreatePriceRequest` now carries `OrganizationId`, the same console override every other endpoint already takes, and the client sends the scope it is already carrying in the URL.

## A second problem found alongside it

That lookup had **no visibility check at all** — keyed only by tenant and plan. Any caller in the tenant could add a price to another organization's plan. Now checked the same way a read is, so a plan that isn't yours reports as missing rather than being silently priceable.

## Verification

Reverted each fix in turn and confirmed the matching test fails:
- reverting the resolve → `Pricing_another_organizations_plan_returns_that_plan_rather_than_missing` and `A_price_forwards_its_requested_organization_to_context_resolution` fail
- reverting the visibility check → `Pricing_a_plan_belonging_to_someone_else_is_refused` fails

Also fixed a latent gap in the test fixture: `ListPricesAsync` was unmocked, so any test reaching the response mapper threw on a null price list.

- backend **255 tests passing**, `dotnet build` 0 errors
- client **61 tests passing**, `tsc -b` clean
- `npm run lint` — no findings in the subscription module

## Note on existing data

No repair needed. Prices created during this window were committed correctly; only the response was wrong. Retrying returns `subscription_price_exists`, which is accurate.