### PR TITLE
fix(security): verify a console-named organization in production again

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7621,9 +7621,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/server/Api/appsettings.prod.json
+++ b/server/Api/appsettings.prod.json
@@ -30,7 +30,6 @@
     "ConsoleOrganizationId": "default",
     "PublicBaseUrl": "https://utilities.seliseblocks.com",
     "IamBaseUrl": "https://iam.seliseblocks.com",
-    "VerifyOrganizationWithIam": false,
     "CurrencyMinorUnits": {
       "BDT": 2,
       "CHF": 2,


### PR DESCRIPTION
Found while reviewing what `dev` → `stg` promotes. Both fixes are on the path to production, so they belong in `dev` before that promotion merges.

## Console organizations were trusted unverified in production

`appsettings.prod.json` carried `"VerifyOrganizationWithIam": false`. The code default is `true` and every other environment relies on that default — production was the only place overriding it.

It matters more now than when it was set. The console organization override was extended from payment to **every subscription endpoint**, so with verification off, any caller whose token organization equals `ConsoleOrganizationId` (`"default"`) can name any organization identifier and have it trusted without a check that it exists:

- read another organization's subscriptions, entitlements, usage and plans
- create plans, prices, subscriptions and usage records underneath them

`PaymentOrganizationResolver` logs a warning on every request that skips the check, describing it as "a real gap" — the setting was never meant to outlive the testing it unblocked.

Production already configures `IamBaseUrl`, so verification has somewhere to go. `appsettings.dev.json` keeps the override deliberately: that is a development environment, and turning it off there is the point.

`stg` never set the flag, so staging was already verifying — this is a production-only regression.

## nanoid advisory

`nanoid` 3.3.16 → 3.3.18, clearing [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high). It arrives through `postcss`, so it is build-time only rather than shipped to browsers. Lockfile-only patch bump; `npm audit` is now clean and the client build passes on it.

## Verification

- `npm audit`: 0 vulnerabilities (was 1 high).
- `dotnet list package --vulnerable --include-transitive`: clean across all six projects.
- Client build succeeds with the bumped dependency installed.
- The prod change removes one line of configuration; no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)