### PR TITLE
feat(subscription): show what a trial actually includes

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -143,6 +143,10 @@ const PlanBuilderWizard = ({
       unitLabel: entitlement?.unitLabel ?? null,
       meterKey: entitlement?.meterKey ?? null,
     })),
+    trialGrants: (draft.trialGrants ?? []).map((grant) => ({
+      meterKey: grant?.meterKey ?? "",
+      includedQuantity: grant?.includedQuantity ?? 0,
+    })),
     prices: (draft.prices ?? []).map((price) => ({
       currencyCode: price?.currencyCode ?? "USD",
       unitAmountMinor: toMinorUnits(price?.amount ?? 0, price?.currencyCode ?? "USD"),

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
@@ -12,6 +12,7 @@ const plan = (overrides: Partial<PlanSummaryData> = {}): PlanSummaryData => ({
   meters: [],
   entitlements: [],
   prices: [],
+  trialGrants: [],
   ...overrides,
 });
 
@@ -136,5 +137,36 @@ describe("PlanSummaryCard", () => {
     expect(
       screen.getByText(/150 signatures included, then overage billed/),
     ).toBeInTheDocument();
+  });
+
+  it("says what a trial actually includes, which is not the plan's own allowance", () => {
+    render(
+      <PlanSummaryCard
+        plan={plan({
+          trialDays: 1,
+          meters: [meter()],
+          trialGrants: [{ meterKey: "ses-signatures", includedQuantity: 5 }],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("During the 1-day trial")).toBeInTheDocument();
+    expect(
+      screen.getByText(/5 signatures, instead of the usual 150/),
+    ).toBeInTheDocument();
+  });
+
+  it("warns that a meter with no grant gives a whole month away during the trial", () => {
+    render(<PlanSummaryCard plan={plan({ trialDays: 14, meters: [meter()] })} />);
+
+    expect(
+      screen.getByText(/150 signatures — the full monthly allowance, with no separate trial limit/),
+    ).toBeInTheDocument();
+  });
+
+  it("says nothing about trial allowances on a plan that measures nothing", () => {
+    render(<PlanSummaryCard plan={plan({ trialDays: 14 })} />);
+
+    expect(screen.queryByText(/During the/)).not.toBeInTheDocument();
   });
 });

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -1,4 +1,4 @@
-import { CircleDollarSign, Gauge, Layers, ShieldCheck } from "lucide-react";
+import { CircleDollarSign, Gauge, Hourglass, Layers, ShieldCheck } from "lucide-react";
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/card/card";
 import { describeEntitlementMeterMismatch } from "../utilities/plan-consistency";
@@ -6,6 +6,7 @@ import {
   formatEntitlementLimit,
   formatMeterAllowance,
   formatPrice,
+  formatTrialAllowance,
 } from "../utilities/subscription-format";
 
 export interface PlanSummaryData {
@@ -39,6 +40,8 @@ export interface PlanSummaryData {
     intervalCount: number;
     quantityItemKey: string | null;
   }[];
+  /** A meter's allowance for the length of the trial, replacing the plan's own. */
+  trialGrants: { meterKey: string; includedQuantity: number }[];
 }
 
 /**
@@ -90,6 +93,26 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
               ? `Charged at signup; the ${plan.trialDays}-day trial governs the allowances, not the price.`
               : `Free for ${plan.trialDays} days, then the first charge is taken.`}
           </p>
+        ) : null}
+
+        {/* Only worth showing where there is something to measure: a trial on a plan with no
+            meters changes nothing but when the first charge falls. */}
+        {plan.trialDays && hasUsage ? (
+          <div className="flex items-start gap-2 text-sm">
+            <Hourglass className="mt-0.5 h-4 w-4 shrink-0 text-blocks-primary-600" />
+            <div className="space-y-0.5">
+              <p className="font-medium">During the {plan.trialDays}-day trial</p>
+              {plan.meters.map((meter, index) => (
+                <p key={index}>
+                  {meter.displayName}:{" "}
+                  {formatTrialAllowance(
+                    meter,
+                    plan.trialGrants.find((grant) => grant.meterKey === meter.meterKey),
+                  )}
+                </p>
+              ))}
+            </div>
+          </div>
         ) : null}
 
         {plan.quantityItems.length > 0 && (

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -93,6 +93,8 @@ export const SubscriptionPlanDetailPage = () => {
     meters: plan.meters,
     entitlements: plan.entitlements,
     prices: plan.prices,
+    // Optional on the response for plans stored before it carried them.
+    trialGrants: plan.trialGrants ?? [],
   };
 
   return (

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
@@ -5,6 +5,7 @@ import {
   formatMeterAllowance,
   formatMoney,
   formatPrice,
+  formatTrialAllowance,
   minorUnitExponent,
   toMajorUnits,
   toMinorUnits,
@@ -154,6 +155,33 @@ describe("formatMeterAllowance", () => {
     });
 
     expect(description).toContain("1 seat included");
+  });
+});
+
+describe("formatTrialAllowance", () => {
+  const meter = { displayName: "Simple Signatures", unitLabel: "signature", includedQuantity: 150 };
+
+  it("says a grant replaces the plan's allowance, not adds to it", () => {
+    expect(formatTrialAllowance(meter, { includedQuantity: 5 })).toBe(
+      "5 signatures, instead of the usual 150",
+    );
+  });
+
+  it("calls out a meter with no grant, which keeps a whole month of allowance", () => {
+    const description = formatTrialAllowance(meter, undefined);
+
+    expect(description).toContain("150 signatures");
+    expect(description).toContain("no separate trial limit");
+  });
+
+  it("does not labour the point when the grant matches the plan", () => {
+    expect(formatTrialAllowance(meter, { includedQuantity: 150 })).toBe("150 signatures");
+  });
+
+  it("keeps the unit singular for a grant of one", () => {
+    expect(formatTrialAllowance(meter, { includedQuantity: 1 })).toBe(
+      "1 signature, instead of the usual 150",
+    );
   });
 });
 

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
@@ -80,6 +80,30 @@ export const formatMeterAllowance = (meter: {
     : `${included}, then unlimited at no charge`;
 };
 
+/**
+ * What one meter allows during the trial.
+ *
+ * A grant *replaces* the plan's allowance rather than adding to it, and a meter with no grant
+ * keeps its full monthly one — which is exactly the case worth spelling out, since a trial that
+ * hands out a whole month of something costly is an invitation to sign up, consume and leave.
+ */
+export const formatTrialAllowance = (
+  meter: { displayName: string; unitLabel: string; includedQuantity: number },
+  grant: { includedQuantity: number } | undefined,
+): string => {
+  const unit = meter.unitLabel || "unit";
+  const plural = (count: number) =>
+    `${count.toLocaleString()} ${unit}${count === 1 ? "" : "s"}`;
+
+  if (!grant) {
+    return `${plural(meter.includedQuantity)} — the full monthly allowance, with no separate trial limit`;
+  }
+
+  return grant.includedQuantity === meter.includedQuantity
+    ? plural(grant.includedQuantity)
+    : `${plural(grant.includedQuantity)}, instead of the usual ${meter.includedQuantity.toLocaleString()}`;
+};
+
 export const formatEntitlementLimit = (entitlement: {
   limitKind: string;
   limit: number | null;


### PR DESCRIPTION
Follow-up to #224, from hand-testing the review step.

The summary listed the plan's own allowances and said nothing about the trial's. A Starter plan with a 1-day trial granting 5 signatures read as though the trial granted 150 — the plan's monthly figure — because that is the only number the card showed.

A trial grant **replaces** a meter's allowance rather than adding to it (`UsageRecordingService.AllowanceFor`, `EntitlementService.LimitFor`), and the two numbers are usually far apart; that is the point of having them. So the summary now has a "During the N-day trial" section listing each meter's real trial allowance, shown in both the builder's live preview and the plan detail page from the same shared card.

A meter with **no** grant is called out rather than left silent — it keeps its whole monthly allowance for the length of the trial, which on anything that costs the seller money is an invitation to sign up, consume and leave. That is exactly what the author needs to see before creating the plan, and it was invisible.

The section only appears where there is something to measure: on a plan with no meters, a trial changes nothing but when the first charge falls.

## Note

`plan-summary-card.test.tsx` was missing the new field on its `PlanSummaryData` factory and nothing caught it — `tsconfig.app.json` excludes `**/*.test.tsx`, so test files are not type-checked at all. Fixed the factory here; the wider gap is left alone.

## Verification

- Client: 98 subscription tests passing, including four new cases for the trial wording and three for the card section; type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)