### PR TITLE
fix(subscription): make subscription renewals actually collect money

### DIFF
--- a/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
@@ -21,9 +21,16 @@ namespace Payment.DomainService.Providers.Stripe;
 /// </remarks>
 public interface IStripeInvoiceClient
 {
+    /// <param name="invoiceId">
+    /// The draft invoice this line belongs to. Named explicitly rather than left pending for the
+    /// next invoice to sweep up: recent Stripe API versions default
+    /// <c>pending_invoice_items_behavior</c> to <c>exclude</c>, so a pending line is silently left
+    /// off and the invoice finalizes at zero — settled, collecting nothing.
+    /// </param>
     Task<StripeInvoiceCallResult> CreateInvoiceItemAsync(
         PaymentProvider provider,
         string customerId,
+        string invoiceId,
         long amountMinor,
         string currencyCode,
         string description,
@@ -79,7 +86,12 @@ public sealed record StripeInvoiceCallResult(
     StripeInvoiceOutcome Outcome,
     string? InvoiceOrItemId = null,
     string? Status = null,
-    string? SafeErrorCode = null)
+    string? SafeErrorCode = null,
+    /// <summary>
+    /// The invoice's <c>amount_due</c>, so a caller can check Stripe is about to collect what was
+    /// asked for. Null on calls that answer with something other than an invoice.
+    /// </summary>
+    long? AmountMinor = null)
 {
     public bool IsSuccess => Outcome == StripeInvoiceOutcome.Success;
 }

--- a/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
@@ -7,10 +7,17 @@ namespace Payment.DomainService.Providers.Stripe;
 /// so Stripe never decides when the next attempt happens.
 /// </summary>
 /// <remarks>
-/// Four calls, each explicit rather than left to Stripe's own background advancement
+/// Four calls, each raised explicitly rather than left to Stripe's own background advancement
 /// (<c>auto_advance</c> is off on creation): an invoice item, the invoice itself, finalizing it,
 /// and paying it. The caller decides when each step happens, which is what keeps this on the
 /// same billing clock as every other renewal attempt instead of starting a second one.
+/// <para>
+/// <c>auto_advance</c> only withholds Stripe's own retry schedule, though — it does not stop
+/// collection. A <c>charge_automatically</c> invoice is charged the moment it is finalized, so
+/// finalizing can return an already-paid invoice and the pay call becomes redundant. Callers
+/// must read the status a step returns rather than assuming payment happens only at
+/// <see cref="PayInvoiceAsync"/>.
+/// </para>
 /// </remarks>
 public interface IStripeInvoiceClient
 {
@@ -23,9 +30,16 @@ public interface IStripeInvoiceClient
         string idempotencyKey,
         CancellationToken cancellationToken);
 
+    /// <param name="defaultPaymentMethodId">
+    /// The card this invoice must be settled with. Named on the invoice rather than left to the
+    /// customer's own default because finalizing collects immediately: without it Stripe charges
+    /// whichever card the customer happens to default to, which is not necessarily the one the
+    /// billing account recorded.
+    /// </param>
     Task<StripeInvoiceCallResult> CreateInvoiceAsync(
         PaymentProvider provider,
         string customerId,
+        string defaultPaymentMethodId,
         string idempotencyKey,
         CancellationToken cancellationToken);
 

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
@@ -30,6 +30,7 @@ public sealed class StripeInvoiceClient : IStripeInvoiceClient
     public Task<StripeInvoiceCallResult> CreateInvoiceItemAsync(
         PaymentProvider provider,
         string customerId,
+        string invoiceId,
         long amountMinor,
         string currencyCode,
         string description,
@@ -38,6 +39,9 @@ public sealed class StripeInvoiceClient : IStripeInvoiceClient
     {
         var form = new StripeForm()
             .Add("customer", customerId)
+            // The invoice this line lands on. Without it the line stays pending and recent API
+            // versions leave it off the invoice entirely, which finalizes at zero.
+            .Add("invoice", invoiceId)
             .Add("amount", amountMinor)
             .Add("currency", currencyCode.ToLowerInvariant())
             .Add("description", description);
@@ -183,14 +187,16 @@ public sealed class StripeInvoiceClient : IStripeInvoiceClient
                     return new StripeInvoiceCallResult(
                         StripeInvoiceOutcome.Success,
                         invoice.Id,
-                        invoice.Status);
+                        invoice.Status,
+                        AmountMinor: invoice.AmountDue);
                 }
 
                 return new StripeInvoiceCallResult(
                     StripeInvoiceOutcome.Rejected,
                     invoice.Id,
                     invoice.Status,
-                    ProviderRejectionParser.SanitizeErrorCode(invoice.Status));
+                    ProviderRejectionParser.SanitizeErrorCode(invoice.Status),
+                    invoice.AmountDue);
             }
 
             return Classify(provider, invoice?.Error, error, operation);

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
@@ -54,6 +54,7 @@ public sealed class StripeInvoiceClient : IStripeInvoiceClient
     public Task<StripeInvoiceCallResult> CreateInvoiceAsync(
         PaymentProvider provider,
         string customerId,
+        string defaultPaymentMethodId,
         string idempotencyKey,
         CancellationToken cancellationToken)
     {
@@ -61,8 +62,13 @@ public sealed class StripeInvoiceClient : IStripeInvoiceClient
             .Add("customer", customerId)
             .Add("collection_method", "charge_automatically")
             // Blocks decides when this advances, not Stripe's own background job — the same
-            // discipline that keeps this off a second billing clock.
-            .Add("auto_advance", false);
+            // discipline that keeps this off a second billing clock. It does not stop the
+            // charge at finalization, only Stripe's retries after one.
+            .Add("auto_advance", false)
+            // Which card settles it, since finalizing collects straight away. Left off, Stripe
+            // reaches for the customer's own default and can take a card this renewal never
+            // chose.
+            .Add("default_payment_method", defaultPaymentMethodId);
 
         return PostInvoiceObjectAsync(
             provider,

--- a/server/Subscription.DomainService/Entities/BillingAccount.cs
+++ b/server/Subscription.DomainService/Entities/BillingAccount.cs
@@ -36,6 +36,24 @@ public sealed class BillingAccount
     /// <summary>The saved method a renewal would charge.</summary>
     public string? DefaultPaymentMethodId { get; set; }
 
+    /// <summary>
+    /// The organization whose merchant configuration holds the card — not the subscriber's.
+    /// </summary>
+    /// <remarks>
+    /// Organizations here are subscribers, not merchants: a tenant configures one payment
+    /// provider and every organization's subscription is charged through it. So the scope that
+    /// resolves the provider and the saved card is the one that took the money at signup, which
+    /// is rarely the organization being billed — a console-created subscription belongs to the
+    /// customer while the charge ran under the console's own.
+    /// <para>
+    /// Recorded from the initial payment rather than read from configuration, so it cannot drift
+    /// from where the card actually lives and stays correct whether the provider is registered
+    /// for one organization or for the whole tenant. Null on accounts created before this was
+    /// recorded; those fall back to the subscriber's organization, which is what they used.
+    /// </para>
+    /// </remarks>
+    public string? ProviderOrganizationId { get; set; }
+
     public int Version { get; set; } = 1;
 
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -300,15 +300,33 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         PaymentDetail payment,
         CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(payment.StoredPaymentMethodPublicId))
+        if (string.IsNullOrWhiteSpace(payment.ShopperReference))
         {
+            _logger.LogWarning(
+                "A paid subscription has no shopper reference to find its card by; renewals " +
+                "will fail until one is recorded");
+
             return;
         }
 
-        var method = await _storedMethods.GetAsync(
+        // Found by the reference the card was saved under, not by a link from the payment.
+        // Hosted checkout never writes StoredPaymentMethodPublicId — only a charge already made
+        // from a stored card does — so reading it here meant every subscription reached its
+        // first renewal with no card, and failed closed a whole billing period after the
+        // mistake was made.
+        var methods = await _storedMethods.ListActiveAsync(
             subscription.TenantId,
-            payment.StoredPaymentMethodPublicId,
+            [new StoredPaymentMethodLookupScope(
+                payment.ShopperReference,
+                payment.OrganizationId)],
             cancellationToken);
+
+        // The card this charge saved, newest first: a shopper who paid twice has more than one,
+        // and the one they just used is the one a renewal should charge.
+        var method = (methods ?? [])
+            .OrderByDescending(candidate => candidate.CreatedAtUtc)
+            .FirstOrDefault(candidate =>
+                candidate.ProviderPayerReference is { Length: > 0 });
 
         if (method?.ProviderPayerReference is not { Length: > 0 } customerId)
         {
@@ -323,6 +341,9 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             subscription.BillingAccountId,
             customerId,
             method.ItemId,
+            // The scope that took the money, which is what later charges must resolve the
+            // provider under. Organizations subscribe; the tenant is the merchant.
+            payment.OrganizationId,
             cancellationToken);
     }
 

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -296,7 +296,9 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             new SubscriptionChargeRequest
             {
                 TenantId = invoice.TenantId,
-                OrganizationId = invoice.OrganizationId,
+                // The merchant's scope, not the subscriber's — see BillingAccount.
+                OrganizationId =
+                    account.ProviderOrganizationId ?? invoice.OrganizationId,
                 ProviderName = account.ProviderName,
                 StoredPaymentMethodId = account.DefaultPaymentMethodId,
                 ProviderCustomerId = account.ProviderCustomerId,

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -201,9 +201,15 @@ on the interface, never on how the charge is actually raised.
 `SubscriptionBillingGatewayResolver` picks which implementation by
 `SubscriptionChargeRequest.ProviderName`:
 
-- **Stripe → `StripeInvoiceBillingGateway`.** Raises a standalone Stripe Invoice per attempt — an
-  item, the invoice itself (`auto_advance=false`, so Blocks controls every step rather than
-  Stripe's own background job), finalize, pay, and a void on decline. **No Stripe Subscription
+- **Stripe → `StripeInvoiceBillingGateway`.** Raises a standalone Stripe Invoice per attempt — the
+  invoice itself (`auto_advance=false`, so Stripe runs no retry schedule of its own), its line
+  item, finalize, pay, and a void on decline. Order matters: the line names the invoice it belongs
+  to, because recent Stripe API versions default `pending_invoice_items_behavior` to `exclude` and
+  a line left pending is simply omitted — the invoice then finalizes owing nothing and reports
+  itself paid. `auto_advance=false` withholds Stripe's retries but not collection, so a
+  `charge_automatically` invoice is charged at finalization and the pay call is often redundant;
+  the gateway reads each step's status instead of assuming where payment happens, and refuses to
+  credit a renewal whose finalized invoice does not owe the amount charged. **No Stripe Subscription
   object exists behind this**, on purpose: a real Subscription would run Stripe's own Smart
   Retries and billing clock in parallel with this one, and the two would drift — Phase 1 rejected
   creating one for exactly that reason, and this task does not revisit it. Dunning is therefore

--- a/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
@@ -88,6 +88,7 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
         string billingAccountId,
         string providerCustomerId,
         string? defaultPaymentMethodId,
+        string? providerOrganizationId,
         CancellationToken cancellationToken)
     {
         var filter = Builders<BillingAccount>.Filter.And(
@@ -115,6 +116,13 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
             update = update.Set(
                 account => account.DefaultPaymentMethodId,
                 defaultPaymentMethodId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(providerOrganizationId))
+        {
+            update = update.Set(
+                account => account.ProviderOrganizationId,
+                providerOrganizationId);
         }
 
         var result = await Accounts(tenantId).UpdateOneAsync(

--- a/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
@@ -30,10 +30,15 @@ public interface IBillingAccountRepository
     /// customer means something is wrong, and quietly adopting it would strand every saved card
     /// on the first.
     /// </remarks>
+    /// <param name="providerOrganizationId">
+    /// The organization whose merchant configuration took the card, which is what later charges
+    /// resolve the provider under — see <see cref="Entities.BillingAccount.ProviderOrganizationId"/>.
+    /// </param>
     Task<bool> TrySetProviderCustomerAsync(
         string tenantId,
         string billingAccountId,
         string providerCustomerId,
         string? defaultPaymentMethodId,
+        string? providerOrganizationId,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -149,22 +149,10 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             return Unavailable("stored_payment_method_token_unavailable", correlationId);
         }
 
-        var item = await _invoices.CreateInvoiceItemAsync(
-            provider,
-            request.ProviderCustomerId!,
-            request.AmountMinor,
-            request.CurrencyCode,
-            request.Description ?? "Subscription renewal",
-            $"{idempotencyKey}:item",
-            cancellationToken);
-
-        if (!item.IsSuccess)
-        {
-            paymentMethodId = string.Empty;
-
-            return Rejected(item, "subscription_invoice_item_failed", correlationId);
-        }
-
+        // The invoice comes first so its line can name it. The reverse order leaves the line
+        // pending for the next invoice to sweep up, and recent Stripe API versions default
+        // pending_invoice_items_behavior to exclude — the invoice then finalizes at zero, reads
+        // as paid because nothing is owed, and the renewal completes having collected nothing.
         var invoice = await _invoices.CreateInvoiceAsync(
             provider,
             request.ProviderCustomerId!,
@@ -179,6 +167,24 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             return Rejected(invoice, "subscription_invoice_create_failed", correlationId);
         }
 
+        var item = await _invoices.CreateInvoiceItemAsync(
+            provider,
+            request.ProviderCustomerId!,
+            invoice.InvoiceOrItemId!,
+            request.AmountMinor,
+            request.CurrencyCode,
+            request.Description ?? "Subscription renewal",
+            $"{idempotencyKey}:item",
+            cancellationToken);
+
+        if (!item.IsSuccess)
+        {
+            paymentMethodId = string.Empty;
+            await _invoices.VoidInvoiceAsync(provider, invoice.InvoiceOrItemId!, cancellationToken);
+
+            return Rejected(item, "subscription_invoice_item_failed", correlationId);
+        }
+
         var finalized = await _invoices.FinalizeInvoiceAsync(
             provider,
             invoice.InvoiceOrItemId!,
@@ -191,6 +197,26 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             await _invoices.VoidInvoiceAsync(provider, invoice.InvoiceOrItemId!, cancellationToken);
 
             return Rejected(finalized, "subscription_invoice_finalize_failed", correlationId);
+        }
+
+        // A finalized invoice must owe exactly what this renewal asked for. Anything else means
+        // the amount never reached Stripe as intended — a line left off leaves nothing owed, and
+        // "nothing owed" arrives here indistinguishable from "already settled". Failing closed
+        // keeps the subscription unpaid and visible instead of advancing a period for free.
+        if (finalized.AmountMinor is { } owed && owed != request.AmountMinor)
+        {
+            paymentMethodId = string.Empty;
+            await _invoices.VoidInvoiceAsync(provider, invoice.InvoiceOrItemId!, cancellationToken);
+
+            _logger.LogError(
+                "A Stripe renewal invoice was not for the amount charged; the renewal was " +
+                "abandoned rather than credited InvoiceHash={InvoiceHash} " +
+                "ExpectedMinor={ExpectedMinor} InvoicedMinor={InvoicedMinor}",
+                PaymentLogValue.Hash(invoice.InvoiceOrItemId!),
+                request.AmountMinor,
+                owed);
+
+            return Unavailable("subscription_invoice_amount_mismatch", correlationId);
         }
 
         if (IsPaid(finalized.Status))

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -168,6 +168,7 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
         var invoice = await _invoices.CreateInvoiceAsync(
             provider,
             request.ProviderCustomerId!,
+            paymentMethodId,
             $"{idempotencyKey}:invoice",
             cancellationToken);
 
@@ -192,6 +193,25 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             return Rejected(finalized, "subscription_invoice_finalize_failed", correlationId);
         }
 
+        if (IsPaid(finalized.Status))
+        {
+            paymentMethodId = string.Empty;
+
+            // Finalizing a charge_automatically invoice collects it there and then; only
+            // Stripe's own retry schedule is withheld by auto_advance. Paying again answers
+            // "Invoice is already paid", which read as a decline and had this report a failed
+            // renewal over money that had in fact moved — then try to void the invoice that
+            // proved it. The period must advance on this, not on a second charge.
+            _logger.LogInformation(
+                "Subscription renewal was collected when its Stripe invoice was finalized " +
+                "InvoiceHash={InvoiceHash}",
+                PaymentLogValue.Hash(invoice.InvoiceOrItemId!));
+
+            return SubscriptionOperationResult<string>.Success(
+                invoice.InvoiceOrItemId!,
+                correlationId);
+        }
+
         var paid = await _invoices.PayInvoiceAsync(
             provider,
             invoice.InvoiceOrItemId!,
@@ -202,6 +222,17 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
 
         if (!paid.IsSuccess)
         {
+            // A pay call that failed over an invoice already paid took the money all the same —
+            // Stripe collected it between finalizing and here. Voiding would be an attempt to
+            // cancel a settled invoice, and reporting a decline would bill the customer twice on
+            // the next attempt.
+            if (IsPaid(paid.Status))
+            {
+                return SubscriptionOperationResult<string>.Success(
+                    invoice.InvoiceOrItemId!,
+                    correlationId);
+            }
+
             await _invoices.VoidInvoiceAsync(provider, invoice.InvoiceOrItemId!, cancellationToken);
 
             return Rejected(paid, "subscription_invoice_payment_declined", correlationId);
@@ -213,6 +244,13 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
 
         return SubscriptionOperationResult<string>.Success(invoice.InvoiceOrItemId!, correlationId);
     }
+
+    /// <summary>
+    /// Stripe's terminal settled status. Compared as an ordinal so a status this code does not
+    /// know reads as unpaid rather than as money received.
+    /// </summary>
+    private static bool IsPaid(string? status) =>
+        string.Equals(status, "paid", StringComparison.Ordinal);
 
     private static SubscriptionOperationResult<string> Rejected(
         StripeInvoiceCallResult result,

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -197,7 +197,9 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             new SubscriptionChargeRequest
             {
                 TenantId = subscription.TenantId,
-                OrganizationId = subscription.OrganizationId,
+                // The merchant's scope, not the subscriber's — see BillingAccount.
+                OrganizationId =
+                    account.ProviderOrganizationId ?? subscription.OrganizationId,
                 ProviderName = account.ProviderName,
                 StoredPaymentMethodId = account.DefaultPaymentMethodId,
                 ProviderCustomerId = account.ProviderCustomerId,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -104,7 +104,11 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 new SubscriptionChargeRequest
                 {
                     TenantId = subscription.TenantId,
-                    OrganizationId = subscription.OrganizationId,
+                    // The merchant's scope, not the subscriber's: the tenant configures one
+                    // provider and every organization is charged through it. Falls back for
+                    // accounts predating the field, which used the subscriber's.
+                    OrganizationId =
+                        account.ProviderOrganizationId ?? subscription.OrganizationId,
                     ProviderName = account.ProviderName,
                     StoredPaymentMethodId = account.DefaultPaymentMethodId,
                     ProviderCustomerId = account.ProviderCustomerId,

--- a/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
@@ -261,11 +261,11 @@ public sealed class SubscriptionRepositoryIntegrationTests
             CancellationToken.None);
 
         (await _accounts.TrySetProviderCustomerAsync(
-            tenantId, account.ItemId, "cus_first", "pm_1",
+            tenantId, account.ItemId, "cus_first", "pm_1", "default",
             CancellationToken.None)).Should().BeTrue();
 
         (await _accounts.TrySetProviderCustomerAsync(
-                tenantId, account.ItemId, "cus_other", null,
+                tenantId, account.ItemId, "cus_other", null, "default",
                 CancellationToken.None))
             .Should().BeFalse("adopting a second customer would strand every saved card on " +
                               "the first");

--- a/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
+++ b/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
@@ -20,6 +20,9 @@ public sealed class StripeInvoiceClientTests
                 HttpMethod.Post,
                 It.Is<Dictionary<string, string>>(form =>
                     form["customer"] == "cus_123" &&
+                    // Named, not left pending — a pending line is dropped by Stripe's current
+                    // default and the invoice finalizes owing nothing.
+                    form["invoice"] == "in_1" &&
                     form["amount"] == "8900" &&
                     form["currency"] == "chf" &&
                     form["description"] == "Professional renewal"),
@@ -30,7 +33,7 @@ public sealed class StripeInvoiceClientTests
             .ReturnsAsync((new StripeInvoice { Id = "ii_1" }, (string?)null));
 
         var result = await Client(http.Object).CreateInvoiceItemAsync(
-            Provider(), "cus_123", 8_900, "CHF", "Professional renewal", "idem-1", CancellationToken.None);
+            Provider(), "cus_123", "in_1", 8_900, "CHF", "Professional renewal", "idem-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
         result.InvoiceOrItemId.Should().Be("ii_1");
@@ -153,7 +156,7 @@ public sealed class StripeInvoiceClientTests
         provider.ApiBaseUrl = "https://127.0.0.1";
 
         var result = await Client(http.Object).CreateInvoiceItemAsync(
-            provider, "cus_123", 1_000, "CHF", "x", "idem-1", CancellationToken.None);
+            provider, "cus_123", "in_1", 1_000, "CHF", "x", "idem-1", CancellationToken.None);
 
         result.Outcome.Should().Be(StripeInvoiceOutcome.Unavailable);
         http.VerifyNoOtherCalls();

--- a/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
+++ b/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
@@ -45,7 +45,8 @@ public sealed class StripeInvoiceClientTests
                 It.Is<Dictionary<string, string>>(form =>
                     form["customer"] == "cus_123" &&
                     form["collection_method"] == "charge_automatically" &&
-                    form["auto_advance"] == "false"),
+                    form["auto_advance"] == "false" &&
+                    form["default_payment_method"] == "pm_456"),
                 "https://api.stripe.com/v1/invoices",
                 It.IsAny<Dictionary<string, string>>(),
                 It.IsAny<CancellationToken>(),
@@ -53,7 +54,7 @@ public sealed class StripeInvoiceClientTests
             .ReturnsAsync((new StripeInvoice { Id = "in_1", Status = "draft" }, (string?)null));
 
         var result = await Client(http.Object).CreateInvoiceAsync(
-            Provider(), "cus_123", "idem-1", CancellationToken.None);
+            Provider(), "cus_123", "pm_456", "idem-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
     }

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -60,6 +60,7 @@ public sealed class StripeInvoiceBillingGatewayTests
             .Setup(client => client.CreateInvoiceItemAsync(
                 It.IsAny<PaymentProvider>(),
                 "cus_123",
+                "in_1",
                 8_900,
                 "CHF",
                 It.IsAny<string>(),
@@ -75,7 +76,8 @@ public sealed class StripeInvoiceBillingGatewayTests
         _invoices
             .Setup(client => client.FinalizeInvoiceAsync(
                 It.IsAny<PaymentProvider>(), "in_1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "open"));
+            .ReturnsAsync(new StripeInvoiceCallResult(
+                StripeInvoiceOutcome.Success, "in_1", "open", AmountMinor: 8_900));
 
         _invoices
             .Setup(client => client.PayInvoiceAsync(
@@ -98,7 +100,7 @@ public sealed class StripeInvoiceBillingGatewayTests
         await Gateway().ChargeAsync(Request(), "sub-renew:sub-1:M20260901T000000Z:1", "corr-1", CancellationToken.None);
 
         _invoices.Verify(client => client.CreateInvoiceItemAsync(
-            It.IsAny<PaymentProvider>(), "cus_123", 8_900, "CHF", It.IsAny<string>(),
+            It.IsAny<PaymentProvider>(), "cus_123", "in_1", 8_900, "CHF", It.IsAny<string>(),
             "sub-renew:sub-1:M20260901T000000Z:1:item", It.IsAny<CancellationToken>()));
         _invoices.Verify(client => client.PayInvoiceAsync(
             It.IsAny<PaymentProvider>(), "in_1", "pm_456",
@@ -113,7 +115,8 @@ public sealed class StripeInvoiceBillingGatewayTests
         _invoices
             .Setup(client => client.FinalizeInvoiceAsync(
                 It.IsAny<PaymentProvider>(), "in_1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "paid"));
+            .ReturnsAsync(new StripeInvoiceCallResult(
+                StripeInvoiceOutcome.Success, "in_1", "paid", AmountMinor: 8_900));
 
         var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
 
@@ -149,6 +152,40 @@ public sealed class StripeInvoiceBillingGatewayTests
             client => client.VoidInvoiceAsync(
                 It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task An_invoice_finalized_for_nothing_is_abandoned_rather_than_credited()
+    {
+        // What a dropped line item looks like from here: finalized, owing nothing, and therefore
+        // reported by Stripe as paid. Crediting it would advance a billing period for free.
+        _invoices
+            .Setup(client => client.FinalizeInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "in_1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(
+                StripeInvoiceOutcome.Success, "in_1", "paid", AmountMinor: 0));
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_invoice_amount_mismatch");
+        _invoices.Verify(
+            client => client.VoidInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "in_1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task The_charged_line_is_attached_to_the_invoice_it_belongs_to()
+    {
+        await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        // Left pending instead, Stripe's current default omits it and the invoice is for nothing.
+        _invoices.Verify(
+            client => client.CreateInvoiceItemAsync(
+                It.IsAny<PaymentProvider>(), "cus_123", "in_1", 8_900, "CHF",
+                It.IsAny<string>(), "idem-1:item", It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -196,8 +233,9 @@ public sealed class StripeInvoiceBillingGatewayTests
         result.ErrorCode.Should().Be("subscription_customer_unresolved");
         _invoices.Verify(
             client => client.CreateInvoiceItemAsync(
-                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>(),
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<long>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -69,7 +69,7 @@ public sealed class StripeInvoiceBillingGatewayTests
 
         _invoices
             .Setup(client => client.CreateInvoiceAsync(
-                It.IsAny<PaymentProvider>(), "cus_123", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<PaymentProvider>(), "cus_123", "pm_456", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "draft"));
 
         _invoices
@@ -103,6 +103,66 @@ public sealed class StripeInvoiceBillingGatewayTests
         _invoices.Verify(client => client.PayInvoiceAsync(
             It.IsAny<PaymentProvider>(), "in_1", "pm_456",
             "sub-renew:sub-1:M20260901T000000Z:1:pay", It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task An_invoice_already_paid_by_finalizing_succeeds_without_paying_again()
+    {
+        // What a charge_automatically invoice actually does: auto_advance withholds Stripe's
+        // retry schedule, not the collection at finalization.
+        _invoices
+            .Setup(client => client.FinalizeInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "in_1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "paid"));
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("in_1");
+        _invoices.Verify(
+            client => client.PayInvoiceAsync(
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _invoices.Verify(
+            client => client.VoidInvoiceAsync(
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_pay_call_rejected_because_the_invoice_is_already_paid_is_not_a_decline()
+    {
+        _invoices
+            .Setup(client => client.PayInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "in_1", "pm_456", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceCallResult(
+                StripeInvoiceOutcome.Rejected, "in_1", "paid", "invoice_already_paid"));
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("in_1");
+
+        // Voiding a settled invoice is the one thing that must never follow from this.
+        _invoices.Verify(
+            client => client.VoidInvoiceAsync(
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task The_invoice_names_the_card_the_billing_account_recorded()
+    {
+        await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        // Without this Stripe collects on the customer's own default card at finalization,
+        // which need not be the one this renewal resolved.
+        _invoices.Verify(
+            client => client.CreateInvoiceAsync(
+                It.IsAny<PaymentProvider>(), "cus_123", "pm_456", "idem-1:invoice",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -25,6 +25,15 @@ public sealed class SubscriptionActivationProcessorTests
 {
     private const string TenantId = "tenant-1";
 
+    /// <summary>The subscriber. Its own subscription and billing account are stamped with this.</summary>
+    private const string OrganizationId = "org-1";
+
+    /// <summary>
+    /// The organization whose merchant configuration takes the money — the console's, for a
+    /// subscription the console created on a customer's behalf.
+    /// </summary>
+    private const string MerchantOrganizationId = "default";
+
     private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
     private readonly Mock<ISubscriptionRepository> _subscriptions = new();
     private readonly Mock<IBillingAccountRepository> _accounts = new();
@@ -214,23 +223,18 @@ public sealed class SubscriptionActivationProcessorTests
             Times.Once);
     }
 
+    /// <summary>
+    /// The regression this guards: adoption read <c>payment.StoredPaymentMethodPublicId</c>, which
+    /// only a charge made <em>from</em> a stored card ever carries. Hosted checkout never writes
+    /// it, so every subscription reached its first renewal with no card on the billing account and
+    /// failed closed — a whole billing period after the mistake, with nothing logged at the time.
+    /// </summary>
     [Fact]
-    public async Task The_provider_customer_is_taken_from_the_saved_card()
+    public async Task The_provider_customer_is_taken_from_the_card_the_charge_saved()
     {
         GivenDueLink();
-        GivenPayment(
-            PaymentStatuses.Authorized,
-            webhookConfirmed: true,
-            storedMethodId: "method-1");
-
-        _storedMethods
-            .Setup(repository => repository.GetAsync(
-                TenantId, "method-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new StoredPaymentMethod
-            {
-                ItemId = "method-1",
-                ProviderPayerReference = "cus_123"
-            });
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
 
         await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
 
@@ -240,9 +244,54 @@ public sealed class SubscriptionActivationProcessorTests
                 "acct-1",
                 "cus_123",
                 "method-1",
+                MerchantOrganizationId,
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "the renewal needs this identifier, and checkout is the only place it appears");
+    }
+
+    /// <summary>
+    /// Organizations here are subscribers, not merchants: a tenant configures one provider and
+    /// every organization is charged through it. So the scope recorded for later charges is the
+    /// one that took the money, which for a console-created subscription is not the subscriber's.
+    /// </summary>
+    [Fact]
+    public async Task The_merchants_organization_is_recorded_rather_than_the_subscribers()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _accounts.Verify(
+            repository => repository.TrySetProviderCustomerAsync(
+                TenantId,
+                "acct-1",
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.Is<string?>(organizationId => organizationId != OrganizationId),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "recording the subscriber's organization would send every renewal looking for a " +
+            "merchant account the customer does not have");
+    }
+
+    [Fact]
+    public async Task A_paid_subscription_with_no_card_to_renew_on_says_so()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        // No saved card: ListActiveAsync is unmocked and returns none.
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _accounts.Verify(
+            repository => repository.TrySetProviderCustomerAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "there is nothing to record, and the activation still stands — the customer paid");
     }
 
     [Fact]
@@ -331,7 +380,9 @@ public sealed class SubscriptionActivationProcessorTests
     private void GivenPayment(
         string status,
         bool webhookConfirmed,
-        string? storedMethodId = null) =>
+        string? storedMethodId = null,
+        string? shopperReference = "shopper-1",
+        string paymentOrganizationId = MerchantOrganizationId) =>
         _payments
             .Setup(repository => repository.GetByIdAsync(
                 TenantId, "pay-1", It.IsAny<CancellationToken>()))
@@ -341,8 +392,35 @@ public sealed class SubscriptionActivationProcessorTests
                 TenantId = TenantId,
                 PaymentStatus = status,
                 WebhookConfirmedAtUtc = webhookConfirmed ? DateTime.UtcNow : null,
-                StoredPaymentMethodPublicId = storedMethodId
+                StoredPaymentMethodPublicId = storedMethodId,
+                ShopperReference = shopperReference,
+                // The console's organization, not the subscriber's: this is what a
+                // console-created subscription actually pays under.
+                OrganizationId = paymentOrganizationId
             });
+
+    /// <summary>The card is found under the reference it was saved with, at that organization.</summary>
+    private void GivenSavedCard(
+        string customerId = "cus_123",
+        string methodId = "method-1",
+        string shopperReference = "shopper-1",
+        string organizationId = MerchantOrganizationId) =>
+        _storedMethods
+            .Setup(repository => repository.ListActiveAsync(
+                TenantId,
+                It.Is<IReadOnlyCollection<StoredPaymentMethodLookupScope>>(scopes =>
+                    scopes.Any(scope =>
+                        scope.ShopperReference == shopperReference &&
+                        scope.OrganizationId == organizationId)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new StoredPaymentMethod
+                {
+                    ItemId = methodId,
+                    ProviderPayerReference = customerId,
+                    CreatedAtUtc = DateTime.UtcNow
+                }
+            ]);
 
     private SubscriptionActivationProcessor Processor() => new(
         _links.Object,


### PR DESCRIPTION
No subscription in this module could renew successfully. Three independent defects sat in a row on the same path, each one masking the next; all three were found by hand-testing a real renewal against Stripe and are fixed here.

## What was broken

**1. The card was looked for in a place nothing ever wrote — `57d06ae`**

`AdoptProviderCustomerAsync` read `payment.StoredPaymentMethodPublicId`, which only a charge made *from* an already-stored card sets. Hosted checkout never writes it, so activation silently returned and every subscription reached its first renewal with no card on record — then failed closed a whole billing period after the mistake was made. The card is now found by the shopper reference it was actually saved under, newest first.

Renewals also resolved the payment provider under the **subscriber's** organization. Organizations here are customers, not merchants: a tenant configures one provider and every organization is charged through it, so the lookup found nothing and returned `subscription_provider_unavailable`. `BillingAccount.ProviderOrganizationId` now records the scope that took the money at signup, and all three off-session charge paths resolve against it.

**2. A paid invoice was charged again — `4382347`**

A `charge_automatically` invoice is collected the moment it is finalized; `auto_advance` withholds Stripe's *retry schedule*, not the collection. The pay call that followed answered "Invoice is already paid", which was read as a decline — so the renewal was recorded as failed over money that had moved, the invoice proving it was put up to be voided, and the next dunning attempt would have billed the customer a second time.

**3. The charge was never on the invoice — `c2ceafb`**

The amount was raised as a *pending* invoice item and the invoice created afterwards, assuming Stripe would sweep it up. Recent API versions default `pending_invoice_items_behavior` to `exclude`, so the line was dropped: the invoice finalized owing nothing, Stripe reported it `paid` because nothing was owed, and the renewal advanced a billing period having collected **no money at all**. Every renewal through this gateway was free.

The invoice is now created first and the line names it, which depends on neither sweep behaviour nor which API version an account is pinned to.

## The guard that makes this class of bug loud

A finalized invoice must owe exactly what was asked for, or the renewal is abandoned with `subscription_invoice_amount_mismatch` rather than credited. Nothing else distinguishes "owes nothing" from "already settled" — both arrive as a paid invoice — and that ambiguity is precisely what let a €0 invoice pass as a successful renewal.

The invoice also now names the card the billing account recorded. Since collection happens at finalization, Stripe was otherwise reaching for the *customer's* default payment method, which need not be the card the renewal resolved. Invisible with one card on file; silently wrong with two.

`d5e4ac7` corrects the README, which asserted both of the wrong beliefs that caused defects 2 and 3.

## Verification

Confirmed end to end against live Stripe: a **€3.00** invoice, paid, with the period advancing 16 Aug → 16 Sep, `DunningAttemptCount` cleared and a `SubscriptionRenewed` event raised. Verified in the Stripe dashboard, not just in our logs — the earlier €0.00 invoices are exactly what taking `status: paid` at face value produces.

2109 unit tests pass. Each new guard was checked by reverting it and confirming its test fails. The `SubscriptionRepositoryIntegrationTests` need a local `mongod` and fail identically on a clean tree.

## Note for reviewers

`BillingAccount.ProviderOrganizationId` is null on accounts created before this and falls back to the subscriber's organization, which is what those used. Any subscription that activated before `57d06ae` still has no card recorded — those need re-saving or a backfill; the fix prevents new ones, it does not repair old ones.

Stacked on top of this: `feat/subscription-invoice-billing-records`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)