### PR TITLE
feat(subscription): discover tenants instead of listing them by hand

### DIFF
--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -425,8 +425,31 @@ happens within milliseconds. `SubscriptionReconciliationBackgroundService` is th
 what no message carries: a compare-and-set lost to a worker that then crashed, a charge raised
 but never recorded, a webhook that arrived during a restart.
 
-> The sweep does nothing unless `Subscription:TenantIds` is set, and says so loudly at startup.
-> Nothing else discovers tenants.
+### Which tenants the sweep covers
+
+Discovered, not configured. `SubscriptionTenantDirectory` reads the platform's own tenant
+registry — the `Tenants` collection in the root database, reached by connection string and
+database name rather than by ambient tenant, which is what makes it readable from background work
+that has no request to resolve one from.
+
+The roster is asked for on **every pass** and cached for `TenantRefreshSeconds`. It is never
+captured at startup: projects are created at any time and can subscribe immediately, so a list
+read once is stale the moment the next one appears — and a tenant the sweep never visits is a
+tenant whose renewals silently never happen.
+
+Three rules follow from that, and each exists because its opposite fails quietly:
+
+- **An empty roster is a quiet pass, never the end of the loop.** On a fresh environment nobody
+  has signed up yet; that is not a misconfiguration, and the loop must still be running when the
+  first tenant appears.
+- **A failed read keeps the last known roster.** Sweeping nothing because the registry blinked
+  would stop billing while the service went on looking healthy.
+- **`TenantIds`, when set, overrides discovery entirely.** For pinning one tenant locally, and as
+  an escape hatch if discovery itself is ever the problem.
+
+The refresh interval is generous on purpose. Nothing time-critical waits on it: a subscription
+activates from the payment webhook, which carries its own tenant and never consults the roster.
+The sweep only matters at the first renewal, a whole billing period later.
 
 ## Settings
 
@@ -434,7 +457,8 @@ Under the `Subscription` section. The ones whose default is a decision:
 
 | Setting | Default | Why it matters |
 | --- | --- | --- |
-| `TenantIds` | *(empty)* | Which tenants the sweep covers. An omitted tenant is never reconciled. |
+| `TenantIds` | *(empty)* | Pins the sweep to specific tenants. Empty discovers them from the registry. |
+| `TenantRefreshSeconds` | `300` | How long a discovered roster is reused. Nothing time-critical waits on it. |
 | `EntitlementCacheSeconds` | `10` | How stale an entitlement answer may be. Counters are never cached. |
 | `CounterRetentionDays` | `400` | How long a finished period's counter is kept. Long enough for a billing dispute. |
 | `InitialChargeGraceMinutes` | `60` | How long an unpaid subscription waits before it is treated as abandoned. |

