### PR TITLE
fix(subscription): raise charges under an idempotency key payment accepts

### DIFF
--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Subscription.DomainService.Utilities;
 
 public static class SubscriptionConstants
@@ -48,7 +51,7 @@ public static class SubscriptionConstants
     /// again after a crash between raising it and recording the link to it.
     /// </remarks>
     public static string InitialChargeKeyFor(string subscriptionId) =>
-        $"sub-init:{subscriptionId}";
+        DeterministicKey($"sub-init:{subscriptionId}");
 
     /// <summary>
     /// A renewal's order id, scoped to the period it charges rather than to the subscription.
@@ -72,7 +75,7 @@ public static class SubscriptionConstants
     /// succeed or fail independently of the attempt before it.
     /// </remarks>
     public static string RenewalKeyFor(string subscriptionId, string periodKey, int attempt) =>
-        $"sub-renew:{subscriptionId}:{periodKey}:{attempt}";
+        DeterministicKey($"sub-renew:{subscriptionId}:{periodKey}:{attempt}");
 
     /// <summary>
     /// A plan change's order id, scoped to the version being changed from.
@@ -86,7 +89,7 @@ public static class SubscriptionConstants
         $"{OrderIdPrefix}{subscriptionId}:planchange:{version}";
 
     public static string PlanChangeKeyFor(string subscriptionId, int version) =>
-        $"sub-planchange:{subscriptionId}:{version}";
+        DeterministicKey($"sub-planchange:{subscriptionId}:{version}");
 
     /// <summary>
     /// A usage invoice's order id, scoped to the period it charges and stable across every
@@ -103,5 +106,25 @@ public static class SubscriptionConstants
     /// free to succeed where the last one declined, not replay its cached failure.
     /// </summary>
     public static string UsageInvoiceKeyFor(string subscriptionId, string periodKey, int attempt) =>
-        $"sub-usage:{subscriptionId}:{periodKey}:{attempt}";
+        DeterministicKey($"sub-usage:{subscriptionId}:{periodKey}:{attempt}");
+
+    /// <summary>
+    /// A stable UUID for a logical idempotency key.
+    /// </summary>
+    /// <remarks>
+    /// Two requirements meet here and only this satisfies both. The payment module refuses any
+    /// idempotency key that does not parse as a UUID, and every charge this module raises has to
+    /// be re-derivable from stored state — a random key would be lost with the process that
+    /// raised it, taking with it the only way the recovery sweep can tell a charge that already
+    /// happened from one that never did.
+    /// <para>
+    /// Hashing gives both: the same inputs produce the same UUID on every machine and every
+    /// restart. The readable name survives as the hash input rather than in the key itself, so
+    /// an initial charge and a renewal for one subscription can never collapse onto the same
+    /// key. Half of a SHA-256 is far more than enough to keep them apart.
+    /// </para>
+    /// </remarks>
+    private static string DeterministicKey(string logicalName) =>
+        new Guid(SHA256.HashData(Encoding.UTF8.GetBytes(logicalName)).AsSpan(0, 16))
+            .ToString();
 }

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -11,6 +11,7 @@ using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
 
 namespace XUnitTest.Subscription;
 
@@ -118,8 +119,15 @@ public sealed class SubscriptionCheckoutServiceTests
             new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
 
         _paymentRequest!.OrderId.Should().Be($"sub:{_subscription.ItemId}");
