### PR TITLE
feat(subscription): account for renewal revenue and give subscribers their invoices

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -558,6 +558,21 @@
             simply swaps with no charge or credit either way.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.GetInvoicePdf(System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Downloads the invoice for one settled billing period as a PDF.
+            </summary>
+            <remarks>
+            <paramref name="paymentId"/> is the payment recorded for the period, as reported by the
+            payment endpoints — not the provider's own invoice id, which is never exposed.
+            <para>
+            The bytes are served from here rather than as a link to the provider. A provider's download
+            URL needs no authentication and does not expire, so returning one would hand out permanent
+            access to a billing document; proxying keeps every download subject to this caller's own
+            authorization.
+            </para>
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.SubscriptionUsageController">
             <summary>
             Metered usage. Served under <c>/api/subscription-usage</c>.

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -26,15 +26,18 @@ public sealed class SubscriptionsController : ControllerBase
     private readonly ISubscriptionCheckoutService _checkout;
     private readonly ISubscriptionCancellationService _cancellation;
     private readonly ISubscriptionPlanChangeService _planChange;
+    private readonly ISubscriptionInvoiceDocumentService _invoiceDocuments;
 
     public SubscriptionsController(
         ISubscriptionCheckoutService checkout,
         ISubscriptionCancellationService cancellation,
-        ISubscriptionPlanChangeService planChange)
+        ISubscriptionPlanChangeService planChange,
+        ISubscriptionInvoiceDocumentService invoiceDocuments)
     {
         _checkout = checkout;
         _cancellation = cancellation;
         _planChange = planChange;
+        _invoiceDocuments = invoiceDocuments;
     }
 
     [HttpPost]
@@ -145,5 +148,44 @@ public sealed class SubscriptionsController : ControllerBase
             cancellationToken);
 
         return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Downloads the invoice for one settled billing period as a PDF.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="paymentId"/> is the payment recorded for the period, as reported by the
+    /// payment endpoints — not the provider's own invoice id, which is never exposed.
+    /// <para>
+    /// The bytes are served from here rather than as a link to the provider. A provider's download
+    /// URL needs no authentication and does not expire, so returning one would hand out permanent
+    /// access to a billing document; proxying keeps every download subject to this caller's own
+    /// authorization.
+    /// </para>
+    /// </remarks>
+    [HttpGet("invoices/{paymentId}/pdf")]
+    [ProducesResponseType(typeof(FileResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<object>), StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetInvoicePdf(
+        string paymentId,
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _invoiceDocuments.GetAsync(
+            paymentId,
+            organizationId,
+            correlationId,
+            cancellationToken);
+
+        if (!result.IsSuccess || result.Value is not { } document)
+        {
+            return result.ToActionResult(correlationId);
+        }
+
+        return File(document.Content, document.ContentType, document.FileName);
     }
 }

--- a/server/Payment.DomainService/Entities/PaymentDetail.cs
+++ b/server/Payment.DomainService/Entities/PaymentDetail.cs
@@ -75,6 +75,16 @@ public sealed class PaymentDetail
     public string? ProviderReference { get; set; }
     public string? ProviderMerchantAccount { get; set; }
 
+    /// <summary>
+    /// The provider's invoice behind this payment, when the money was collected through one.
+    /// </summary>
+    /// <remarks>
+    /// Held so the invoice document can be fetched from the provider on demand rather than its
+    /// download URL being stored: the URL is effectively a bearer token for the document, and one
+    /// kept in the database outlives any decision to stop sharing it.
+    /// </remarks>
+    public string? ProviderInvoiceId { get; set; }
+
     public string IdempotencyKey { get; set; } = string.Empty;
     public string RequestHash { get; set; } = string.Empty;
     public string CorrelationId { get; set; } = string.Empty;

--- a/server/Payment.DomainService/Enums/PaymentFlows.cs
+++ b/server/Payment.DomainService/Enums/PaymentFlows.cs
@@ -6,9 +6,21 @@ public static class PaymentFlows
 
     public const string RecurringCharge = "RECURRING_CHARGE";
 
+    /// <summary>
+    /// A subscription period settled as a provider invoice rather than a bare charge.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="RecurringCharge"/> because the money arrives already captured and
+    /// with an invoice document behind it: there is no authorize-then-capture step to reserve a
+    /// lease for, and the record exists so the charge can be reconciled and its invoice fetched,
+    /// not so anything can be driven from it.
+    /// </remarks>
+    public const string SubscriptionInvoice = "SUBSCRIPTION_INVOICE";
+
     public static readonly string[] All =
     [
         HostedCheckout,
-        RecurringCharge
+        RecurringCharge,
+        SubscriptionInvoice
     ];
 }

--- a/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
@@ -71,7 +71,30 @@ public interface IStripeInvoiceClient
         PaymentProvider provider,
         string invoiceId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Downloads an invoice's rendered PDF.
+    /// </summary>
+    /// <remarks>
+    /// Two calls behind one method — read the invoice for a current <c>invoice_pdf</c> link, then
+    /// fetch it — because the link is the part that must not escape. It carries no authentication
+    /// of its own, so anyone holding it can read the document; keeping the fetch on this side of
+    /// the API means access stays the caller's own, and stays revocable.
+    /// </remarks>
+    Task<StripeInvoiceDocument?> DownloadInvoicePdfAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        CancellationToken cancellationToken);
 }
