### PR TITLE
fix(subscription): show a quantity item's ceiling in the plan summary

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -121,6 +121,7 @@ const PlanBuilderWizard = ({
       itemKey: item?.itemKey ?? "",
       unitLabel: item?.unitLabel ?? "",
       defaultQuantity: item?.defaultQuantity ?? 0,
+      maxQuantity: item?.maxQuantity ?? null,
     })),
     meters: (draft.meters ?? []).map((meter) => ({
       meterKey: meter?.meterKey ?? "",

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
@@ -115,8 +115,8 @@ describe("PlanSummaryCard", () => {
       <PlanSummaryCard
         plan={plan({
           quantityItems: [
-            { itemKey: "", unitLabel: "user", defaultQuantity: 1 },
-            { itemKey: "", unitLabel: "workspace", defaultQuantity: 3 },
+            { itemKey: "", unitLabel: "user", defaultQuantity: 1, maxQuantity: null },
+            { itemKey: "", unitLabel: "workspace", defaultQuantity: 3, maxQuantity: null },
           ],
           entitlements: [
             { key: "", limitKind: "Boolean", limit: null, unitLabel: null },
@@ -129,6 +129,30 @@ describe("PlanSummaryCard", () => {
     expect(screen.getByText(/1 user included by default/)).toBeInTheDocument();
     expect(screen.getByText(/3 workspaces included by default/)).toBeInTheDocument();
     expect(screen.getByText("shared-templates:")).toBeInTheDocument();
+  });
+
+  it("shows the ceiling on a quantity item that has one", () => {
+    // The cap is part of what the plan sells, and the one quantity rule that refuses a
+    // subscription outright rather than just costing more — a buyer comparing tiers has to
+    // see it.
+    render(
+      <PlanSummaryCard
+        plan={plan({
+          quantityItems: [
+            {
+              itemKey: "team-members",
+              unitLabel: "team member",
+              defaultQuantity: 1,
+              maxQuantity: 20,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText(/1 team member included by default, up to 20/),
+    ).toBeInTheDocument();
   });
 
   it("describes a meter's allowance and what happens past it", () => {

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -15,7 +15,12 @@ export interface PlanSummaryData {
   organizationLabel: string;
   trialDays: number | null;
   trialRequiresPaymentMethod: boolean;
-  quantityItems: { itemKey: string; unitLabel: string; defaultQuantity: number }[];
+  quantityItems: {
+    itemKey: string;
+    unitLabel: string;
+    defaultQuantity: number;
+    maxQuantity: number | null;
+  }[];
   meters: {
     meterKey: string;
     displayName: string;
@@ -123,6 +128,12 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
                 <p key={index}>
                   {item.defaultQuantity.toLocaleString()} {item.unitLabel}
                   {item.defaultQuantity === 1 ? "" : "s"} included by default
+                  {/* The ceiling is part of what the plan sells — a buyer choosing between
+                      tiers needs to see it, and it is the one quantity rule that refuses a
+                      subscription outright rather than just costing more. */}
+                  {item.maxQuantity === null
+                    ? ""
+                    : `, up to ${item.maxQuantity.toLocaleString()}`}
                 </p>
               ))}
             </div>

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -89,6 +89,7 @@ export const SubscriptionPlanDetailPage = () => {
       itemKey: item.itemKey,
       unitLabel: item.unitLabel,
       defaultQuantity: item.defaultQuantity,
+      maxQuantity: item.maxQuantity,
     })),
     meters: plan.meters,
     entitlements: plan.entitlements,


### PR DESCRIPTION
A plan capped at 20 team members previewed as *"1 team member included by default"* — with no mention of the cap.

That matters more than a missing label: the ceiling is the one quantity rule that **refuses a subscription outright** rather than just changing the price. An author reviewing the plan before publishing had no way to confirm they'd set it, and a buyer reading the same card on the plan detail page could not see what they were being sold.

The detail page's own quantity cards already rendered it. Only the shared `PlanSummaryCard` did not — and could not, because `PlanSummaryData` never carried `maxQuantity`. Now carried through from both callers (the builder's live preview and the detail page), and omitted cleanly when a plan sets no ceiling rather than rendering a dangling qualifier.

Before / after for a Teams-style plan:

```
1 team member included by default
1 team member included by default, up to 20
```

## Verification

`npm --prefix client run test -- --run subscription` — 12 files, 103 tests, all passing, including a new case for the ceiling and the existing no-ceiling cases. Type-check and lint clean.

Worth noting the existing test fixtures needed `maxQuantity` added, which is what confirms the field was genuinely absent from the shape rather than merely unrendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)