### PR TITLE
feat(subscription): retire a price without editing or deleting it

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -65,6 +65,11 @@ export interface PlanBuilderProps {
    * empty is also the honest answer for a plan that has none yet.
    */
   existingPrices?: PlanPrice[];
+  /**
+   * Retires one of the prices above. Omitted where nothing can be retired — creating a plan.
+   */
+  onRetirePrice?: (priceId: string) => void;
+  retiringPriceId?: string | null;
   /** Rejecting leaves the draft alone and shows the reason; the caller navigates on success. */
   onSubmit: (values: CreateSubscriptionPlanFormValues) => Promise<void>;
 }
@@ -85,6 +90,8 @@ const PlanBuilderWizard = ({
   submittingLabel,
   isSubmitting,
   existingPrices = [],
+  onRetirePrice,
+  retiringPriceId = null,
   onSubmit,
 }: PlanBuilderProps) => {
   const { currentStep, nextStep, previousStep, totalSteps } = useStepper();
@@ -211,6 +218,8 @@ const PlanBuilderWizard = ({
                     <StepPricingModel
                       isEditing={isEditing}
                       existingPrices={existingPrices}
+                      onRetirePrice={onRetirePrice}
+                      retiringPriceId={retiringPriceId}
                     />
                   )}
                   {currentStep === 3 && <StepUsageLimits />}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -7,6 +7,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui-kits/form/form";
+import { Button } from "@/components/ui-kits/button/button";
 import { Input } from "@/components/ui-kits/input/input";
 import {
   Select,
@@ -36,6 +37,8 @@ import { CardListItem, CardListShell } from "./card-list-shell";
 export const PlanPriceFields = ({
   isEditing = false,
   existingPrices = [],
+  onRetirePrice,
+  retiringPriceId = null,
 }: {
   isEditing?: boolean;
   /**
@@ -45,6 +48,9 @@ export const PlanPriceFields = ({
    * cannot see the monthly price already there is the one who adds a second.
    */
   existingPrices?: PlanPrice[];
+  /** Omitted when nothing can be retired — creating a plan, or no price on it yet. */
+  onRetirePrice?: (priceId: string) => void;
+  retiringPriceId?: string | null;
 }) => {
   const { control, formState } = useFormContext<CreateSubscriptionPlanFormValues>();
   const prices = useFieldArray({ control, name: "prices" });
@@ -74,14 +80,30 @@ export const PlanPriceFields = ({
           </p>
           <ul className="mt-2 space-y-1">
             {existingPrices.map((price) => (
-              <li key={price.priceId} className="text-sm">
-                {formatPrice(price)}
+              <li
+                key={price.priceId}
+                className="flex items-center justify-between gap-3 text-sm"
+              >
+                <span>{formatPrice(price)}</span>
+                {onRetirePrice && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={retiringPriceId !== null}
+                    onClick={() => onRetirePrice(price.priceId)}
+                    className="h-7 shrink-0 text-xs text-muted-foreground hover:text-destructive"
+                  >
+                    {retiringPriceId === price.priceId ? "Retiring…" : "Retire"}
+                  </Button>
+                )}
               </li>
             ))}
           </ul>
           <p className="mt-2 text-xs text-muted-foreground">
-            These cannot be changed here. A price is what a subscription was sold on, so it is
-            superseded by adding another rather than edited.
+            Retiring stops a price being sold. Anyone already on it keeps their terms and their
+            renewals — a subscription bills from what it was sold on, not from this list. Prices
+            are never edited or deleted, only superseded.
           </p>
         </div>
       )}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -49,9 +49,13 @@ const PRICING_SHAPES = [
 export const StepPricingModel = ({
   isEditing = false,
   existingPrices = [],
+  onRetirePrice,
+  retiringPriceId = null,
 }: {
   isEditing?: boolean;
   existingPrices?: PlanPrice[];
+  onRetirePrice?: (priceId: string) => void;
+  retiringPriceId?: string | null;
 }) => {
   const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
   const pricingShape = useWatch({ control, name: "pricingShape" });
@@ -325,7 +329,12 @@ export const StepPricingModel = ({
       {/* Last in the step because a price may multiply a quantity item, which is defined above
           it. Not gated on the pricing shape: every plan needs a price, whatever its shape. */}
       {pricingShape && (
-        <PlanPriceFields isEditing={isEditing} existingPrices={existingPrices} />
+        <PlanPriceFields
+          isEditing={isEditing}
+          existingPrices={existingPrices}
+          onRetirePrice={onRetirePrice}
+          retiringPriceId={retiringPriceId}
+        />
       )}
 
       {!pricingShape && (

--- a/client/app/cross-modules/utilities/subscription/hooks/use-archive-subscription-price.ts
+++ b/client/app/cross-modules/utilities/subscription/hooks/use-archive-subscription-price.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { subscriptionService } from "../services/subscription.service";
+
+export const useArchiveSubscriptionPrice = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      priceId,
+      organizationId,
+    }: {
+      priceId: string;
+      organizationId?: string;
+    }) => subscriptionService.archivePrice(priceId, organizationId),
+    onSuccess: (plan) => {
+      queryClient.invalidateQueries({ queryKey: ["subscription-plans"] });
+      queryClient.invalidateQueries({
+        queryKey: ["subscription-plan", plan.planId],
+      });
+    },
+  });
+};

--- a/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
@@ -1,11 +1,12 @@
 import { AlertCircle } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Card } from "@/components/ui-kits/card/card";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { toast } from "@/hooks/use-toast";
 import { PlanBuilder } from "../components/plan-builder/plan-builder";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { useArchiveSubscriptionPrice } from "../hooks/use-archive-subscription-price";
 import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-price";
 import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
@@ -25,6 +26,8 @@ export const EditSubscriptionPlanPage = () => {
   );
   const { mutateAsync: updatePlan, isPending } = useUpdateSubscriptionPlan();
   const { mutateAsync: createPrice, isPending: isPricing } = useCreateSubscriptionPrice();
+  const { mutateAsync: archivePrice } = useArchiveSubscriptionPrice();
+  const [retiringPriceId, setRetiringPriceId] = useState<string | null>(null);
 
   const detailPath = withOrganizationScope(
     `${basePath}/${encodeURIComponent(planId ?? "")}`,
@@ -104,6 +107,28 @@ export const EditSubscriptionPlanPage = () => {
       submittingLabel="Saving…"
       isSubmitting={isPending || isPricing}
       existingPrices={plan.prices}
+      retiringPriceId={retiringPriceId}
+      onRetirePrice={async (priceId) => {
+        setRetiringPriceId(priceId);
+
+        try {
+          await archivePrice({ priceId, organizationId: plan.organizationId ?? undefined });
+          toast({
+            title: "Price retired",
+            description:
+              "It is no longer offered. Anyone already on it keeps their terms and renewals.",
+          });
+        } catch (error) {
+          toast({
+            variant: "destructive",
+            title: "The price could not be retired",
+            description:
+              error instanceof Error ? error.message : "Try again in a moment.",
+          });
+        } finally {
+          setRetiringPriceId(null);
+        }
+      }}
       onSubmit={async (values) => {
         const { failures } = await submitPlanWithPrices({
           planRequest: toUpdatePlanRequest(values, plan.organizationId),

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
@@ -75,10 +76,14 @@ const renderPage = (subscriptionPlan: SubscriptionPlan) => {
     error: null,
   });
 
+  // A real client rather than a mocked mutation hook: the page retires a price through one,
+  // and stubbing that away would let the wiring break without a test noticing.
   render(
-    <MemoryRouter>
-      <SubscriptionPlanDetailPage />
-    </MemoryRouter>,
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter>
+        <SubscriptionPlanDetailPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 };
 

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -7,9 +7,11 @@ import { Badge } from "@/components/ui-kits/badge/badge";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card, CardTitle } from "@/components/ui-kits/card/card";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import { toast } from "@/hooks/use-toast";
 import { ORGANIZATION_PAGE_SIZE } from "../constants/subscription.constants";
 import { PlanSummaryCard, type PlanSummaryData } from "../components/plan-summary-card";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { useArchiveSubscriptionPrice } from "../hooks/use-archive-subscription-price";
 import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
 import { describeEntitlementMeterMismatch } from "../utilities/plan-consistency";
@@ -25,6 +27,9 @@ export const SubscriptionPlanDetailPage = () => {
     planId,
     organizationScope,
   );
+
+  const { mutateAsync: archivePrice } = useArchiveSubscriptionPrice();
+  const [retiringPriceId, setRetiringPriceId] = useState<string | null>(null);
 
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData } = useGetOrganizations({
@@ -78,6 +83,27 @@ export const SubscriptionPlanDetailPage = () => {
       </main>
     );
   }
+
+  const retirePrice = async (priceId: string) => {
+    setRetiringPriceId(priceId);
+
+    try {
+      await archivePrice({ priceId, organizationId: plan.organizationId ?? undefined });
+      toast({
+        title: "Price retired",
+        description:
+          "It is no longer offered. Anyone already on it keeps their terms and renewals.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "The price could not be retired",
+        description: error instanceof Error ? error.message : "Try again in a moment.",
+      });
+    } finally {
+      setRetiringPriceId(null);
+    }
+  };
 
   const summary: PlanSummaryData = {
     displayName: plan.displayName,
@@ -234,9 +260,24 @@ export const SubscriptionPlanDetailPage = () => {
                     {/* Subscribing names the price by this id, so leaving it off the page meant
                         nobody could subscribe without reading the API first. */}
                     <IdentifierField label="Price id" value={price.priceId} />
-                    <Badge variant="outline" className="mt-2 font-normal">
-                      {price.currencyCode}
-                    </Badge>
+                    <div className="mt-2 flex items-center justify-between gap-2">
+                      <Badge variant="outline" className="font-normal">
+                        {price.currencyCode}
+                      </Badge>
+                      {/* Offered here rather than only in the builder: editing closes as soon
+                          as somebody subscribes, which is exactly when a price most needs
+                          taking off the menu. */}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={retiringPriceId !== null}
+                        onClick={() => retirePrice(price.priceId)}
+                        className="h-7 text-xs text-muted-foreground hover:text-destructive"
+                      >
+                        {retiringPriceId === price.priceId ? "Retiring…" : "Retire"}
+                      </Button>
+                    </div>
                   </Card>
                 ))}
               </div>

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
@@ -115,6 +115,35 @@ class SubscriptionService {
 
     return response.data;
   }
+
+  /**
+   * Takes a price off the menu. It is never edited or deleted: a price identifier is what every
+   * subscription records having been sold on, so it is superseded rather than rewritten.
+   * Anyone already subscribed keeps billing on their snapshot, untouched.
+   */
+  async archivePrice(
+    priceId: string,
+    organizationId?: string,
+  ): Promise<SubscriptionPlan> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+    const response =
+      await serviceInstances.utitlitiesService.put<
+        SubscriptionApiResponse<SubscriptionPlan>
+      >(
+        `${SUBSCRIPTION_PLAN_PRICES_ENDPOINT}/${encodeURIComponent(priceId)}/archive${query}`,
+        {},
+      );
+
+    if (!response.success || !response.data) {
+      throw new Error(
+        response.error?.message || "The price could not be retired.",
+      );
+    }
+
+    return response.data;
+  }
 }
 
 export const subscriptionService = new SubscriptionService();

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -516,6 +516,21 @@
             subscription bills from its own copy of the plan's terms, which an edit cannot reach.
             </summary>
         </member>
+        <member name="M:Api.Controllers.SubscriptionPlansController.ArchivePrice(System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Takes a price off the menu.
+            </summary>
+            <remarks>
+            Nothing already sold on it changes: a subscription bills from the price snapshot copied
+            onto it at signup and never reads the catalogue again. What stops is selling it — a new
+            subscription or a plan change naming this price is refused from here on.
+            <para>
+            There is deliberately no way to edit or delete a price. A price identifier is what every
+            subscription records having been sold on, so it is superseded by adding another and
+            retiring this one, never rewritten underneath the subscriptions that reference it.
+            </para>
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.SubscriptionsController">
             <summary>
             An organization's own subscription. Served under <c>/api/subscriptions</c>.

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -123,4 +123,38 @@ public sealed class SubscriptionPlansController : ControllerBase
 
         return result.ToActionResult(correlationId);
     }
+
+    /// <summary>
+    /// Takes a price off the menu.
+    /// </summary>
+    /// <remarks>
+    /// Nothing already sold on it changes: a subscription bills from the price snapshot copied
+    /// onto it at signup and never reads the catalogue again. What stops is selling it — a new
+    /// subscription or a plan change naming this price is refused from here on.
+    /// <para>
+    /// There is deliberately no way to edit or delete a price. A price identifier is what every
+    /// subscription records having been sold on, so it is superseded by adding another and
+    /// retiring this one, never rewritten underneath the subscriptions that reference it.
+    /// </para>
+    /// </remarks>
+    [HttpPut("prices/{priceId}/archive")]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> ArchivePrice(
+        string priceId,
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _catalogue.ArchivePriceAsync(
+            priceId,
+            organizationId,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
 }

--- a/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
@@ -51,6 +51,20 @@ public interface ISubscriptionCatalogueRepository
         string planId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Takes a price off the menu without removing it.
+    /// </summary>
+    /// <remarks>
+    /// Compare-and-set on Active, so archiving one already archived reports false rather than
+    /// claiming to have changed something. Existing subscribers are untouched by design: they
+    /// bill from the snapshot copied onto the subscription, and never read this row again.
+    /// </remarks>
+    Task<bool> TryArchivePriceAsync(
+        string tenantId,
+        string priceId,
+        DateTime archivedAtUtc,
+        CancellationToken cancellationToken);
+
     Task<bool> TrySetPriceMirrorAsync(
         string tenantId,
         string priceId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -211,6 +211,29 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
                 Builders<Price>.Filter.Eq(price => price.Status, CatalogueStatus.Active)))
             .ToListAsync(cancellationToken);
 
+    public async Task<bool> TryArchivePriceAsync(
+        string tenantId,
+        string priceId,
+        DateTime archivedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var result = await Prices(tenantId).UpdateOneAsync(
+            Builders<Price>.Filter.And(
+                Builders<Price>.Filter.Eq(price => price.TenantId, tenantId),
+                Builders<Price>.Filter.Eq(price => price.ItemId, priceId),
+
+                // Only an active price can be archived, so a repeated call is reported rather
+                // than silently succeeding, and a draft is not quietly retired before it sold.
+                Builders<Price>.Filter.Eq(price => price.Status, CatalogueStatus.Active)),
+            Builders<Price>.Update
+                .Set(price => price.Status, CatalogueStatus.Archived)
+                .Set(price => price.LastUpdatedDateUtc, archivedAtUtc)
+                .Inc(price => price.Version, 1),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     public async Task<bool> TrySetPriceMirrorAsync(
         string tenantId,
         string priceId,

--- a/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
@@ -26,6 +26,20 @@ public interface IPlanCatalogueService
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Takes a price off the menu. Answers with the plan as it now stands.
+    /// </summary>
+    /// <remarks>
+    /// Nobody already subscribed is affected: a subscription bills from the price snapshot
+    /// copied onto it and never reads the catalogue again. What stops is selling it — a new
+    /// subscription or a plan change naming an archived price is refused.
+    /// </remarks>
+    Task<SubscriptionOperationResult<PlanResponse>> ArchivePriceAsync(
+        string priceId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken);
+
     Task<SubscriptionOperationResult<PlanResponse>> CreatePriceAsync(
         CreatePriceRequest request,
         string correlationId,

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -284,6 +284,74 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             cancellationToken);
     }
 
+    public async Task<SubscriptionOperationResult<PlanResponse>> ArchivePriceAsync(
+        string priceId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            organizationId,
+            cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<PlanResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        var price = await _catalogue.GetPriceAsync(
+            context.TenantId,
+            priceId,
+            cancellationToken);
+
+        if (price is null)
+        {
+            return NotFound(correlationId);
+        }
+
+        var plan = await _catalogue.GetPlanAsync(
+            context.TenantId,
+            price.PlanId,
+            cancellationToken);
+
+        // The same visibility check creating a price makes, and for the same reason: the price
+        // lookup above is keyed only by tenant, so without this any caller in the tenant could
+        // retire a price on another organization's plan.
+        if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
+        {
+            return NotFound(correlationId);
+        }
+
+        if (!await _catalogue.TryArchivePriceAsync(
+                context.TenantId,
+                priceId,
+                DateTime.UtcNow,
+                cancellationToken))
+        {
+            // Already archived, or never active. Reported rather than treated as success, so a
+            // second click does not read as having retired something a moment ago.
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_price_not_active",
+                "This price is not on the menu, so it cannot be taken off it.",
+                correlationId);
+        }
+
+        _logger.LogInformation(
+            "Subscription price archived TenantHash={TenantHash} PlanHash={PlanHash} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(plan.ItemId),
+            correlationId);
+
+        return await GetPlanAsync(
+            plan.ItemId,
+            context.OrganizationId,
+            correlationId,
+            cancellationToken);
+    }
+
     public async Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
         string? organizationId,
         string correlationId,

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -666,6 +666,91 @@ public sealed class PlanCatalogueServiceTests
             "the portal has to be able to say why editing is closed before offering it");
     }
 
+    [Fact]
+    public async Task Archiving_a_price_takes_it_off_the_menu()
+    {
+        StorePlan(StoredPlan());
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price { ItemId = "price-1", TenantId = TenantId, PlanId = "plan-1" });
+        _catalogue
+            .Setup(repository => repository.TryArchivePriceAsync(
+                TenantId, "price-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Service().ArchivePriceAsync(
+            "price-1", null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _catalogue.Verify(
+            repository => repository.TryArchivePriceAsync(
+                TenantId, "price-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Archiving_a_price_that_is_already_off_the_menu_is_a_conflict()
+    {
+        // Reported rather than treated as success, so a second click does not read as having
+        // retired something a moment ago.
+        StorePlan(StoredPlan());
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price { ItemId = "price-1", TenantId = TenantId, PlanId = "plan-1" });
+        _catalogue
+            .Setup(repository => repository.TryArchivePriceAsync(
+                TenantId, "price-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().ArchivePriceAsync(
+            "price-1", null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be("subscription_price_not_active");
+    }
+
+    [Fact]
+    public async Task Another_organizations_price_cannot_be_archived()
+    {
+        // The price lookup is keyed only by tenant, so without the plan's visibility check any
+        // caller in the tenant could retire another organization's price.
+        var plan = StoredPlan();
+        plan.OrganizationId = "org-9";
+        StorePlan(plan);
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price { ItemId = "price-1", TenantId = TenantId, PlanId = "plan-1" });
+
+        var result = await Service().ArchivePriceAsync(
+            "price-1", null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        _catalogue.Verify(
+            repository => repository.TryArchivePriceAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_price_that_does_not_exist_is_not_found()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Price?)null);
+
+        var result = await Service().ArchivePriceAsync(
+            "price-1", null, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+    }
+
     private void StorePlan(Plan plan) =>
         _catalogue
             .Setup(repository => repository.GetPlanAsync(

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -112,6 +112,33 @@ public sealed class SubscriptionCreationServiceTests
             "back to the payment");
     }
 
+    /// <summary>
+    /// The half of retiring a price that does the work: taking one off the menu means nothing
+    /// unless the sale itself refuses it. Existing subscribers are unaffected either way — they
+    /// bill from the snapshot copied onto the subscription and never read this row again.
+    /// </summary>
+    [Fact]
+    public async Task A_price_that_has_been_retired_can_no_longer_be_sold()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var price = NewPrice();
+                price.Status = CatalogueStatus.Archived;
+
+                return price;
+            });
+
+        var result = await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_price_not_found");
+        _created.Should().BeNull();
+    }
+
     [Fact]
     public async Task Usage_is_metered_monthly_even_on_a_yearly_plan()
     {


### PR DESCRIPTION
A plan accumulated prices with no way to stop offering one. Correcting a mistake meant adding the right price beside the wrong one and leaving both on sale, with nothing marking which was current.

> **Stacked on #240**, whose read-only price panel this adds the control to. Retarget to `dev` once that merges.

## Most of this already existed

`CatalogueStatus` has carried `Archived` since the module was written, with the intent stated on the enum itself:

> *Whether a plan or price may be sold. Retiring one never removes it: existing subscribers hold a snapshot and keep running on terms that are no longer on the menu.*

`ListPricesAsync` already filters to `Active`, and **both** sale paths — `SubscriptionCreationService` and `SubscriptionPlanChangeService` — already refuse a non-Active price. The only missing piece was a way to set it. I estimated this as comparable to the plan-edit work when you asked; that was wrong, and it's much smaller.

## What's new

`PUT /api/subscription-plans/prices/{priceId}/archive`

- **Compare-and-set on `Active`**, so a second attempt returns `subscription_price_not_active` rather than reporting success for something retired a moment ago.
- **The plan's visibility is checked first.** The price lookup is keyed only by tenant, so without it any caller in the tenant could retire another organization's price — the same check `CreatePriceAsync` already makes, for the same reason.
- Answers with the plan as it now stands, so the caller doesn't need a second round trip.

## Deliberately no edit and no delete

A subscription copies its price onto itself (`PriceSnapshot` — *"A subscriber's price must not move because someone edited the catalogue"*), and `GetPriceAsync` is only ever called when someone is being **sold** something. Renewals never read the row.

So editing wouldn't break billing — it would leave two subscribers recorded on one `priceId` at different amounts, with nothing anywhere saying the row changed. That's a reconciliation lie rather than a billing bug, and the harder kind to find. Deleting has the same shape: billing survives on the snapshot, but every subscription referencing that id loses its answer to "what was this sold on?".

## Where the control lives

On the **plan detail page** as well as the builder. I initially put it only in the builder and then noticed the flaw: editing is blocked outright once anyone subscribes, which is precisely when a price most needs taking off the menu.

## Verification

2125 backend unit tests and 107 client tests pass.

New coverage: archiving succeeds, is a conflict when repeated, is refused for another organization's plan, and is not-found for a price that doesn't exist. Plus one that pins the half doing the actual work — **a retired price can no longer be sold** — which nothing tested before, even though the rejection has always been in the code.

The detail page's tests needed a real `QueryClientProvider` rather than a stubbed mutation, so the retire wiring can't break unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)