### PR TITLE
fix(security): stop echoing environment values in the dev-https warning

### DIFF
--- a/client/app/cross-modules/utilities/payment/components/stored-payment-methods-section.test.tsx
+++ b/client/app/cross-modules/utilities/payment/components/stored-payment-methods-section.test.tsx
@@ -271,7 +271,7 @@ describe("StoredPaymentMethodsSection", () => {
       screen.getByRole("button", { name: "Remove Visa ending in 4242" }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Remove method|Remove$/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Remove method$/ }));
 
     await waitFor(() => expect(removeMethodMock).toHaveBeenCalledWith("pm-1"));
     await waitFor(() =>
@@ -288,7 +288,7 @@ describe("StoredPaymentMethodsSection", () => {
       screen.getByRole("button", { name: "Remove Visa ending in 4242" }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Remove method|Remove$/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Remove method$/ }));
 
     await waitFor(() =>
       expect(toastMock).toHaveBeenCalledWith(
@@ -304,7 +304,7 @@ describe("StoredPaymentMethodsSection", () => {
       screen.getByRole("button", { name: "Remove Visa ending in 4242" }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Remove method|Remove$/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Remove method$/ }));
 
     await waitFor(() =>
       expect(toastMock).toHaveBeenCalledWith(
@@ -323,7 +323,7 @@ describe("StoredPaymentMethodsSection", () => {
       screen.getByRole("button", { name: "Remove Visa ending in 4242" }),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Remove method|Remove$/ }));
+    fireEvent.click(screen.getByRole("button", { name: /^Remove method$/ }));
 
     await waitFor(() =>
       expect(toastMock).toHaveBeenCalledWith(

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -14,8 +14,18 @@ function resolveDevHttps(): { cert: Buffer; key: Buffer } | undefined {
     return undefined;
   }
   if (!fs.existsSync(certPath) || !fs.existsSync(keyPath)) {
+    // Names the variable that is wrong rather than echoing its value: these come from the
+    // environment, and a warning that prints environment values back out is how secrets end up
+    // in CI logs and terminal scrollback. Which variable to check is the useful half anyway.
+    const missing = [
+      fs.existsSync(certPath) ? null : "BLOCKS_SSL_CERT",
+      fs.existsSync(keyPath) ? null : "BLOCKS_SSL_KEY",
+    ]
+      .filter(Boolean)
+      .join(" and ");
+
     console.warn(
-      `[dev-https] cert/key file missing (cert=${certPath}, key=${keyPath}) — serving HTTP.`,
+      `[dev-https] ${missing} points at a file that does not exist — serving HTTP.`,
     );
     return undefined;
   }


### PR DESCRIPTION
Clears CodeQL alerts [34](https://github.com/SELISEdigitalplatforms/blocks-utilities/security/code-scanning/34) and 122–125, all high, all flagged against `dev` and carried by #227.

## Alert 34 — clear-text logging (`js/clear-text-logging`)

`client/vite.config.ts` printed the raw `BLOCKS_SSL_CERT` and `BLOCKS_SSL_KEY` values when the files they name are missing. They are paths rather than secrets, so this is not a leak of key material — but they come from the environment and land in CI logs and terminal scrollback, and the rule is right that reading environment values back out is the wrong habit for this code to be teaching.

The warning now names *which* variable is wrong instead of echoing it. That is the useful half anyway: nobody debugging this needs the path read back to them, they need to know which of the two to check.

```
[dev-https] BLOCKS_SSL_CERT points at a file that does not exist — serving HTTP.
```

Control flow and the HTTPS/HTTP fallback are untouched, as the Autofix suggestion advised.

## Alerts 122–125 — missing regexp anchor (`js/regex/missing-regexp-anchor`)

`/Remove method|Remove$/` in `stored-payment-methods-section.test.tsx` matched that phrase anywhere in an accessible name. Not a security issue in a test matcher — there is no untrusted input and no security decision — but it was genuinely loose: the dialog's confirm button is exactly `"Remove method"`, so `/^Remove method$/` is both what was meant and stricter, and it can no longer collide with the per-row `"Remove Visa ending in 4242"` buttons.

## Verification

- All 19 `stored-payment-methods-section` tests pass with the anchored matcher.
- Type-check clean; client build succeeds.
- `vite.config.ts` still reports its two pre-existing `no-console` lint errors — two before this change and two after, unchanged.

## Not fixed here

Eight other high alerts are open and none are in the subscription or payment work this promotion adds:

- `js/incomplete-hostname-regexp` and `js/regex/missing-regexp-anchor` in `app/idp/iam/constants/endpoint.constant.ts` (31, 37, 38) — needs tracing which regex CodeQL sees these base URLs flowing into before changing anything.
- `js/xss` in `app/components/logo/index.tsx` (32) and `js/xss-through-dom` in `profile-image-uploader.tsx` (33) — genuine XSS classes worth their own change.
- `js/file-system-race` in `e2e/global-setup.ts` (39).

There are also 62 medium alerts, most of them `Log entries created from user input` across `Utility.DomainService` and `Payment.DomainService`. That is one systemic pattern rather than 62 defects, and it wants a shared sanitising helper rather than 62 patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)