### PR TITLE
fix(subscription): let one unreachable tenant skip its pass, not the sweep

### DIFF
--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -91,48 +91,69 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
                 return;
             }
 
-            using var scope = _scopeFactory.CreateScope();
-            var services = scope.ServiceProvider;
-
-            // Background work has no request to read a tenant from, so one is established for
-            // the duration — the same discipline the payment work consumer follows.
-            using var context = services
-                .GetRequiredService<IPaymentTenantContextScopeFactory>()
-                .Establish(tenantId);
-
-            using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+            try
             {
-                ["TenantHash"] = PaymentLogValue.Hash(tenantId),
-                ["SubscriptionSweepId"] = Guid.NewGuid().ToString("N")
-            });
-
-            var activation = services.GetRequiredService<ISubscriptionActivationProcessor>();
-            var renewals = services.GetRequiredService<ISubscriptionRenewalProcessor>();
-            var usageRating = services.GetRequiredService<ISubscriptionUsageRatingProcessor>();
-            var outbox = services.GetRequiredService<ISubscriptionOutboxProcessor>();
-
-            var settled = await activation.ProcessDueAsync(tenantId, stoppingToken);
-            var recovered = await activation.RecoverStaleAsync(tenantId, stoppingToken);
-            var renewed = await renewals.ProcessDueAsync(tenantId, stoppingToken);
-            var periodsClosed = await usageRating.CloseDuePeriodsAsync(tenantId, stoppingToken);
-            var invoicesCharged = await usageRating.ChargeDueInvoicesAsync(tenantId, stoppingToken);
-            var published = await outbox.PublishDueAsync(tenantId, stoppingToken);
-
-            if (settled + recovered + renewed + periodsClosed + invoicesCharged + published > 0)
-            {
-                _logger.LogInformation(
-                    "Subscription reconciliation pass completed SettledCount={SettledCount} " +
-                    "RecoveredCount={RecoveredCount} RenewedCount={RenewedCount} " +
-                    "UsagePeriodsClosedCount={UsagePeriodsClosedCount} " +
-                    "UsageInvoicesChargedCount={UsageInvoicesChargedCount} " +
-                    "PublishedCount={PublishedCount}",
-                    settled,
-                    recovered,
-                    renewed,
-                    periodsClosed,
-                    invoicesCharged,
-                    published);
+                await SweepTenantAsync(tenantId, stoppingToken);
             }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                // One tenant's failure ends that tenant's pass, never the sweep. The roster is
+                // discovered rather than curated, so it will contain tenants this service cannot
+                // reach — one never provisioned a database, one mid-migration. Letting that
+                // escape would abort the loop at whatever position the bad tenant happens to
+                // occupy and silently stop billing every tenant ordered after it.
+                _logger.LogWarning(
+                    exception,
+                    "Subscription reconciliation skipped a tenant after an error " +
+                    "TenantHash={TenantHash}",
+                    PaymentLogValue.Hash(tenantId));
+            }
+        }
+    }
+
+    private async Task SweepTenantAsync(string tenantId, CancellationToken stoppingToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var services = scope.ServiceProvider;
+
+        // Background work has no request to read a tenant from, so one is established for
+        // the duration — the same discipline the payment work consumer follows.
+        using var context = services
+            .GetRequiredService<IPaymentTenantContextScopeFactory>()
+            .Establish(tenantId);
+
+        using var logScope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["TenantHash"] = PaymentLogValue.Hash(tenantId),
+            ["SubscriptionSweepId"] = Guid.NewGuid().ToString("N")
+        });
+
+        var activation = services.GetRequiredService<ISubscriptionActivationProcessor>();
+        var renewals = services.GetRequiredService<ISubscriptionRenewalProcessor>();
+        var usageRating = services.GetRequiredService<ISubscriptionUsageRatingProcessor>();
+        var outbox = services.GetRequiredService<ISubscriptionOutboxProcessor>();
+
+        var settled = await activation.ProcessDueAsync(tenantId, stoppingToken);
+        var recovered = await activation.RecoverStaleAsync(tenantId, stoppingToken);
+        var renewed = await renewals.ProcessDueAsync(tenantId, stoppingToken);
+        var periodsClosed = await usageRating.CloseDuePeriodsAsync(tenantId, stoppingToken);
+        var invoicesCharged = await usageRating.ChargeDueInvoicesAsync(tenantId, stoppingToken);
+        var published = await outbox.PublishDueAsync(tenantId, stoppingToken);
+
+        if (settled + recovered + renewed + periodsClosed + invoicesCharged + published > 0)
+        {
+            _logger.LogInformation(
+                "Subscription reconciliation pass completed SettledCount={SettledCount} " +
+                "RecoveredCount={RecoveredCount} RenewedCount={RenewedCount} " +
+                "UsagePeriodsClosedCount={UsagePeriodsClosedCount} " +
+                "UsageInvoicesChargedCount={UsageInvoicesChargedCount} " +
+                "PublishedCount={PublishedCount}",
+                settled,
+                recovered,
+                renewed,
+                periodsClosed,
+                invoicesCharged,
+                published);
         }
     }
 


### PR DESCRIPTION
Found on the first local worker run against real tenant data, immediately after #234 made the roster discovered rather than curated.

```
Could not initialize database for tenant '45E5…'
 ---> Database information is missing for tenant: 45E5…
   at SubscriptionActivationProcessor.ProcessDueAsync
   at SubscriptionReconciliationBackgroundService.SweepAsync
```

## Why this is worse than a noisy log

`SweepAsync` looped over tenants with **no isolation**. The first tenant that threw ended the whole pass, and every tenant ordered after it was skipped. The next pass reached the same tenant and died in the same place — so the skip was permanent, and silent: the outer handler logged "pass failed and will be retried" while renewals, usage rating and outbox publishing quietly stopped for every tenant behind the bad one.

A hand-curated `TenantIds` list hid this, because it only ever contained tenants somebody had checked. A **discovered** roster is the platform's own, and it legitimately contains tenants this service cannot reach — one never provisioned a database, one mid-migration, one belonging to a product that does not use subscriptions. That is not an error to fix in the registry; it is a normal condition the sweep has to tolerate.

The local run demonstrated it exactly: an unrelated tenant with no database information aborted the pass before the tenant under test was ever visited.

## The fix

Each tenant's work runs inside its own `try`. A failure logs the tenant hash and the sweep moves to the next one. `OperationCanceledException` still propagates, so shutdown is unaffected.

The body moved into `SweepTenantAsync` unchanged — the diff looks larger than it is because of the indentation change.

## Verification

- Builds clean.
- Behaviour confirmed against the live dev registry: the sweep now logs one warning for the unreachable tenant and continues to the rest.