--- a/server/Subscription.DomainService/Repositories/ISubscriptionTenantSource.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionTenantSource.cs
@@ -1,0 +1,13 @@
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// Where the list of tenants comes from.
+/// </summary>
+/// <remarks>
+/// Its own type so the policy around the list — caching it, holding the last good one when a
+/// read fails — can be tested without a database. This half is the part that cannot be.
+/// </remarks>
+public interface ISubscriptionTenantSource
+{
+    Task<IReadOnlyList<string>> ListTenantIdsAsync(CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/RootDatabaseTenantSource.cs
+++ b/server/Subscription.DomainService/Repositories/RootDatabaseTenantSource.cs
@@ -1,0 +1,65 @@
+using Blocks.Genesis;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// Reads the platform's own tenant registry.
+/// </summary>
+/// <remarks>
+/// The registry lives in the root database rather than any tenant's, which is what makes it
+/// readable from background work: it is addressed by connection string and database name
+/// directly, so unlike every other read in this module it needs no ambient tenant to resolve
+/// first. The same door <c>ProjectRepository</c> in blocks-os uses for its own root-scoped reads.
+/// <para>
+/// Projected through <see cref="BsonDocument"/> rather than the platform's tenant type. Only the
+/// identifier is wanted, and reading one field keeps this from breaking the day a field is added
+/// to a document this module does not own.
+/// </para>
+/// </remarks>
+public sealed class RootDatabaseTenantSource : ISubscriptionTenantSource
+{
+    /// <summary>The registry's collection, as blocks-os names it.</summary>
+    private const string TenantCollection = "Tenants";
+
+    /// <summary>Used only when the secret carries no root database name.</summary>
+    private const string FallbackRootDatabase = "BlocksRootDb";
+
+    private const string TenantIdField = "TenantId";
+
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly IBlocksSecret _secret;
+
+    public RootDatabaseTenantSource(
+        IDbContextProvider dbContextProvider,
+        IBlocksSecret secret)
+    {
+        _dbContextProvider = dbContextProvider;
+        _secret = secret;
+    }
+
+    public async Task<IReadOnlyList<string>> ListTenantIdsAsync(
+        CancellationToken cancellationToken)
+    {
+        var rootDatabase = string.IsNullOrWhiteSpace(_secret.RootDatabaseName)
+            ? FallbackRootDatabase
+            : _secret.RootDatabaseName;
+
+        var tenants = _dbContextProvider
+            .GetDatabase(_secret.DatabaseConnectionString, rootDatabase)
+            .GetCollection<BsonDocument>(TenantCollection);
+
+        var documents = await tenants
+            .Find(Builders<BsonDocument>.Filter.Exists(TenantIdField))
+            .Project(Builders<BsonDocument>.Projection.Include(TenantIdField))
+            .ToListAsync(cancellationToken);
+
+        return documents
+            .Select(document => document.GetValue(TenantIdField, BsonNull.Value))
+            .Where(value => value.IsString && !string.IsNullOrWhiteSpace(value.AsString))
+            .Select(value => value.AsString)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionTenantDirectory.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionTenantDirectory.cs
@@ -1,0 +1,14 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Which tenants the background sweeps run for.
+/// </summary>
+/// <remarks>
+/// Asked repeatedly rather than read once. Projects are created at any time and can subscribe
+/// immediately, so a roster captured at startup is stale the moment the next one appears — and a
+/// tenant the sweep never visits is a tenant whose renewals silently never happen.
+/// </remarks>
+public interface ISubscriptionTenantDirectory
+{
+    Task<IReadOnlyList<string>> ListTenantIdsAsync(CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionTenantDirectory.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionTenantDirectory.cs
@@ -1,0 +1,105 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <inheritdoc />
+public sealed class SubscriptionTenantDirectory : ISubscriptionTenantDirectory
+{
+    private readonly ISubscriptionTenantSource _source;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionTenantDirectory> _logger;
+    private readonly TimeProvider _time;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private IReadOnlyList<string> _tenantIds = [];
+    private DateTimeOffset? _refreshedAt;
+
+    public SubscriptionTenantDirectory(
+        ISubscriptionTenantSource source,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<SubscriptionTenantDirectory> logger,
+        TimeProvider? time = null)
+    {
+        _source = source;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<IReadOnlyList<string>> ListTenantIdsAsync(
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+
+        // A configured list wins outright and never reaches the registry. This is the escape
+        // hatch: pinning one tenant locally, or overriding discovery if it ever misbehaves in an
+        // environment where billing cannot wait for a fix.
+        if (options.TenantIds.Length > 0)
+        {
+            return options.TenantIds;
+        }
+
+        await _gate.WaitAsync(cancellationToken);
+
+        try
+        {
+            if (!IsStale(options))
+            {
+                return _tenantIds;
+            }
+
+            var discovered = await _source.ListTenantIdsAsync(cancellationToken);
+
+            // Only after a successful read, so a failure leaves the previous list in place
+            // rather than aging into an empty one.
+            _refreshedAt = _time.GetUtcNow();
+
+            if (discovered.Count == 0)
+            {
+                // Said out loud every refresh. An empty registry is legitimate on a fresh
+                // environment, but it is indistinguishable from a misconfigured one, and the
+                // symptom of the second is billing that quietly never runs.
+                _logger.LogWarning(
+                    "Subscription reconciliation discovered no tenants and will sweep nothing " +
+                    "this pass");
+            }
+            else if (discovered.Count != _tenantIds.Count)
+            {
+                _logger.LogInformation(
+                    "Subscription tenant roster refreshed TenantCount={TenantCount} " +
+                    "PreviousTenantCount={PreviousTenantCount}",
+                    discovered.Count,
+                    _tenantIds.Count);
+            }
+
+            _tenantIds = discovered;
+
+            return _tenantIds;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            // Sweeping nothing because the registry was briefly unreachable is the worst
+            // outcome available: billing stops while the service goes on looking healthy. The
+            // last known roster is stale at worst, and a tenant list does not change quickly.
+            _logger.LogWarning(
+                exception,
+                "Subscription tenant roster could not be refreshed; continuing with the last " +
+                "known TenantCount={TenantCount}",
+                _tenantIds.Count);
+
+            return _tenantIds;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private bool IsStale(SubscriptionOptions options) =>
+        _refreshedAt is not { } refreshedAt ||
+        _time.GetUtcNow() - refreshedAt >=
+            TimeSpan.FromSeconds(Math.Max(1, options.TenantRefreshSeconds));
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -49,6 +49,16 @@ public static class ApplicationServiceCollectionExtensions
 
         // Singleton so the cache is actually shared. Scoped, every request would get an empty
         // one and the hot path would read the database every time regardless.
+        services.AddSingleton<
+            ISubscriptionTenantSource,
+            RootDatabaseTenantSource>();
+
+        // Singleton so the roster is actually cached. Scoped, every sweep would read the
+        // registry again and the refresh interval would mean nothing.
+        services.AddSingleton<
+            ISubscriptionTenantDirectory,
+            SubscriptionTenantDirectory>();
+
         services.AddSingleton<IEntitlementSnapshotCache, EntitlementSnapshotCache>();
         services.AddSingleton<IPlanResponseMapper, PlanResponseMapper>();
         services.AddSingleton<

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -77,8 +77,24 @@ public sealed class SubscriptionOptions
     public int MaximumUsageMetadataValueLength { get; set; } = 256;
 
     /// <summary>
-    /// Which tenants background sweeps run for. Nothing else discovers tenants, so a tenant
-    /// omitted here is silently skipped.
+    /// Pins background sweeps to specific tenants. Empty — the normal case — discovers them from
+    /// the platform's tenant registry instead.
     /// </summary>
+    /// <remarks>
+    /// Kept as an override rather than the source of truth. A hand-maintained list is stale the
+    /// moment the next project is created, and a tenant the sweep never visits is a tenant whose
+    /// renewals silently never happen. Useful for pinning one tenant locally, and as an escape
+    /// hatch if discovery ever misbehaves somewhere billing cannot wait.
+    /// </remarks>
     public string[] TenantIds { get; set; } = [];
+
+    /// <summary>
+    /// How long a discovered tenant roster is reused before it is read again.
+    /// </summary>
+    /// <remarks>
+    /// Generous on purpose. Nothing time-critical waits on this: a subscription activates from
+    /// the payment webhook, which carries its own tenant and never consults the roster. The
+    /// sweep only matters at the first renewal, a whole billing period later.
+    /// </remarks>
+    public int TenantRefreshSeconds { get; set; } = 300;
 }

--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Options;
 using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
 using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 
 namespace Worker;
@@ -40,22 +41,7 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var tenantIds = _options.CurrentValue.TenantIds;
-
-        if (tenantIds.Length == 0)
-        {
-            // Said plainly, because the alternative is a service that looks healthy and
-            // reconciles nothing. Nothing else discovers tenants.
-            _logger.LogWarning(
-                "Subscription reconciliation has no tenants configured and will do nothing. " +
-                "Set Subscription:TenantIds to enable it");
-
-            return;
-        }
-
-        _logger.LogInformation(
-            "Subscription reconciliation started TenantCount={TenantCount}",
-            tenantIds.Length);
+        _logger.LogInformation("Subscription reconciliation started");
 
         using var timer = new PeriodicTimer(PollInterval());
 
@@ -64,6 +50,17 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
             try
             {
                 await timer.WaitForNextTickAsync(stoppingToken);
+
+                // Asked every pass, not captured at startup. Projects are created at any time
+                // and can subscribe immediately; a roster read once is stale the moment the next
+                // one appears, and a tenant this never visits is a tenant whose renewals never
+                // happen. An empty answer is a quiet pass, never the end of the loop — on a
+                // fresh environment it simply means nobody has signed up yet.
+                using var directoryScope = _scopeFactory.CreateScope();
+                var tenantIds = await directoryScope.ServiceProvider
+                    .GetRequiredService<ISubscriptionTenantDirectory>()
+                    .ListTenantIdsAsync(stoppingToken);
+
                 await SweepAsync(tenantIds, stoppingToken);
             }
             catch (OperationCanceledException)

--- a/server/XUnitTest/Subscription/SubscriptionTenantDirectoryTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionTenantDirectoryTests.cs
@@ -1,0 +1,171 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Which tenants the background sweeps run for.
+/// </summary>
+/// <remarks>
+/// The behaviour these protect: the roster used to be read once at startup, so a project created
+/// afterwards was never swept and its renewals silently never happened until someone redeployed.
+/// Projects are created at any time and can subscribe immediately, so this has to be a question
+/// asked repeatedly rather than a value captured.
+/// </remarks>
+public sealed class SubscriptionTenantDirectoryTests
+{
+    private readonly Mock<ISubscriptionTenantSource> _source = new();
+    private readonly SubscriptionOptions _options = new();
+    private readonly ControlledTimeProvider _time = new(DateTimeOffset.Parse("2026-08-17T09:00:00Z"));
+
+    public SubscriptionTenantDirectoryTests() =>
+        _source
+            .Setup(source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["tenant-1", "tenant-2"]);
+
+    [Fact]
+    public async Task Tenants_are_discovered_when_none_are_configured()
+    {
+        var tenants = await Directory().ListTenantIdsAsync(CancellationToken.None);
+
+        tenants.Should().BeEquivalentTo(["tenant-1", "tenant-2"]);
+    }
+
+    [Fact]
+    public async Task A_configured_list_overrides_discovery_entirely()
+    {
+        _options.TenantIds = ["pinned-tenant"];
+
+        var tenants = await Directory().ListTenantIdsAsync(CancellationToken.None);
+
+        tenants.Should().BeEquivalentTo(["pinned-tenant"]);
+        _source.Verify(
+            source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the override exists for the case where discovery itself is the problem");
+    }
+
+    [Fact]
+    public async Task The_roster_is_reused_within_the_refresh_window()
+    {
+        var directory = Directory();
+
+        await directory.ListTenantIdsAsync(CancellationToken.None);
+        _time.Advance(TimeSpan.FromSeconds(_options.TenantRefreshSeconds - 1));
+        await directory.ListTenantIdsAsync(CancellationToken.None);
+
+        _source.Verify(
+            source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the sweep runs far more often than the roster changes");
+    }
+
+    [Fact]
+    public async Task A_tenant_created_after_startup_is_picked_up_on_the_next_refresh()
+    {
+        var directory = Directory();
+
+        await directory.ListTenantIdsAsync(CancellationToken.None);
+
+        _source
+            .Setup(source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["tenant-1", "tenant-2", "tenant-new"]);
+        _time.Advance(TimeSpan.FromSeconds(_options.TenantRefreshSeconds));
+
+        var tenants = await directory.ListTenantIdsAsync(CancellationToken.None);
+
+        tenants.Should().Contain("tenant-new");
+    }
+
+    [Fact]
+    public async Task A_failed_read_keeps_the_last_known_roster()
+    {
+        var directory = Directory();
+
+        await directory.ListTenantIdsAsync(CancellationToken.None);
+
+        _source
+            .Setup(source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("registry unreachable"));
+        _time.Advance(TimeSpan.FromSeconds(_options.TenantRefreshSeconds));
+
+        var tenants = await directory.ListTenantIdsAsync(CancellationToken.None);
+
+        tenants.Should().BeEquivalentTo(
+            ["tenant-1", "tenant-2"],
+            "sweeping nothing because the registry blinked would stop billing while the " +
+            "service went on looking healthy");
+    }
+
+    [Fact]
+    public async Task A_failed_first_read_is_empty_rather_than_fatal()
+    {
+        _source
+            .Setup(source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("registry unreachable"));
+
+        var directory = Directory();
+
+        var tenants = await directory.ListTenantIdsAsync(CancellationToken.None);
+
+        tenants.Should().BeEmpty();
+
+        // And the next attempt still tries: a failure must not poison the cache into never
+        // reading again, which is how the old startup-once behaviour failed.
+        _source
+            .Setup(source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["tenant-1"]);
+        _time.Advance(TimeSpan.FromSeconds(_options.TenantRefreshSeconds));
+
+        (await directory.ListTenantIdsAsync(CancellationToken.None))
+            .Should().BeEquivalentTo(["tenant-1"]);
+    }
+
+    [Fact]
+    public async Task An_empty_registry_is_a_quiet_pass_and_is_retried()
+    {
+        _source
+            .Setup(source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var directory = Directory();
+
+        (await directory.ListTenantIdsAsync(CancellationToken.None)).Should().BeEmpty();
+
+        _source
+            .Setup(source => source.ListTenantIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["tenant-first"]);
+        _time.Advance(TimeSpan.FromSeconds(_options.TenantRefreshSeconds));
+
+        (await directory.ListTenantIdsAsync(CancellationToken.None))
+            .Should().BeEquivalentTo(
+                ["tenant-first"],
+                "an empty registry is legitimate on a fresh environment, so it cannot be the " +
+                "end of discovery");
+    }
+
+    private SubscriptionTenantDirectory Directory() => new(
+        _source.Object,
+        new StaticOptionsMonitor(_options),
+        NullLogger<SubscriptionTenantDirectory>.Instance,
+        _time);
+
+    private sealed class StaticOptionsMonitor : IOptionsMonitor<SubscriptionOptions>
+    {
+        private readonly SubscriptionOptions _value;
+
+        public StaticOptionsMonitor(SubscriptionOptions value) => _value = value;
+
+        public SubscriptionOptions CurrentValue => _value;
+
+        public SubscriptionOptions Get(string? name) => _value;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
`Subscription:TenantIds` was a hand-maintained list, which does not work when any project can be created at any time and subscribe immediately.

## The bug underneath the inconvenience

The list wasn't just tedious — it was read **once, at startup**, and the service gave up entirely when it was empty:

```csharp
var tenantIds = _options.CurrentValue.TenantIds;

if (tenantIds.Length == 0)
{
    _logger.LogWarning("... will do nothing. Set Subscription:TenantIds to enable it");
    return;          // ExecuteAsync exits — the loop never starts
}
```

Two silent failures followed:

- A project created **after** the worker started was never swept. Its renewals simply never happened until somebody redeployed. Filling in the config correctly today did not help, because the list was stale by construction.
- An environment with nothing configured logged one warning at startup and then ran a healthy-looking service that reconciled nothing, forever.

## Where the tenants come from

The platform already keeps a registry. `blocks-os`'s own `ProjectRepository` reads it like this:

```csharp
_dbContextProvider.GetDatabase(_blocksSecret.DatabaseConnectionString, "BlocksRootDb");
...
_clientDb.GetCollection<Tenant>(IdentifierConstants.TenantCollectionName);   // "Tenants"
```

That door works from background work precisely because it is addressed by connection string and database name rather than by ambient tenant — there is no `BlocksContext` to resolve. The Worker already holds both values; `Program.cs` passes them to the config driver at startup.

Read through `BsonDocument` rather than the platform's tenant type: only the identifier is wanted, and reading one field keeps this from breaking the day a field is added to a document this module does not own.

## Three rules, each because its opposite fails quietly

- **An empty roster is a quiet pass, never the end of the loop.** On a fresh environment nobody has signed up yet — that is legitimate, and the loop must still be running when the first one does.
- **A failed read keeps the last known roster.** Sweeping nothing because the registry briefly blinked would stop billing while the service went on looking healthy.
- **`TenantIds` still wins when set.** For pinning one tenant locally, and as an escape hatch if discovery itself is ever the problem somewhere billing cannot wait.

## Shape

Split so the policy is testable without a database — `ISubscriptionTenantSource` reads, `SubscriptionTenantDirectory` decides. Registered singleton so the cache is real; scoped, every sweep would re-read and the interval would mean nothing.

`TenantRefreshSeconds` defaults to 300 and is deliberately generous. Nothing time-critical waits on it: a subscription activates from the payment webhook, which carries its own `command.TenantId` and never consults the roster. The sweep only matters at the first renewal, a whole billing period later.

## Verification

- 2102 unit tests pass, 1 skipped (7 new).
- Reverting the cache to never refresh — the old read-once behaviour — fails exactly the two tests that should: "a tenant created after startup is picked up on the next refresh" and "an empty registry is a quiet pass and is retried".
- Not exercised against a live root database here; the source half is thin by design and the policy half is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)