### PR TITLE
feat(subscription): author prices in the builder, edit unsold plans, and warn on entitlement mismatches

### DIFF
--- a/client/app/cross-modules/utilities/payment/components/payment-filters.test.tsx
+++ b/client/app/cross-modules/utilities/payment/components/payment-filters.test.tsx
@@ -4,6 +4,15 @@ import { EMPTY_PAYMENT_FILTERS } from "../models/payment.model";
 import type { PaymentFilters } from "../models/payment.model";
 import { PaymentFiltersPanel } from "./payment-filters";
 
+// The organization filter reaches IAM through react-query, which these tests render without a
+// client. Stubbed rather than provided, because none of them are about that filter.
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({
+    data: { organizations: [{ itemId: "organization-2", name: "Test Org" }] },
+    isError: false,
+  }),
+}));
+
 const renderPanel = (
   overrides: Partial<PaymentFilters> = {},
   activeFilterCount = 0,

--- a/client/app/cross-modules/utilities/payment/pages/create-payment-page.test.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/create-payment-page.test.tsx
@@ -8,6 +8,15 @@ const { createPayment } = vi.hoisted(() => ({
   createPayment: vi.fn(),
 }));
 
+// The organization selector reaches IAM through react-query, which these tests render without a
+// client. Stubbed rather than provided, because none of them are about the selector.
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({
+    data: { organizations: [{ itemId: "organization-2", name: "Test Org" }] },
+    isError: false,
+  }),
+}));
+
 vi.mock("../hooks/use-create-payment", () => ({
   useCreatePayment: () => ({
     mutateAsync: createPayment,

--- a/client/app/cross-modules/utilities/payment/pages/payment-list-page.test.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/payment-list-page.test.tsx
@@ -24,6 +24,15 @@ vi.mock("../hooks/use-payments", () => ({
   },
 }));
 
+// The filter panel's organization selector reaches IAM through react-query, which these tests
+// render without a client. Stubbed rather than provided, because none of them are about it.
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({
+    data: { organizations: [{ itemId: "organization-2", name: "Test Org" }] },
+    isError: false,
+  }),
+}));
+
 // The refund dialog the list opens talks to react-query on its own.
 vi.mock("../hooks/use-create-payment-refund", () => ({
   useCreatePaymentRefund: () => ({

--- a/client/app/cross-modules/utilities/payment/pages/payment-provider-list-page.test.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/payment-provider-list-page.test.tsx
@@ -16,6 +16,15 @@ vi.mock("react-router", async (importOriginal) => ({
   useParams: () => ({ itemId: "tenant-1" }),
 }));
 
+// The organization column resolves names through IAM over react-query, which these tests render
+// without a client. Stubbed rather than provided, because none of them are about that column.
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({
+    data: { organizations: [{ itemId: "organization-2", name: "Test Org" }] },
+    isError: false,
+  }),
+}));
+
 vi.mock("../hooks/use-payment-providers", () => ({
   usePaymentProviders: () => ({ ...providersState, refetch: refetchMock }),
 }));

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -1,0 +1,270 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ArrowLeft, ArrowRight, Check, ChevronDown, Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
+import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui-kits/collapsible/collapsible";
+import { toast } from "@/hooks/use-toast";
+import StepHorizontalTrackBar from "@/components/stepper/horizontal-track-bar";
+import StepVerticalTrackBar from "@/components/stepper/vertical-track-bar";
+import StepperProviderComponent, { useStepper } from "@/components/stepper/stepper-provider";
+import type { Steps } from "@/components/stepper/stepper-models";
+import {
+  ORGANIZATION_PAGE_SIZE,
+  TENANT_WIDE_ORGANIZATION,
+} from "../../constants/subscription.constants";
+import {
+  BILLING_INTERVAL_NAMES,
+  ENTITLEMENT_LIMIT_KIND_NAMES,
+} from "../../models/subscription-plan.model";
+import {
+  buildSubscriptionPlanSchema,
+  type CreateSubscriptionPlanFormValues,
+} from "../../schemas/subscription-plan.schema";
+import { FLAT_FEE } from "../../schemas/subscription-price.schema";
+import { toMinorUnits } from "../../utilities/subscription-format";
+import { PlanSummaryCard, type PlanSummaryData } from "../plan-summary-card";
+import { SubscriptionPlanPageHeader } from "../subscription-plan-page-header";
+import { StepIdentity } from "./step-identity";
+import { StepPricingModel } from "./step-pricing-model";
+import { StepReview } from "./step-review";
+import { StepTrial } from "./step-trial";
+import { StepUsageLimits } from "./step-usage-limits";
+
+const STEPS: Steps = [
+  { id: 1, title: "Identity" },
+  { id: 2, title: "Pricing model" },
+  { id: 3, title: "Usage limits" },
+  { id: 4, title: "Trial" },
+  { id: 5, title: "Review" },
+];
+
+export interface PlanBuilderProps {
+  /**
+   * Editing differs in three ways only: the code and organization are fixed, prices already exist
+   * so a new one is optional, and the wording. Everything else is the same walkthrough, which is
+   * why it is one component — two copies would drift the moment a step changed.
+   */
+  mode: "create" | "edit";
+  defaultValues: CreateSubscriptionPlanFormValues;
+  title: string;
+  description: string;
+  backTo: string;
+  submitLabel: string;
+  submittingLabel: string;
+  isSubmitting: boolean;
+  /** Rejecting leaves the draft alone and shows the reason; the caller navigates on success. */
+  onSubmit: (values: CreateSubscriptionPlanFormValues) => Promise<void>;
+}
+
+export const PlanBuilder = (props: PlanBuilderProps) => (
+  <StepperProviderComponent steps={STEPS}>
+    <PlanBuilderWizard {...props} />
+  </StepperProviderComponent>
+);
+
+const PlanBuilderWizard = ({
+  mode,
+  defaultValues,
+  title,
+  description,
+  backTo,
+  submitLabel,
+  submittingLabel,
+  isSubmitting,
+  onSubmit,
+}: PlanBuilderProps) => {
+  const { currentStep, nextStep, previousStep, totalSteps } = useStepper();
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const isEditing = mode === "edit";
+
+  const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
+  const { data: organizationsData } = useGetOrganizations({
+    projectKey: tenantId,
+    page: 0,
+    pageSize: ORGANIZATION_PAGE_SIZE,
+  });
+
+  const schema = useMemo(
+    () => buildSubscriptionPlanSchema({ requirePrice: !isEditing }),
+    [isEditing],
+  );
+
+  const form = useForm<CreateSubscriptionPlanFormValues>({
+    resolver: zodResolver(schema),
+    mode: "onBlur",
+    defaultValues,
+  });
+
+  const draft = useWatch({ control: form.control });
+
+  const organizationLabel =
+    !draft.organizationId || draft.organizationId === TENANT_WIDE_ORGANIZATION
+      ? "Tenant-wide"
+      : (organizationsData?.organizations.find(
+          (organization) => organization.itemId === draft.organizationId,
+        )?.name ?? draft.organizationId);
+
+  const summary: PlanSummaryData = {
+    displayName: draft.displayName ?? "",
+    code: draft.code ?? "",
+    organizationLabel,
+    trialDays: draft.trialDays ?? null,
+    trialRequiresPaymentMethod: draft.trialRequiresPaymentMethod ?? true,
+    quantityItems: (draft.quantityItems ?? []).map((item) => ({
+      itemKey: item?.itemKey ?? "",
+      unitLabel: item?.unitLabel ?? "",
+      defaultQuantity: item?.defaultQuantity ?? 0,
+    })),
+    meters: (draft.meters ?? []).map((meter) => ({
+      meterKey: meter?.meterKey ?? "",
+      displayName: meter?.displayName ?? "",
+      unitLabel: meter?.unitLabel ?? "",
+      includedQuantity: meter?.includedQuantity ?? 0,
+      overageAllowed: meter?.overageAllowed ?? false,
+      // Only the currency matters to the summary — its presence is what decides whether
+      // overage reads as billed or given away.
+      rateTables: (meter?.rateTables ?? [])
+        .map((table) => table?.currencyCode)
+        .filter((currencyCode): currencyCode is string => Boolean(currencyCode))
+        .map((currencyCode) => ({ currencyCode })),
+    })),
+    entitlements: (draft.entitlements ?? []).map((entitlement) => ({
+      key: entitlement?.key ?? "",
+      limitKind: ENTITLEMENT_LIMIT_KIND_NAMES[entitlement?.limitKind ?? 0],
+      limit: entitlement?.limit ?? null,
+      unitLabel: entitlement?.unitLabel ?? null,
+      meterKey: entitlement?.meterKey ?? null,
+    })),
+    prices: (draft.prices ?? []).map((price) => ({
+      currencyCode: price?.currencyCode ?? "USD",
+      unitAmountMinor: toMinorUnits(price?.amount ?? 0, price?.currencyCode ?? "USD"),
+      interval: BILLING_INTERVAL_NAMES[price?.interval ?? 2],
+      intervalCount: price?.intervalCount ?? 1,
+      quantityItemKey:
+        !price?.quantityItemKey || price.quantityItemKey === FLAT_FEE
+          ? null
+          : price.quantityItemKey,
+    })),
+  };
+
+  const isLastStep = currentStep === totalSteps;
+
+  const submit = async () => {
+    setSubmissionError(null);
+
+    if (!(await form.trigger())) {
+      toast({
+        variant: "destructive",
+        title: "Check the highlighted fields",
+        description: "Some steps still have something to fix before this can be saved.",
+      });
+      return;
+    }
+
+    try {
+      await onSubmit(form.getValues());
+    } catch (error) {
+      setSubmissionError(
+        error instanceof Error ? error.message : "This plan could not be saved.",
+      );
+    }
+  };
+
+  return (
+    <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
+      <SubscriptionPlanPageHeader title={title} description={description} backTo={backTo} />
+
+      <FormProvider {...form}>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+          }}
+        >
+          <div className="grid gap-5 xl:grid-cols-[14rem_minmax(0,1fr)_22rem]">
+            <div className="hidden xl:block">
+              <Card className="sticky top-5 rounded-xl">
+                <StepVerticalTrackBar />
+              </Card>
+            </div>
+            <div className="xl:hidden">
+              <Card className="rounded-xl">
+                <StepHorizontalTrackBar />
+              </Card>
+            </div>
+
+            <Card className="min-w-0 rounded-xl">
+              {currentStep === 1 && <StepIdentity isEditing={isEditing} />}
+              {currentStep === 2 && <StepPricingModel isEditing={isEditing} />}
+              {currentStep === 3 && <StepUsageLimits />}
+              {currentStep === 4 && <StepTrial />}
+              {currentStep === 5 && <StepReview plan={summary} />}
+
+              {submissionError && (
+                <div
+                  role="alert"
+                  className="mt-5 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+                >
+                  {submissionError}
+                </div>
+              )}
+
+              {!isLastStep && (
+                <Collapsible className="mt-5 xl:hidden">
+                  <CollapsibleTrigger className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+                    <ChevronDown className="h-4 w-4" />
+                    Preview this plan so far
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="pt-3">
+                    <PlanSummaryCard plan={summary} />
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
+
+              <div className="mt-6 flex justify-between border-t pt-5">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={previousStep}
+                  disabled={currentStep === 1 || isSubmitting}
+                >
+                  <ArrowLeft className="mr-2 h-4 w-4" />
+                  Back
+                </Button>
+
+                {isLastStep ? (
+                  <Button type="button" onClick={submit} disabled={isSubmitting}>
+                    {isSubmitting ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Check className="mr-2 h-4 w-4" />
+                    )}
+                    {isSubmitting ? submittingLabel : submitLabel}
+                  </Button>
+                ) : (
+                  <Button type="button" onClick={nextStep}>
+                    Next
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </Card>
+
+            <div className="hidden xl:block">
+              <div className="sticky top-5">
+                <PlanSummaryCard plan={summary} />
+              </div>
+            </div>
+          </div>
+        </form>
+      </FormProvider>
+    </main>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -31,7 +31,7 @@ import { CardListItem, CardListShell } from "./card-list-shell";
  * ordinary case is more than one — a monthly and an annual price are two prices on the same plan,
  * and so is the same plan sold in two currencies.
  */
-export const PlanPriceFields = () => {
+export const PlanPriceFields = ({ isEditing = false }: { isEditing?: boolean }) => {
   const { control, formState } = useFormContext<CreateSubscriptionPlanFormValues>();
   const prices = useFieldArray({ control, name: "prices" });
   const quantityItems = useWatch({ control, name: "quantityItems" });
@@ -43,10 +43,13 @@ export const PlanPriceFields = () => {
   return (
     <div className="space-y-3">
       <div>
-        <h3 className="text-sm font-semibold">How much does it cost?</h3>
+        <h3 className="text-sm font-semibold">
+          {isEditing ? "Add a price" : "How much does it cost?"}
+        </h3>
         <p className="mt-1 text-xs text-muted-foreground">
-          The recurring charge itself, separate from any overage above. Add one per billing
-          cadence you sell — monthly and annually are two prices.
+          {isEditing
+            ? "Prices are separate from the plan's terms, so the ones it already has are left alone. Anything added here is created alongside your edit."
+            : "The recurring charge itself, separate from any overage above. Add one per billing cadence you sell — monthly and annually are two prices."}
         </p>
       </div>
 

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -1,0 +1,186 @@
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui-kits/form/form";
+import { Input } from "@/components/ui-kits/input/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import {
+  BILLING_INTERVAL_OPTIONS,
+  SUBSCRIPTION_CURRENCY_OPTIONS,
+} from "../../constants/subscription.constants";
+import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import {
+  defaultSubscriptionPriceFormValues,
+  FLAT_FEE,
+} from "../../schemas/subscription-price.schema";
+import { CardListItem, CardListShell } from "./card-list-shell";
+
+/**
+ * The prices the plan will be sold on. A repeatable list rather than one price, because the
+ * ordinary case is more than one — a monthly and an annual price are two prices on the same plan,
+ * and so is the same plan sold in two currencies.
+ */
+export const PlanPriceFields = () => {
+  const { control, formState } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const prices = useFieldArray({ control, name: "prices" });
+  const quantityItems = useWatch({ control, name: "quantityItems" });
+
+  // The "add at least one" issue lands on the array itself, which no per-field FormMessage
+  // renders — the same trap the rate-table tier ordering hit.
+  const listError = formState.errors.prices?.message ?? formState.errors.prices?.root?.message;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-sm font-semibold">How much does it cost?</h3>
+        <p className="mt-1 text-xs text-muted-foreground">
+          The recurring charge itself, separate from any overage above. Add one per billing
+          cadence you sell — monthly and annually are two prices.
+        </p>
+      </div>
+
+      <CardListShell
+        addLabel="Add another price"
+        onAdd={() => prices.append({ ...defaultSubscriptionPriceFormValues })}
+      >
+        {prices.fields.map((field, index) => (
+          <CardListItem key={field.id} onRemove={() => prices.remove(index)}>
+            <div className="grid grid-cols-2 gap-2">
+              <FormField
+                control={control}
+                name={`prices.${index}.currencyCode`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Currency</FormLabel>
+                    <Select value={inputField.value} onValueChange={inputField.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {SUBSCRIPTION_CURRENCY_OPTIONS.map((currency) => (
+                          <SelectItem key={currency.code} value={currency.code}>
+                            {currency.code}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name={`prices.${index}.amount`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Amount</FormLabel>
+                    <FormControl>
+                      <Input {...inputField} type="number" min={0} step="0.01" placeholder="89.00" />
+                    </FormControl>
+                    <FormDescription className="text-xs">
+                      In major units — 89.00, not 8900.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-2">
+              <FormField
+                control={control}
+                name={`prices.${index}.interval`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Billed every</FormLabel>
+                    <Select
+                      value={String(inputField.value)}
+                      onValueChange={(value) => inputField.onChange(Number(value))}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {BILLING_INTERVAL_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={String(option.value)}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name={`prices.${index}.intervalCount`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">How many</FormLabel>
+                    <FormControl>
+                      <Input {...inputField} type="number" min={1} max={36} />
+                    </FormControl>
+                    <FormDescription className="text-xs">
+                      3 with &ldquo;month&rdquo; is quarterly.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={control}
+              name={`prices.${index}.quantityItemKey`}
+              render={({ field: inputField }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">What this multiplies</FormLabel>
+                  <Select value={inputField.value} onValueChange={inputField.onChange}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value={FLAT_FEE}>Flat fee</SelectItem>
+                      {(quantityItems ?? [])
+                        .filter((item) => item.itemKey)
+                        .map((item) => (
+                          <SelectItem key={item.itemKey} value={item.itemKey}>
+                            Per {item.unitLabel || item.itemKey}
+                          </SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardListItem>
+        ))}
+      </CardListShell>
+
+      {listError && (
+        <p className="text-sm text-destructive" role="alert">
+          {listError}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-identity.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-identity.tsx
@@ -30,7 +30,14 @@ import {
 } from "../../constants/subscription.constants";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 
-export const StepIdentity = () => {
+/**
+ * @param isEditing
+ * Locks the code and the organization. Neither may move once a plan exists: a code is what
+ * configuration points at, and a scope change would take the plan out from under whoever can see
+ * it. The server ignores both on an edit; showing them read-only says so rather than letting
+ * someone type a change that silently does nothing.
+ */
+export const StepIdentity = ({ isEditing = false }: { isEditing?: boolean }) => {
   const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData, isError: organizationsFailed } = useGetOrganizations({
@@ -72,11 +79,18 @@ export const StepIdentity = () => {
             <FormItem>
               <FormLabel>Code</FormLabel>
               <FormControl>
-                <Input {...field} placeholder="pro" autoComplete="off" spellCheck={false} />
+                <Input
+                  {...field}
+                  placeholder="pro"
+                  autoComplete="off"
+                  spellCheck={false}
+                  disabled={isEditing}
+                />
               </FormControl>
               <FormDescription>
-                Shown to no one but your own systems — the stable id you&apos;ll call this plan by.
-                Lowercase letters, digits, hyphens and underscores only.
+                {isEditing
+                  ? "Fixed once the plan exists — this is what your own systems call it by."
+                  : "Shown to no one but your own systems — the stable id you'll call this plan by. Lowercase letters, digits, hyphens and underscores only."}
               </FormDescription>
               <FormMessage />
             </FormItem>
@@ -89,7 +103,11 @@ export const StepIdentity = () => {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Organization</FormLabel>
-              <Select value={field.value} onValueChange={field.onChange}>
+              <Select
+                value={field.value}
+                onValueChange={field.onChange}
+                disabled={isEditing}
+              >
                 <FormControl>
                   <SelectTrigger>
                     <SelectValue />
@@ -107,9 +125,11 @@ export const StepIdentity = () => {
                 </SelectContent>
               </Select>
               <FormDescription>
-                {organizationsFailed
-                  ? "Organizations could not be loaded; you can still create a tenant-wide plan."
-                  : "Which organization this plan belongs to. Scope it to one organization only when it shouldn't be offered to everyone."}
+                {isEditing
+                  ? "Fixed once the plan exists — moving it would take the plan out from under whoever can see it."
+                  : organizationsFailed
+                    ? "Organizations could not be loaded; you can still create a tenant-wide plan."
+                    : "Which organization this plan belongs to. Scope it to one organization only when it shouldn't be offered to everyone."}
               </FormDescription>
               <FormMessage />
             </FormItem>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -21,6 +21,7 @@ import { METER_AGGREGATION_OPTIONS } from "../../constants/subscription.constant
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 import { CardListItem, CardListShell } from "./card-list-shell";
 import { MeterRateTableFields } from "./meter-rate-table-fields";
+import { PlanPriceFields } from "./plan-price-fields";
 import { ThresholdChipInput } from "./threshold-chip-input";
 
 const PRICING_SHAPES = [
@@ -313,6 +314,10 @@ export const StepPricingModel = () => {
           </CardListShell>
         </div>
       )}
+
+      {/* Last in the step because a price may multiply a quantity item, which is defined above
+          it. Not gated on the pricing shape: every plan needs a price, whatever its shape. */}
+      {pricingShape && <PlanPriceFields />}
 
       {!pricingShape && (
         <Card className="flex flex-col items-center gap-2 rounded-xl py-8 text-center text-sm text-muted-foreground">

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -45,7 +45,7 @@ const PRICING_SHAPES = [
   },
 ];
 
-export const StepPricingModel = () => {
+export const StepPricingModel = ({ isEditing = false }: { isEditing?: boolean }) => {
   const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
   const pricingShape = useWatch({ control, name: "pricingShape" });
 
@@ -317,7 +317,7 @@ export const StepPricingModel = () => {
 
       {/* Last in the step because a price may multiply a quantity item, which is defined above
           it. Not gated on the pricing shape: every plan needs a price, whatever its shape. */}
-      {pricingShape && <PlanPriceFields />}
+      {pricingShape && <PlanPriceFields isEditing={isEditing} />}
 
       {!pricingShape && (
         <Card className="flex flex-col items-center gap-2 rounded-xl py-8 text-center text-sm text-muted-foreground">

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from "lucide-react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import {
   FormControl,
@@ -15,7 +16,9 @@ import {
   SelectValue,
 } from "@/components/ui-kits/select/select";
 import { ENTITLEMENT_LIMIT_KIND_OPTIONS } from "../../constants/subscription.constants";
+import { ENTITLEMENT_LIMIT_KIND_NAMES } from "../../models/subscription-plan.model";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import { describeEntitlementMeterMismatch } from "../../utilities/plan-consistency";
 import { CardListItem, CardListShell } from "./card-list-shell";
 
 export const StepUsageLimits = () => {
@@ -48,6 +51,22 @@ export const StepUsageLimits = () => {
       >
         {entitlements.fields.map((field, index) => {
           const limitKind = entitlementValues?.[index]?.limitKind ?? field.limitKind;
+          const draft = entitlementValues?.[index];
+          const mismatch = draft
+            ? describeEntitlementMeterMismatch(
+                {
+                  limitKind: ENTITLEMENT_LIMIT_KIND_NAMES[draft.limitKind ?? 0],
+                  limit: draft.limit ?? null,
+                  meterKey: draft.meterKey ?? null,
+                },
+                (meters ?? []).map((meter) => ({
+                  meterKey: meter.meterKey ?? "",
+                  unitLabel: meter.unitLabel ?? "",
+                  includedQuantity: meter.includedQuantity ?? 0,
+                  overageAllowed: meter.overageAllowed ?? false,
+                })),
+              )
+            : null;
 
           return (
             <CardListItem key={field.id} onRemove={() => entitlements.remove(index)}>
@@ -145,6 +164,16 @@ export const StepUsageLimits = () => {
                     )}
                   />
                 </>
+              )}
+
+              {/* A warning, not a validation error: permitting more than the meter includes is a
+                  real configuration — the excess is simply billed as overage — so this says what
+                  will happen rather than refusing to submit it. */}
+              {mismatch && (
+                <p className="flex items-start gap-1.5 text-xs text-warning-700">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  {mismatch}
+                </p>
               )}
             </CardListItem>
           );

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -1,6 +1,7 @@
 import { CircleDollarSign, Gauge, Layers, ShieldCheck } from "lucide-react";
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/card/card";
+import { describeEntitlementMeterMismatch } from "../utilities/plan-consistency";
 import {
   formatEntitlementLimit,
   formatMeterAllowance,
@@ -23,7 +24,14 @@ export interface PlanSummaryData {
     /** Drives whether overage is described as billed or given away. */
     rateTables?: { currencyCode: string }[];
   }[];
-  entitlements: { key: string; limitKind: string; limit: number | null; unitLabel: string | null }[];
+  entitlements: {
+    key: string;
+    limitKind: string;
+    limit: number | null;
+    unitLabel: string | null;
+    /** The meter this draws down, so the summary can say when the two disagree. */
+    meterKey: string | null;
+  }[];
   prices: {
     currencyCode: string;
     unitAmountMinor: number;
@@ -116,12 +124,21 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
           <div className="flex items-start gap-2 text-sm">
             <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-blocks-primary-600" />
             <div className="space-y-0.5">
-              {plan.entitlements.map((entitlement, index) => (
-                <p key={index}>
-                  <span className="font-medium">{entitlement.key}:</span>{" "}
-                  {formatEntitlementLimit(entitlement)}
-                </p>
-              ))}
+              {plan.entitlements.map((entitlement, index) => {
+                const mismatch = describeEntitlementMeterMismatch(entitlement, plan.meters);
+
+                return (
+                  <div key={index}>
+                    <p>
+                      <span className="font-medium">{entitlement.key}:</span>{" "}
+                      {formatEntitlementLimit(entitlement)}
+                    </p>
+                    {mismatch && (
+                      <p className="text-xs text-warning-700">{mismatch}</p>
+                    )}
+                  </div>
+                );
+              })}
             </div>
           </div>
         )}

--- a/client/app/cross-modules/utilities/subscription/hooks/use-update-subscription-plan.ts
+++ b/client/app/cross-modules/utilities/subscription/hooks/use-update-subscription-plan.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { UpdateSubscriptionPlanRequest } from "../models/subscription-plan.model";
+import { subscriptionService } from "../services/subscription.service";
+
+export const useUpdateSubscriptionPlan = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      planId,
+      request,
+    }: {
+      planId: string;
+      request: UpdateSubscriptionPlanRequest;
+    }) => subscriptionService.updatePlan(planId, request),
+    onSuccess: (plan) => {
+      queryClient.invalidateQueries({ queryKey: ["subscription-plans"] });
+      queryClient.invalidateQueries({
+        queryKey: ["subscription-plan", plan.planId],
+      });
+    },
+  });
+};

--- a/client/app/cross-modules/utilities/subscription/index.ts
+++ b/client/app/cross-modules/utilities/subscription/index.ts
@@ -2,3 +2,4 @@ export { SubscriptionPlanListPage } from "./pages/subscription-plan-list-page";
 export { SubscriptionPlanDetailPage } from "./pages/subscription-plan-detail-page";
 export { CreateSubscriptionPlanPage } from "./pages/create-subscription-plan-page";
 export { CreateSubscriptionPricePage } from "./pages/create-subscription-price-page";
+export { EditSubscriptionPlanPage } from "./pages/edit-subscription-plan-page";

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -27,6 +27,8 @@ export const ENTITLEMENT_LIMIT_KIND = {
 /** Indexed by the numeric value a form holds, so a draft can be read the way a response reads. */
 export const ENTITLEMENT_LIMIT_KIND_NAMES = ["Boolean", "Count", "Unlimited"] as const;
 
+export const BILLING_INTERVAL_NAMES = ["Day", "Week", "Month", "Year"] as const;
+
 export type BillingIntervalName = keyof typeof BILLING_INTERVAL;
 export type MeterAggregationName = keyof typeof METER_AGGREGATION;
 export type EntitlementLimitKindName = keyof typeof ENTITLEMENT_LIMIT_KIND;

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -97,10 +97,22 @@ export interface SubscriptionPlan {
   trialDays: number | null;
   trialRequiresPaymentMethod: boolean;
   version: number;
+  /**
+   * Whether anything has ever subscribed to this plan. True closes editing: a subscription bills
+   * from its own copy of the plan's terms, which an edit cannot reach.
+   */
+  hasSubscribers: boolean;
   quantityItems: PlanQuantityItem[];
   meters: PlanMeter[];
   entitlements: PlanEntitlement[];
   prices: PlanPrice[];
+  /** Optional for the same reason rate tables are: plans stored before this was returned lack it. */
+  trialGrants?: PlanTrialGrant[];
+}
+
+export interface PlanTrialGrant {
+  meterKey: string;
+  includedQuantity: number;
 }
 
 export interface CreatePlanQuantityItemRequest {
@@ -144,6 +156,24 @@ export interface CreateSubscriptionPlanRequest {
   description?: string;
   featuresJson?: string;
   /** Omitted entirely for a tenant-wide plan. */
+  organizationId?: string;
+  trialDays?: number;
+  trialRequiresPaymentMethod: boolean;
+  quantityItems: CreatePlanQuantityItemRequest[];
+  meters: CreatePlanMeterRequest[];
+  entitlements: CreatePlanEntitlementRequest[];
+  trialGrants: CreatePlanTrialGrantRequest[];
+}
+
+/**
+ * Rewrites what a plan sells. Carries no code and no scope: the server takes both from the stored
+ * plan, because neither may move once anything points at it.
+ */
+export interface UpdateSubscriptionPlanRequest {
+  displayName: string;
+  description?: string;
+  featuresJson?: string;
+  /** Names the plan's organization for the console. It never changes the plan's scope. */
   organizationId?: string;
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -24,6 +24,9 @@ export const ENTITLEMENT_LIMIT_KIND = {
   Unlimited: 2,
 } as const;
 
+/** Indexed by the numeric value a form holds, so a draft can be read the way a response reads. */
+export const ENTITLEMENT_LIMIT_KIND_NAMES = ["Boolean", "Count", "Unlimited"] as const;
+
 export type BillingIntervalName = keyof typeof BILLING_INTERVAL;
 export type MeterAggregationName = keyof typeof METER_AGGREGATION;
 export type EntitlementLimitKindName = keyof typeof ENTITLEMENT_LIMIT_KIND;

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
@@ -1,335 +1,63 @@
-import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowLeft, ArrowRight, Check, ChevronDown, Loader2 } from "lucide-react";
-import { useState } from "react";
-import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useNavigate, useParams } from "react-router";
-import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
-import { useProjectStore } from "@seliseblocks/genesis-os";
-import { Button } from "@/components/ui-kits/button/button";
-import { Card } from "@/components/ui-kits/card/card";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui-kits/collapsible/collapsible";
 import { toast } from "@/hooks/use-toast";
-import StepHorizontalTrackBar from "@/components/stepper/horizontal-track-bar";
-import StepVerticalTrackBar from "@/components/stepper/vertical-track-bar";
-import StepperProviderComponent, { useStepper } from "@/components/stepper/stepper-provider";
-import type { Steps } from "@/components/stepper/stepper-models";
-import {
-  ORGANIZATION_PAGE_SIZE,
-  TENANT_WIDE_ORGANIZATION,
-} from "../constants/subscription.constants";
-import { PlanSummaryCard, type PlanSummaryData } from "../components/plan-summary-card";
-import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
-import { StepIdentity } from "../components/plan-builder/step-identity";
-import { StepPricingModel } from "../components/plan-builder/step-pricing-model";
-import { StepReview } from "../components/plan-builder/step-review";
-import { StepTrial } from "../components/plan-builder/step-trial";
-import { StepUsageLimits } from "../components/plan-builder/step-usage-limits";
-import { withOrganizationScope } from "../hooks/use-organization-scope";
+import { PlanBuilder } from "../components/plan-builder/plan-builder";
 import { useCreateSubscriptionPlan } from "../hooks/use-create-subscription-plan";
 import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-price";
-import {
-  createSubscriptionPlanSchema,
-  defaultSubscriptionPlanFormValues,
-  type CreateSubscriptionPlanFormValues,
-} from "../schemas/subscription-plan.schema";
-import { FLAT_FEE } from "../schemas/subscription-price.schema";
-import {
-  BILLING_INTERVAL_NAMES,
-  ENTITLEMENT_LIMIT_KIND_NAMES,
-  type CreateSubscriptionPlanRequest,
-} from "../models/subscription-plan.model";
+import { withOrganizationScope } from "../hooks/use-organization-scope";
+import { defaultSubscriptionPlanFormValues } from "../schemas/subscription-plan.schema";
+import { toCreatePlanRequest } from "../utilities/plan-form-mapping";
 import { submitPlanWithPrices } from "../utilities/submit-plan-with-prices";
-import { toMinorUnits } from "../utilities/subscription-format";
-
-const STEPS: Steps = [
-  { id: 1, title: "Identity" },
-  { id: 2, title: "Pricing model" },
-  { id: 3, title: "Usage limits" },
-  { id: 4, title: "Trial" },
-  { id: 5, title: "Review" },
-];
 
 export const CreateSubscriptionPlanPage = () => {
-  return (
-    <StepperProviderComponent steps={STEPS}>
-      <CreateSubscriptionPlanWizard />
-    </StepperProviderComponent>
-  );
-};
-
-const CreateSubscriptionPlanWizard = () => {
   const { itemId } = useParams();
   const navigate = useNavigate();
-  const { currentStep, nextStep, previousStep, totalSteps } = useStepper();
-  const { mutateAsync, isPending } = useCreateSubscriptionPlan();
+  const { mutateAsync: createPlan, isPending } = useCreateSubscriptionPlan();
   const { mutateAsync: createPrice, isPending: isPricing } = useCreateSubscriptionPrice();
-  // One submission spans both calls, so the buttons must stay locked through the price loop too.
-  const isSubmitting = isPending || isPricing;
-  const [submissionError, setSubmissionError] = useState<string | null>(null);
   const listPath = `/app/${itemId ?? ""}/subscription/plans`;
 
-  const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
-  const { data: organizationsData } = useGetOrganizations({
-    projectKey: tenantId,
-    page: 0,
-    pageSize: ORGANIZATION_PAGE_SIZE,
-  });
-
-  const form = useForm<CreateSubscriptionPlanFormValues>({
-    resolver: zodResolver(createSubscriptionPlanSchema),
-    mode: "onBlur",
-    defaultValues: defaultSubscriptionPlanFormValues,
-  });
-
-  const draft = useWatch({ control: form.control });
-
-  const organizationLabel =
-    !draft.organizationId || draft.organizationId === TENANT_WIDE_ORGANIZATION
-      ? "Tenant-wide"
-      : (organizationsData?.organizations.find(
-          (organization) => organization.itemId === draft.organizationId,
-        )?.name ?? draft.organizationId);
-
-  const summary: PlanSummaryData = {
-    displayName: draft.displayName ?? "",
-    code: draft.code ?? "",
-    organizationLabel,
-    trialDays: draft.trialDays ?? null,
-    trialRequiresPaymentMethod: draft.trialRequiresPaymentMethod ?? true,
-    quantityItems: (draft.quantityItems ?? []).map((item) => ({
-      itemKey: item?.itemKey ?? "",
-      unitLabel: item?.unitLabel ?? "",
-      defaultQuantity: item?.defaultQuantity ?? 0,
-    })),
-    meters: (draft.meters ?? []).map((meter) => ({
-      meterKey: meter?.meterKey ?? "",
-      displayName: meter?.displayName ?? "",
-      unitLabel: meter?.unitLabel ?? "",
-      includedQuantity: meter?.includedQuantity ?? 0,
-      overageAllowed: meter?.overageAllowed ?? false,
-      // Only the currency matters to the summary — its presence is what decides whether
-      // overage reads as billed or given away.
-      rateTables: (meter?.rateTables ?? [])
-        .map((table) => table?.currencyCode)
-        .filter((currencyCode): currencyCode is string => Boolean(currencyCode))
-        .map((currencyCode) => ({ currencyCode })),
-    })),
-    entitlements: (draft.entitlements ?? []).map((entitlement) => ({
-      key: entitlement?.key ?? "",
-      limitKind: ENTITLEMENT_LIMIT_KIND_NAMES[entitlement?.limitKind ?? 0],
-      limit: entitlement?.limit ?? null,
-      unitLabel: entitlement?.unitLabel ?? null,
-      meterKey: entitlement?.meterKey ?? null,
-    })),
-    prices: (draft.prices ?? []).map((price) => ({
-      currencyCode: price?.currencyCode ?? "USD",
-      unitAmountMinor: toMinorUnits(price?.amount ?? 0, price?.currencyCode ?? "USD"),
-      interval: BILLING_INTERVAL_NAMES[price?.interval ?? 2],
-      intervalCount: price?.intervalCount ?? 1,
-      quantityItemKey:
-        !price?.quantityItemKey || price.quantityItemKey === FLAT_FEE
-          ? null
-          : price.quantityItemKey,
-    })),
-  };
-
-  const isLastStep = currentStep === totalSteps;
-
-  const submit = async () => {
-    setSubmissionError(null);
-
-    const valid = await form.trigger();
-
-    if (!valid) {
-      toast({
-        variant: "destructive",
-        title: "Check the highlighted fields",
-        description: "Some steps still have something to fix before this plan can be created.",
-      });
-      return;
-    }
-
-    const values = form.getValues();
-
-    const request: CreateSubscriptionPlanRequest = {
-      code: values.code.trim(),
-      displayName: values.displayName.trim(),
-      description: values.description?.trim() || undefined,
-      featuresJson: values.featuresJson?.trim() || undefined,
-      organizationId:
-        values.organizationId === TENANT_WIDE_ORGANIZATION ? undefined : values.organizationId,
-      trialDays: values.trialDays,
-      trialRequiresPaymentMethod: values.trialRequiresPaymentMethod,
-      quantityItems: values.quantityItems.map((item) => ({
-        itemKey: item.itemKey.trim(),
-        unitLabel: item.unitLabel.trim(),
-        minQuantity: item.minQuantity,
-        maxQuantity: item.maxQuantity,
-        defaultQuantity: item.defaultQuantity,
-      })),
-      meters: values.meters.map((meter) => ({
-        meterKey: meter.meterKey.trim(),
-        displayName: meter.displayName.trim(),
-        unitLabel: meter.unitLabel.trim(),
-        aggregation: meter.aggregation,
-        includedQuantity: meter.includedQuantity,
-        overageAllowed: meter.overageAllowed,
-        thresholdPercents: meter.thresholdPercents,
-        rateTables: meter.rateTables.map((table) => ({
-          currencyCode: table.currencyCode,
-          tiers: table.tiers,
-        })),
-      })),
-      entitlements: values.entitlements.map((entitlement) => ({
-        key: entitlement.key.trim(),
-        limitKind: entitlement.limitKind,
-        limit: entitlement.limit,
-        meterKey: entitlement.meterKey?.trim() || undefined,
-        unitLabel: entitlement.unitLabel?.trim() || undefined,
-      })),
-      trialGrants: values.trialGrants.map((grant) => ({
-        meterKey: grant.meterKey.trim(),
-        includedQuantity: grant.includedQuantity,
-      })),
-    };
-
-    let plan;
-    let failures: string[];
-
-    try {
-      ({ plan, failures } = await submitPlanWithPrices({
-        planRequest: request,
-        prices: values.prices,
-        createPlan: mutateAsync,
-        createPrice,
-      }));
-    } catch (error) {
-      setSubmissionError(
-        error instanceof Error ? error.message : "The plan could not be created.",
-      );
-      return;
-    }
-
-    // Carries the organization the plan was just scoped to. Without it the detail page
-    // resolves as the console organization, and a plan belonging to someone else reads as
-    // missing — the plan is created and then immediately unreachable.
-    const detailPath = withOrganizationScope(
-      `${listPath}/${encodeURIComponent(plan.planId)}`,
-      plan.organizationId,
-    );
-
-    if (failures.length > 0) {
-      toast({
-        variant: "destructive",
-        title: `${plan.displayName} was created, but ${failures.length} price${failures.length === 1 ? "" : "s"} was not`,
-        description: `${failures.join(" ")} Add the missing prices from the plan page.`,
-      });
-    } else {
-      toast({
-        variant: "success",
-        title: "Plan created",
-        description: `${plan.displayName} is ready to subscribe to.`,
-      });
-    }
-
-    navigate(detailPath);
-  };
-
   return (
-    <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
-      <SubscriptionPlanPageHeader
-        title="Create subscription plan"
-        description="A guided walkthrough — nothing is created until you review and confirm at the end."
-        backTo={listPath}
-      />
+    <PlanBuilder
+      mode="create"
+      defaultValues={defaultSubscriptionPlanFormValues}
+      title="Create subscription plan"
+      description="A guided walkthrough — nothing is created until you review and confirm at the end."
+      backTo={listPath}
+      submitLabel="Create plan"
+      submittingLabel="Creating plan…"
+      // One submission spans both calls, so the buttons stay locked through the price loop too.
+      isSubmitting={isPending || isPricing}
+      onSubmit={async (values) => {
+        const { plan, failures } = await submitPlanWithPrices({
+          planRequest: toCreatePlanRequest(values),
+          prices: values.prices,
+          createPlan,
+          createPrice,
+        });
 
-      <FormProvider {...form}>
-        <form
-          onSubmit={(event) => {
-            event.preventDefault();
-          }}
-        >
-          <div className="grid gap-5 xl:grid-cols-[14rem_minmax(0,1fr)_22rem]">
-            <div className="hidden xl:block">
-              <Card className="sticky top-5 rounded-xl">
-                <StepVerticalTrackBar />
-              </Card>
-            </div>
-            <div className="xl:hidden">
-              <Card className="rounded-xl">
-                <StepHorizontalTrackBar />
-              </Card>
-            </div>
+        if (failures.length > 0) {
+          toast({
+            variant: "destructive",
+            title: `${plan.displayName} was created, but ${failures.length} price${failures.length === 1 ? "" : "s"} was not`,
+            description: `${failures.join(" ")} Add the missing prices from the plan page.`,
+          });
+        } else {
+          toast({
+            variant: "success",
+            title: "Plan created",
+            description: `${plan.displayName} is ready to subscribe to.`,
+          });
+        }
 
-            <Card className="min-w-0 rounded-xl">
-              {currentStep === 1 && <StepIdentity />}
-              {currentStep === 2 && <StepPricingModel />}
-              {currentStep === 3 && <StepUsageLimits />}
-              {currentStep === 4 && <StepTrial />}
-              {currentStep === 5 && <StepReview plan={summary} />}
-
-              {submissionError && (
-                <div
-                  role="alert"
-                  className="mt-5 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive"
-                >
-                  {submissionError}
-                </div>
-              )}
-
-              {!isLastStep && (
-                <Collapsible className="mt-5 xl:hidden">
-                  <CollapsibleTrigger className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
-                    <ChevronDown className="h-4 w-4" />
-                    Preview this plan so far
-                  </CollapsibleTrigger>
-                  <CollapsibleContent className="pt-3">
-                    <PlanSummaryCard plan={summary} />
-                  </CollapsibleContent>
-                </Collapsible>
-              )}
-
-              <div className="mt-6 flex justify-between border-t pt-5">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={previousStep}
-                  disabled={currentStep === 1 || isSubmitting}
-                >
-                  <ArrowLeft className="mr-2 h-4 w-4" />
-                  Back
-                </Button>
-
-                {isLastStep ? (
-                  <Button type="button" onClick={submit} disabled={isSubmitting}>
-                    {isSubmitting ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                      <Check className="mr-2 h-4 w-4" />
-                    )}
-                    {isSubmitting ? "Creating plan…" : "Create plan"}
-                  </Button>
-                ) : (
-                  <Button type="button" onClick={nextStep}>
-                    Next
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Button>
-                )}
-              </div>
-            </Card>
-
-            <div className="hidden xl:block">
-              <div className="sticky top-5">
-                <PlanSummaryCard plan={summary} />
-              </div>
-            </div>
-          </div>
-        </form>
-      </FormProvider>
-    </main>
+        // Carries the organization the plan was just scoped to. Without it the detail page
+        // resolves as the console organization, and a plan belonging to someone else reads as
+        // missing — the plan is created and then immediately unreachable.
+        navigate(
+          withOrganizationScope(
+            `${listPath}/${encodeURIComponent(plan.planId)}`,
+            plan.organizationId,
+          ),
+        );
+      }}
+    />
   );
 };

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
@@ -30,15 +30,20 @@ import { StepTrial } from "../components/plan-builder/step-trial";
 import { StepUsageLimits } from "../components/plan-builder/step-usage-limits";
 import { withOrganizationScope } from "../hooks/use-organization-scope";
 import { useCreateSubscriptionPlan } from "../hooks/use-create-subscription-plan";
+import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-price";
 import {
   createSubscriptionPlanSchema,
   defaultSubscriptionPlanFormValues,
   type CreateSubscriptionPlanFormValues,
 } from "../schemas/subscription-plan.schema";
+import { FLAT_FEE } from "../schemas/subscription-price.schema";
 import {
+  BILLING_INTERVAL_NAMES,
   ENTITLEMENT_LIMIT_KIND_NAMES,
   type CreateSubscriptionPlanRequest,
 } from "../models/subscription-plan.model";
+import { submitPlanWithPrices } from "../utilities/submit-plan-with-prices";
+import { toMinorUnits } from "../utilities/subscription-format";
 
 const STEPS: Steps = [
   { id: 1, title: "Identity" },
@@ -61,6 +66,9 @@ const CreateSubscriptionPlanWizard = () => {
   const navigate = useNavigate();
   const { currentStep, nextStep, previousStep, totalSteps } = useStepper();
   const { mutateAsync, isPending } = useCreateSubscriptionPlan();
+  const { mutateAsync: createPrice, isPending: isPricing } = useCreateSubscriptionPrice();
+  // One submission spans both calls, so the buttons must stay locked through the price loop too.
+  const isSubmitting = isPending || isPricing;
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const listPath = `/app/${itemId ?? ""}/subscription/plans`;
 
@@ -117,7 +125,16 @@ const CreateSubscriptionPlanWizard = () => {
       unitLabel: entitlement?.unitLabel ?? null,
       meterKey: entitlement?.meterKey ?? null,
     })),
-    prices: [],
+    prices: (draft.prices ?? []).map((price) => ({
+      currencyCode: price?.currencyCode ?? "USD",
+      unitAmountMinor: toMinorUnits(price?.amount ?? 0, price?.currencyCode ?? "USD"),
+      interval: BILLING_INTERVAL_NAMES[price?.interval ?? 2],
+      intervalCount: price?.intervalCount ?? 1,
+      quantityItemKey:
+        !price?.quantityItemKey || price.quantityItemKey === FLAT_FEE
+          ? null
+          : price.quantityItemKey,
+    })),
   };
 
   const isLastStep = currentStep === totalSteps;
@@ -180,29 +197,46 @@ const CreateSubscriptionPlanWizard = () => {
       })),
     };
 
+    let plan;
+    let failures: string[];
+
     try {
-      const plan = await mutateAsync(request);
-
-      toast({
-        variant: "success",
-        title: "Plan created",
-        description: `${plan.displayName} is ready.`,
-      });
-
-      // Carries the organization the plan was just scoped to. Without it the detail page
-      // resolves as the console organization, and a plan belonging to someone else reads as
-      // missing — the plan is created and then immediately unreachable.
-      navigate(
-        withOrganizationScope(
-          `${listPath}/${encodeURIComponent(plan.planId)}`,
-          plan.organizationId,
-        ),
-      );
+      ({ plan, failures } = await submitPlanWithPrices({
+        planRequest: request,
+        prices: values.prices,
+        createPlan: mutateAsync,
+        createPrice,
+      }));
     } catch (error) {
       setSubmissionError(
         error instanceof Error ? error.message : "The plan could not be created.",
       );
+      return;
     }
+
+    // Carries the organization the plan was just scoped to. Without it the detail page
+    // resolves as the console organization, and a plan belonging to someone else reads as
+    // missing — the plan is created and then immediately unreachable.
+    const detailPath = withOrganizationScope(
+      `${listPath}/${encodeURIComponent(plan.planId)}`,
+      plan.organizationId,
+    );
+
+    if (failures.length > 0) {
+      toast({
+        variant: "destructive",
+        title: `${plan.displayName} was created, but ${failures.length} price${failures.length === 1 ? "" : "s"} was not`,
+        description: `${failures.join(" ")} Add the missing prices from the plan page.`,
+      });
+    } else {
+      toast({
+        variant: "success",
+        title: "Plan created",
+        description: `${plan.displayName} is ready to subscribe to.`,
+      });
+    }
+
+    navigate(detailPath);
   };
 
   return (
@@ -264,20 +298,20 @@ const CreateSubscriptionPlanWizard = () => {
                   type="button"
                   variant="outline"
                   onClick={previousStep}
-                  disabled={currentStep === 1 || isPending}
+                  disabled={currentStep === 1 || isSubmitting}
                 >
                   <ArrowLeft className="mr-2 h-4 w-4" />
                   Back
                 </Button>
 
                 {isLastStep ? (
-                  <Button type="button" onClick={submit} disabled={isPending}>
-                    {isPending ? (
+                  <Button type="button" onClick={submit} disabled={isSubmitting}>
+                    {isSubmitting ? (
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                     ) : (
                       <Check className="mr-2 h-4 w-4" />
                     )}
-                    {isPending ? "Creating plan…" : "Create plan"}
+                    {isSubmitting ? "Creating plan…" : "Create plan"}
                   </Button>
                 ) : (
                   <Button type="button" onClick={nextStep}>

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
@@ -35,7 +35,10 @@ import {
   defaultSubscriptionPlanFormValues,
   type CreateSubscriptionPlanFormValues,
 } from "../schemas/subscription-plan.schema";
-import type { CreateSubscriptionPlanRequest } from "../models/subscription-plan.model";
+import {
+  ENTITLEMENT_LIMIT_KIND_NAMES,
+  type CreateSubscriptionPlanRequest,
+} from "../models/subscription-plan.model";
 
 const STEPS: Steps = [
   { id: 1, title: "Identity" },
@@ -44,8 +47,6 @@ const STEPS: Steps = [
   { id: 4, title: "Trial" },
   { id: 5, title: "Review" },
 ];
-
-const LIMIT_KIND_NAME = ["Boolean", "Count", "Unlimited"] as const;
 
 export const CreateSubscriptionPlanPage = () => {
   return (
@@ -111,9 +112,10 @@ const CreateSubscriptionPlanWizard = () => {
     })),
     entitlements: (draft.entitlements ?? []).map((entitlement) => ({
       key: entitlement?.key ?? "",
-      limitKind: LIMIT_KIND_NAME[entitlement?.limitKind ?? 0],
+      limitKind: ENTITLEMENT_LIMIT_KIND_NAMES[entitlement?.limitKind ?? 0],
       limit: entitlement?.limit ?? null,
       unitLabel: entitlement?.unitLabel ?? null,
+      meterKey: entitlement?.meterKey ?? null,
     })),
     prices: [],
   };

--- a/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
@@ -1,0 +1,134 @@
+import { AlertCircle } from "lucide-react";
+import { useMemo } from "react";
+import { useNavigate, useParams } from "react-router";
+import { Card } from "@/components/ui-kits/card/card";
+import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import { toast } from "@/hooks/use-toast";
+import { PlanBuilder } from "../components/plan-builder/plan-builder";
+import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-price";
+import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
+import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
+import { useUpdateSubscriptionPlan } from "../hooks/use-update-subscription-plan";
+import { planToFormValues, toUpdatePlanRequest } from "../utilities/plan-form-mapping";
+import { submitPlanWithPrices } from "../utilities/submit-plan-with-prices";
+
+export const EditSubscriptionPlanPage = () => {
+  const { itemId, planId } = useParams();
+  const navigate = useNavigate();
+  const organizationScope = useOrganizationScope();
+  const basePath = `/app/${itemId ?? ""}/subscription/plans`;
+
+  const { data: plan, error, isError, isLoading } = useSubscriptionPlan(
+    planId,
+    organizationScope,
+  );
+  const { mutateAsync: updatePlan, isPending } = useUpdateSubscriptionPlan();
+  const { mutateAsync: createPrice, isPending: isPricing } = useCreateSubscriptionPrice();
+
+  const detailPath = withOrganizationScope(
+    `${basePath}/${encodeURIComponent(planId ?? "")}`,
+    plan?.organizationId ?? organizationScope,
+  );
+
+  // Computed once from the loaded plan: the builder seeds its form from this, and a new object on
+  // every render would fight whatever is being typed.
+  const defaultValues = useMemo(() => (plan ? planToFormValues(plan) : null), [plan]);
+
+  if (isLoading) {
+    return (
+      <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
+        <Skeleton className="h-32 w-full rounded-2xl" />
+        <Skeleton className="h-96 w-full rounded-xl" />
+      </main>
+    );
+  }
+
+  if (isError || !plan || !defaultValues) {
+    return (
+      <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
+        <SubscriptionPlanPageHeader
+          title="Edit plan"
+          description="This plan could not be loaded."
+          backTo={withOrganizationScope(basePath, organizationScope)}
+        />
+        <Card className="flex min-h-56 flex-col items-center justify-center text-center">
+          <span className="rounded-full bg-destructive/10 p-4 text-destructive">
+            <AlertCircle className="h-7 w-7" />
+          </span>
+          <h3 className="mt-4 text-lg font-semibold">Plan not found</h3>
+          <p className="mt-1 max-w-md text-sm text-muted-foreground">
+            {error instanceof Error
+              ? error.message
+              : "It may belong to another organization, or no longer exists."}
+          </p>
+        </Card>
+      </main>
+    );
+  }
+
+  // The server refuses this outright; saying so here means nobody fills in a form for nothing.
+  if (plan.hasSubscribers) {
+    return (
+      <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
+        <SubscriptionPlanPageHeader
+          title={plan.displayName}
+          description="This plan can no longer be edited."
+          backTo={detailPath}
+          backLabel="Back to plan"
+        />
+        <Card className="flex min-h-56 flex-col items-center justify-center gap-2 text-center">
+          <span className="rounded-full bg-warning-100 p-4 text-warning-700">
+            <AlertCircle className="h-7 w-7" />
+          </span>
+          <h3 className="mt-2 text-lg font-semibold">Somebody has subscribed to this plan</h3>
+          <p className="max-w-lg text-sm text-muted-foreground">
+            Subscribing copies the plan&apos;s terms onto the subscription, and the bills already
+            raised were worked out from that copy. Changing the plan now could not reach anyone
+            already on it, and the catalogue would stop matching what they are being charged.
+            Create a new plan and move subscribers across instead.
+          </p>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <PlanBuilder
+      mode="edit"
+      defaultValues={defaultValues}
+      title={`Edit ${plan.displayName}`}
+      description="Rewrites what this plan sells. Nothing is saved until you confirm at the end."
+      backTo={detailPath}
+      submitLabel="Save changes"
+      submittingLabel="Saving…"
+      isSubmitting={isPending || isPricing}
+      onSubmit={async (values) => {
+        const { failures } = await submitPlanWithPrices({
+          planRequest: toUpdatePlanRequest(values, plan.organizationId),
+          prices: values.prices,
+          // The same two-step: the plan is saved first, and prices added after it. A price that
+          // fails must not read as a failed save, because the edit has already landed.
+          createPlan: (request) => updatePlan({ planId: plan.planId, request }),
+          createPrice,
+        });
+
+        if (failures.length > 0) {
+          toast({
+            variant: "destructive",
+            title: `Changes saved, but ${failures.length} price${failures.length === 1 ? "" : "s"} was not added`,
+            description: `${failures.join(" ")} Add them from the plan page.`,
+          });
+        } else {
+          toast({
+            variant: "success",
+            title: "Changes saved",
+            description: `${values.displayName} is up to date.`,
+          });
+        }
+
+        navigate(detailPath);
+      }}
+    />
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { AlertCircle, AlertTriangle, Layers, Plus } from "lucide-react";
+import { AlertCircle, AlertTriangle, Layers, Pencil, Plus } from "lucide-react";
 import { Link, useParams } from "react-router";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
@@ -102,12 +102,33 @@ export const SubscriptionPlanDetailPage = () => {
         description={plan.description || "No description provided."}
         backTo={listPath}
         actions={
-          <Button asChild>
-            <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`, plan.organizationId)}>
-              <Plus className="mr-2 h-4 w-4" />
-              Add price
-            </Link>
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            {/* Disabled rather than hidden: someone looking for the edit button needs to be told
+                why it is gone, not left to wonder whether it was ever there. */}
+            {plan.hasSubscribers ? (
+              <Button
+                variant="outline"
+                disabled
+                title="Somebody has subscribed to this plan, so its terms can no longer be changed."
+              >
+                <Pencil className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+            ) : (
+              <Button variant="outline" asChild>
+                <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/edit`, plan.organizationId)}>
+                  <Pencil className="mr-2 h-4 w-4" />
+                  Edit
+                </Link>
+              </Button>
+            )}
+            <Button asChild>
+              <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`, plan.organizationId)}>
+                <Plus className="mr-2 h-4 w-4" />
+                Add price
+              </Link>
+            </Button>
+          </div>
         }
       />
 

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { AlertCircle, Layers, Plus } from "lucide-react";
+import { AlertCircle, AlertTriangle, Layers, Plus } from "lucide-react";
 import { Link, useParams } from "react-router";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
@@ -12,6 +12,7 @@ import { PlanSummaryCard, type PlanSummaryData } from "../components/plan-summar
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
 import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
+import { describeEntitlementMeterMismatch } from "../utilities/plan-consistency";
 import { formatEntitlementLimit, formatMeterAllowance, formatPrice } from "../utilities/subscription-format";
 
 export const SubscriptionPlanDetailPage = () => {
@@ -156,14 +157,24 @@ export const SubscriptionPlanDetailPage = () => {
           {plan.entitlements.length > 0 && (
             <Section title="Entitlements">
               <div className="grid gap-3 sm:grid-cols-2">
-                {plan.entitlements.map((entitlement) => (
-                  <Card key={entitlement.key} className="rounded-lg">
-                    <p className="font-medium">{entitlement.key}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {formatEntitlementLimit(entitlement)}
-                    </p>
-                  </Card>
-                ))}
+                {plan.entitlements.map((entitlement) => {
+                  const mismatch = describeEntitlementMeterMismatch(entitlement, plan.meters);
+
+                  return (
+                    <Card key={entitlement.key} className="rounded-lg">
+                      <p className="font-medium">{entitlement.key}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {formatEntitlementLimit(entitlement)}
+                      </p>
+                      {mismatch && (
+                        <p className="mt-2 flex items-start gap-1.5 text-xs text-warning-700">
+                          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                          {mismatch}
+                        </p>
+                      )}
+                    </Card>
+                  );
+                })}
               </div>
             </Section>
           )}

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
@@ -1,9 +1,20 @@
+import type { SafeParseReturnType } from "zod";
 import { describe, expect, it } from "vitest";
 import {
+  buildSubscriptionPlanSchema,
   createSubscriptionPlanSchema,
   defaultSubscriptionPlanFormValues,
 } from "./subscription-plan.schema";
+import { FLAT_FEE } from "./subscription-price.schema";
 import { TENANT_WIDE_ORGANIZATION } from "../constants/subscription.constants";
+
+const price = {
+  currencyCode: "EUR",
+  amount: 3,
+  interval: 2,
+  intervalCount: 1,
+  quantityItemKey: FLAT_FEE,
+};
 
 const validPlan = {
   ...defaultSubscriptionPlanFormValues,
@@ -11,6 +22,9 @@ const validPlan = {
   displayName: "Pro",
   organizationId: TENANT_WIDE_ORGANIZATION,
 };
+
+const issuePaths = (result: SafeParseReturnType<unknown, unknown>) =>
+  result.success ? [] : result.error.issues.map((issue) => issue.path);
 
 describe("createSubscriptionPlanSchema", () => {
   it("accepts a minimal tenant-wide plan", () => {
@@ -172,5 +186,67 @@ describe("createSubscriptionPlanSchema", () => {
     if (result.success) {
       expect(typeof result.data.meters[0].aggregation).toBe("number");
     }
+  });
+
+  it("refuses a plan with no price, which nobody could subscribe to", () => {
+    const result = createSubscriptionPlanSchema.safeParse({ ...validPlan, prices: [] });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["prices"]);
+  });
+
+  it("allows a plan with no price when editing, where prices are added separately", () => {
+    const result = buildSubscriptionPlanSchema({ requirePrice: false }).safeParse({
+      ...validPlan,
+      prices: [],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a price charging for a quantity item the plan does not define", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      prices: [{ ...price, quantityItemKey: "seat" }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["prices", 0, "quantityItemKey"]);
+  });
+
+  it("accepts a price charging for a quantity item the plan does define", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      quantityItems: [
+        {
+          itemKey: "seat",
+          unitLabel: "seat",
+          minQuantity: 1,
+          defaultQuantity: 1,
+        },
+      ],
+      prices: [{ ...price, quantityItemKey: "seat" }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects two prices with identical terms, which the server would reject after creating the plan", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      prices: [price, { ...price, amount: 99 }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["prices", 1, "currencyCode"]);
+  });
+
+  it("accepts a monthly and an annual price on the same plan", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      prices: [price, { ...price, interval: 3, amount: 30 }],
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -6,6 +6,11 @@ import {
   SUBSCRIPTION_PLAN_CODE_MAX_LENGTH,
   TENANT_WIDE_ORGANIZATION,
 } from "../constants/subscription.constants";
+import {
+  defaultSubscriptionPriceFormValues,
+  FLAT_FEE,
+  subscriptionPriceFieldsSchema,
+} from "./subscription-price.schema";
 
 // "unit" starts with a consonant sound ("you-nit") despite its spelling, so a plain vowel-letter
 // check would wrongly produce "an unit label" — the one exception among today's labels.
@@ -119,7 +124,18 @@ const trialGrantSchema = z.object({
 export const PRICING_SHAPE_OPTIONS = ["seats", "usage", "both"] as const;
 export type PricingShape = (typeof PRICING_SHAPE_OPTIONS)[number];
 
-export const createSubscriptionPlanSchema = z
+/** What identifies a price to the server, so two rows that would collide can be caught here. */
+const priceTerms = (price: z.infer<typeof subscriptionPriceFieldsSchema>) =>
+  `${price.currencyCode}|${price.interval}|${price.intervalCount}|${price.quantityItemKey}`;
+
+/**
+ * @param requirePrice
+ * Whether the plan must carry at least one price. True when creating — a plan with no price
+ * cannot be checked out, so finishing the builder without one produces something unusable. False
+ * when editing, where prices already exist and are added separately.
+ */
+export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: boolean }) =>
+  z
   .object({
     code: z
       .string()
@@ -150,6 +166,7 @@ export const createSubscriptionPlanSchema = z
     meters: z.array(meterSchema),
     entitlements: z.array(entitlementSchema),
     trialGrants: z.array(trialGrantSchema),
+    prices: z.array(subscriptionPriceFieldsSchema),
   })
   .superRefine((plan, context) => {
     if (plan.featuresJson && !isJsonObject(plan.featuresJson)) {
@@ -181,7 +198,45 @@ export const createSubscriptionPlanSchema = z
         });
       }
     });
+
+    if (requirePrice && plan.prices.length === 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["prices"],
+        message: "Add at least one price — nobody can subscribe to a plan that has none.",
+      });
+    }
+
+    const itemKeys = new Set(plan.quantityItems.map((item) => item.itemKey));
+    const seenTerms = new Set<string>();
+
+    plan.prices.forEach((price, index) => {
+      if (price.quantityItemKey !== FLAT_FEE && !itemKeys.has(price.quantityItemKey)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["prices", index, "quantityItemKey"],
+          message: "This plan does not define that quantity item.",
+        });
+      }
+
+      // The server rejects a second price with the same terms, and it is rejected after the plan
+      // itself has been created — so catching it here is the difference between fixing a field
+      // and being left with a half-priced plan.
+      const terms = priceTerms(price);
+
+      if (seenTerms.has(terms)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["prices", index, "currencyCode"],
+          message: "Another price already charges on exactly these terms.",
+        });
+      }
+
+      seenTerms.add(terms);
+    });
   });
+
+export const createSubscriptionPlanSchema = buildSubscriptionPlanSchema({ requirePrice: true });
 
 export type CreateSubscriptionPlanFormValues = z.infer<typeof createSubscriptionPlanSchema>;
 
@@ -198,4 +253,7 @@ export const defaultSubscriptionPlanFormValues: CreateSubscriptionPlanFormValues
   meters: [],
   entitlements: [],
   trialGrants: [],
+  // One empty row, not none: a plan needs a price, and an admin who never notices the section is
+  // the one who ends up with a plan nobody can subscribe to.
+  prices: [defaultSubscriptionPriceFormValues],
 };

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
@@ -6,7 +6,12 @@ import { z } from "zod";
  */
 export const FLAT_FEE = "__flat_fee__";
 
-export const createSubscriptionPriceSchema = z.object({
+/**
+ * One price's own fields, shared by the standalone add-price form and the repeatable price list
+ * inside the plan builder — a plan usually sells on more than one of these (monthly and annually
+ * are two prices), and both places have to describe a price the same way.
+ */
+export const subscriptionPriceFieldsSchema = z.object({
   currencyCode: z
     .string()
     .trim()
@@ -19,6 +24,8 @@ export const createSubscriptionPriceSchema = z.object({
   intervalCount: z.coerce.number().int().min(1).max(36),
   quantityItemKey: z.string().min(1),
 });
+
+export const createSubscriptionPriceSchema = subscriptionPriceFieldsSchema;
 
 export type CreateSubscriptionPriceFormValues = z.infer<typeof createSubscriptionPriceSchema>;
 

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
@@ -7,6 +7,7 @@ import type {
   CreateSubscriptionPlanRequest,
   CreateSubscriptionPriceRequest,
   SubscriptionPlan,
+  UpdateSubscriptionPlanRequest,
 } from "../models/subscription-plan.model";
 
 interface SubscriptionApiError {
@@ -74,6 +75,24 @@ class SubscriptionService {
     if (!response.success || !response.data) {
       throw new Error(
         response.error?.message || "The plan could not be created.",
+      );
+    }
+
+    return response.data;
+  }
+
+  async updatePlan(
+    planId: string,
+    request: UpdateSubscriptionPlanRequest,
+  ): Promise<SubscriptionPlan> {
+    const response =
+      await serviceInstances.utitlitiesService.put<
+        SubscriptionApiResponse<SubscriptionPlan>
+      >(`${SUBSCRIPTION_PLANS_ENDPOINT}/${encodeURIComponent(planId)}`, request);
+
+    if (!response.success || !response.data) {
+      throw new Error(
+        response.error?.message || "The plan could not be saved.",
       );
     }
 

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-consistency.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-consistency.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { describeEntitlementMeterMismatch } from "./plan-consistency";
+
+const meter = (overrides: Partial<Parameters<typeof describeEntitlementMeterMismatch>[1][number]> = {}) => ({
+  meterKey: "ses-signatures",
+  unitLabel: "signature",
+  includedQuantity: 150,
+  overageAllowed: true,
+  ...overrides,
+});
+
+const counted = (limit: number) => ({
+  limitKind: "Count",
+  limit,
+  meterKey: "ses-signatures",
+});
+
+describe("describeEntitlementMeterMismatch", () => {
+  it("says nothing when the limit matches the meter's allowance", () => {
+    expect(describeEntitlementMeterMismatch(counted(150), [meter()])).toBeNull();
+  });
+
+  it("warns that the excess is billed while still reported as allowed", () => {
+    const message = describeEntitlementMeterMismatch(counted(500), [meter()]);
+
+    expect(message).toContain("500 signatures");
+    expect(message).toContain("150");
+    expect(message).toContain("350 signatures are billed as overage");
+  });
+
+  it("warns that the excess is unreachable when the meter blocks instead of billing", () => {
+    const message = describeEntitlementMeterMismatch(counted(500), [
+      meter({ overageAllowed: false }),
+    ]);
+
+    expect(message).toContain("blocks at 150");
+    expect(message).toContain("can never be used");
+  });
+
+  it("warns when the entitlement permits less than the meter includes", () => {
+    const message = describeEntitlementMeterMismatch(counted(100), [meter()]);
+
+    expect(message).toContain("Permits only 100 signatures");
+    expect(message).toContain("50 signatures of the allowance can never be used");
+  });
+
+  it("says nothing for entitlements that carry no number", () => {
+    expect(
+      describeEntitlementMeterMismatch(
+        { limitKind: "Unlimited", limit: null, meterKey: "ses-signatures" },
+        [meter()],
+      ),
+    ).toBeNull();
+    expect(
+      describeEntitlementMeterMismatch(
+        { limitKind: "Boolean", limit: null, meterKey: null },
+        [meter()],
+      ),
+    ).toBeNull();
+  });
+
+  it("says nothing while the meter is still being chosen", () => {
+    expect(describeEntitlementMeterMismatch(counted(500), [])).toBeNull();
+  });
+
+  it("uses a singular unit for a difference of one", () => {
+    expect(describeEntitlementMeterMismatch(counted(151), [meter()])).toContain(
+      "1 signature is billed",
+    );
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-consistency.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-consistency.ts
@@ -1,0 +1,62 @@
+/**
+ * An entitlement and its meter answer two different questions — "may they?" and "what does it
+ * cost?" — and nothing on the server makes them agree. A plan can permit 500 signatures while
+ * the meter includes 150, and both halves behave exactly as authored: the app is told the
+ * customer is allowed all 500, and 350 of them are billed as overage. That is a real
+ * configuration, so this reports it rather than rejecting it.
+ */
+export interface EntitlementConsistencyInput {
+  /** The stringified limit kind a response carries — "Boolean", "Count" or "Unlimited". */
+  limitKind: string;
+  limit: number | null;
+  meterKey: string | null;
+}
+
+export interface MeterConsistencyInput {
+  meterKey: string;
+  unitLabel: string;
+  includedQuantity: number;
+  overageAllowed: boolean;
+}
+
+const plural = (count: number, unitLabel: string) =>
+  `${count.toLocaleString()} ${unitLabel}${count === 1 ? "" : "s"}`;
+
+/**
+ * What is inconsistent between a counted entitlement and the meter that draws it down, in the
+ * words of what will actually happen to a subscriber. Null when the two agree, or when there is
+ * nothing to compare — an uncounted entitlement, or a meter this plan does not define yet.
+ */
+export const describeEntitlementMeterMismatch = (
+  entitlement: EntitlementConsistencyInput,
+  meters: MeterConsistencyInput[],
+): string | null => {
+  if (entitlement.limitKind !== "Count" || entitlement.limit === null || !entitlement.meterKey) {
+    return null;
+  }
+
+  const meter = meters.find((candidate) => candidate.meterKey === entitlement.meterKey);
+
+  if (!meter) {
+    return null;
+  }
+
+  const limit = entitlement.limit;
+  const included = meter.includedQuantity;
+
+  if (limit === included) {
+    return null;
+  }
+
+  const unit = meter.unitLabel || "unit";
+
+  if (limit > included) {
+    const excess = limit - included;
+
+    return meter.overageAllowed
+      ? `Permits ${plural(limit, unit)} but the meter includes only ${included.toLocaleString()}, so ${plural(excess, unit)} ${excess === 1 ? "is" : "are"} billed as overage while still reported as allowed.`
+      : `Permits ${plural(limit, unit)} but the meter blocks at ${included.toLocaleString()}, so the last ${plural(excess, unit)} can never be used.`;
+  }
+
+  return `Permits only ${plural(limit, unit)} but the meter includes ${included.toLocaleString()}, so ${plural(included - limit, unit)} of the allowance can never be used.`;
+};

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import { TENANT_WIDE_ORGANIZATION } from "../constants/subscription.constants";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+import { createSubscriptionPlanSchema } from "../schemas/subscription-plan.schema";
+import { planToFormValues, toUpdatePlanRequest } from "./plan-form-mapping";
+
+const storedPlan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan => ({
+  planId: "plan-1",
+  code: "starter",
+  displayName: "Starter",
+  description: "For small teams",
+  featuresJson: null,
+  organizationId: "org-1",
+  trialDays: 1,
+  trialRequiresPaymentMethod: true,
+  version: 1,
+  hasSubscribers: false,
+  quantityItems: [
+    {
+      itemKey: "seat",
+      unitLabel: "seat",
+      minQuantity: 1,
+      maxQuantity: 50,
+      defaultQuantity: 1,
+    },
+  ],
+  meters: [
+    {
+      meterKey: "ses-signatures",
+      displayName: "Simple Signatures",
+      unitLabel: "signature",
+      aggregation: "Sum",
+      includedQuantity: 150,
+      overageAllowed: true,
+      thresholdPercents: [80, 100],
+      rateTables: [
+        {
+          currencyCode: "EUR",
+          tiers: [
+            { upToQuantity: 1000, unitAmountMinor: 5 },
+            { upToQuantity: null, unitAmountMinor: 3 },
+          ],
+        },
+      ],
+    },
+  ],
+  entitlements: [
+    {
+      key: "ses-signatures",
+      limitKind: "Count",
+      limit: 150,
+      meterKey: "ses-signatures",
+      unitLabel: "signature",
+    },
+  ],
+  prices: [
+    {
+      priceId: "price-1",
+      currencyCode: "EUR",
+      unitAmountMinor: 300,
+      interval: "Month",
+      intervalCount: 1,
+      quantityItemKey: null,
+    },
+  ],
+  trialGrants: [{ meterKey: "ses-signatures", includedQuantity: 5 }],
+  ...overrides,
+});
+
+describe("planToFormValues", () => {
+  it("turns response enum names back into the numbers the form and request use", () => {
+    const values = planToFormValues(storedPlan());
+
+    expect(values.meters[0].aggregation).toBe(0);
+    expect(values.entitlements[0].limitKind).toBe(1);
+  });
+
+  it("keeps trial grants, which an edit would otherwise drop", () => {
+    expect(planToFormValues(storedPlan()).trialGrants).toEqual([
+      { meterKey: "ses-signatures", includedQuantity: 5 },
+    ]);
+  });
+
+  it("opens on a pricing shape that reveals what the plan actually has", () => {
+    expect(planToFormValues(storedPlan()).pricingShape).toBe("both");
+    expect(planToFormValues(storedPlan({ quantityItems: [] })).pricingShape).toBe("usage");
+    expect(planToFormValues(storedPlan({ meters: [] })).pricingShape).toBe("seats");
+  });
+
+  it("starts with no price rows, because saving does not touch existing prices", () => {
+    expect(planToFormValues(storedPlan()).prices).toEqual([]);
+  });
+
+  it("reads a tenant-wide plan back as the sentinel the picker uses", () => {
+    expect(planToFormValues(storedPlan({ organizationId: null })).organizationId).toBe(
+      TENANT_WIDE_ORGANIZATION,
+    );
+  });
+
+  it("carries an unbounded final tier across as undefined, not null", () => {
+    const table = planToFormValues(storedPlan()).meters[0].rateTables[0];
+
+    expect(table.tiers[1].upToQuantity).toBeUndefined();
+  });
+
+  it("produces a draft the create schema still accepts, apart from the price it now lacks", () => {
+    const values = planToFormValues(storedPlan());
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...values,
+      prices: [
+        {
+          currencyCode: "EUR",
+          amount: 3,
+          interval: 2,
+          intervalCount: 1,
+          quantityItemKey: "seat",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("toUpdatePlanRequest", () => {
+  it("names the plan's own organization so the server can find it", () => {
+    const request = toUpdatePlanRequest(planToFormValues(storedPlan()), "org-1");
+
+    expect(request.organizationId).toBe("org-1");
+  });
+
+  it("omits the organization for a tenant-wide plan", () => {
+    const request = toUpdatePlanRequest(planToFormValues(storedPlan()), null);
+
+    expect(request.organizationId).toBeUndefined();
+  });
+
+  it("sends no code, which the server takes from the stored plan", () => {
+    const request = toUpdatePlanRequest(planToFormValues(storedPlan()), "org-1");
+
+    expect(request).not.toHaveProperty("code");
+  });
+
+  it("round-trips a plan's terms unchanged when nothing was edited", () => {
+    const request = toUpdatePlanRequest(planToFormValues(storedPlan()), "org-1");
+
+    expect(request.displayName).toBe("Starter");
+    expect(request.meters[0]).toMatchObject({
+      meterKey: "ses-signatures",
+      aggregation: 0,
+      includedQuantity: 150,
+      thresholdPercents: [80, 100],
+    });
+    expect(request.trialGrants).toEqual([
+      { meterKey: "ses-signatures", includedQuantity: 5 },
+    ]);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -1,0 +1,145 @@
+import { TENANT_WIDE_ORGANIZATION } from "../constants/subscription.constants";
+import {
+  ENTITLEMENT_LIMIT_KIND,
+  METER_AGGREGATION,
+  type CreateSubscriptionPlanRequest,
+  type SubscriptionPlan,
+  type UpdateSubscriptionPlanRequest,
+} from "../models/subscription-plan.model";
+import type { CreateSubscriptionPlanFormValues } from "../schemas/subscription-plan.schema";
+import { defaultSubscriptionPlanFormValues } from "../schemas/subscription-plan.schema";
+
+/**
+ * What a plan is made of, in the shape both creating and editing send. Everything the two have in
+ * common lives here so an edit cannot quietly send a different body than a create.
+ */
+const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
+  displayName: values.displayName.trim(),
+  description: values.description?.trim() || undefined,
+  featuresJson: values.featuresJson?.trim() || undefined,
+  trialDays: values.trialDays,
+  trialRequiresPaymentMethod: values.trialRequiresPaymentMethod,
+  quantityItems: values.quantityItems.map((item) => ({
+    itemKey: item.itemKey.trim(),
+    unitLabel: item.unitLabel.trim(),
+    minQuantity: item.minQuantity,
+    maxQuantity: item.maxQuantity,
+    defaultQuantity: item.defaultQuantity,
+  })),
+  meters: values.meters.map((meter) => ({
+    meterKey: meter.meterKey.trim(),
+    displayName: meter.displayName.trim(),
+    unitLabel: meter.unitLabel.trim(),
+    aggregation: meter.aggregation,
+    includedQuantity: meter.includedQuantity,
+    overageAllowed: meter.overageAllowed,
+    thresholdPercents: meter.thresholdPercents,
+    rateTables: meter.rateTables.map((table) => ({
+      currencyCode: table.currencyCode,
+      tiers: table.tiers,
+    })),
+  })),
+  entitlements: values.entitlements.map((entitlement) => ({
+    key: entitlement.key.trim(),
+    limitKind: entitlement.limitKind,
+    limit: entitlement.limit,
+    meterKey: entitlement.meterKey?.trim() || undefined,
+    unitLabel: entitlement.unitLabel?.trim() || undefined,
+  })),
+  trialGrants: values.trialGrants.map((grant) => ({
+    meterKey: grant.meterKey.trim(),
+    includedQuantity: grant.includedQuantity,
+  })),
+});
+
+export const toCreatePlanRequest = (
+  values: CreateSubscriptionPlanFormValues,
+): CreateSubscriptionPlanRequest => ({
+  code: values.code.trim(),
+  organizationId:
+    values.organizationId === TENANT_WIDE_ORGANIZATION ? undefined : values.organizationId,
+  ...toPlanDefinition(values),
+});
+
+/**
+ * @param organizationId
+ * The plan's own organization, which the server needs to find it — it never moves the scope.
+ */
+export const toUpdatePlanRequest = (
+  values: CreateSubscriptionPlanFormValues,
+  organizationId: string | null,
+): UpdateSubscriptionPlanRequest => ({
+  organizationId: organizationId ?? undefined,
+  ...toPlanDefinition(values),
+});
+
+/** Response enums arrive as names; the form and the request body both want the number. */
+const aggregationValue = (name: string): number =>
+  METER_AGGREGATION[name as keyof typeof METER_AGGREGATION] ?? METER_AGGREGATION.Sum;
+
+const limitKindValue = (name: string): number =>
+  ENTITLEMENT_LIMIT_KIND[name as keyof typeof ENTITLEMENT_LIMIT_KIND] ??
+  ENTITLEMENT_LIMIT_KIND.Boolean;
+
+/**
+ * A stored plan as a builder draft.
+ *
+ * Prices start empty rather than loaded: the update endpoint does not touch prices, so the ones
+ * the plan already has are left where they are and anything listed here is a new price to create.
+ * Showing them as editable rows would promise an edit that cannot happen.
+ */
+export const planToFormValues = (
+  plan: SubscriptionPlan,
+): CreateSubscriptionPlanFormValues => ({
+  ...defaultSubscriptionPlanFormValues,
+  code: plan.code,
+  displayName: plan.displayName,
+  description: plan.description ?? "",
+  featuresJson: plan.featuresJson ?? "",
+  organizationId: plan.organizationId ?? TENANT_WIDE_ORGANIZATION,
+  trialDays: plan.trialDays ?? undefined,
+  trialRequiresPaymentMethod: plan.trialRequiresPaymentMethod,
+  // The step reveals its sections from this, so a plan with meters has to open on the shape that
+  // shows them — otherwise editing a usage plan starts by looking like it has no meters at all.
+  pricingShape:
+    plan.quantityItems.length > 0 && plan.meters.length > 0
+      ? "both"
+      : plan.meters.length > 0
+        ? "usage"
+        : "seats",
+  quantityItems: plan.quantityItems.map((item) => ({
+    itemKey: item.itemKey,
+    unitLabel: item.unitLabel,
+    minQuantity: item.minQuantity,
+    maxQuantity: item.maxQuantity ?? undefined,
+    defaultQuantity: item.defaultQuantity,
+  })),
+  meters: plan.meters.map((meter) => ({
+    meterKey: meter.meterKey,
+    displayName: meter.displayName,
+    unitLabel: meter.unitLabel,
+    aggregation: aggregationValue(meter.aggregation),
+    includedQuantity: meter.includedQuantity,
+    overageAllowed: meter.overageAllowed,
+    thresholdPercents: meter.thresholdPercents ?? [],
+    rateTables: (meter.rateTables ?? []).map((table) => ({
+      currencyCode: table.currencyCode,
+      tiers: table.tiers.map((tier) => ({
+        upToQuantity: tier.upToQuantity ?? undefined,
+        unitAmountMinor: tier.unitAmountMinor,
+      })),
+    })),
+  })),
+  entitlements: plan.entitlements.map((entitlement) => ({
+    key: entitlement.key,
+    limitKind: limitKindValue(entitlement.limitKind),
+    limit: entitlement.limit ?? undefined,
+    meterKey: entitlement.meterKey ?? undefined,
+    unitLabel: entitlement.unitLabel ?? undefined,
+  })),
+  trialGrants: (plan.trialGrants ?? []).map((grant) => ({
+    meterKey: grant.meterKey,
+    includedQuantity: grant.includedQuantity,
+  })),
+  prices: [],
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+import { FLAT_FEE } from "../schemas/subscription-price.schema";
+import { submitPlanWithPrices } from "./submit-plan-with-prices";
+
+const planRequest = {
+  code: "starter",
+  displayName: "Starter",
+  trialRequiresPaymentMethod: true,
+  quantityItems: [],
+  meters: [],
+  entitlements: [],
+  trialGrants: [],
+};
+
+const createdPlan = (organizationId: string | null = null) =>
+  ({
+    planId: "plan-1",
+    displayName: "Starter",
+    organizationId,
+  }) as SubscriptionPlan;
+
+const price = (overrides: Partial<Parameters<typeof submitPlanWithPrices>[0]["prices"][number]> = {}) => ({
+  currencyCode: "EUR",
+  amount: 3,
+  interval: 2,
+  intervalCount: 1,
+  quantityItemKey: FLAT_FEE,
+  ...overrides,
+});
+
+describe("submitPlanWithPrices", () => {
+  it("creates the plan first, then a price per row", async () => {
+    const createPlan = vi.fn().mockResolvedValue(createdPlan());
+    const createPrice = vi.fn().mockResolvedValue(createdPlan());
+
+    const result = await submitPlanWithPrices({
+      planRequest,
+      prices: [price(), price({ interval: 3, amount: 30 })],
+      createPlan,
+      createPrice,
+    });
+
+    expect(createPlan).toHaveBeenCalledOnce();
+    expect(createPrice).toHaveBeenCalledTimes(2);
+    expect(createPrice.mock.calls[0][0]).toMatchObject({ planId: "plan-1", interval: 2 });
+    expect(createPrice.mock.calls[1][0]).toMatchObject({ interval: 3 });
+    expect(result.failures).toEqual([]);
+  });
+
+  it("converts the amount to minor units and drops the flat-fee sentinel", async () => {
+    const createPrice = vi.fn().mockResolvedValue(createdPlan());
+
+    await submitPlanWithPrices({
+      planRequest,
+      prices: [price({ amount: 3.5 })],
+      createPlan: vi.fn().mockResolvedValue(createdPlan()),
+      createPrice,
+    });
+
+    expect(createPrice.mock.calls[0][0]).toMatchObject({
+      unitAmountMinor: 350,
+      quantityItemKey: undefined,
+    });
+  });
+
+  it("names the plan's organization on every price", async () => {
+    const createPrice = vi.fn().mockResolvedValue(createdPlan("org-x"));
+
+    await submitPlanWithPrices({
+      planRequest,
+      prices: [price()],
+      createPlan: vi.fn().mockResolvedValue(createdPlan("org-x")),
+      createPrice,
+    });
+
+    expect(createPrice.mock.calls[0][0]).toMatchObject({ organizationId: "org-x" });
+  });
+
+  it("keeps the created plan and reports the prices that failed", async () => {
+    const createPrice = vi
+      .fn()
+      .mockResolvedValueOnce(createdPlan())
+      .mockRejectedValueOnce(new Error("A price with these terms already exists."));
+
+    const result = await submitPlanWithPrices({
+      planRequest,
+      prices: [price(), price({ amount: 30 })],
+      createPlan: vi.fn().mockResolvedValue(createdPlan()),
+      createPrice,
+    });
+
+    expect(result.plan.planId).toBe("plan-1");
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toContain("Price 2");
+    expect(result.failures[0]).toContain("A price with these terms already exists.");
+  });
+
+  it("carries on after a failing price so a later one still lands", async () => {
+    const createPrice = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("nope"))
+      .mockResolvedValueOnce(createdPlan());
+
+    const result = await submitPlanWithPrices({
+      planRequest,
+      prices: [price(), price({ amount: 30 })],
+      createPlan: vi.fn().mockResolvedValue(createdPlan()),
+      createPrice,
+    });
+
+    expect(createPrice).toHaveBeenCalledTimes(2);
+    expect(result.failures).toHaveLength(1);
+  });
+
+  it("throws without pricing anything when the plan itself fails", async () => {
+    const createPrice = vi.fn();
+
+    await expect(
+      submitPlanWithPrices({
+        planRequest,
+        prices: [price()],
+        createPlan: vi.fn().mockRejectedValue(new Error("A plan with this code already exists.")),
+        createPrice,
+      }),
+    ).rejects.toThrow("A plan with this code already exists.");
+
+    expect(createPrice).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
@@ -1,5 +1,4 @@
 import type {
-  CreateSubscriptionPlanRequest,
   CreateSubscriptionPriceRequest,
   SubscriptionPlan,
 } from "../models/subscription-plan.model";
@@ -24,15 +23,16 @@ export interface PlanSubmissionResult {
  *
  * A failing *plan* is different: nothing was created, so it throws and the caller keeps the form.
  */
-export const submitPlanWithPrices = async ({
+export const submitPlanWithPrices = async <TPlanRequest,>({
   planRequest,
   prices,
   createPlan,
   createPrice,
 }: {
-  planRequest: CreateSubscriptionPlanRequest;
+  planRequest: TPlanRequest;
   prices: CreateSubscriptionPriceFormValues[];
-  createPlan: (request: CreateSubscriptionPlanRequest) => Promise<SubscriptionPlan>;
+  /** Creating or saving — both return the plan, and both are followed by the same price loop. */
+  createPlan: (request: TPlanRequest) => Promise<SubscriptionPlan>;
   createPrice: (request: CreateSubscriptionPriceRequest) => Promise<SubscriptionPlan>;
 }): Promise<PlanSubmissionResult> => {
   const plan = await createPlan(planRequest);

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
@@ -1,0 +1,65 @@
+import type {
+  CreateSubscriptionPlanRequest,
+  CreateSubscriptionPriceRequest,
+  SubscriptionPlan,
+} from "../models/subscription-plan.model";
+import type { CreateSubscriptionPriceFormValues } from "../schemas/subscription-price.schema";
+import { FLAT_FEE } from "../schemas/subscription-price.schema";
+import { toMinorUnits } from "./subscription-format";
+
+export interface PlanSubmissionResult {
+  plan: SubscriptionPlan;
+  /** One line per price that did not land, in the words the author will see. */
+  failures: string[];
+}
+
+/**
+ * Creates a plan and then its prices.
+ *
+ * Two calls rather than one, because a price cannot be posted until the plan it belongs to has an
+ * id. That ordering is the whole reason this exists: once the plan is created it stays created,
+ * so a price that fails must not be reported as a failed submission — resubmitting would only
+ * collide on the plan code, and the author would have lost the plan they already have. A failing
+ * price is collected and reported instead, leaving the rest to be added from the plan page.
+ *
+ * A failing *plan* is different: nothing was created, so it throws and the caller keeps the form.
+ */
+export const submitPlanWithPrices = async ({
+  planRequest,
+  prices,
+  createPlan,
+  createPrice,
+}: {
+  planRequest: CreateSubscriptionPlanRequest;
+  prices: CreateSubscriptionPriceFormValues[];
+  createPlan: (request: CreateSubscriptionPlanRequest) => Promise<SubscriptionPlan>;
+  createPrice: (request: CreateSubscriptionPriceRequest) => Promise<SubscriptionPlan>;
+}): Promise<PlanSubmissionResult> => {
+  const plan = await createPlan(planRequest);
+  const failures: string[] = [];
+
+  for (const [index, price] of prices.entries()) {
+    try {
+      await createPrice({
+        planId: plan.planId,
+        // The plan may belong to an organization the console is not itself in, and the server
+        // resolves each request on its own — without naming it, the plan reads as missing.
+        organizationId: plan.organizationId ?? undefined,
+        currencyCode: price.currencyCode,
+        unitAmountMinor: toMinorUnits(price.amount, price.currencyCode),
+        interval: price.interval,
+        intervalCount: price.intervalCount,
+        quantityItemKey:
+          price.quantityItemKey === FLAT_FEE ? undefined : price.quantityItemKey,
+      });
+    } catch (error) {
+      failures.push(
+        `Price ${index + 1} (${price.currencyCode} ${price.amount}): ${
+          error instanceof Error ? error.message : "could not be added"
+        }`,
+      );
+    }
+  }
+
+  return { plan, failures };
+};

--- a/client/app/router.tsx
+++ b/client/app/router.tsx
@@ -13,6 +13,7 @@ import SubscriptionPlansPage from "./routes/dashboard/subscription-plans";
 import SubscriptionPlanCreateRoute from "./routes/dashboard/subscription-plan-create";
 import SubscriptionPlanDetailRoute from "./routes/dashboard/subscription-plan-detail";
 import SubscriptionPlanPriceCreateRoute from "./routes/dashboard/subscription-plan-price-create";
+import SubscriptionPlanEditRoute from "./routes/dashboard/subscription-plan-edit";
 import {
   AuthResolver,
   PublicGuard,
@@ -139,6 +140,10 @@ export const router = createBrowserRouter([
                   {
                     path: "subscription/plans/:planId",
                     element: <SubscriptionPlanDetailRoute />,
+                  },
+                  {
+                    path: "subscription/plans/:planId/edit",
+                    element: <SubscriptionPlanEditRoute />,
                   },
                   {
                     path: "subscription/plans/:planId/prices/create",

--- a/client/app/routes/dashboard/subscription-plan-edit.tsx
+++ b/client/app/routes/dashboard/subscription-plan-edit.tsx
@@ -1,0 +1,5 @@
+import { EditSubscriptionPlanPage } from "@blocks-utilities/subscription";
+
+export default function SubscriptionPlanEditRoute() {
+  return <EditSubscriptionPlanPage />;
+}

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -510,6 +510,12 @@
             What a tenant sells. Served under <c>/api/subscription-plans</c>.
             </summary>
         </member>
+        <member name="M:Api.Controllers.SubscriptionPlansController.UpdatePlan(System.String,Subscription.DomainService.Requests.UpdatePlanRequest,System.Threading.CancellationToken)">
+            <summary>
+            Rewrites what a plan sells. Refused with 409 once anything has subscribed to it — a
+            subscription bills from its own copy of the plan's terms, which an edit cannot reach.
+            </summary>
+        </member>
         <member name="T:Api.Controllers.SubscriptionsController">
             <summary>
             An organization's own subscription. Served under <c>/api/subscriptions</c>.

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -79,6 +79,32 @@ public sealed class SubscriptionPlansController : ControllerBase
         return result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Rewrites what a plan sells. Refused with 409 once anything has subscribed to it — a
+    /// subscription bills from its own copy of the plan's terms, which an edit cannot reach.
+    /// </summary>
+    [HttpPut("{planId}")]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UpdatePlan(
+        string planId,
+        [FromBody] UpdatePlanRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _catalogue.UpdatePlanAsync(
+            planId,
+            request,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
     [HttpPost("prices")]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status400BadRequest)]

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -126,6 +126,26 @@ Entitlement is then one document read with no join, and editing the catalogue st
 retroactive: a subscriber keeps the terms they were sold until something deliberately migrates
 them. That is the correct billing semantic as well as the faster read.
 
+## Editing a plan ends when the first subscriber arrives
+
+`PUT /subscription-plans/{planId}` rewrites what a plan sells. It refuses with
+`subscription_plan_in_use` as soon as anything has subscribed, in any status — cancelled included.
+
+That falls straight out of the snapshot rule above. An edit reaches the catalogue and nothing
+else, so a plan that was sold would leave the catalogue saying one thing while every live
+subscription bills from its own copy of something older; a cancelled subscription's past invoices
+were computed from those terms too. Create a new plan and migrate instead — that is what
+`ChangePlanAsync` is for.
+
+The code and the organization come from the stored plan, never the request: a code is what
+configuration points at, and a scope change would move the plan out from under whoever can see it.
+Prices are separate documents and are untouched. Reads return `hasSubscribers` so a caller can say
+why editing is closed before offering it.
+
+`PlanDefinitionRequestValidator` holds every rule about a plan's contents, and both creating and
+editing include it — an edit that could store what a create would have refused is a hole, and one
+rule is the only way to be sure the two agree.
+
 ## Periods are derived, never advanced
 
 `BillingPeriodCalculator` is pure and static, and the instant is always a parameter. Asking

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -88,6 +88,18 @@ public interface ISubscriptionRepository
         SubscriptionOutboxEvent outboxEvent,
         CancellationToken cancellationToken);
 
+    /// <summary>Whether anything has ever subscribed to a plan, whatever became of it since.</summary>
+    /// <remarks>
+    /// Any status counts, cancelled included. Subscribing copies the plan's terms onto the
+    /// subscription, and those terms are what its past invoices were computed from — so a plan
+    /// that was ever sold has a history that editing the catalogue entry would silently
+    /// contradict.
+    /// </remarks>
+    Task<bool> AnySubscriberAsync(
+        string tenantId,
+        string planId,
+        CancellationToken cancellationToken);
+
     /// <summary>Subscriptions whose first charge never completed, for the recovery sweep.</summary>
     Task<IReadOnlyList<SubscriptionDetail>> ListStaleAsync(
         string tenantId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -112,6 +112,20 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
                     orderId)))
             .FirstOrDefaultAsync(cancellationToken);
 
+    public async Task<bool> AnySubscriberAsync(
+        string tenantId,
+        string planId,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.Plan.PlanId,
+                    planId)))
+            .Project(subscription => subscription.ItemId)
+            .Limit(1)
+            .FirstOrDefaultAsync(cancellationToken) is not null;
+
     public async Task<bool> TryTransitionAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Requests/CreatePlanRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePlanRequest.cs
@@ -1,35 +1,12 @@
 namespace Subscription.DomainService.Requests;
 
-public sealed class CreatePlanRequest
+public sealed class CreatePlanRequest : PlanDefinitionRequest
 {
     public string Code { get; set; } = string.Empty;
-
-    public string DisplayName { get; set; } = string.Empty;
-
-    public string? Description { get; set; }
-
-    /// <summary>
-    /// Arbitrary plan features as JSON. Stored verbatim and handed back untouched; nothing here
-    /// interprets it, which is what lets a second product ship its own flags without a change
-    /// to this module.
-    /// </summary>
-    public string? FeaturesJson { get; set; }
 
     /// <summary>
     /// Scope the plan to one organization instead of the whole tenant. Omit for the ordinary
     /// case where the tenant sells the same plan to everyone.
     /// </summary>
     public string? OrganizationId { get; set; }
-
-    public int? TrialDays { get; set; }
-
-    public bool TrialRequiresPaymentMethod { get; set; } = true;
-
-    public List<PlanQuantityItemRequest> QuantityItems { get; set; } = [];
-
-    public List<PlanMeterRequest> Meters { get; set; } = [];
-
-    public List<PlanEntitlementRequest> Entitlements { get; set; } = [];
-
-    public List<TrialGrantRequest> TrialGrants { get; set; } = [];
 }

--- a/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
+++ b/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
@@ -1,0 +1,36 @@
+namespace Subscription.DomainService.Requests;
+
+/// <summary>
+/// What a plan sells, shared by authoring one and editing one.
+/// </summary>
+/// <remarks>
+/// Everything a plan is *made of* lives here; what it *is* — its code and the organization it is
+/// scoped to — belongs to the request that creates it, because neither may change afterwards. A
+/// code is what configuration points at, and a scope change would move a plan out from under the
+/// organization that can see it.
+/// </remarks>
+public abstract class PlanDefinitionRequest
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Arbitrary plan features as JSON. Stored verbatim and handed back untouched; nothing here
+    /// interprets it, which is what lets a second product ship its own flags without a change
+    /// to this module.
+    /// </summary>
+    public string? FeaturesJson { get; set; }
+
+    public int? TrialDays { get; set; }
+
+    public bool TrialRequiresPaymentMethod { get; set; } = true;
+
+    public List<PlanQuantityItemRequest> QuantityItems { get; set; } = [];
+
+    public List<PlanMeterRequest> Meters { get; set; } = [];
+
+    public List<PlanEntitlementRequest> Entitlements { get; set; } = [];
+
+    public List<TrialGrantRequest> TrialGrants { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Requests/UpdatePlanRequest.cs
+++ b/server/Subscription.DomainService/Requests/UpdatePlanRequest.cs
@@ -1,0 +1,15 @@
+namespace Subscription.DomainService.Requests;
+
+/// <summary>
+/// Rewrites what a plan sells. Refused once anything has subscribed to it — see
+/// <see cref="Services.IPlanCatalogueService.UpdatePlanAsync"/>.
+/// </summary>
+public sealed class UpdatePlanRequest : PlanDefinitionRequest
+{
+    /// <summary>
+    /// The organization whose plan this is. Ignored unless the caller is the console
+    /// (<c>Payment:ConsoleOrganizationId</c>) — everyone else edits their own organization's
+    /// plans, whatever this says. It names the plan to find; it never moves the plan's scope.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+}

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -49,6 +49,20 @@ public sealed class PlanResponse
     public List<PlanEntitlementResponse> Entitlements { get; init; } = [];
 
     public List<PlanPriceResponse> Prices { get; init; } = [];
+
+    /// <summary>
+    /// How much of each meter a trial includes. Returned because an edit rewrites the whole plan:
+    /// what a caller cannot read back, it cannot preserve, and the grants would be dropped by
+    /// anyone editing anything else.
+    /// </summary>
+    public List<PlanTrialGrantResponse> TrialGrants { get; init; } = [];
+}
+
+public sealed class PlanTrialGrantResponse
+{
+    public string MeterKey { get; init; } = string.Empty;
+
+    public long IncludedQuantity { get; init; }
 }
 
 public sealed class PlanQuantityItemResponse

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -34,6 +34,14 @@ public sealed class PlanResponse
 
     public int Version { get; init; }
 
+    /// <summary>
+    /// Whether anything has ever subscribed to this plan. True closes editing: subscribing copies
+    /// the plan's terms onto the subscription, so a plan that was sold has a history that editing
+    /// the catalogue entry would contradict. Returned so a caller can say why before offering the
+    /// edit, rather than after a form has been filled in.
+    /// </summary>
+    public bool HasSubscribers { get; init; }
+
     public List<PlanQuantityItemResponse> QuantityItems { get; init; } = [];
 
     public List<PlanMeterResponse> Meters { get; init; } = [];

--- a/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
@@ -10,6 +10,22 @@ public interface IPlanCatalogueService
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Rewrites what a plan sells, leaving its code, scope and prices where they are.
+    /// </summary>
+    /// <remarks>
+    /// Refused with <c>subscription_plan_in_use</c> once anything has subscribed. Subscribing
+    /// copies the plan's terms onto the subscription and bills from that copy, so editing a plan
+    /// that was sold cannot reach the people already on it — it would leave the catalogue saying
+    /// one thing and every live subscription another. A plan nobody has bought has no such
+    /// history, which is the only case this allows.
+    /// </remarks>
+    Task<SubscriptionOperationResult<PlanResponse>> UpdatePlanAsync(
+        string planId,
+        UpdatePlanRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
     Task<SubscriptionOperationResult<PlanResponse>> CreatePriceAsync(
         CreatePriceRequest request,
         string correlationId,

--- a/server/Subscription.DomainService/Services/IPlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/IPlanResponseMapper.cs
@@ -5,5 +5,13 @@ namespace Subscription.DomainService.Services;
 
 public interface IPlanResponseMapper
 {
-    PlanResponse ToResponse(Plan plan, IReadOnlyList<Price> prices);
+    /// <param name="hasSubscribers">
+    /// Whether anything has ever subscribed to this plan, which is what decides whether it may
+    /// still be edited. Defaulted for the paths that have not asked — a plan just created has no
+    /// subscriber by definition.
+    /// </param>
+    PlanResponse ToResponse(
+        Plan plan,
+        IReadOnlyList<Price> prices,
+        bool hasSubscribers = false);
 }

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -16,23 +16,29 @@ namespace Subscription.DomainService.Services;
 public sealed class PlanCatalogueService : IPlanCatalogueService
 {
     private readonly ISubscriptionCatalogueRepository _catalogue;
+    private readonly ISubscriptionRepository _subscriptions;
     private readonly ISubscriptionContextResolver _contextResolver;
     private readonly IValidator<CreatePlanRequest> _planValidator;
+    private readonly IValidator<UpdatePlanRequest> _planUpdateValidator;
     private readonly IValidator<CreatePriceRequest> _priceValidator;
     private readonly IPlanResponseMapper _mapper;
     private readonly ILogger<PlanCatalogueService> _logger;
 
     public PlanCatalogueService(
         ISubscriptionCatalogueRepository catalogue,
+        ISubscriptionRepository subscriptions,
         ISubscriptionContextResolver contextResolver,
         IValidator<CreatePlanRequest> planValidator,
+        IValidator<UpdatePlanRequest> planUpdateValidator,
         IValidator<CreatePriceRequest> priceValidator,
         IPlanResponseMapper mapper,
         ILogger<PlanCatalogueService> logger)
     {
         _catalogue = catalogue;
+        _subscriptions = subscriptions;
         _contextResolver = contextResolver;
         _planValidator = planValidator;
+        _planUpdateValidator = planUpdateValidator;
         _priceValidator = priceValidator;
         _mapper = mapper;
         _logger = logger;
@@ -71,6 +77,11 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         var context = resolution.Context!;
         var plan = BuildPlan(request, context.TenantId);
 
+        plan.Code = request.Code;
+        plan.OrganizationId = string.IsNullOrWhiteSpace(request.OrganizationId)
+            ? null
+            : request.OrganizationId;
+
         if (!await _catalogue.TryCreatePlanAsync(plan, cancellationToken))
         {
             return SubscriptionOperationResult<PlanResponse>.Failure(
@@ -90,6 +101,95 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         return SubscriptionOperationResult<PlanResponse>.Success(
             _mapper.ToResponse(plan, []),
             correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<PlanResponse>> UpdatePlanAsync(
+        string planId,
+        UpdatePlanRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            request.OrganizationId,
+            cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<PlanResponse>(correlationId);
+        }
+
+        var invalid = await SubscriptionValidation.CheckAsync<UpdatePlanRequest, PlanResponse>(
+            _planUpdateValidator,
+            request,
+            "subscription_plan_invalid",
+            "The plan is invalid.",
+            correlationId,
+            cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var context = resolution.Context!;
+        var plan = await _catalogue.GetPlanAsync(
+            context.TenantId,
+            planId,
+            cancellationToken);
+
+        if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
+        {
+            return NotFound(correlationId);
+        }
+
+        if (await _subscriptions.AnySubscriberAsync(context.TenantId, plan.ItemId, cancellationToken))
+        {
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_in_use",
+                "This plan has been subscribed to, so its terms can no longer be changed. " +
+                "Create a new plan instead and move subscribers to it.",
+                correlationId);
+        }
+
+        // The plan's own identity survives: only what it sells is rewritten. Code and
+        // organization come from the stored plan rather than the request, which cannot name them.
+        var edited = BuildPlan(request, context.TenantId);
+        edited.Code = plan.Code;
+        edited.OrganizationId = plan.OrganizationId;
+
+        // Guarded by the version just read: a second edit landing in between moves it on, and
+        // this one is refused rather than overwriting what it never saw.
+        if (!await _catalogue.TryUpdatePlanAsync(
+                context.TenantId,
+                plan.ItemId,
+                plan.Version,
+                edited,
+                cancellationToken))
+        {
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_changed",
+                "This plan changed while you were editing it. Reload it and apply your changes " +
+                "again.",
+                correlationId);
+        }
+
+        _logger.LogInformation(
+            "Subscription plan updated TenantHash={TenantHash} PlanHash={PlanHash} Code={Code} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(plan.ItemId),
+            PaymentLogValue.Label(plan.Code),
+            correlationId);
+
+        return await GetPlanAsync(
+            plan.ItemId,
+            context.OrganizationId,
+            correlationId,
+            cancellationToken);
     }
 
     public async Task<SubscriptionOperationResult<PlanResponse>> CreatePriceAsync(
@@ -214,7 +314,12 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
                 plan.ItemId,
                 cancellationToken);
 
-            responses.Add(_mapper.ToResponse(plan, prices));
+            var hasSubscribers = await _subscriptions.AnySubscriberAsync(
+                context.TenantId,
+                plan.ItemId,
+                cancellationToken);
+
+            responses.Add(_mapper.ToResponse(plan, prices, hasSubscribers));
         }
 
         return SubscriptionOperationResult<IReadOnlyList<PlanResponse>>.Success(
@@ -254,8 +359,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             plan.ItemId,
             cancellationToken);
 
+        var hasSubscribers = await _subscriptions.AnySubscriberAsync(
+            context.TenantId,
+            plan.ItemId,
+            cancellationToken);
+
         return SubscriptionOperationResult<PlanResponse>.Success(
-            _mapper.ToResponse(plan, prices),
+            _mapper.ToResponse(plan, prices, hasSubscribers),
             correlationId);
     }
 
@@ -279,13 +389,14 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             "The plan does not exist.",
             correlationId);
 
-    private static Plan BuildPlan(CreatePlanRequest request, string tenantId) => new()
+    /// <summary>
+    /// The parts of a plan that come from the request. Creating fills in the code and scope
+    /// afterwards; editing copies them off the stored plan, which is what keeps an edit from
+    /// moving a plan out from under the organization that can see it.
+    /// </summary>
+    private static Plan BuildPlan(PlanDefinitionRequest request, string tenantId) => new()
     {
         TenantId = tenantId,
-        OrganizationId = string.IsNullOrWhiteSpace(request.OrganizationId)
-            ? null
-            : request.OrganizationId,
-        Code = request.Code,
         DisplayName = request.DisplayName,
         Description = request.Description,
         FeaturesJson = request.FeaturesJson,

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -13,7 +13,10 @@ namespace Subscription.DomainService.Services;
 /// </remarks>
 public sealed class PlanResponseMapper : IPlanResponseMapper
 {
-    public PlanResponse ToResponse(Plan plan, IReadOnlyList<Price> prices)
+    public PlanResponse ToResponse(
+        Plan plan,
+        IReadOnlyList<Price> prices,
+        bool hasSubscribers = false)
     {
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(prices);
@@ -29,6 +32,7 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
             TrialDays = plan.TrialDays,
             TrialRequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
             Version = plan.Version,
+            HasSubscribers = hasSubscribers,
             QuantityItems = plan.QuantityItems
                 .Select(item => new PlanQuantityItemResponse
                 {

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -78,6 +78,13 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     UnitLabel = entitlement.UnitLabel
                 })
                 .ToList(),
+            TrialGrants = plan.TrialGrants
+                .Select(grant => new PlanTrialGrantResponse
+                {
+                    MeterKey = grant.MeterKey,
+                    IncludedQuantity = grant.IncludedQuantity
+                })
+                .ToList(),
             Prices = prices
                 .Select(price => new PlanPriceResponse
                 {

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -62,6 +62,9 @@ public static class ApplicationServiceCollectionExtensions
             IValidator<CreatePlanRequest>,
             CreatePlanRequestValidator>();
         services.AddTransient<
+            IValidator<UpdatePlanRequest>,
+            UpdatePlanRequestValidator>();
+        services.AddTransient<
             IValidator<CreatePriceRequest>,
             CreatePriceRequestValidator>();
         services.AddTransient<

--- a/server/Subscription.DomainService/Validators/CreatePlanRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePlanRequestValidator.cs
@@ -1,6 +1,4 @@
-using System.Text.Json;
 using FluentValidation;
-using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
 
 namespace Subscription.DomainService.Validators;
@@ -8,10 +6,11 @@ namespace Subscription.DomainService.Validators;
 public sealed class CreatePlanRequestValidator : AbstractValidator<CreatePlanRequest>
 {
     private const int MaximumCodeLength = 64;
-    private const int MaximumFeaturesLength = 16_384;
 
     public CreatePlanRequestValidator()
     {
+        Include(new PlanDefinitionRequestValidator());
+
         RuleFor(request => request.Code)
             .NotEmpty()
             .MaximumLength(MaximumCodeLength)
@@ -19,146 +18,5 @@ public sealed class CreatePlanRequestValidator : AbstractValidator<CreatePlanReq
             .WithMessage(
                 "A plan code may contain only lowercase letters, digits, hyphens and underscores.")
             .WithErrorCode("subscription_plan_code_invalid");
-
-        RuleFor(request => request.DisplayName).NotEmpty().MaximumLength(200);
-
-        RuleFor(request => request.TrialDays)
-            .InclusiveBetween(1, 365)
-            .When(request => request.TrialDays.HasValue);
-
-        RuleFor(request => request.FeaturesJson)
-            .Must(BeAJsonObject)
-            .When(request => !string.IsNullOrWhiteSpace(request.FeaturesJson))
-            .WithMessage(
-                "Plan features must be a JSON object. It is stored verbatim and returned to " +
-                "callers, so it has to be something they can parse.")
-            .WithErrorCode("subscription_plan_features_invalid");
-
-        RuleForEach(request => request.QuantityItems)
-            .ChildRules(item =>
-            {
-                item.RuleFor(quantity => quantity.ItemKey).NotEmpty().MaximumLength(64);
-                item.RuleFor(quantity => quantity.UnitLabel).NotEmpty().MaximumLength(64);
-                item.RuleFor(quantity => quantity.MinQuantity).GreaterThanOrEqualTo(0);
-                item.RuleFor(quantity => quantity)
-                    .Must(quantity =>
-                        quantity.MaxQuantity is null ||
-                        quantity.MaxQuantity >= quantity.MinQuantity)
-                    .WithName(nameof(PlanQuantityItemRequest.MaxQuantity))
-                    .WithMessage("A maximum quantity cannot be below the minimum.");
-            });
-
-        RuleForEach(request => request.Meters)
-            .ChildRules(meter =>
-            {
-                meter.RuleFor(definition => definition.MeterKey).NotEmpty().MaximumLength(64);
-                meter.RuleFor(definition => definition.UnitLabel).NotEmpty().MaximumLength(64);
-                meter.RuleFor(definition => definition.IncludedQuantity)
-                    .GreaterThanOrEqualTo(0);
-                meter.RuleForEach(definition => definition.ThresholdPercents)
-                    .InclusiveBetween(1, 100);
-                meter.RuleFor(definition => definition.RateTables)
-                    .Must(HaveWellOrderedTiers)
-                    .WithMessage(
-                        "Rate tiers must ascend, and only the last may be unbounded — " +
-                        "otherwise a quantity falls into two bands and the bill depends on " +
-                        "which is read first.")
-                    .WithErrorCode("subscription_meter_tiers_invalid");
-            });
-
-        RuleForEach(request => request.Entitlements)
-            .ChildRules(entitlement =>
-            {
-                entitlement.RuleFor(definition => definition.Key).NotEmpty().MaximumLength(64);
-                entitlement.RuleFor(definition => definition)
-                    .Must(definition =>
-                        definition.LimitKind != EntitlementLimitKind.Count ||
-                        (definition.Limit.HasValue &&
-                         !string.IsNullOrWhiteSpace(definition.MeterKey)))
-                    .WithName(nameof(PlanEntitlementRequest.Limit))
-                    .WithMessage(
-                        "A counted entitlement needs both a limit and the meter that draws it down.");
-            });
-
-        RuleFor(request => request)
-            .Must(EveryEntitlementMeterExists)
-            .WithName(nameof(CreatePlanRequest.Entitlements))
-            .WithMessage(
-                "An entitlement names a meter the plan does not define, so nothing would ever " +
-                "draw it down.")
-            .WithErrorCode("subscription_entitlement_meter_unknown");
-
-        RuleFor(request => request)
-            .Must(EveryTrialGrantMeterExists)
-            .WithName(nameof(CreatePlanRequest.TrialGrants))
-            .WithMessage("A trial grant names a meter the plan does not define.")
-            .WithErrorCode("subscription_trial_grant_meter_unknown");
-    }
-
-    private static bool BeAJsonObject(string? featuresJson)
-    {
-        if (featuresJson is null || featuresJson.Length > MaximumFeaturesLength)
-        {
-            return false;
-        }
-
-        try
-        {
-            using var document = JsonDocument.Parse(featuresJson);
-
-            return document.RootElement.ValueKind == JsonValueKind.Object;
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
-
-    private static bool HaveWellOrderedTiers(List<MeterRateTableRequest> rateTables) =>
-        rateTables.TrueForAll(table =>
-        {
-            var tiers = table.Tiers;
-
-            if (tiers.Count == 0)
-            {
-                return true;
-            }
-
-            // Only the final tier may be open-ended; an unbounded band in the middle would
-            // swallow every band after it.
-            if (tiers.Take(tiers.Count - 1).Any(tier => tier.UpToQuantity is null))
-            {
-                return false;
-            }
-
-            // Every bound, including the last when it is closed — checking only the leading
-            // ones lets a final band sit below its predecessor and swallow the tier before it.
-            var bounds = tiers
-                .Where(tier => tier.UpToQuantity.HasValue)
-                .Select(tier => tier.UpToQuantity!.Value)
-                .ToArray();
-
-            return Array.TrueForAll(bounds, bound => bound > 0) &&
-                   bounds.Zip(bounds.Skip(1)).All(pair => pair.Second > pair.First);
-        });
-
-    private static bool EveryEntitlementMeterExists(CreatePlanRequest request)
-    {
-        var meterKeys = request.Meters
-            .Select(meter => meter.MeterKey)
-            .ToHashSet(StringComparer.Ordinal);
-
-        return request.Entitlements.TrueForAll(entitlement =>
-            string.IsNullOrWhiteSpace(entitlement.MeterKey) ||
-            meterKeys.Contains(entitlement.MeterKey));
-    }
-
-    private static bool EveryTrialGrantMeterExists(CreatePlanRequest request)
-    {
-        var meterKeys = request.Meters
-            .Select(meter => meter.MeterKey)
-            .ToHashSet(StringComparer.Ordinal);
-
-        return request.TrialGrants.TrueForAll(grant => meterKeys.Contains(grant.MeterKey));
     }
 }

--- a/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using FluentValidation;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Validators;
+
+/// <summary>
+/// Everything a plan's own contents have to satisfy, whether it is being created or edited.
+/// </summary>
+/// <remarks>
+/// Its own validator rather than two copies: an edit that could store something a create would
+/// have rejected is a hole, and the only way to be sure the two agree is for there to be one
+/// rule.
+/// </remarks>
+public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefinitionRequest>
+{
+    private const int MaximumFeaturesLength = 16_384;
+
+    public PlanDefinitionRequestValidator()
+    {
+        RuleFor(request => request.DisplayName).NotEmpty().MaximumLength(200);
+
+        RuleFor(request => request.TrialDays)
+            .InclusiveBetween(1, 365)
+            .When(request => request.TrialDays.HasValue);
+
+        RuleFor(request => request.FeaturesJson)
+            .Must(BeAJsonObject)
+            .When(request => !string.IsNullOrWhiteSpace(request.FeaturesJson))
+            .WithMessage(
+                "Plan features must be a JSON object. It is stored verbatim and returned to " +
+                "callers, so it has to be something they can parse.")
+            .WithErrorCode("subscription_plan_features_invalid");
+
+        RuleForEach(request => request.QuantityItems)
+            .ChildRules(item =>
+            {
+                item.RuleFor(quantity => quantity.ItemKey).NotEmpty().MaximumLength(64);
+                item.RuleFor(quantity => quantity.UnitLabel).NotEmpty().MaximumLength(64);
+                item.RuleFor(quantity => quantity.MinQuantity).GreaterThanOrEqualTo(0);
+                item.RuleFor(quantity => quantity)
+                    .Must(quantity =>
+                        quantity.MaxQuantity is null ||
+                        quantity.MaxQuantity >= quantity.MinQuantity)
+                    .WithName(nameof(PlanQuantityItemRequest.MaxQuantity))
+                    .WithMessage("A maximum quantity cannot be below the minimum.");
+            });
+
+        RuleForEach(request => request.Meters)
+            .ChildRules(meter =>
+            {
+                meter.RuleFor(definition => definition.MeterKey).NotEmpty().MaximumLength(64);
+                meter.RuleFor(definition => definition.UnitLabel).NotEmpty().MaximumLength(64);
+                meter.RuleFor(definition => definition.IncludedQuantity)
+                    .GreaterThanOrEqualTo(0);
+                meter.RuleForEach(definition => definition.ThresholdPercents)
+                    .InclusiveBetween(1, 100);
+                meter.RuleFor(definition => definition.RateTables)
+                    .Must(HaveWellOrderedTiers)
+                    .WithMessage(
+                        "Rate tiers must ascend, and only the last may be unbounded — " +
+                        "otherwise a quantity falls into two bands and the bill depends on " +
+                        "which is read first.")
+                    .WithErrorCode("subscription_meter_tiers_invalid");
+            });
+
+        RuleForEach(request => request.Entitlements)
+            .ChildRules(entitlement =>
+            {
+                entitlement.RuleFor(definition => definition.Key).NotEmpty().MaximumLength(64);
+                entitlement.RuleFor(definition => definition)
+                    .Must(definition =>
+                        definition.LimitKind != EntitlementLimitKind.Count ||
+                        (definition.Limit.HasValue &&
+                         !string.IsNullOrWhiteSpace(definition.MeterKey)))
+                    .WithName(nameof(PlanEntitlementRequest.Limit))
+                    .WithMessage(
+                        "A counted entitlement needs both a limit and the meter that draws it down.");
+            });
+
+        RuleFor(request => request)
+            .Must(EveryEntitlementMeterExists)
+            .WithName(nameof(PlanDefinitionRequest.Entitlements))
+            .WithMessage(
+                "An entitlement names a meter the plan does not define, so nothing would ever " +
+                "draw it down.")
+            .WithErrorCode("subscription_entitlement_meter_unknown");
+
+        RuleFor(request => request)
+            .Must(EveryTrialGrantMeterExists)
+            .WithName(nameof(PlanDefinitionRequest.TrialGrants))
+            .WithMessage("A trial grant names a meter the plan does not define.")
+            .WithErrorCode("subscription_trial_grant_meter_unknown");
+    }
+
+    private static bool BeAJsonObject(string? featuresJson)
+    {
+        if (featuresJson is null || featuresJson.Length > MaximumFeaturesLength)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(featuresJson);
+
+            return document.RootElement.ValueKind == JsonValueKind.Object;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HaveWellOrderedTiers(List<MeterRateTableRequest> rateTables) =>
+        rateTables.TrueForAll(table =>
+        {
+            var tiers = table.Tiers;
+
+            if (tiers.Count == 0)
+            {
+                return true;
+            }
+
+            // Only the final tier may be open-ended; an unbounded band in the middle would
+            // swallow every band after it.
+            if (tiers.Take(tiers.Count - 1).Any(tier => tier.UpToQuantity is null))
+            {
+                return false;
+            }
+
+            // Every bound, including the last when it is closed — checking only the leading
+            // ones lets a final band sit below its predecessor and swallow the tier before it.
+            var bounds = tiers
+                .Where(tier => tier.UpToQuantity.HasValue)
+                .Select(tier => tier.UpToQuantity!.Value)
+                .ToArray();
+
+            return Array.TrueForAll(bounds, bound => bound > 0) &&
+                   bounds.Zip(bounds.Skip(1)).All(pair => pair.Second > pair.First);
+        });
+
+    private static bool EveryEntitlementMeterExists(PlanDefinitionRequest request)
+    {
+        var meterKeys = request.Meters
+            .Select(meter => meter.MeterKey)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return request.Entitlements.TrueForAll(entitlement =>
+            string.IsNullOrWhiteSpace(entitlement.MeterKey) ||
+            meterKeys.Contains(entitlement.MeterKey));
+    }
+
+    private static bool EveryTrialGrantMeterExists(PlanDefinitionRequest request)
+    {
+        var meterKeys = request.Meters
+            .Select(meter => meter.MeterKey)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return request.TrialGrants.TrueForAll(grant => meterKeys.Contains(grant.MeterKey));
+    }
+}

--- a/server/Subscription.DomainService/Validators/UpdatePlanRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/UpdatePlanRequestValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Validators;
+
+/// <summary>
+/// Nothing of its own: an edit rewrites exactly what a create authored, minus the code and scope
+/// it may not touch.
+/// </summary>
+public sealed class UpdatePlanRequestValidator : AbstractValidator<UpdatePlanRequest>
+{
+    public UpdatePlanRequestValidator() => Include(new PlanDefinitionRequestValidator());
+}

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -22,9 +22,11 @@ public sealed class PlanCatalogueServiceTests
     private const string OrganizationId = "org-1";
 
     private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
     private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
     private readonly Mock<ICurrencyMinorUnitResolver> _currencyResolver = new();
     private Plan? _created;
+    private Plan? _updated;
 
     public PlanCatalogueServiceTests()
     {
@@ -500,10 +502,182 @@ public sealed class PlanCatalogueServiceTests
             "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
+    [Fact]
+    public async Task A_plan_nobody_has_subscribed_to_can_be_rewritten()
+    {
+        StorePlan(StoredPlan());
+        _catalogue
+            .Setup(repository => repository.TryUpdatePlanAsync(
+                TenantId, "plan-1", 1, It.IsAny<Plan>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, int, Plan, CancellationToken>(
+                (_, _, _, plan, _) => _updated = plan)
+            .ReturnsAsync(true);
+
+        var result = await Service().UpdatePlanAsync(
+            "plan-1",
+            EditedPlan(),
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _updated!.DisplayName.Should().Be("Professional plus");
+        _updated.Entitlements[0].Limit.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task Editing_keeps_the_code_and_scope_the_request_cannot_name()
+    {
+        var stored = StoredPlan();
+        stored.OrganizationId = "org-1";
+        StorePlan(stored);
+        _catalogue
+            .Setup(repository => repository.TryUpdatePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<Plan>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, int, Plan, CancellationToken>(
+                (_, _, _, plan, _) => _updated = plan)
+            .ReturnsAsync(true);
+
+        await Service().UpdatePlanAsync("plan-1", EditedPlan(), "corr-1", CancellationToken.None);
+
+        _updated!.Code.Should().Be("professional",
+            "configuration points at the code, so an edit may not move it");
+        _updated.OrganizationId.Should().Be("org-1",
+            "changing the scope would move the plan out from under whoever can see it");
+    }
+
+    /// <summary>
+    /// The reason editing is closed at all: subscribing copies the plan's terms onto the
+    /// subscription and bills from that copy, so an edit cannot reach anyone already on it.
+    /// </summary>
+    [Fact]
+    public async Task A_plan_that_has_been_subscribed_to_is_refused()
+    {
+        StorePlan(StoredPlan());
+        _subscriptions
+            .Setup(repository => repository.AnySubscriberAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Service().UpdatePlanAsync(
+            "plan-1",
+            EditedPlan(),
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be("subscription_plan_in_use");
+        _catalogue.Verify(
+            repository => repository.TryUpdatePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<Plan>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Another_organizations_plan_reads_as_missing_rather_than_editable()
+    {
+        var stored = StoredPlan();
+        stored.OrganizationId = "somebody-else";
+        StorePlan(stored);
+
+        var result = await Service().UpdatePlanAsync(
+            "plan-1",
+            EditedPlan(),
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+    }
+
+    [Fact]
+    public async Task An_edit_that_lost_the_version_race_is_refused_rather_than_overwriting()
+    {
+        StorePlan(StoredPlan());
+        _catalogue
+            .Setup(repository => repository.TryUpdatePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<Plan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().UpdatePlanAsync(
+            "plan-1",
+            EditedPlan(),
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be("subscription_plan_changed");
+    }
+
+    [Fact]
+    public async Task An_edit_is_held_to_the_same_rules_as_authoring()
+    {
+        StorePlan(StoredPlan());
+        var request = EditedPlan();
+        request.Entitlements[0].MeterKey = "not-a-meter";
+
+        var result = await Service().UpdatePlanAsync(
+            "plan-1",
+            request,
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ValidationErrors.Should().NotBeNull();
+        _catalogue.Verify(
+            repository => repository.TryUpdatePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<Plan>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "an edit that stored something a create would have refused would be a hole");
+    }
+
+    [Fact]
+    public async Task A_requested_organization_on_update_is_forwarded_to_context_resolution()
+    {
+        StorePlan(StoredPlan());
+        var request = EditedPlan();
+        request.OrganizationId = "org-9";
+
+        await Service().UpdatePlanAsync("plan-1", request, "corr-1", CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync("corr-1", "org-9", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_plan_that_has_been_subscribed_to_says_so_when_read()
+    {
+        StorePlan(StoredPlan());
+        _subscriptions
+            .Setup(repository => repository.AnySubscriberAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Service().GetPlanAsync(
+            "plan-1",
+            null,
+            "corr-1",
+            CancellationToken.None);
+
+        result.Value!.HasSubscribers.Should().BeTrue(
+            "the portal has to be able to say why editing is closed before offering it");
+    }
+
+    private void StorePlan(Plan plan) =>
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, plan.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plan);
+
     private PlanCatalogueService Service() => new(
         _catalogue.Object,
+        _subscriptions.Object,
         _contextResolver.Object,
         new CreatePlanRequestValidator(),
+        new UpdatePlanRequestValidator(),
         new CreatePriceRequestValidator(_currencyResolver.Object),
         new PlanResponseMapper(),
         NullLogger<PlanCatalogueService>.Instance);
@@ -513,8 +687,24 @@ public sealed class PlanCatalogueServiceTests
         ItemId = "plan-1",
         TenantId = TenantId,
         Code = "professional",
+        Version = 1,
         QuantityItems = [new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat" }]
     };
+
+    /// <summary>The same plan as <see cref="NewPlan"/>, renamed — an edit names no code.</summary>
+    private static UpdatePlanRequest EditedPlan()
+    {
+        var authored = NewPlan();
+
+        return new UpdatePlanRequest
+        {
+            DisplayName = "Professional plus",
+            QuantityItems = authored.QuantityItems,
+            Meters = authored.Meters,
+            Entitlements = authored.Entitlements,
+            TrialGrants = authored.TrialGrants
+        };
+    }
 
     private static CreatePlanRequest NewPlan() => new()
     {


### PR DESCRIPTION
Three gaps found while hand-testing the plan builder, plus one data-loss bug and one broken test file found along the way.

## Warn when an entitlement disagrees with its meter

An entitlement and its meter answer two different questions — "may they?" and "what does it cost?" — and nothing made them agree. A plan permitting 500 signatures against a meter including 150 behaves exactly as authored: the app is told all 500 are allowed, and 350 of them are billed as overage.

That is a real configuration, so this reports it rather than rejecting it. One description feeds the builder card that can fix it, the live preview, and the plan detail page, so the three never drift. It also covers the reverse case, and the blocked-meter case where the excess is simply unreachable.

## Author a plan's prices inside the builder

Overage pricing already lived in step 2, so money was half in the builder and half on a page you only reached after the plan existed — and the builder finished by handing over a plan its own detail page calls unusable: *"No price yet — subscribers cannot check out until one exists."*

Prices are now a repeatable list in step 2, because the ordinary case is more than one: a monthly and an annual price are two prices on the same plan. At least one is required when creating.

Submitting is two calls, since a price needs the plan's id. Once the plan is created it stays created, so a failing price is collected and reported rather than read as a failed submission — resubmitting would only collide on the plan code and lose the plan already made. Two rows with identical terms are caught in the form instead, where the fix is a field edit rather than a half-priced plan. The standalone add-price page stays for prices added later.

## Edit a plan that nobody has subscribed to

There was no way to correct a plan once created. Two real cases had already hit it: entitlement limits that disagreed with their meter, and a plan that needed overage pricing added.

`PUT /subscription-plans/{planId}` rewrites what a plan sells, and refuses with `subscription_plan_in_use` the moment anything has subscribed — any status, cancelled included. That is not caution: subscribing copies the plan's terms onto the subscription and bills from that copy, so an edit cannot reach anyone already on it, and a cancelled subscription's past invoices were computed from those terms too. Create a new plan and migrate instead.

Code and scope come from the stored plan, never the request — a code is what configuration points at, and a scope change would move a plan out from under whoever can see it. Prices are separate documents and are untouched. `PlanDefinitionRequestValidator` now holds every rule about a plan's contents and both creating and editing include it, because an edit that could store what a create would have refused is a hole.

On the client, the builder became one component taking a mode rather than a second wizard. Editing shows code and organization read-only, makes a price optional, and a subscribed plan never opens the form at all — the page explains why, and the Edit button is disabled rather than hidden so nobody hunts for it. Reads return `hasSubscribers` so that can be said before a form is filled in rather than after.

## Two things found along the way

**Trial grants were not returned on the plan response.** Since an edit rewrites the whole plan, they would have been silently dropped by anyone editing something else entirely. Now returned, with a test that fails if they stop round-tripping.

**Four payment test files had been failing on `dev`.** Those pages started reading organizations from IAM, which goes through react-query, and the tests render without a client — every case threw "No QueryClient set" before reaching its assertion. Stubbed the same way `create-payment-provider-page` already does.

## Verification

- Client: 293 test files, 1893 assertions passing; type-check and lint clean on everything touched.
- Server: 263 unit tests passing. The Mongo integration tests need a local `mongod` and were not run.
- Five client test files still fail to *collect* on `dev` — a parse error in `project-card.test.tsx` and an `assets/github-icon.svg` resolution error in four others. Untouched by this branch and left alone; no assertions fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)