+
+/// <summary>
+/// A rendered invoice document, held in memory because an invoice PDF is a few kilobytes and
+/// streaming one through would keep a provider connection open for the caller's whole download.
+/// </summary>
+public sealed record StripeInvoiceDocument(
+    byte[] Content,
+    string ContentType,
+    string? InvoiceNumber);
 
 public enum StripeInvoiceOutcome
 {

--- a/server/Payment.DomainService/Providers/Stripe/StripeFileUrl.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeFileUrl.cs
@@ -1,0 +1,22 @@
+namespace Payment.DomainService.Providers.Stripe;
+
+/// <summary>
+/// Checks that a file link taken from a Stripe response is served by Stripe.
+/// </summary>
+/// <remarks>
+/// Invoice PDFs come from <c>files.stripe.com</c>, not the API host, so
+/// <see cref="StripeEndpointPolicy"/> — which guards the API base URL — says nothing about them.
+/// A URL read out of a response body is still input: without this the credential-bearing fetch
+/// would follow wherever that body pointed, which is the shape of a server-side request forgery
+/// even when the response is genuinely Stripe's.
+/// </remarks>
+public static class StripeFileUrl
+{
+    private const string FileHost = "files.stripe.com";
+
+    public static bool IsStripeHosted(string? url) =>
+        Uri.TryCreate(url, UriKind.Absolute, out var parsed) &&
+        parsed.Scheme == Uri.UriSchemeHttps &&
+        (parsed.Host.Equals(FileHost, StringComparison.OrdinalIgnoreCase) ||
+         parsed.Host.Equals(StripeConstants.ApiHost, StringComparison.OrdinalIgnoreCase));
+}

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoice.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoice.cs
@@ -21,6 +21,16 @@ public sealed class StripeInvoice
     [JsonPropertyName("currency")]
     public string? Currency { get; set; }
 
+    [JsonPropertyName("number")]
+    public string? Number { get; set; }
+
+    /// <summary>
+    /// Stripe's link to the rendered PDF. Unauthenticated and long-lived, so it is fetched when a
+    /// document is asked for and never stored or handed to a caller.
+    /// </summary>
+    [JsonPropertyName("invoice_pdf")]
+    public string? InvoicePdf { get; set; }
+
     /// <summary>Present instead of the invoice fields when Stripe rejects the call.</summary>
     [JsonPropertyName("error")]
     public StripeError? Error { get; set; }

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using Blocks.Genesis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,17 +12,20 @@ namespace Payment.DomainService.Providers.Stripe;
 public sealed class StripeInvoiceClient : IStripeInvoiceClient
 {
     private readonly IHttpService _httpService;
+    private readonly IHttpClientFactory _httpClients;
     private readonly StripeEndpointPolicy _endpointPolicy;
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ILogger<StripeInvoiceClient> _logger;
 
     public StripeInvoiceClient(
         IHttpService httpService,
+        IHttpClientFactory httpClients,
         StripeEndpointPolicy endpointPolicy,
         IOptionsMonitor<PaymentOptions> options,
         ILogger<StripeInvoiceClient> logger)
     {
         _httpService = httpService;
+        _httpClients = httpClients;
         _endpointPolicy = endpointPolicy;
         _options = options;
         _logger = logger;
@@ -150,6 +154,114 @@ public sealed class StripeInvoiceClient : IStripeInvoiceClient
                 "Voiding a declined Stripe invoice failed InvoiceHash={InvoiceHash} ExceptionType={ExceptionType}",
                 PaymentLogValue.Hash(invoiceId),
                 exception.GetType().Name);
+        }
+    }
+
+    public async Task<StripeInvoiceDocument?> DownloadInvoicePdfAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        if (!_endpointPolicy.IsAllowed(provider.ApiBaseUrl))
+        {
+            return null;
+        }
+
+        var invoice = await ReadInvoiceAsync(provider, invoiceId, cancellationToken);
+
+        if (invoice?.InvoicePdf is not { Length: > 0 } pdfUrl)
+        {
+            _logger.LogWarning(
+                "A Stripe invoice has no PDF to download InvoiceHash={InvoiceHash}",
+                PaymentLogValue.Hash(invoiceId));
+
+            return null;
+        }
+
+        // Stripe serves the PDF from files.stripe.com rather than the API host, so the endpoint
+        // policy's API check does not cover it. Confirming the host is Stripe's keeps a link out
+        // of a response from redirecting this fetch at somewhere else entirely.
+        if (!StripeFileUrl.IsStripeHosted(pdfUrl))
+        {
+            _logger.LogError(
+                "A Stripe invoice PDF link pointed somewhere unexpected and was not followed " +
+                "InvoiceHash={InvoiceHash}",
+                PaymentLogValue.Hash(invoiceId));
+
+            return null;
+        }
+
+        try
+        {
+            using var client = _httpClients.CreateClient(nameof(StripeInvoiceClient));
+            client.Timeout = TimeSpan.FromSeconds(
+                Math.Clamp(_options.CurrentValue.ProviderTimeoutSeconds, 1, 60));
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, pdfUrl);
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                StripeConstants.AuthorizationScheme,
+                provider.ApiKey);
+
+            using var response = await client.SendAsync(request, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Downloading a Stripe invoice PDF failed Status={Status} " +
+                    "InvoiceHash={InvoiceHash}",
+                    (int)response.StatusCode,
+                    PaymentLogValue.Hash(invoiceId));
+
+                return null;
+            }
+
+            return new StripeInvoiceDocument(
+                await response.Content.ReadAsByteArrayAsync(cancellationToken),
+                response.Content.Headers.ContentType?.MediaType ?? "application/pdf",
+                invoice.Number);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "Downloading a Stripe invoice PDF failed ExceptionType={ExceptionType} " +
+                "InvoiceHash={InvoiceHash}",
+                exception.GetType().Name,
+                PaymentLogValue.Hash(invoiceId));
+
+            return null;
+        }
+    }
+
+    private async Task<StripeInvoice?> ReadInvoiceAsync(
+        PaymentProvider provider,
+        string invoiceId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var (invoice, _) = await _httpService.SendFormUrlEncoded<StripeInvoice>(
+                HttpMethod.Get,
+                new Dictionary<string, string>(StringComparer.Ordinal),
+                StripeUrl.Build(
+                    provider.ApiBaseUrl,
+                    $"v1/invoices/{Uri.EscapeDataString(invoiceId)}"),
+                StripeRequestHeaders.Create(provider, $"read:{invoiceId}"),
+                cancellationToken,
+                Math.Clamp(_options.CurrentValue.ProviderTimeoutSeconds, 1, 60));
+
+            return invoice is { Id: not null, Error: null } ? invoice : null;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "Reading a Stripe invoice failed ExceptionType={ExceptionType} " +
+                "InvoiceHash={InvoiceHash}",
+                exception.GetType().Name,
+                PaymentLogValue.Hash(invoiceId));
+
+            return null;
         }
     }
 

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -299,6 +299,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 // The merchant's scope, not the subscriber's — see BillingAccount.
                 OrganizationId =
                     account.ProviderOrganizationId ?? invoice.OrganizationId,
