### PR TITLE
fix(subscription): show the identifiers a caller has to send back

### DIFF
--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+
+const { useSubscriptionPlan } = vi.hoisted(() => ({ useSubscriptionPlan: vi.fn() }));
+
+vi.mock("../hooks/use-subscription-plan", () => ({ useSubscriptionPlan }));
+
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({
+    data: { organizations: [{ itemId: "org-1", name: "AmLora Test Org" }] },
+    isError: false,
+  }),
+}));
+
+vi.mock("@seliseblocks/genesis-os", () => ({
+  useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
+}));
+
+import { SubscriptionPlanDetailPage } from "./subscription-plan-detail-page";
+
+const plan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan => ({
+  planId: "plan-1",
+  code: "personal101",
+  displayName: "Personal - 101",
+  description: null,
+  featuresJson: null,
+  organizationId: "org-1",
+  trialDays: null,
+  trialRequiresPaymentMethod: true,
+  version: 1,
+  hasSubscribers: false,
+  quantityItems: [],
+  meters: [
+    {
+      meterKey: "ses-signatures",
+      displayName: "Simple Signatures (SES)",
+      unitLabel: "signature",
+      aggregation: "Sum",
+      includedQuantity: 150,
+      overageAllowed: true,
+      thresholdPercents: [80],
+      rateTables: [],
+    },
+  ],
+  entitlements: [
+    {
+      key: "ses-signatures",
+      limitKind: "Count",
+      limit: 150,
+      meterKey: "ses-signatures",
+      unitLabel: "signature",
+    },
+  ],
+  prices: [
+    {
+      priceId: "price-abc-123",
+      currencyCode: "EUR",
+      unitAmountMinor: 300,
+      interval: "Month",
+      intervalCount: 1,
+      quantityItemKey: null,
+    },
+  ],
+  trialGrants: [],
+  ...overrides,
+});
+
+const renderPage = (subscriptionPlan: SubscriptionPlan) => {
+  useSubscriptionPlan.mockReturnValue({
+    data: subscriptionPlan,
+    isLoading: false,
+    isError: false,
+    error: null,
+  });
+
+  render(
+    <MemoryRouter>
+      <SubscriptionPlanDetailPage />
+    </MemoryRouter>,
+  );
+};
+
+/**
+ * These guard one recurring failure rather than the page's looks: every identifier an integrator
+ * has to send back was missing from the page that exists to tell them what to send. Finding a
+ * meter key meant reading the API — the exact errand this portal was built to remove.
+ */
+describe("SubscriptionPlanDetailPage identifiers", () => {
+  // Asserted through the copy control rather than the text: this plan names its entitlement
+  // after its meter, so "ses-signatures" legitimately appears three times on the page.
+  it("shows the meter key every usage call has to carry", () => {
+    renderPage(plan());
+
+    expect(screen.getByText("Meter key")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy Meter key ses-signatures" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the price id subscribing has to name", () => {
+    renderPage(plan());
+
+    expect(screen.getByText("price-abc-123")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Copy Price id price-abc-123" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows which meter an entitlement draws down", () => {
+    renderPage(plan());
+
+    expect(screen.getByText("Draws down")).toBeInTheDocument();
+  });
+
+  it("says nothing about a drawn-down meter for an entitlement that counts nothing", () => {
+    renderPage(
+      plan({
+        entitlements: [
+          {
+            key: "priority-support",
+            limitKind: "Boolean",
+            limit: null,
+            meterKey: null,
+            unitLabel: null,
+          },
+        ],
+      }),
+    );
+
+    expect(screen.queryByText("Draws down")).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { AlertCircle, AlertTriangle, Layers, Pencil, Plus } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { AlertCircle, AlertTriangle, Check, Copy, Layers, Pencil, Plus } from "lucide-react";
 import { Link, useParams } from "react-router";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
@@ -160,7 +160,11 @@ export const SubscriptionPlanDetailPage = () => {
                 {plan.meters.map((meter) => (
                   <Card key={meter.meterKey} className="rounded-lg">
                     <p className="font-medium">{meter.displayName}</p>
-                    <p className="text-sm text-muted-foreground">
+                    {/* The value every POST /subscription-usage call has to carry. Showing only
+                        the display name sent integrators to the API to find out what to send,
+                        which is the errand this page exists to save them. */}
+                    <IdentifierField label="Meter key" value={meter.meterKey} />
+                    <p className="mt-2 text-sm text-muted-foreground">
                       {formatMeterAllowance(meter)}
                     </p>
                     {/* Optional-chained deliberately: a plan stored before the response
@@ -186,9 +190,14 @@ export const SubscriptionPlanDetailPage = () => {
                   return (
                     <Card key={entitlement.key} className="rounded-lg">
                       <p className="font-medium">{entitlement.key}</p>
-                      <p className="text-sm text-muted-foreground">
+                      <p className="mt-1 text-sm text-muted-foreground">
                         {formatEntitlementLimit(entitlement)}
                       </p>
+                      {/* Which meter draws this down was equally invisible, so a limit could not
+                          be traced to the counter that enforces it without reading the API. */}
+                      {entitlement.meterKey && (
+                        <IdentifierField label="Draws down" value={entitlement.meterKey} />
+                      )}
                       {mismatch && (
                         <p className="mt-2 flex items-start gap-1.5 text-xs text-warning-700">
                           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -221,6 +230,9 @@ export const SubscriptionPlanDetailPage = () => {
                 {plan.prices.map((price) => (
                   <Card key={price.priceId} className="rounded-lg">
                     <p className="font-medium">{formatPrice(price)}</p>
+                    {/* Subscribing names the price by this id, so leaving it off the page meant
+                        nobody could subscribe without reading the API first. */}
+                    <IdentifierField label="Price id" value={price.priceId} />
                     <Badge variant="outline" className="mt-2 font-normal">
                       {price.currencyCode}
                     </Badge>
@@ -236,6 +248,50 @@ export const SubscriptionPlanDetailPage = () => {
         </div>
       </div>
     </main>
+  );
+};
+
+/**
+ * An identifier the caller has to send verbatim, shown so it can be read and copied rather than
+ * retyped. Monospaced because a slug that is retyped by eye is a slug that arrives with a typo.
+ */
+const IdentifierField = ({ label, value }: { label: string; value: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+
+    const timer = setTimeout(() => setCopied(false), 1500);
+
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <div className="mt-1 flex items-center gap-1.5">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">{value}</code>
+      <button
+        type="button"
+        // Optional-chained: clipboard access is unavailable outside a secure context, and a
+        // page that throws there would take the whole plan view down over a convenience.
+        onClick={() => {
+          navigator.clipboard?.writeText(value).then(
+            () => setCopied(true),
+            () => setCopied(false),
+          );
+        }}
+        aria-label={`Copy ${label} ${value}`}
+        className="text-muted-foreground transition hover:text-foreground"
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-blocks-primary-600" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+      </button>
+    </div>
   );
 };
 


### PR DESCRIPTION
Found in dev testing: finding a meter key to record usage meant reading `GET /subscription-plans` directly, because the plan page never showed it.

That is the errand this portal exists to remove. An integrator should not have to read the API to learn what the API wants.

## Three identifiers were hidden

| Where | What was missing | Why it matters |
|---|---|---|
| Meters | `meterKey` — only `displayName` was rendered | Every `POST /subscription-usage` call has to carry it |
| Prices | `priceId` | `POST /subscriptions` names the price by it, so the page could not tell you how to subscribe |
| Entitlements | the `meterKey` it draws down | A limit could not be traced to the counter that enforces it |

The inconsistency is what made it easy to miss: quantity items already showed `itemKey` as their heading and entitlements showed their own `key`. Meters and prices were the two that hid theirs, and they are the two an integrator needs most.

## The fix

Each is shown monospaced with a copy control — a slug retyped by eye is a slug that arrives with a typo, and these are pasted straight into API calls.

Clipboard access is optional-chained: it is unavailable outside a secure context, and a plan page should not go down over a convenience.

## Verification

- New page tests assert each identifier is rendered and copyable, and that an uncounted entitlement shows no "Draws down" line.
- Asserted through the copy control's accessible name rather than the text, because a plan that names its entitlement after its meter legitimately shows the same slug three times — the first draft of the test failed on exactly that.
- 102 subscription tests pass; type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)