-        _idempotencyKey.Should().Be($"sub-init:{_subscription.ItemId}",
+
+        // Asserted through the deriving function rather than as a literal: the key is a UUID
+        // hashed from the subscription, and what matters is that checkout and the recovery sweep
+        // derive the same one, not what it spells.
+        _idempotencyKey.Should().Be(
+            SubscriptionConstants.InitialChargeKeyFor(_subscription.ItemId),
             "a retried request must find the same payment, not raise a second one");
+        Guid.TryParse(_idempotencyKey, out _).Should().BeTrue(
+            "the payment module refuses an idempotency key that is not a UUID");
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionConstantsTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionConstantsTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The idempotency keys every subscription charge is raised under.
+/// </summary>
+/// <remarks>
+/// The regression these guard: the keys read as "sub-init:{id}" and the payment module refuses
+/// any idempotency key that does not parse as a UUID. Every charge this module raises — the
+/// first one, every renewal, every dunning retry, every plan change and every overage invoice —
+/// was rejected before it reached a provider. Nothing caught it because the subscription tests
+/// mock the payment service, so the format rule sat on the far side of a boundary neither side
+/// tested.
+/// </remarks>
+public sealed class SubscriptionConstantsTests
+{
+    private const string SubscriptionId = "8a7b6c5d-4e3f-2a1b-0c9d-8e7f6a5b4c3d";
+    private const string PeriodKey = "M20260901T000000Z";
+
+    public static TheoryData<string, string> EveryKey() => new()
+    {
+        { "initial charge", SubscriptionConstants.InitialChargeKeyFor(SubscriptionId) },
+        { "renewal", SubscriptionConstants.RenewalKeyFor(SubscriptionId, PeriodKey, 1) },
+        { "plan change", SubscriptionConstants.PlanChangeKeyFor(SubscriptionId, 3) },
+        { "usage invoice", SubscriptionConstants.UsageInvoiceKeyFor(SubscriptionId, PeriodKey, 1) }
+    };
+
+    [Theory]
+    [MemberData(nameof(EveryKey))]
+    public void Every_charge_key_is_a_uuid_the_payment_module_will_accept(
+        string description,
+        string key)
+    {
+        Guid.TryParse(key, out _).Should().BeTrue(
+            "the payment module rejects {0} keys that are not a UUID",
+            description);
+
+        key.Length.Should().BeLessThanOrEqualTo(64);
+    }
+
+    [Fact]
+    public void A_key_is_the_same_every_time_it_is_derived()
+    {
+        SubscriptionConstants.InitialChargeKeyFor(SubscriptionId)
+            .Should().Be(
+                SubscriptionConstants.InitialChargeKeyFor(SubscriptionId),
+                "the recovery sweep re-derives this to find a charge raised before a crash — a " +
+                "key that moved would let the same period be charged twice");
+    }
+
+    [Fact]
+    public void Two_subscriptions_never_share_a_key()
+    {
+        SubscriptionConstants.InitialChargeKeyFor(SubscriptionId)
+            .Should().NotBe(SubscriptionConstants.InitialChargeKeyFor("another-subscription"));
+    }
+
+    [Fact]
+    public void The_first_charge_and_a_renewal_of_one_subscription_are_separate_keys()
+    {
+        SubscriptionConstants.InitialChargeKeyFor(SubscriptionId)
+            .Should().NotBe(
+                SubscriptionConstants.RenewalKeyFor(SubscriptionId, PeriodKey, 1),
+                "the readable name survives as the hash input precisely so these cannot collapse " +
+                "onto one key and have the renewal replay the signup charge");
+    }
+
+    [Fact]
+    public void Each_dunning_attempt_gets_its_own_key()
+    {
+        SubscriptionConstants.RenewalKeyFor(SubscriptionId, PeriodKey, 1)
+            .Should().NotBe(
+                SubscriptionConstants.RenewalKeyFor(SubscriptionId, PeriodKey, 2),
+                "a retry is a new charge attempt, not a replay of the declined one");
+    }
+
+    [Fact]
+    public void Each_period_gets_its_own_renewal_key()
+    {
+        SubscriptionConstants.RenewalKeyFor(SubscriptionId, PeriodKey, 1)
+            .Should().NotBe(
+                SubscriptionConstants.RenewalKeyFor(SubscriptionId, "M20261001T000000Z", 1));
+    }
+
+    [Fact]
+    public void Each_plan_change_gets_its_own_key()
+    {
+        SubscriptionConstants.PlanChangeKeyFor(SubscriptionId, 3)
+            .Should().NotBe(SubscriptionConstants.PlanChangeKeyFor(SubscriptionId, 4));
+    }
+
+    [Fact]
+    public void Each_overage_attempt_gets_its_own_key()
+    {
+        SubscriptionConstants.UsageInvoiceKeyFor(SubscriptionId, PeriodKey, 1)
+            .Should().NotBe(
+                SubscriptionConstants.UsageInvoiceKeyFor(SubscriptionId, PeriodKey, 2));
+    }
+
+    /// <summary>
+    /// Order ids are not UUIDs — the payment module only caps their length — so they keep the
+    /// readable form that makes a subscription's charges findable by eye.
+    /// </summary>
+    [Fact]
+    public void Order_ids_stay_readable_and_within_the_payment_modules_limit()
+    {
+        SubscriptionConstants.OrderIdFor(SubscriptionId)
+            .Should().Be($"sub:{SubscriptionId}").And.HaveLength(40);
+
+        SubscriptionConstants.RenewalOrderIdFor(SubscriptionId, PeriodKey)
+            .Length.Should().BeLessThanOrEqualTo(80);
+
+        SubscriptionConstants.UsageInvoiceOrderIdFor(SubscriptionId, PeriodKey)
+            .Length.Should().BeLessThanOrEqualTo(80);
+
+        SubscriptionConstants.PlanChangeOrderIdFor(SubscriptionId, 3)
+            .Length.Should().BeLessThanOrEqualTo(80);
+    }
+}


### PR DESCRIPTION
Found in dev testing: subscribing to a plan returned

```json
{ "code": "invalid_idempotency_key",
  "message": "Idempotency-Key must be a UUID with at most 64 characters." }
```

## What was broken

`PaymentPreflightService` requires `Guid.TryParse(idempotencyKey)`. Every key this module derives reads `sub-init:{id}`, `sub-renew:{id}:{period}:{attempt}`, and so on — none of them parse.

So it is not only signup. **Every charge the subscription module raises was rejected before it reached a provider**: the first charge, every renewal, every dunning retry, every plan change, and every overage invoice. The entire money path, in all four call sites.

## Why nothing caught it

The subscription tests mock the payment service, so the format rule sat on the far side of a boundary neither side tested — payment tested that it rejects a non-UUID, subscription tested that it passes *a* key, and no test asserted the two agreed.

The new tests fix that by restating the payment module's rule where the keys are built: every key must parse as a UUID and stay within 64 characters. I verified they catch it by reverting the fix — `Every_charge_key_is_a_uuid_the_payment_module_will_accept` then fails with `key: "sub-init:8a7b6c5d-…"`, exactly the shape the API rejected.

## The fix

The keys must stay **derived, not random** — that is what lets the recovery sweep tell a charge that already happened from one that never did. A random key would be lost with the process that raised it, and the sweep would re-charge.

So the logical name is hashed into a UUID: same inputs, same key, on every machine and every restart. The readable name survives as the hash input rather than in the key itself, so an initial charge and a renewal of the same subscription cannot collapse onto one key and have the renewal replay the signup charge.

Order ids are deliberately untouched — the payment module only caps their length, so they keep the readable `sub:{id}` form that makes a subscription's charges findable by eye. There is a test pinning that too.

## Verification

- 2095 unit tests pass, 1 skipped, 0 failures (12 new).
- Reverting the fix fails the new tests, so they guard the regression rather than describing it.
- `RecurringChargeBillingGateway` passes the key through unchanged, so the UUID reaches payment intact. `StripeInvoiceBillingGateway` suffixes `:item` / `:pay` for Stripe's own header, which takes arbitrary strings — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)