+                SubscriberOrganizationId = invoice.OrganizationId,
                 ProviderName = account.ProviderName,
                 StoredPaymentMethodId = account.DefaultPaymentMethodId,
                 ProviderCustomerId = account.ProviderCustomerId,

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -251,6 +251,39 @@ charges.
 backoff — this is a business cadence for asking a customer to fix a card, not load-shedding
 against a failing dependency) govern the cycle.
 
+## What a settled period leaves behind
+
+Every settled period is recorded as a `PaymentDetail` with `PaymentFlow = SUBSCRIPTION_INVOICE`,
+already `CAPTURED` — an invoice paid at finalization has no authorize-then-capture step left to
+drive. Renewals therefore appear wherever payments appear, and
+`SubscriptionDetail.LastRenewalPaymentDetailId` names a real payment.
+
+Two organizations are recorded, and the distinction matters:
+
+| Field | Holds | Used for |
+| --- | --- | --- |
+| `OrganizationId` | the merchant's scope | resolving the provider and the card, as the charge did |
+| `CustomerOrganizationId` | the subscriber | attributing the revenue, and authorizing invoice reads |
+
+The write is best effort. By that point the money has moved, so a bookkeeping failure logs an error
+and still reports the renewal paid — failing instead would have the next dunning attempt charge the
+customer a second time.
+
+`GET /api/subscriptions/invoices/{paymentId}/pdf` returns that period's invoice as a PDF, scoped to
+the caller's organization (`?organizationId=` honored only for the console, as everywhere else). The
+`paymentId` is the payment above, never the provider's invoice id.
+
+The bytes are proxied rather than the provider's own link returned. A Stripe `invoice_pdf` URL
+carries no authentication and does not expire, so handing one out grants permanent access to a
+billing document and puts it beyond this module's reach. For the same reason the link is read fresh
+from the provider per request instead of stored — nothing in the database should be a standing key to
+a customer's invoice. `StripeFileUrl` confirms the link is Stripe-hosted before the credentialed
+fetch follows it, since a URL taken from a response body is still input.
+
+A payment with no `CustomerOrganizationId` — one recorded before the subscriber was captured — is
+refused rather than shown to whoever asks. Absent, another organization's, and not-a-subscription
+all return the same not-found, so the refusal cannot be used to enumerate a tenant's payments.
+
 ## Tax
 
 `PriceSnapshot.TaxRateBasisPoints` — manual, not jurisdiction-derived. Whoever authors a price

--- a/server/Subscription.DomainService/Services/ISubscriptionInvoiceDocumentService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionInvoiceDocumentService.cs
@@ -1,0 +1,27 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Reads the invoice document behind a subscription payment.
+/// </summary>
+public interface ISubscriptionInvoiceDocumentService
+{
+    /// <param name="paymentId">
+    /// The payment recorded for a settled subscription period — not the provider's invoice id,
+    /// which is an internal detail a caller is never given.
+    /// </param>
+    /// <param name="requestedOrganizationId">
+    /// An organization named by the request. Honoured only for the console, on the same policy as
+    /// every other subscription read.
+    /// </param>
+    Task<SubscriptionOperationResult<SubscriptionInvoiceDocument>> GetAsync(
+        string paymentId,
+        string? requestedOrganizationId,
+        string correlationId,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>An invoice rendered for download.</summary>
+public sealed record SubscriptionInvoiceDocument(
+    byte[] Content,
+    string ContentType,
+    string FileName);

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -33,6 +33,7 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
     private readonly IStoredPaymentMethodRepository _storedMethods;
     private readonly IProviderTokenProtector _tokenProtector;
     private readonly IStripeInvoiceClient _invoices;
+    private readonly ICurrencyMinorUnitResolver _amounts;
     private readonly ILogger<StripeInvoiceBillingGateway> _logger;
     private readonly TimeProvider _time;
 
@@ -42,6 +43,7 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
         IStoredPaymentMethodRepository storedMethods,
         IProviderTokenProtector tokenProtector,
         IStripeInvoiceClient invoices,
+        ICurrencyMinorUnitResolver amounts,
         ILogger<StripeInvoiceBillingGateway> logger,
         TimeProvider? time = null)
     {
@@ -50,6 +52,7 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
         _storedMethods = storedMethods;
         _tokenProtector = tokenProtector;
         _invoices = invoices;
+        _amounts = amounts;
         _logger = logger;
         _time = time ?? TimeProvider.System;
     }
@@ -233,9 +236,13 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
                 "InvoiceHash={InvoiceHash}",
                 PaymentLogValue.Hash(invoice.InvoiceOrItemId!));
 
-            return SubscriptionOperationResult<string>.Success(
+            return await RecordSettlementAsync(
+                provider,
+                request,
                 invoice.InvoiceOrItemId!,
-                correlationId);
+                idempotencyKey,
+                correlationId,
+                cancellationToken);
         }
 
         var paid = await _invoices.PayInvoiceAsync(
@@ -254,9 +261,13 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             // the next attempt.
             if (IsPaid(paid.Status))
             {
-                return SubscriptionOperationResult<string>.Success(
+                return await RecordSettlementAsync(
+                    provider,
+                    request,
                     invoice.InvoiceOrItemId!,
-                    correlationId);
+                    idempotencyKey,
+                    correlationId,
+                    cancellationToken);
             }
 
             await _invoices.VoidInvoiceAsync(provider, invoice.InvoiceOrItemId!, cancellationToken);
@@ -268,7 +279,139 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             "Subscription renewal charged through a Stripe invoice InvoiceHash={InvoiceHash}",
             PaymentLogValue.Hash(invoice.InvoiceOrItemId!));
 
