### PR TITLE
feat(payment): let a tenant's console provider serve every organization

### DIFF
--- a/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.test.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.test.tsx
@@ -97,10 +97,11 @@ describe("CreatePaymentProviderPage organization selection", () => {
       </MemoryRouter>,
     );
 
-    // The default is "use my current organization", which must send nothing at all —
-    // an empty string would be a real organization id as far as the server is concerned.
+    // The default names no organization, which must send nothing at all — an empty string
+    // would be a real organization id as far as the server is concerned. Naming none is what
+    // makes the configuration serve every organization that has none of its own.
     expect(screen.getAllByRole("combobox")[1]).toHaveTextContent(
-      "Use my current organization",
+      "Every organization in this tenant",
     );
 
     await fillRequiredStripeFields(user);

--- a/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.tsx
@@ -279,7 +279,7 @@ export const CreatePaymentProviderPage = () => {
                           </FormControl>
                           <SelectContent>
                             <SelectItem value={CONTEXT_ORGANIZATION}>
-                              Use my current organization
+                              Every organization in this tenant
                             </SelectItem>
                             {organizations.map((organization) => (
                               <SelectItem
@@ -293,8 +293,8 @@ export const CreatePaymentProviderPage = () => {
                         </Select>
                         <FormDescription>
                           {organizationsFailed
-                            ? "Organizations could not be loaded; registering will use your current organization."
-                            : "Which organization this configuration serves. Immutable — it decides which key ring encrypts the credentials."}
+                            ? "Organizations could not be loaded; this configuration will serve every organization in the tenant."
+                            : "Which organization this configuration serves. Left as-is it serves every organization that has none of its own. Immutable — it decides which key ring encrypts the credentials."}
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/server/Payment.DomainService/Providers/Adyen/AdyenInitiationRequestFactory.cs
+++ b/server/Payment.DomainService/Providers/Adyen/AdyenInitiationRequestFactory.cs
@@ -66,7 +66,12 @@ public sealed class AdyenInitiationRequestFactory : IProviderInitiationRequestFa
                 TenantReference = Convert.ToBase64String(
                     Encoding.UTF8.GetBytes(payment.TenantId)),
                 SiteId = provider.SiteId,
-                OrganizationId = context.OrganizationId
+
+                // The payment's organization, not the caller's — the two differ whenever the
+                // console takes a payment for another organization. Intake compares what comes
+                // back against the payment's own, so echoing the caller's makes every one of
+                // those webhooks unauthorized and leaves the payment in Processing for good.
+                OrganizationId = payment.OrganizationId
             },
             StorePaymentMethodMode = request.ShouldSavePaymentMethod
                 ? "askForConsent"

--- a/server/Payment.DomainService/README.md
+++ b/server/Payment.DomainService/README.md
@@ -62,6 +62,41 @@ The same rule governs reads — payment listing and saved-card lookup — so an 
 cannot be written under one rule and read back under another. It is applied in one place,
 `PaymentOrganizationScope.RequestMayNameOrganization`.
 
+### Which configuration serves an operation
+
+Registration decides which organization a configuration *belongs to*. Resolution decides which
+configurations may *serve* an organization, and the two are not the same question. Every
+provider lookup walks an ordered chain, defined once in `PaymentProviderScopeChain`:
+
+| Order | Candidate | Why |
+| --- | --- | --- |
+| 1 | the caller's own organization | a configuration of its own always wins, so nothing a tenant already set up changes meaning |
+| 2 | `null` | the tenant-level configuration that predates organization scoping |
+| 3 | `Payment:ConsoleOrganizationId` | a tenant that configured one merchant account from the console meant it for the tenant |
+
+Without the third step, a configuration registered from the console — which is where most
+tenants configure one — is stored under a real organization identifier and therefore serves
+only the console. Every other organization resolves nothing and every operation reports the
+provider unavailable, which is not a permission the tenant ever intended to withhold.
+
+This widens which configuration answers, never whose data is reachable: the tenant is fixed by
+the caller's token before any candidate is tried. `Payment:TreatConsoleOrganizationAsTenantWide`
+turns the third step off for a tenant whose console account is deliberately its own — a
+platform-owned test merchant — and emptying `ConsoleOrganizationId` turns it off along with
+everything else that value governs.
+
+**A configuration is returned exactly as stored.** Every encryption scope downstream reads the
+row's own organization rather than the one that was asked for, so a shared configuration's
+credentials stay on the key ring they were sealed under and nothing has to be re-encrypted for
+it to be shared. This is also why the fix is in resolution rather than in registration: rewriting
+a stored organization would move existing ciphertext to a different ring under an unchanged key
+id, where it fails as tampering rather than as a missing key — reported as
+`secrets_unreadable`, which reads to a caller as "provider not found".
+
+One consequence worth knowing: because a shared configuration answers for many organizations,
+its cache entry exists under each of their keys. Changing or rotating it evicts all of them
+(`IPaymentProviderCache.RemoveAll`), not just the organization it is stored under.
+
 **`ConsoleOrganizationId` is a magic value and its safety depends on the configuration.**
 Anyone whose token carries it gets the console's reach over every organization in their
 tenant. If `default` is a real organization for your tenants, move the console to an
@@ -482,6 +517,17 @@ distinction existed (no `EncryptionScopeResolvedAtUtc`) falls back to `Organizat
 the correct answer at the time — every organization was still a merchant when it was written.
 Token protection fails closed if no provider configuration resolves, rather than guessing which
 ring to use.
+
+> **Fixed.** Both fields were computed at write time but never persisted, so every card came
+> back with no resolved scope and fell through to `OrganizationId` regardless. That was
+> invisible while the two agreed, and became a live fault the moment one configuration served
+> several organizations: the token is sealed under the configuration's scope and would be read
+> under the caller's — a different ring, so the card saves and then cannot be charged. All three
+> paths that write a freshly protected token now record its scope.
+>
+> Cards saved **before** that carry no `EncryptionScopeResolvedAtUtc` and keep decrypting under
+> `OrganizationId`, which is where their tokens really are. Nothing backfills the field:
+> stamping it would claim an encryption scope those tokens never used.
 
 ## Which payments a caller sees
 

--- a/server/Payment.DomainService/Repositories/PaymentRepository.cs
+++ b/server/Payment.DomainService/Repositories/PaymentRepository.cs
@@ -1,18 +1,27 @@
 using System.Collections.Concurrent;
 using Blocks.Genesis;
+using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
 
 namespace Payment.DomainService.Repositories;
 
 public sealed class PaymentRepository : IPaymentRepository
 {
     private readonly IDbContextProvider _dbContextProvider;
+    private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
 
-    public PaymentRepository(IDbContextProvider dbContextProvider) => _dbContextProvider = dbContextProvider;
+    public PaymentRepository(
+        IDbContextProvider dbContextProvider,
+        IOptionsMonitor<PaymentOptions> options)
+    {
+        _dbContextProvider = dbContextProvider;
+        _options = options;
+    }
 
     public async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
     {
@@ -94,30 +103,33 @@ public sealed class PaymentRepository : IPaymentRepository
                 true));
         var providers = Providers(tenantId);
 
-        if (!string.IsNullOrWhiteSpace(organizationId))
+        // Most specific first: the caller's own configuration, then the tenant's, then the
+        // console's — see PaymentProviderScopeChain for why that last one counts as the
+        // tenant's. The tenant is already fixed by the caller's token, so this widens which
+        // configuration answers, never whose data is reachable.
+        foreach (var candidate in PaymentProviderScopeChain.Candidates(
+                     organizationId,
+                     _options.CurrentValue))
         {
-            var owned = await providers
+            var found = await providers
                 .Find(Builders<PaymentProvider>.Filter.And(
                     filter,
                     Builders<PaymentProvider>.Filter.Eq(
                         x => x.OrganizationId,
-                        organizationId)))
+                        candidate)))
                 .FirstOrDefaultAsync(cancellationToken);
 
-            if (owned != null)
+            if (found != null)
             {
-                return owned;
+                // Returned as stored. Everything downstream that derives an encryption scope
+                // reads this row's own organization rather than the one asked for, so a
+                // credential stays on the key ring it was sealed under and nothing has to be
+                // re-encrypted for a configuration to be shared.
+                return found;
             }
         }
 
-        // The tenant's own configuration, serving any organization without one of its own.
-        return await providers
-            .Find(Builders<PaymentProvider>.Filter.And(
-                filter,
-                Builders<PaymentProvider>.Filter.Eq(
-                    x => x.OrganizationId,
-                    null)))
-            .FirstOrDefaultAsync(cancellationToken);
+        return null;
     }
 
     public async Task<bool> TryCreateAsync(PaymentDetail payment, CancellationToken cancellationToken)

--- a/server/Payment.DomainService/Repositories/StoredPaymentMethodRepository.cs
+++ b/server/Payment.DomainService/Repositories/StoredPaymentMethodRepository.cs
@@ -148,6 +148,10 @@ public sealed class StoredPaymentMethodRepository : IStoredPaymentMethodReposito
                 .Set(candidate => candidate.ProviderTokenCiphertext, method.ProviderTokenCiphertext)
                 .Set(candidate => candidate.ProviderTokenFingerprint, method.ProviderTokenFingerprint)
                 .Set(candidate => candidate.TokenEncryptionKeyId, method.TokenEncryptionKeyId)
+
+                // A replacement token is freshly protected, so its scope travels with it.
+                .Set(candidate => candidate.EncryptionOrganizationId, method.EncryptionOrganizationId)
+                .Set(candidate => candidate.EncryptionScopeResolvedAtUtc, method.EncryptionScopeResolvedAtUtc)
                 .Set(candidate => candidate.ProviderPayerReference, method.ProviderPayerReference)
                 .Set(candidate => candidate.Brand, method.Brand)
                 .Set(candidate => candidate.LastFour, method.LastFour)
@@ -242,6 +246,15 @@ public sealed class StoredPaymentMethodRepository : IStoredPaymentMethodReposito
             .Set(candidate => candidate.ProviderPayerReference, method.ProviderPayerReference)
             .Set(candidate => candidate.ProviderCardFingerprint, method.ProviderCardFingerprint)
             .Set(candidate => candidate.OrganizationId, method.OrganizationId)
+
+            // Which merchant account's ring protected the token, recorded alongside the token
+            // itself. Without it PaymentEncryptionScope.From falls back to OrganizationId — the
+            // caller this card is offered to — and the two are only the same while every
+            // organization has a configuration of its own. Once a tenant's configuration serves
+            // several of them, the token is sealed under the configuration's scope and would be
+            // read under the caller's: a different ring, and an unreadable card.
+            .Set(candidate => candidate.EncryptionOrganizationId, method.EncryptionOrganizationId)
+            .Set(candidate => candidate.EncryptionScopeResolvedAtUtc, method.EncryptionScopeResolvedAtUtc)
             .Unset(candidate => candidate.StoredPaymentMethodToken)
             .Set(candidate => candidate.Type, method.Type)
             .Set(candidate => candidate.Brand, method.Brand)
@@ -298,6 +311,11 @@ public sealed class StoredPaymentMethodRepository : IStoredPaymentMethodReposito
                     .Set(candidate => candidate.Status, PaymentMethodStatus.Active)
                     .Set(candidate => candidate.ProviderTokenCiphertext, method.ProviderTokenCiphertext)
                     .Set(candidate => candidate.TokenEncryptionKeyId, method.TokenEncryptionKeyId)
+
+                    // Re-consented against a freshly resolved configuration, so the scope that
+                    // protected this token is recorded with it rather than left as it was.
+                    .Set(candidate => candidate.EncryptionOrganizationId, method.EncryptionOrganizationId)
+                    .Set(candidate => candidate.EncryptionScopeResolvedAtUtc, method.EncryptionScopeResolvedAtUtc)
                     .Unset(candidate => candidate.StoredPaymentMethodToken)
                     .Set(candidate => candidate.Type, method.Type)
                     .Set(candidate => candidate.Brand, method.Brand)

--- a/server/Payment.DomainService/Services/IPaymentProviderCache.cs
+++ b/server/Payment.DomainService/Services/IPaymentProviderCache.cs
@@ -28,4 +28,16 @@ public interface IPaymentProviderCache
         string tenantId,
         string? organizationId,
         string providerName);
+
+    /// <summary>
+    /// Drops every organization's entry for one of a tenant's providers.
+    /// </summary>
+    /// <remarks>
+    /// One configuration can be cached under many keys, because entries are keyed by the
+    /// organization that <em>asked</em> and a tenant-level configuration answers for every
+    /// organization without one of its own. Evicting only the organization a row is stored
+    /// under would leave every other organization holding the previous credentials —
+    /// already decrypted — until the entry expired on its own.
+    /// </remarks>
+    void RemoveAll(string tenantId, string providerName);
 }

--- a/server/Payment.DomainService/Services/PaymentProviderCache.cs
+++ b/server/Payment.DomainService/Services/PaymentProviderCache.cs
@@ -109,6 +109,26 @@ public sealed class PaymentProviderCache : IPaymentProviderCache
             CreateKey(tenantId, organizationId, providerName),
             out _);
 
+    public void RemoveAll(string tenantId, string providerName)
+    {
+        var prefix = $"{tenantId}:";
+        var suffix = $":{providerName}";
+
+        // Keys is a snapshot on a concurrent dictionary, so removing while walking it is safe.
+        foreach (var key in _entries.Keys)
+        {
+            // The provider is matched without regard to case, unlike the key that was written.
+            // Resolution matches provider names case-insensitively, so two spellings can each
+            // hold an entry for the same configuration; over-evicting costs one re-read, while
+            // under-evicting leaves decrypted credentials in memory after they were replaced.
+            if (key.StartsWith(prefix, StringComparison.Ordinal) &&
+                key.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                _entries.TryRemove(key, out _);
+            }
+        }
+    }
+
     /// <summary>
     /// Separates an organization's entry from the tenant-level one it may fall back to, so a
     /// second organization is never served the first one's configuration.

--- a/server/Payment.DomainService/Services/PaymentProviderConfigurationService.cs
+++ b/server/Payment.DomainService/Services/PaymentProviderConfigurationService.cs
@@ -167,9 +167,11 @@ public sealed class PaymentProviderConfigurationService :
 
         try
         {
-            // The organization's own entry: evicting the tenant-level one would leave this
-            // organization still serving the configuration that was just changed.
-            _cache.Remove(tenantId, organizationId, providerName);
+            // Every organization's entry, not just this configuration's own. A tenant-level
+            // configuration answers for every organization that has none of its own, so it is
+            // cached under each of their keys, and evicting one would leave the rest serving
+            // the configuration that was just changed.
+            _cache.RemoveAll(tenantId, providerName);
 
             refreshed = await _cache.RefreshAsync(
                 tenantId,

--- a/server/Payment.DomainService/Services/PaymentProviderCredentialRotationService.cs
+++ b/server/Payment.DomainService/Services/PaymentProviderCredentialRotationService.cs
@@ -248,9 +248,11 @@ public sealed class PaymentProviderCredentialRotationService :
 
         try
         {
-            // The organization's own entry: evicting the tenant-level one would leave this
-            // organization still serving the credentials that were just rotated away.
-            _cache.Remove(tenantId, organizationId, providerName);
+            // Every organization's entry, not just this configuration's own. A tenant-level
+            // configuration answers for every organization that has none of its own, so it is
+            // cached under each of their keys — already decrypted — and evicting one would
+            // leave the rest holding the credentials that were just rotated away.
+            _cache.RemoveAll(tenantId, providerName);
 
             refreshed = await _cache.RefreshAsync(
                 tenantId,

--- a/server/Payment.DomainService/Utilities/PaymentOptions.cs
+++ b/server/Payment.DomainService/Utilities/PaymentOptions.cs
@@ -85,6 +85,27 @@ public sealed class PaymentOptions
     public string ConsoleOrganizationId { get; set; } = "default";
 
     /// <summary>
+    /// Whether a provider the console registered serves every organization in its tenant that
+    /// has no configuration of its own.
+    /// </summary>
+    /// <remarks>
+    /// A tenant configures one merchant account and its organizations buy through it, but a
+    /// configuration registered from the console is stored under
+    /// <see cref="ConsoleOrganizationId"/> — a real identifier, not the tenant-level null that
+    /// provider resolution already falls back to. Without this, every organization but the
+    /// console resolves nothing and every operation reports the provider unavailable, which is
+    /// not a permission the tenant ever intended to withhold.
+    /// <para>
+    /// It widens resolution only. Which configuration encrypted a credential is still decided by
+    /// the row that is found, so nothing moves between key rings and no stored data changes
+    /// meaning. What it costs is the ability to keep a provider for the console alone: set this
+    /// to <c>false</c> for a tenant that registers a console-only account — a platform-owned
+    /// test merchant, say — and wants its own organizations kept off it.
+    /// </para>
+    /// </remarks>
+    public bool TreatConsoleOrganizationAsTenantWide { get; set; } = true;
+
+    /// <summary>
     /// How long a scope's encryption key ring is held before it is re-read from the vault. A
     /// rotated ring is not picked up by a running process until this elapses, so it trades
     /// vault traffic against rotation latency the same way <see cref="ProviderCacheSeconds"/>

--- a/server/Payment.DomainService/Utilities/PaymentProviderScopeChain.cs
+++ b/server/Payment.DomainService/Utilities/PaymentProviderScopeChain.cs
@@ -1,0 +1,63 @@
+namespace Payment.DomainService.Utilities;
+
+/// <summary>
+/// The organizations whose provider configuration may serve a caller, most specific first.
+/// </summary>
+/// <remarks>
+/// Pure and synchronous for the same reason as <see cref="PaymentOrganizationScope"/>: one
+/// definition, so a payment cannot be taken through a configuration that a later capture, refund
+/// or renewal then fails to find.
+/// <para>
+/// The two answer different questions and should not be confused.
+/// <see cref="PaymentOrganizationScope"/> asks whether a caller may <em>name</em> an organization,
+/// which is authorization. This asks which configurations may <em>serve</em> the organization
+/// already resolved, which is lookup — it grants nobody any reach they did not have, because the
+/// tenant is fixed by the caller's token before any of these are tried.
+/// </para>
+/// </remarks>
+public static class PaymentProviderScopeChain
+{
+    /// <summary>
+    /// Candidates in resolution order, without repeats. A null entry means the tenant-level
+    /// configuration.
+    /// </summary>
+    /// <remarks>
+    /// The order is the whole rule:
+    /// <list type="number">
+    /// <item>the caller's own organization — a configuration of its own always wins, so nothing
+    /// a tenant has already set up changes meaning;</item>
+    /// <item>null — the tenant-level configuration that predates organization scoping;</item>
+    /// <item>the console's, when <see cref="PaymentOptions.TreatConsoleOrganizationAsTenantWide"/>
+    /// allows it, because a tenant that configured one merchant account from the console meant it
+    /// for the tenant.</item>
+    /// </list>
+    /// De-duplicated so the console's own callers do not query the same organization twice.
+    /// </remarks>
+    public static IReadOnlyList<string?> Candidates(
+        string? callerOrganizationId,
+        PaymentOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var caller = callerOrganizationId?.Trim();
+        var candidates = new List<string?>(3);
+
+        if (!string.IsNullOrEmpty(caller))
+        {
+            candidates.Add(caller);
+        }
+
+        candidates.Add(null);
+
+        var console = options.ConsoleOrganizationId?.Trim();
+
+        if (options.TreatConsoleOrganizationAsTenantWide &&
+            !string.IsNullOrEmpty(console) &&
+            !string.Equals(console, caller, StringComparison.Ordinal))
+        {
+            candidates.Add(console);
+        }
+
+        return candidates;
+    }
+}

--- a/server/XUnitTest/Integration/PaymentCaptureRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PaymentCaptureRepositoryIntegrationTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Repositories;
+using XUnitTest.Payment;
 
 namespace XUnitTest.Integration;
 
@@ -13,7 +14,8 @@ public sealed class PaymentCaptureRepositoryIntegrationTests
 
     public PaymentCaptureRepositoryIntegrationTests(MongoIntegrationFixture fixture)
     {
-        _payments = new PaymentRepository(fixture.DbContextProvider);
+        _payments = new PaymentRepository(fixture.DbContextProvider,
+            TestPaymentOptions.Monitor());
         _repository = new PaymentCaptureRepository(fixture.DbContextProvider);
     }
 

--- a/server/XUnitTest/Integration/PaymentRefundRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PaymentRefundRepositoryIntegrationTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Repositories;
+using XUnitTest.Payment;
 
 namespace XUnitTest.Integration;
 
@@ -13,7 +14,8 @@ public sealed class PaymentRefundRepositoryIntegrationTests
 
     public PaymentRefundRepositoryIntegrationTests(MongoIntegrationFixture fixture)
     {
-        _payments = new PaymentRepository(fixture.DbContextProvider);
+        _payments = new PaymentRepository(fixture.DbContextProvider,
+            TestPaymentOptions.Monitor());
         _repository = new PaymentRefundRepository(fixture.DbContextProvider);
     }
 

--- a/server/XUnitTest/Integration/PaymentRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PaymentRepositoryIntegrationTests.cs
@@ -6,6 +6,7 @@ using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Models.HostedCheckout;
 using Payment.DomainService.Repositories;
+using XUnitTest.Payment;
 
 namespace XUnitTest.Integration;
 
@@ -18,7 +19,8 @@ public sealed class PaymentRepositoryIntegrationTests
     public PaymentRepositoryIntegrationTests(MongoIntegrationFixture fixture)
     {
         _fixture = fixture;
-        _repository = new PaymentRepository(fixture.DbContextProvider);
+        _repository = new PaymentRepository(fixture.DbContextProvider,
+            TestPaymentOptions.Monitor());
     }
 
     private static PaymentDetail NewPayment(string tenantId) => new()
@@ -173,6 +175,72 @@ public sealed class PaymentRepositoryIntegrationTests
                 MerchantId = "tenant-merchant",
                 IsEnabled = true
             });
+
+        (await _repository.GetProviderAsync(
+                tenantId, "organization-with-none", providerName, CancellationToken.None))!
+            .MerchantId.Should().Be("tenant-merchant");
+    }
+
+    /// <summary>
+    /// A tenant that configured one merchant account from the console meant it for the tenant,
+    /// so its organizations resolve it rather than reporting the provider unavailable.
+    /// </summary>
+    [Fact]
+    public async Task An_organization_falls_back_to_the_configuration_the_console_registered()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var providerName = "stripe-" + Guid.NewGuid().ToString("N");
+
+        await _fixture.Collection<PaymentProvider>("PaymentProviders").InsertOneAsync(
+            new PaymentProvider
+            {
+                ItemId = Guid.NewGuid().ToString(),
+                TenantId = tenantId,
+                OrganizationId = TestPaymentOptions.ConsoleOrganizationId,
+                ProviderName = providerName,
+                MerchantId = "console-merchant",
+                IsEnabled = true
+            });
+
+        var found = await _repository.GetProviderAsync(
+            tenantId, "organization-with-none", providerName, CancellationToken.None);
+
+        found!.MerchantId.Should().Be("console-merchant");
+
+        // Returned as stored. Every later encryption scope reads this, so a shared
+        // configuration's credentials stay on the key ring they were sealed under.
+        found.OrganizationId.Should().Be(TestPaymentOptions.ConsoleOrganizationId);
+    }
+
+    /// <summary>
+    /// The tenant's own configuration outranks the console's, so nothing a tenant already set
+    /// up changes meaning.
+    /// </summary>
+    [Fact]
+    public async Task A_tenant_level_configuration_outranks_the_consoles()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var providerName = "stripe-" + Guid.NewGuid().ToString("N");
+        var providers = _fixture.Collection<PaymentProvider>("PaymentProviders");
+
+        await providers.InsertOneAsync(new PaymentProvider
+        {
+            ItemId = Guid.NewGuid().ToString(),
+            TenantId = tenantId,
+            OrganizationId = null,
+            ProviderName = providerName,
+            MerchantId = "tenant-merchant",
+            IsEnabled = true
+        });
+        await providers.InsertOneAsync(new PaymentProvider
+        {
+            ItemId = Guid.NewGuid().ToString(),
+            TenantId = tenantId,
+            OrganizationId = TestPaymentOptions.ConsoleOrganizationId,
+            ProviderName = providerName,
+            MerchantId = "console-merchant",
+            IsEnabled = true
+        });
 
         (await _repository.GetProviderAsync(
                 tenantId, "organization-with-none", providerName, CancellationToken.None))!

--- a/server/XUnitTest/Integration/StoredPaymentMethodRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/StoredPaymentMethodRepositoryIntegrationTests.cs
@@ -3,6 +3,7 @@ using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Repositories;
 using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
 
 namespace XUnitTest.Integration;
 
@@ -28,6 +29,54 @@ public sealed class StoredPaymentMethodRepositoryIntegrationTests
         Brand = "visa",
         LastFour = "4242"
     };
+
+    /// <summary>
+    /// The merchant account whose key ring protected the token, which is not the caller the card
+    /// is offered to once one configuration serves several organizations.
+    /// </summary>
+    [Fact]
+    public async Task Saving_a_card_records_the_scope_that_encrypted_its_token()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var shopper = Guid.NewGuid().ToString();
+        var method = NewMethod(tenantId, shopper);
+        method.OrganizationId = "org-subscriber";
+        method.EncryptionOrganizationId = "default";
+        method.EncryptionScopeResolvedAtUtc = DateTime.UtcNow;
+
+        await _repository.UpsertFromProviderAsync(method, DateTime.UtcNow, CancellationToken.None);
+
+        var stored = await _repository.GetByTokenFingerprintAsync(
+            tenantId, shopper, "adyen", method.ProviderTokenFingerprint!, CancellationToken.None);
+
+        stored!.OrganizationId.Should().Be("org-subscriber");
+        stored.EncryptionOrganizationId.Should().Be("default");
+        stored.EncryptionScopeResolvedAtUtc.Should().NotBeNull();
+
+        // Without both, PaymentEncryptionScope.From falls back to OrganizationId and reads the
+        // token under the subscriber's ring rather than the one that sealed it.
+        PaymentEncryptionScope.From(stored).OrganizationId.Should().Be("default");
+    }
+
+    /// <summary>
+    /// A card written before the scope was recorded keeps decrypting the way it was written.
+    /// </summary>
+    [Fact]
+    public async Task A_card_saved_without_a_recorded_scope_still_reads_under_its_organization()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var shopper = Guid.NewGuid().ToString();
+        var method = NewMethod(tenantId, shopper);
+        method.OrganizationId = "org-legacy";
+
+        await _repository.UpsertFromProviderAsync(method, DateTime.UtcNow, CancellationToken.None);
+
+        var stored = await _repository.GetByTokenFingerprintAsync(
+            tenantId, shopper, "adyen", method.ProviderTokenFingerprint!, CancellationToken.None);
+
+        stored!.EncryptionScopeResolvedAtUtc.Should().BeNull();
+        PaymentEncryptionScope.From(stored).OrganizationId.Should().Be("org-legacy");
+    }
 
     [Fact]
     public async Task Upsert_then_list_and_get_reflect_active_method()

--- a/server/XUnitTest/Payment/AdyenInitiationRequestFactoryTests.cs
+++ b/server/XUnitTest/Payment/AdyenInitiationRequestFactoryTests.cs
@@ -79,6 +79,49 @@ public sealed class AdyenInitiationRequestFactoryTests
         Create(provider).CaptureDelayHours.Should().BeNull();
     }
 
+    [Fact]
+    public void The_session_echoes_the_payments_organization_not_the_callers()
+    {
+        // The console taking a payment for another organization: the caller is the console and
+        // the payment belongs to org-a. Intake compares what comes back against the payment's
+        // own organization, so echoing the caller's would make the webhook unauthorized and
+        // leave the payment in Processing for good.
+        var session = AdyenInitiationRequestFactory.ReadSession(
+            Create(Provider(), callerOrganizationId: "default", paymentOrganizationId: "org-a"));
+
+        session.Metadata.OrganizationId.Should().Be("org-a");
+    }
+
+    [Fact]
+    public void A_payment_with_no_organization_echoes_none()
+    {
+        var session = AdyenInitiationRequestFactory.ReadSession(
+            Create(Provider(), callerOrganizationId: "default", paymentOrganizationId: null));
+
+        session.Metadata.OrganizationId.Should().BeNull();
+    }
+
+    private ProviderInitiationRequest Create(
+        PaymentProvider provider,
+        string? callerOrganizationId,
+        string? paymentOrganizationId) =>
+        _factory.Create(
+            new MakePaymentRequest { CustomerEmail = "shopper@example.com" },
+            new PaymentExecutionContext("tenant-1", "actor-1", callerOrganizationId),
+            new PaymentDetail
+            {
+                TenantId = "tenant-1",
+                CurrencyCode = "EUR",
+                OrganizationId = paymentOrganizationId
+            },
+            provider,
+            "https://payments.example/return",
+            "payment-reference",
+            "shopper-reference",
+            null,
+            includeStoredPaymentMethods: true,
+            minorUnits: 2500);
+
     private ProviderInitiationRequest Create(PaymentProvider provider) =>
         _factory.Create(
             new MakePaymentRequest { CustomerEmail = "shopper@example.com" },

--- a/server/XUnitTest/Payment/PaymentProviderAdministrationTests.cs
+++ b/server/XUnitTest/Payment/PaymentProviderAdministrationTests.cs
@@ -217,7 +217,7 @@ public sealed class PaymentProviderAdministrationTests
             CancellationToken.None);
 
         _cache.Verify(
-            x => x.Remove(TenantId, It.IsAny<string>(), PaymentConstants.StripeProvider),
+            x => x.RemoveAll(TenantId, PaymentConstants.StripeProvider),
             Times.Once);
         _cache.Verify(
             x => x.RefreshAsync(
@@ -586,7 +586,7 @@ public sealed class PaymentProviderAdministrationTests
             CancellationToken.None);
 
         _cache.Verify(
-            x => x.Remove(TenantId, It.IsAny<string>(), PaymentConstants.StripeProvider),
+            x => x.RemoveAll(TenantId, PaymentConstants.StripeProvider),
             Times.Once);
     }
 

--- a/server/XUnitTest/Payment/PaymentProviderCacheTests.cs
+++ b/server/XUnitTest/Payment/PaymentProviderCacheTests.cs
@@ -226,6 +226,69 @@ public sealed class PaymentProviderCacheTests
         scoped!.MerchantId.Should().Be("organization-merchant");
     }
 
+    [Fact]
+    public async Task Removing_a_provider_drops_every_organizations_entry()
+    {
+        var secrets = new Mock<IPaymentProviderSecretHydrator>();
+        secrets.Setup(value => value.HydrateAsync(
+                It.IsAny<PaymentProvider>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var cache = CreateCache(secrets.Object);
+        var loadCount = 0;
+
+        Task<PaymentProvider?> Load()
+        {
+            loadCount++;
+
+            return Task.FromResult<PaymentProvider?>(Provider());
+        }
+
+        // One tenant-level configuration, cached under three different askers.
+        await cache.GetAsync("tenant", "org-a", "provider", Load);
+        await cache.GetAsync("tenant", "org-b", "provider", Load);
+        await cache.GetAsync("tenant", null, "provider", Load);
+        loadCount.Should().Be(3);
+
+        cache.RemoveAll("tenant", "provider");
+
+        await cache.GetAsync("tenant", "org-a", "provider", Load);
+        await cache.GetAsync("tenant", "org-b", "provider", Load);
+        await cache.GetAsync("tenant", null, "provider", Load);
+
+        // All three reloaded: rotated credentials must not survive anywhere, already decrypted.
+        loadCount.Should().Be(6);
+    }
+
+    [Fact]
+    public async Task Removing_a_provider_leaves_other_tenants_and_providers_alone()
+    {
+        var secrets = new Mock<IPaymentProviderSecretHydrator>();
+        secrets.Setup(value => value.HydrateAsync(
+                It.IsAny<PaymentProvider>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var cache = CreateCache(secrets.Object);
+        var loadCount = 0;
+
+        Task<PaymentProvider?> Load()
+        {
+            loadCount++;
+
+            return Task.FromResult<PaymentProvider?>(Provider());
+        }
+
+        await cache.GetAsync("tenant", "org-a", "other-provider", Load);
+        await cache.GetAsync("other-tenant", "org-a", "provider", Load);
+        loadCount.Should().Be(2);
+
+        cache.RemoveAll("tenant", "provider");
+
+        await cache.GetAsync("tenant", "org-a", "other-provider", Load);
+        await cache.GetAsync("other-tenant", "org-a", "provider", Load);
+        loadCount.Should().Be(2);
+    }
+
     private static PaymentProviderCache CreateCache(
         IPaymentProviderSecretHydrator secrets)
     {

--- a/server/XUnitTest/Payment/PaymentProviderConfigurationServiceTests.cs
+++ b/server/XUnitTest/Payment/PaymentProviderConfigurationServiceTests.cs
@@ -96,9 +96,10 @@ public sealed class PaymentProviderConfigurationServiceTests
 
         result.IsSuccess.Should().BeTrue();
         result.Provider!.Version.Should().Be(6);
-        _cache.Verify(cache => cache.Remove(
+        // Every organization's entry, because a tenant-level configuration is cached under
+        // each of theirs, not only under its own.
+        _cache.Verify(cache => cache.RemoveAll(
             TenantId,
-            null,
             current.ProviderName), Times.Once);
         _cache.Verify(cache => cache.RefreshAsync(
             TenantId,
@@ -149,8 +150,7 @@ public sealed class PaymentProviderConfigurationServiceTests
             PaymentFailureKind.Conflict);
         result.ErrorCode.Should().Be(
             "payment_provider_version_conflict");
-        _cache.Verify(cache => cache.Remove(
-            It.IsAny<string>(),
+        _cache.Verify(cache => cache.RemoveAll(
             It.IsAny<string>(),
             It.IsAny<string>()), Times.Never);
     }

--- a/server/XUnitTest/Payment/PaymentProviderCredentialRotationTests.cs
+++ b/server/XUnitTest/Payment/PaymentProviderCredentialRotationTests.cs
@@ -286,9 +286,10 @@ public sealed class PaymentProviderCredentialRotationTests
         storedProviderCiphertext.Should().NotBeNullOrWhiteSpace();
         storedTenantCiphertext.Should().NotBeNullOrWhiteSpace();
         storedKeyId.Should().Be(KeyId);
-        cache.Verify(item => item.Remove(
+        // Rotated credentials must not survive in another organization's entry, already
+        // decrypted, until it expires.
+        cache.Verify(item => item.RemoveAll(
             TenantId,
-            It.IsAny<string>(),
             current.ProviderName), Times.Once);
         cache.Verify(item => item.RefreshAsync(
             TenantId,

--- a/server/XUnitTest/Payment/PaymentProviderScopeChainTests.cs
+++ b/server/XUnitTest/Payment/PaymentProviderScopeChainTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Payment.DomainService.Utilities;
+
+namespace XUnitTest.Payment;
+
+/// <summary>Which configurations may serve a caller, and in what order.</summary>
+public sealed class PaymentProviderScopeChainTests
+{
+    [Fact]
+    public void An_organizations_own_configuration_is_tried_first()
+    {
+        var candidates = PaymentProviderScopeChain.Candidates("org-a", Options());
+
+        // A tenant that has already configured an organization must not have that meaning
+        // changed by this rule.
+        candidates.Should().Equal("org-a", null, "default");
+    }
+
+    [Fact]
+    public void The_console_is_not_queried_twice_for_its_own_callers()
+    {
+        var candidates = PaymentProviderScopeChain.Candidates("default", Options());
+
+        candidates.Should().Equal("default", null);
+    }
+
+    [Fact]
+    public void A_caller_with_no_organization_still_reaches_the_tenants_configuration()
+    {
+        PaymentProviderScopeChain.Candidates(null, Options())
+            .Should().Equal(null, "default");
+        PaymentProviderScopeChain.Candidates("   ", Options())
+            .Should().Equal(null, "default");
+    }
+
+    [Fact]
+    public void A_console_only_tenant_keeps_its_configuration_to_itself()
+    {
+        var options = Options();
+        options.TreatConsoleOrganizationAsTenantWide = false;
+
+        // The escape hatch for a platform-owned merchant account that the tenant's own
+        // organizations must not reach.
+        PaymentProviderScopeChain.Candidates("org-a", options)
+            .Should().Equal("org-a", null);
+    }
+
+    [Fact]
+    public void Turning_the_console_off_entirely_also_turns_this_off()
+    {
+        var options = Options();
+        options.ConsoleOrganizationId = string.Empty;
+
+        PaymentProviderScopeChain.Candidates("org-a", options)
+            .Should().Equal("org-a", null);
+    }
+
+    [Fact]
+    public void The_tenants_own_configuration_always_outranks_the_consoles()
+    {
+        // Ordering is the whole rule: a null-organization row predates scoping and is the
+        // tenant's deliberate choice, so it must win over the console's.
+        var candidates = PaymentProviderScopeChain.Candidates("org-a", Options()).ToList();
+
+        candidates.FindIndex(candidate => candidate is null)
+            .Should().BeLessThan(candidates.FindIndex(candidate => candidate == "default"));
+    }
+
+    [Fact]
+    public void Options_are_required() =>
+        FluentActions.Invoking(() => PaymentProviderScopeChain.Candidates("org-a", null!))
+            .Should().Throw<ArgumentNullException>();
+
+    private static PaymentOptions Options() => new()
+    {
+        ConsoleOrganizationId = TestPaymentOptions.ConsoleOrganizationId,
+        TreatConsoleOrganizationAsTenantWide = true
+    };
+}


### PR DESCRIPTION
A project configures one payment provider from the console. Every organization in that project should be able to take payments and run subscriptions through it, without each registering its own copy of the same merchant credentials. Today only the console can: the row is stored under `Payment:ConsoleOrganizationId` (`"default"`), and resolution matched the caller's organization exactly before falling back only to a `null` one. Everyone else got `payment_provider_unavailable`.

This is also the root cause behind #237, where `BillingAccount.ProviderOrganizationId` had to be added to record the merchant scope explicitly so a renewal could find the provider that took the first payment.

## Resolution changes; registration does not

Provider lookup now walks an ordered chain, defined once in `PaymentProviderScopeChain`:

| Order | Candidate | Why |
| --- | --- | --- |
| 1 | the caller's own organization | its own configuration always wins, so nothing a tenant already set up changes meaning |
| 2 | `null` | the tenant-level row that predates organization scoping |
| 3 | `ConsoleOrganizationId` | a tenant that configured one merchant account from the console meant it for the tenant |

**Nothing is migrated, and that is the point.** The row is returned exactly as stored, and every encryption scope downstream reads the row's own organization rather than the one asked for, so credentials stay on the key ring they were sealed under.

The alternative — storing `null` at registration — was rejected on exactly that: `PaymentEncryptionScope.From(provider)` derives the ring name from `OrganizationId`, so flipping a stored row moves it from `payment-keyring-{tenant}-default-<hash>` to `payment-keyring-{tenant}` while `SecretsEncryptionKeyId` stays put. The ring resolves, the key id matches, and AES-GCM fails as *tampering* — surfacing as `secrets_unreadable`, i.e. "provider not found". It would also need every tenant's credentials re-entered.

`TreatConsoleOrganizationAsTenantWide` (default `true`) turns step 3 off for a tenant whose console account is deliberately its own — a platform-owned test merchant. Emptying `ConsoleOrganizationId` turns it off along with everything else that value governs.

The accepted trade-off: that identifier stops being purely an authorization sentinel and becomes part of resolution. Contained by living in one named, switchable place.

## Three faults this exposes, fixed here

**Cache eviction was per-organization.** Entries are keyed by the organization that *asked*, so one shared configuration is now held under many keys, each carrying credentials that are already decrypted. Eviction cleared only the key matching the row's stored organization, so changing or rotating a configuration left every other organization serving the previous version until the entry aged out — up to `ProviderCacheSeconds` later, silently.

**A saved card never recorded which merchant account encrypted it.** `EncryptionOrganizationId` and `EncryptionScopeResolvedAtUtc` have existed since card tokens moved onto the merchant's ring, and the lifecycle service computed both — but no write path persisted either, so every card fell through to the legacy `OrganizationId` branch. Harmless while the two agreed; a live fault the moment one configuration serves several organizations, because the token is sealed under the configuration's scope and read under the caller's. The card saves and then cannot be charged. **This had to land with the resolution change, not after it.** Existing rows are deliberately not backfilled — their tokens really are on the `OrganizationId` ring, and an absent timestamp is what says so.

**Adyen echoed the caller's organization where Stripe echoes the payment's.** They differ whenever the console pays on another organization's behalf. Intake compares the echoed value against the payment's own with ordinal equality, so those webhooks were answered unauthorized and the payment stayed in Processing.

## Verification

2120 unit tests pass. `PaymentProviderScopeChainTests` covers precedence, de-duplication when the caller *is* the console, blank callers, and both off-switches; the Adyen tests were confirmed to fail without their fix.

Integration coverage added for the three-tier lookup and for the card's encryption scope (including that a legacy row without the timestamp still resolves under `OrganizationId`). These need a local `mongod` and do not run here — they fail identically on a clean tree.

**Not verified here:** the client test for the relabelled option. Vitest could not start a worker in this environment (both pools time out with no tests run), so only `tsc --noEmit` and `eslint` were run against the changed files, both clean. Worth a local run before merge.

Live checks worth doing on dev, with the existing `"default"` provider left exactly as it is: `POST /api/payments/create` as a non-console organization should now resolve where it previously failed; a card saved on that checkout should carry `EncryptionOrganizationId: "default"` and a non-null `EncryptionScopeResolvedAtUtc`; and rotating credentials should take effect immediately for that organization rather than after the cache expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)