-        return SubscriptionOperationResult<string>.Success(invoice.InvoiceOrItemId!, correlationId);
+        return await RecordSettlementAsync(
+            provider,
+            request,
+            invoice.InvoiceOrItemId!,
+            idempotencyKey,
+            correlationId,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Writes the settled invoice as a payment, and answers with its id.
+    /// </summary>
+    /// <remarks>
+    /// Without this a Stripe renewal left no payment record at all: the invoice id was returned
+    /// where a payment id was expected, so a tenant's renewal revenue was invisible to the payment
+    /// portal and only first checkouts ever appeared. Every non-Stripe renewal already records one
+    /// through <see cref="RecurringChargeBillingGateway"/> — this closes the gap rather than
+    /// inventing a second way to account for money.
+    /// <para>
+    /// Recorded already captured, because that is what it is: an invoice paid at finalization has
+    /// no authorize-then-capture step left to drive. The write is best effort — the money has
+    /// moved, so a bookkeeping failure must not report a failed renewal and have the next attempt
+    /// charge the customer a second time. It degrades to the invoice id and an error worth
+    /// alerting on.
+    /// </para>
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<string>> RecordSettlementAsync(
+        PaymentProvider provider,
+        SubscriptionChargeRequest request,
+        string invoiceId,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        // Its own key, so this record can never collide with one a charge attempt reserved.
+        var paymentIdempotencyKey = $"{idempotencyKey}:settled";
+
+        try
+        {
+            if (!_amounts.TryConvertBack(
+                    request.AmountMinor,
+                    request.CurrencyCode,
+                    out var amount))
+            {
+                _logger.LogError(
+                    "A settled subscription invoice could not be recorded because its currency " +
+                    "has no configured minor units Currency={Currency}",
+                    PaymentLogValue.Label(request.CurrencyCode));
+
+                return SubscriptionOperationResult<string>.Success(invoiceId, correlationId);
+            }
+
+            var payment = NewPayment(
+                provider,
+                request,
+                invoiceId,
+                paymentIdempotencyKey,
+                correlationId,
+                amount);
+
+            if (await _payments.TryCreateAsync(payment, cancellationToken))
+            {
+                return SubscriptionOperationResult<string>.Success(
+                    payment.ItemId,
+                    correlationId);
+            }
+
+            // Already recorded, by a sweep that took the money and then lost its own answer.
+            // Returning the existing id keeps a replay pointing at one payment rather than
+            // appearing to be a second one.
+            var existing = await _payments.GetByIdempotencyKeyAsync(
+                request.TenantId,
+                paymentIdempotencyKey,
+                cancellationToken);
+
+            return SubscriptionOperationResult<string>.Success(
+                existing?.ItemId ?? invoiceId,
+                correlationId);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogError(
+                exception,
+                "A settled subscription invoice could not be recorded as a payment; the money " +
+                "was taken and the renewal stands InvoiceHash={InvoiceHash}",
+                PaymentLogValue.Hash(invoiceId));
+
+            return SubscriptionOperationResult<string>.Success(invoiceId, correlationId);
+        }
+    }
+
+    private PaymentDetail NewPayment(
+        PaymentProvider provider,
+        SubscriptionChargeRequest request,
+        string invoiceId,
+        string paymentIdempotencyKey,
+        string correlationId,
+        decimal amount)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        return new PaymentDetail
+        {
+            TenantId = request.TenantId,
+            ProviderName = request.ProviderName.ToUpperInvariant(),
+            PaymentStatus = PaymentStatuses.Captured,
+            PaymentFlow = PaymentFlows.SubscriptionInvoice,
+            Amount = (double)amount,
+            PreciseAmount = amount,
+            CurrencyCode = request.CurrencyCode.ToUpperInvariant(),
+            IsRecurring = true,
+            RecurringProcessingModel = "Subscription",
+            StoredPaymentMethodPublicId = request.StoredPaymentMethodId,
+
+            // The merchant's scope, matching where the provider and card were resolved, so this
+            // payment answers provider lookups the same way the charge did.
+            OrganizationId = request.OrganizationId,
+
+            // Who the money is for, which is the question reconciliation actually asks.
+            CustomerOrganizationId = request.SubscriberOrganizationId,
+            CustomerId = request.ProviderCustomerId,
+            OrderId = request.OrderId,
+            Description = request.Description?.Trim(),
+            ProviderInvoiceId = invoiceId,
+            ProviderMerchantAccount = provider.MerchantId,
+            MerchantId = provider.MerchantId,
+            IdempotencyKey = paymentIdempotencyKey,
+            RequestHash = paymentIdempotencyKey,
+            CorrelationId = correlationId,
+            CreatedAtUtc = now,
+            LastUpdatedDateUtc = now,
+            PaymentDate = now
+        };
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
@@ -8,7 +8,21 @@ public sealed class SubscriptionChargeRequest
 {
     public string TenantId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The merchant's scope — whose provider configuration and saved card settle this.
+    /// </summary>
+    /// <remarks>
+    /// Rarely the organization being billed. A tenant configures one provider and every
+    /// organization's subscription is charged through it, so this is the scope that holds the
+    /// card, while <see cref="SubscriberOrganizationId"/> is who the money is for.
+    /// </remarks>
     public string OrganizationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The organization whose subscription this pays for, recorded so the revenue can be
+    /// attributed. Null leaves the payment attributed to the merchant scope alone.
+    /// </summary>
+    public string? SubscriberOrganizationId { get; set; }
 
     public string ProviderName { get; set; } = string.Empty;
 

--- a/server/Subscription.DomainService/Services/SubscriptionInvoiceDocumentService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionInvoiceDocumentService.cs
@@ -1,0 +1,162 @@
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Hands a subscriber the invoice document behind one of their subscription payments.
+/// </summary>
+/// <remarks>
+/// The provider's own download link is never returned. It carries no authentication and does not
+/// expire, so returning one would grant permanent access to anyone it reached and put the document
+/// beyond this service's reach the moment it left. Fetching it here keeps the check on every
+/// download, and keeps access revocable by revoking the caller's.
+/// <para>
+/// The link is also read fresh each time rather than stored, so nothing in the database is a
+/// standing key to a customer's billing document.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionInvoiceDocumentService : ISubscriptionInvoiceDocumentService
+{
+    private readonly ISubscriptionContextResolver _context;
+    private readonly IPaymentRepository _payments;
+    private readonly IPaymentProviderCache _providers;
+    private readonly IStripeInvoiceClient _invoices;
+    private readonly ILogger<SubscriptionInvoiceDocumentService> _logger;
+
+    public SubscriptionInvoiceDocumentService(
+        ISubscriptionContextResolver context,
+        IPaymentRepository payments,
+        IPaymentProviderCache providers,
+        IStripeInvoiceClient invoices,
+        ILogger<SubscriptionInvoiceDocumentService> logger)
+    {
+        _context = context;
+        _payments = payments;
+        _providers = providers;
+        _invoices = invoices;
+        _logger = logger;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionInvoiceDocument>> GetAsync(
+        string paymentId,
+        string? requestedOrganizationId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = await _context.ResolveAsync(
+            correlationId,
+            requestedOrganizationId,
+            cancellationToken);
+
+        if (resolution.Context is not { } context)
+        {
+            return resolution.ToFailure<SubscriptionInvoiceDocument>(correlationId);
+        }
+
+        var payment = await _payments.GetByIdAsync(
+            context.TenantId,
+            paymentId,
+            cancellationToken);
+
+        // One answer for absent, for another organization's, and for a payment that is not a
+        // subscription invoice at all. Distinguishing them would let a caller enumerate the
+        // tenant's payments by the shape of the refusal.
+        if (payment is null ||
+            !string.Equals(
+                payment.PaymentFlow,
+                PaymentFlows.SubscriptionInvoice,
+                StringComparison.Ordinal) ||
+            !OwnedBy(payment.CustomerOrganizationId, context.OrganizationId) ||
+            payment.ProviderInvoiceId is not { Length: > 0 } invoiceId)
+        {
+            return NotFound(correlationId);
+        }
+
+        // Resolved under the payment's own organization, which is the merchant scope that took
+        // the money — not the subscriber's, which has no provider configured.
+        var provider = await _providers.GetAsync(
+            context.TenantId,
+            payment.OrganizationId ?? context.OrganizationId,
+            payment.ProviderName,
+            () => _payments.GetProviderAsync(
+                context.TenantId,
+                payment.OrganizationId ?? context.OrganizationId,
+                payment.ProviderName,
+                cancellationToken));
+
+        if (provider is not { IsEnabled: true, ApiKey.Length: > 0 })
+        {
+            _logger.LogWarning(
+                "An invoice document was asked for but its provider could not be resolved " +
+                "Provider={Provider}",
+                PaymentLogValue.Label(payment.ProviderName));
+
+            return SubscriptionOperationResult<SubscriptionInvoiceDocument>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_invoice_provider_unavailable",
+                "This invoice cannot be fetched right now.",
+                correlationId);
+        }
+
+        var document = await _invoices.DownloadInvoicePdfAsync(
+            provider,
+            invoiceId,
+            cancellationToken);
+
+        if (document is null)
+        {
+            return SubscriptionOperationResult<SubscriptionInvoiceDocument>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_invoice_document_unavailable",
+                "This invoice's document could not be fetched right now.",
+                correlationId);
+        }
+
+        return SubscriptionOperationResult<SubscriptionInvoiceDocument>.Success(
+            new SubscriptionInvoiceDocument(
+                document.Content,
+                document.ContentType,
+                FileNameFor(document.InvoiceNumber, payment.ItemId)),
+            correlationId);
+    }
+
+    /// <summary>
+    /// Whether this payment belongs to the asking organization.
+    /// </summary>
+    /// <remarks>
+    /// Payments recorded before the subscriber was captured carry no owning organization. Those
+    /// are refused rather than shown to whoever asks: an unattributed billing document is exactly
+    /// the thing not to hand out on a guess.
+    /// </remarks>
+    private static bool OwnedBy(string? subscriberOrganizationId, string callerOrganizationId) =>
+        subscriberOrganizationId is { Length: > 0 } &&
+        string.Equals(subscriberOrganizationId, callerOrganizationId, StringComparison.Ordinal);
+
+    private static string FileNameFor(string? invoiceNumber, string paymentId) =>
+        $"invoice-{Sanitize(invoiceNumber ?? paymentId)}.pdf";
+
+    /// <summary>
+    /// Keeps a provider-supplied invoice number from shaping the download filename, which is
+    /// echoed into a Content-Disposition header.
+    /// </summary>
+    private static string Sanitize(string value)
+    {
+        var safe = new string([.. value
+            .Where(character => char.IsAsciiLetterOrDigit(character) || character is '-' or '_')]);
+
+        return safe.Length == 0 ? "document" : safe[..Math.Min(safe.Length, 60)];
+    }
+
+    private static SubscriptionOperationResult<SubscriptionInvoiceDocument> NotFound(
+        string correlationId) =>
+        SubscriptionOperationResult<SubscriptionInvoiceDocument>.Failure(
+            PaymentFailureKind.NotFound,
+            "subscription_invoice_not_found",
+            "No invoice was found for this payment.",
+            correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -200,6 +200,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 // The merchant's scope, not the subscriber's — see BillingAccount.
                 OrganizationId =
                     account.ProviderOrganizationId ?? subscription.OrganizationId,
+                SubscriberOrganizationId = subscription.OrganizationId,
                 ProviderName = account.ProviderName,
                 StoredPaymentMethodId = account.DefaultPaymentMethodId,
                 ProviderCustomerId = account.ProviderCustomerId,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -109,6 +109,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                     // accounts predating the field, which used the subscriber's.
                     OrganizationId =
                         account.ProviderOrganizationId ?? subscription.OrganizationId,
+                    SubscriberOrganizationId = subscription.OrganizationId,
                     ProviderName = account.ProviderName,
                     StoredPaymentMethodId = account.DefaultPaymentMethodId,
                     ProviderCustomerId = account.ProviderCustomerId,

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -104,6 +104,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionPlanChangeService,
             SubscriptionPlanChangeService>();
+        services.AddScoped<
+            ISubscriptionInvoiceDocumentService,
+            SubscriptionInvoiceDocumentService>();
         services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();

--- a/server/XUnitTest/Payment/StripeFileUrlTests.cs
+++ b/server/XUnitTest/Payment/StripeFileUrlTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Payment.DomainService.Providers.Stripe;
+
+namespace XUnitTest.Payment;
+
+/// <summary>Deciding whether a file link out of a Stripe response may be followed.</summary>
+public sealed class StripeFileUrlTests
+{
+    [Theory]
+    [InlineData("https://files.stripe.com/links/abc")]
+    [InlineData("https://FILES.STRIPE.COM/links/abc")]
+    [InlineData("https://api.stripe.com/v1/invoices/in_1/pdf")]
+    public void Stripes_own_file_hosts_are_followed(string url) =>
+        StripeFileUrl.IsStripeHosted(url).Should().BeTrue();
+
+    [Theory]
+    // The credential travels on this fetch, so a link pointing elsewhere is a request forgery
+    // waiting to happen — including hosts that merely end in Stripe's domain.
+    [InlineData("https://files.stripe.com.evil.test/links/abc")]
+    [InlineData("https://evil.test/files.stripe.com")]
+    [InlineData("http://files.stripe.com/links/abc")]
+    [InlineData("https://localhost/links/abc")]
+    [InlineData("https://169.254.169.254/latest/meta-data")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("/links/abc")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Anything_else_is_refused(string? url) =>
+        StripeFileUrl.IsStripeHosted(url).Should().BeFalse();
+}

--- a/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
+++ b/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
@@ -200,7 +200,12 @@ public sealed class StripeInvoiceClientTests
     }
 
     private static StripeInvoiceClient Client(IHttpService http) =>
-        new(http, new StripeEndpointPolicy(), Options(), NullLogger<StripeInvoiceClient>.Instance);
+        new(
+            http,
+            Mock.Of<IHttpClientFactory>(),
+            new StripeEndpointPolicy(),
+            Options(),
+            NullLogger<StripeInvoiceClient>.Instance);
 
     private static IOptionsMonitor<PaymentOptions> Options()
     {

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -23,11 +23,25 @@ public sealed class StripeInvoiceBillingGatewayTests
     private readonly Mock<IStoredPaymentMethodRepository> _storedMethods = new();
     private readonly Mock<IProviderTokenProtector> _tokenProtector = new();
     private readonly Mock<IStripeInvoiceClient> _invoices = new();
+    private readonly Mock<ICurrencyMinorUnitResolver> _amounts = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 8, 31, 22, 0, 0, TimeSpan.Zero));
 
     public StripeInvoiceBillingGatewayTests()
     {
+        _amounts
+            .Setup(resolver => resolver.TryConvertBack(8_900, "CHF", out It.Ref<decimal>.IsAny))
+            .Returns((long _, string _, out decimal amount) =>
+            {
+                amount = 89.00m;
+                return true;
+            });
+
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         _providers
             .Setup(cache => cache.GetAsync(
                 TenantId,
@@ -86,12 +100,86 @@ public sealed class StripeInvoiceBillingGatewayTests
     }
 
     [Fact]
-    public async Task A_full_success_returns_the_invoice_id()
+    public async Task A_full_success_records_the_payment_and_returns_its_id()
     {
+        PaymentDetail? recorded = null;
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .Callback((PaymentDetail payment, CancellationToken _) => recorded = payment)
+            .ReturnsAsync(true);
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        // The invoice id used to come back here, where a payment id was expected — which is why
+        // renewals never reached the payment portal.
+        recorded.Should().NotBeNull();
+        result.Value.Should().Be(recorded!.ItemId);
+        result.Value.Should().NotBe("in_1");
+    }
+
+    [Fact]
+    public async Task The_recorded_payment_carries_what_reconciliation_needs()
+    {
+        PaymentDetail? recorded = null;
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .Callback((PaymentDetail payment, CancellationToken _) => recorded = payment)
+            .ReturnsAsync(true);
+
+        var request = Request();
+        request.SubscriberOrganizationId = "org-subscriber";
+
+        await Gateway().ChargeAsync(request, "idem-1", "corr-1", CancellationToken.None);
+
+        recorded.Should().NotBeNull();
+        recorded!.PaymentStatus.Should().Be(PaymentStatuses.Captured);
+        recorded.PaymentFlow.Should().Be(PaymentFlows.SubscriptionInvoice);
+        recorded.PreciseAmount.Should().Be(89.00m);
+        recorded.CurrencyCode.Should().Be("CHF");
+        recorded.ProviderInvoiceId.Should().Be("in_1");
+        recorded.OrderId.Should().Be(request.OrderId);
+
+        // The merchant's scope settles it; the subscriber is who the revenue belongs to.
+        recorded.OrganizationId.Should().Be(OrganizationId);
+        recorded.CustomerOrganizationId.Should().Be("org-subscriber");
+    }
+
+    [Fact]
+    public async Task A_settled_invoice_that_cannot_be_recorded_still_reports_the_renewal_paid()
+    {
+        // The money has moved. Reporting a failure here would have the next dunning attempt
+        // charge the customer again over a bookkeeping problem.
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("mongo unreachable"));
+
         var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().Be("in_1");
+    }
+
+    [Fact]
+    public async Task A_replayed_settlement_points_at_the_payment_already_recorded()
+    {
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _payments
+            .Setup(repository => repository.GetByIdempotencyKeyAsync(
+                TenantId, "idem-1:settled", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail { ItemId = "pay-existing" });
+
+        var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("pay-existing");
     }
 
     [Fact]
@@ -121,7 +209,14 @@ public sealed class StripeInvoiceBillingGatewayTests
         var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("in_1");
+
+        // Collected at finalization still has to be booked, or this path would advance the
+        // period with no payment record behind it.
+        _payments.Verify(
+            repository => repository.TryCreateAsync(
+                It.Is<PaymentDetail>(payment => payment.ProviderInvoiceId == "in_1"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
         _invoices.Verify(
             client => client.PayInvoiceAsync(
                 It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<string>(),
@@ -145,7 +240,11 @@ public sealed class StripeInvoiceBillingGatewayTests
         var result = await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be("in_1");
+        _payments.Verify(
+            repository => repository.TryCreateAsync(
+                It.Is<PaymentDetail>(payment => payment.ProviderInvoiceId == "in_1"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
 
         // Voiding a settled invoice is the one thing that must never follow from this.
         _invoices.Verify(
@@ -283,6 +382,7 @@ public sealed class StripeInvoiceBillingGatewayTests
         _storedMethods.Object,
         _tokenProtector.Object,
         _invoices.Object,
+        _amounts.Object,
         NullLogger<StripeInvoiceBillingGateway>.Instance,
         _time);
 

--- a/server/XUnitTest/Subscription/SubscriptionBillingGatewayResolverTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionBillingGatewayResolverTests.cs
@@ -38,6 +38,7 @@ public sealed class SubscriptionBillingGatewayResolverTests
             Mock.Of<IStoredPaymentMethodRepository>(),
             Mock.Of<IProviderTokenProtector>(),
             stripeInvoices.Object,
+            currency.Object,
             NullLogger<StripeInvoiceBillingGateway>.Instance);
 
         var resolver = new SubscriptionBillingGatewayResolver(stripeGateway, recurringGateway);
@@ -86,6 +87,7 @@ public sealed class SubscriptionBillingGatewayResolverTests
             Mock.Of<IStoredPaymentMethodRepository>(),
             Mock.Of<IProviderTokenProtector>(),
             stripeInvoices.Object,
+            currency.Object,
             NullLogger<StripeInvoiceBillingGateway>.Instance);
 
         var resolver = new SubscriptionBillingGatewayResolver(stripeGateway, recurringGateway);

--- a/server/XUnitTest/Subscription/SubscriptionInvoiceDocumentServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionInvoiceDocumentServiceTests.cs
@@ -1,0 +1,229 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>Serving a subscriber the invoice behind one of their subscription payments.</summary>
+public sealed class SubscriptionInvoiceDocumentServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string CallerOrganizationId = "org-subscriber";
+    private const string MerchantOrganizationId = "default";
+    private const string PaymentId = "pay-1";
+
+    private readonly Mock<ISubscriptionContextResolver> _context = new();
+    private readonly Mock<IPaymentRepository> _payments = new();
+    private readonly Mock<IPaymentProviderCache> _providers = new();
+    private readonly Mock<IStripeInvoiceClient> _invoices = new();
+
+    public SubscriptionInvoiceDocumentServiceTests()
+    {
+        _context
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, CallerOrganizationId, "actor-1", "user-1")));
+
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, PaymentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPayment());
+
+        _providers
+            .Setup(cache => cache.GetAsync(
+                TenantId,
+                MerchantOrganizationId,
+                PaymentConstants.StripeProvider,
+                It.IsAny<Func<Task<PaymentProvider?>>>()))
+            .ReturnsAsync(new PaymentProvider
+            {
+                ProviderName = PaymentConstants.StripeProvider,
+                IsEnabled = true,
+                ApiKey = "sk_test_1",
+                ApiBaseUrl = StripeConstants.ApiBaseUrl
+            });
+
+        _invoices
+            .Setup(client => client.DownloadInvoicePdfAsync(
+                It.IsAny<PaymentProvider>(), "in_1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceDocument([1, 2, 3], "application/pdf", "TVUYQTSF-0002"));
+    }
+
+    [Fact]
+    public async Task The_owning_organization_gets_the_document()
+    {
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Content.Should().Equal([1, 2, 3]);
+        result.Value.ContentType.Should().Be("application/pdf");
+        result.Value.FileName.Should().Be("invoice-TVUYQTSF-0002.pdf");
+    }
+
+    [Fact]
+    public async Task The_provider_is_resolved_at_the_merchant_scope_that_took_the_money()
+    {
+        await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        // The subscriber's own organization has no provider configured — resolving there would
+        // make every invoice undownloadable.
+        _providers.Verify(
+            cache => cache.GetAsync(
+                TenantId,
+                MerchantOrganizationId,
+                PaymentConstants.StripeProvider,
+                It.IsAny<Func<Task<PaymentProvider?>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Another_organizations_invoice_is_not_found()
+    {
+        var payment = NewPayment();
+        payment.CustomerOrganizationId = "org-somebody-else";
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, PaymentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(payment);
+
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        await NothingWasDownloaded();
+    }
+
+    [Fact]
+    public async Task A_payment_with_no_subscriber_recorded_is_not_handed_out()
+    {
+        // Payments taken before the subscriber was captured. An unattributed billing document is
+        // the last thing to serve on a guess.
+        var payment = NewPayment();
+        payment.CustomerOrganizationId = null;
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, PaymentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(payment);
+
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        await NothingWasDownloaded();
+    }
+
+    [Fact]
+    public async Task A_payment_that_is_not_a_subscription_invoice_is_not_found()
+    {
+        var payment = NewPayment();
+        payment.PaymentFlow = PaymentFlows.HostedCheckout;
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, PaymentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(payment);
+
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        await NothingWasDownloaded();
+    }
+
+    [Fact]
+    public async Task A_missing_payment_is_not_found()
+    {
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, PaymentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PaymentDetail?)null);
+
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        result.ErrorCode.Should().Be("subscription_invoice_not_found");
+    }
+
+    [Fact]
+    public async Task An_unresolved_caller_never_reaches_the_payment()
+    {
+        _context
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Validation,
+                "subscription_organization_missing",
+                "No organization."));
+
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_organization_missing");
+        _payments.Verify(
+            repository => repository.GetByIdAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_document_the_provider_will_not_give_up_is_reported_as_unavailable()
+    {
+        _invoices
+            .Setup(client => client.DownloadInvoicePdfAsync(
+                It.IsAny<PaymentProvider>(), "in_1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StripeInvoiceDocument?)null);
+
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.Unavailable);
+        result.ErrorCode.Should().Be("subscription_invoice_document_unavailable");
+    }
+
+    [Fact]
+    public async Task An_invoice_number_cannot_shape_the_download_filename()
+    {
+        // The number reaches a Content-Disposition header, so it is provider-supplied text in a
+        // response header until it is stripped.
+        _invoices
+            .Setup(client => client.DownloadInvoicePdfAsync(
+                It.IsAny<PaymentProvider>(), "in_1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StripeInvoiceDocument(
+                [1], "application/pdf", "../../etc/passwd\"; x=\"y"));
+
+        var result = await Service().GetAsync(PaymentId, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.FileName.Should().Be("invoice-etcpasswdxy.pdf");
+    }
+
+    private async Task NothingWasDownloaded() =>
+        await Task.Run(() => _invoices.Verify(
+            client => client.DownloadInvoicePdfAsync(
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never));
+
+    private static PaymentDetail NewPayment() => new()
+    {
+        ItemId = PaymentId,
+        TenantId = TenantId,
+        ProviderName = PaymentConstants.StripeProvider,
+        PaymentFlow = PaymentFlows.SubscriptionInvoice,
+        PaymentStatus = PaymentStatuses.Captured,
+        OrganizationId = MerchantOrganizationId,
+        CustomerOrganizationId = CallerOrganizationId,
+        ProviderInvoiceId = "in_1"
+    };
+
+    private SubscriptionInvoiceDocumentService Service() => new(
+        _context.Object,
+        _payments.Object,
+        _providers.Object,
+        _invoices.Object,
+        NullLogger<SubscriptionInvoiceDocumentService>.Instance);
+}


### PR DESCRIPTION
Two gaps that only became visible once renewals actually collected money (#237): the revenue could not be reconciled, and subscribers had no document for what they paid.

> **Stacked on #237.** Based on `fix/subscription-renewal-merchant-scope` because both commits change `StripeInvoiceBillingGateway`, which #237 rewrites. Review that one first; retarget this to `dev` once it merges.

## Renewals were invisible to the payment portal — `6019525`

The invoice gateway returned a Stripe invoice id where a payment id was expected, so it wrote no `PaymentDetail` at all. A tenant's entire renewal revenue was absent from the payment portal — only first checkouts ever appeared — and `SubscriptionDetail.LastRenewalPaymentDetailId` held an `in_…` that resolved to nothing. Every non-Stripe renewal already books one through `RecurringChargeBillingGateway`, so this closes a gap rather than adding a second way to account for money.

Booked already `CAPTURED`, which is what an invoice paid at finalization is — there is no authorize-then-capture step left to drive from it.

Two organizations are recorded, because one field cannot answer both questions:

| Field | Holds | Used for |
| --- | --- | --- |
| `OrganizationId` | the merchant's scope | resolving the provider and card, as the charge did |
| `CustomerOrganizationId` | the subscriber | attributing revenue, and authorizing invoice reads |

**The write is deliberately best effort.** The money has moved by that point, so a bookkeeping failure logs an error and still reports the renewal paid. Failing instead would send the next dunning attempt to charge the customer a second time — the same trap #237 fixes twice over. Covered by a test, along with replay pointing at the payment already recorded rather than looking like a second charge.

## Subscribers had no invoice document — `f1e76fc`

```
GET /api/subscriptions/invoices/{paymentId}/pdf
```

Scoped to the caller's organization on the same console-override policy as every other subscription read. The identifier is the payment recorded for the period; the provider's invoice id stays internal.

**The document is proxied, not linked.** A Stripe `invoice_pdf` URL carries no authentication and never expires, so returning one would grant permanent access to a billing document and put it beyond any later decision to stop sharing it. For the same reason the link is read fresh from Stripe per request rather than stored — nothing in the database should be a standing key to a customer's invoice.

Three things worth a reviewer's eye:

- `StripeFileUrl` confirms the link is Stripe-hosted before the credentialed fetch follows it. PDFs come from `files.stripe.com`, which the existing `StripeEndpointPolicy` API-host check does not cover, and a URL read out of a response body is still input — otherwise this is a server-side request forgery waiting for a bad response. Tested against suffix tricks (`files.stripe.com.evil.test`), plain HTTP, localhost and the cloud metadata address.
- The provider-supplied invoice number is stripped before it reaches `Content-Disposition`.
- Absent, another organization's, and not-a-subscription all return the same not-found, so the refusal cannot be used to enumerate a tenant's payments. A payment with no subscriber recorded — one predating `6019525` — is refused rather than served on a guess.

## Verification

2133 unit tests pass; `SubscriptionRepositoryIntegrationTests` need a local `mongod` and fail identically on a clean tree.

**The PDF path has not been exercised against live Stripe** — unit tests only, since it needs a running API plus a renewal recorded by `6019525`. Existing renewals predate it and carry no `ProviderInvoiceId`, so the endpoint returns not-found for them; a fresh renewal produces a downloadable one. Worth a manual pass before this reaches staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)