### PR TITLE
fix: stop a renewal presenting a card the shopper removed

### DIFF
--- a/server/Payment.DomainService/Repositories/IStoredPaymentMethodRepository.cs
+++ b/server/Payment.DomainService/Repositories/IStoredPaymentMethodRepository.cs
@@ -23,6 +23,28 @@ public interface IStoredPaymentMethodRepository
         IReadOnlyCollection<StoredPaymentMethodLookupScope> scopes,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// The provider's own identifier for this shopper, from any card they have ever saved
+    /// within these scopes — removed ones included.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <see cref="ListActiveAsync"/>. Who the shopper is at the provider does
+    /// not stop being true when their last card is removed, and treating it as though it did
+    /// makes a returning shopper a brand new customer: their history splits, saved cards are
+    /// never offered back to them, and anything holding the old identifier — a subscription's
+    /// billing account, say — is left pointing at a customer nothing writes to any more.
+    /// <para>
+    /// Same scope pairing as <see cref="ListActiveAsync"/>, so this reveals nothing that a
+    /// caller entitled to list those cards could not already read. Only the identifier is
+    /// returned, never the removed card.
+    /// </para>
+    /// </remarks>
+    Task<string?> FindProviderPayerReferenceAsync(
+        string tenantId,
+        IReadOnlyCollection<StoredPaymentMethodLookupScope> scopes,
+        string providerName,
+        CancellationToken cancellationToken);
+
     Task<StoredPaymentMethod?> GetAsync(
         string tenantId,
         string itemId,

--- a/server/Payment.DomainService/Repositories/StoredPaymentMethodRepository.cs
+++ b/server/Payment.DomainService/Repositories/StoredPaymentMethodRepository.cs
@@ -73,6 +73,22 @@ public sealed class StoredPaymentMethodRepository : IStoredPaymentMethodReposito
         var builder = Builders<StoredPaymentMethod>.Filter;
 
         return builder.And(
+            ScopeFilter(tenantId, scopes),
+            builder.Eq(
+                method => method.Status,
+                PaymentMethodStatus.Active));
+    }
+
+    /// <summary>
+    /// The tenant and the shopper-and-organization pairs, without any status condition.
+    /// </summary>
+    private static FilterDefinition<StoredPaymentMethod> ScopeFilter(
+        string tenantId,
+        IReadOnlyCollection<StoredPaymentMethodLookupScope> scopes)
+    {
+        var builder = Builders<StoredPaymentMethod>.Filter;
+
+        return builder.And(
             builder.Eq(method => method.TenantId, tenantId),
             builder.Or(
                 scopes.Select(scope => builder.And(
@@ -81,10 +97,41 @@ public sealed class StoredPaymentMethodRepository : IStoredPaymentMethodReposito
                         scope.ShopperReference),
                     builder.Eq(
                         method => method.OrganizationId,
-                        scope.OrganizationId)))),
-            builder.Eq(
-                method => method.Status,
-                PaymentMethodStatus.Active));
+                        scope.OrganizationId)))));
+    }
+
+    public async Task<string?> FindProviderPayerReferenceAsync(
+        string tenantId,
+        IReadOnlyCollection<StoredPaymentMethodLookupScope> scopes,
+        string providerName,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scopes);
+
+        if (scopes.Count == 0 || string.IsNullOrWhiteSpace(providerName))
+        {
+            return null;
+        }
+
+        // The scope pairing of BuildActiveFilter without its status clause: identity outlives
+        // the card that established it. Newest first, so a shopper whose identifier genuinely
+        // changed is recognised by their most recent one rather than their first.
+        var methods = await Collection(tenantId)
+            .Find(ScopeFilter(tenantId, scopes))
+            .SortByDescending(candidate => candidate.CreatedAtUtc)
+            .Limit(200)
+            .ToListAsync(cancellationToken);
+
+        // Matched here rather than in the query so the comparison stays case-insensitive, as
+        // it was when this read the shopper's active cards.
+        return methods
+            .FirstOrDefault(candidate =>
+                string.Equals(
+                    candidate.ProviderName,
+                    providerName,
+                    StringComparison.OrdinalIgnoreCase) &&
+                !string.IsNullOrWhiteSpace(candidate.ProviderPayerReference))?
+            .ProviderPayerReference;
     }
 
     public Task<StoredPaymentMethod?> GetAsync(

--- a/server/Payment.DomainService/Services/HostedCheckoutInitiationService.cs
+++ b/server/Payment.DomainService/Services/HostedCheckoutInitiationService.cs
@@ -348,25 +348,24 @@ public sealed class HostedCheckoutInitiationService : IPaymentInitiationService
         // Scoped to this payment's organization, which is what the card was stamped with when
         // it was saved. A payer identity minted for one organization means nothing to another,
         // and naming it there would attach this payment to a customer that has never been seen.
-        var methods = await _storedPaymentMethods.ListActiveAsync(
+        //
+        // Asked of every card the shopper has saved, not only the ones still active: removing
+        // a card does not make its owner a different person. Reading only active cards meant a
+        // shopper who removed their last one came back as a stranger and was given a second
+        // provider customer — which is how a subscription's billing account ended up naming a
+        // customer that no later payment would ever write to.
+        //
+        // Recognising a returning shopper is an improvement, not a requirement, so nothing
+        // here may prevent a payment: an unresolved reference simply means a new customer.
+        return await _storedPaymentMethods.FindProviderPayerReferenceAsync(
             payment.TenantId,
             [
                 new StoredPaymentMethodLookupScope(
                     shopperReference,
                     payment.OrganizationId)
             ],
+            providerName,
             cancellationToken);
-
-        // Recognising a returning shopper is an improvement, not a requirement, so nothing
-        // here may prevent a payment: an unresolved reference simply means a new customer.
-        return methods?
-            .FirstOrDefault(method =>
-                string.Equals(
-                    method.ProviderName,
-                    providerName,
-                    StringComparison.OrdinalIgnoreCase) &&
-                !string.IsNullOrWhiteSpace(method.ProviderPayerReference))?
-            .ProviderPayerReference;
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Enums/SetProviderCustomerOutcome.cs
+++ b/server/Subscription.DomainService/Enums/SetProviderCustomerOutcome.cs
@@ -1,0 +1,30 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// What recording a billing account's provider identifiers actually did.
+/// </summary>
+/// <remarks>
+/// Three answers rather than a bool because they call for three different reactions, and the
+/// bool this replaced collapsed the two that matter into one the caller discarded.
+/// </remarks>
+public enum SetProviderCustomerOutcome
+{
+    /// <summary>The account already named this customer and this card. Nothing to do.</summary>
+    Unchanged = 0,
+
+    /// <summary>A blank account was filled in for the first time. The ordinary first charge.</summary>
+    Recorded = 1,
+
+    /// <summary>
+    /// The account named a different customer and now names this one.
+    /// </summary>
+    /// <remarks>
+    /// Expected after a shopper's provider identity genuinely moves, and worth a log line every
+    /// time: it is also what a misrouted payment looks like, and the two are told apart by
+    /// whether it keeps happening.
+    /// </remarks>
+    Repointed = 2,
+
+    /// <summary>No such account. Renewals have nothing to charge.</summary>
+    AccountMissing = 3
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -336,7 +336,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             return;
         }
 
-        await _billingAccounts.TrySetProviderCustomerAsync(
+        var outcome = await _billingAccounts.TrySetProviderCustomerAsync(
             subscription.TenantId,
             subscription.BillingAccountId,
             customerId,
@@ -345,6 +345,30 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             // provider under. Organizations subscribe; the tenant is the merchant.
             payment.OrganizationId,
             cancellationToken);
+
+        // Never discarded. Whether the card a renewal will present actually got recorded is the
+        // one thing this method exists to decide, and the silence here is what let a billing
+        // account sit for a month pointing at a removed card while everything else read healthy.
+        switch (outcome)
+        {
+            case SetProviderCustomerOutcome.Repointed:
+                _logger.LogWarning(
+                    "A subscription's billing account moved to a different provider customer; " +
+                    "cards saved against the previous one are no longer reachable " +
+                    "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash}",
+                    PaymentLogValue.Hash(subscription.TenantId),
+                    PaymentLogValue.Hash(subscription.ItemId));
+                break;
+
+            case SetProviderCustomerOutcome.AccountMissing:
+                _logger.LogError(
+                    "A paid subscription has no billing account to record its card against; " +
+                    "renewals will find no payment method " +
+                    "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash}",
+                    PaymentLogValue.Hash(subscription.TenantId),
+                    PaymentLogValue.Hash(subscription.ItemId));
+                break;
+        }
     }
 
     private async Task<bool> AbandonAsync(

--- a/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Blocks.Genesis;
 using MongoDB.Driver;
 using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
 
 namespace Subscription.DomainService.Repositories;
 
@@ -83,7 +84,7 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
                     billingAccountId)))
             .FirstOrDefaultAsync(cancellationToken);
 
-    public async Task<bool> TrySetProviderCustomerAsync(
+    public async Task<SetProviderCustomerOutcome> TrySetProviderCustomerAsync(
         string tenantId,
         string billingAccountId,
         string providerCustomerId,
@@ -91,20 +92,26 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
         string? providerOrganizationId,
         CancellationToken cancellationToken)
     {
+        // Identity only. The customer this account already names is deliberately not part of
+        // the filter: a charge that confirmed against a different one is the charge that holds
+        // the card a renewal will present, so it is the one worth keeping. See the interface
+        // for why refusing was the more damaging option.
         var filter = Builders<BillingAccount>.Filter.And(
             Builders<BillingAccount>.Filter.Eq(
                 account => account.TenantId,
                 tenantId),
             Builders<BillingAccount>.Filter.Eq(
                 account => account.ItemId,
-                billingAccountId),
-            Builders<BillingAccount>.Filter.Or(
-                Builders<BillingAccount>.Filter.Eq(
-                    account => account.ProviderCustomerId,
-                    null),
-                Builders<BillingAccount>.Filter.Eq(
-                    account => account.ProviderCustomerId,
-                    providerCustomerId)));
+                billingAccountId));
+
+        var existing = await Accounts(tenantId)
+            .Find(filter)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (existing is null)
+        {
+            return SetProviderCustomerOutcome.AccountMissing;
+        }
 
         var update = Builders<BillingAccount>.Update
             .Set(account => account.ProviderCustomerId, providerCustomerId)
@@ -125,12 +132,26 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
                 providerOrganizationId);
         }
 
-        var result = await Accounts(tenantId).UpdateOneAsync(
+        await Accounts(tenantId).UpdateOneAsync(
             filter,
             update,
             cancellationToken: cancellationToken);
 
-        return result.ModifiedCount == 1;
+        // Read from what was there before the write, not from the write's own modified count:
+        // an account already naming this customer but carrying a stale card is still a change
+        // worth making, and one naming a different customer is worth saying out loud even when
+        // every other field happened to match.
+        if (string.IsNullOrWhiteSpace(existing.ProviderCustomerId))
+        {
+            return SetProviderCustomerOutcome.Recorded;
+        }
+
+        return string.Equals(
+            existing.ProviderCustomerId,
+            providerCustomerId,
+            StringComparison.Ordinal)
+            ? SetProviderCustomerOutcome.Unchanged
+            : SetProviderCustomerOutcome.Repointed;
     }
 
     private async Task<BillingAccount?> FindAsync(

--- a/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
@@ -1,3 +1,4 @@
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Entities;
 
 namespace Subscription.DomainService.Repositories;
@@ -23,18 +24,26 @@ public interface IBillingAccountRepository
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Records the provider's identifiers once the first charge has confirmed them.
+    /// Records the provider's identifiers once a charge has confirmed them.
     /// </summary>
     /// <remarks>
-    /// Only fills a blank customer id, never overwrites one. A second charge naming a different
-    /// customer means something is wrong, and quietly adopting it would strand every saved card
-    /// on the first.
+    /// Adopts a customer id that differs from the one already stored, and reports having done
+    /// so through <see cref="SetProviderCustomerOutcome"/> so the caller can say it out loud.
+    /// <para>
+    /// This used to refuse, on the reasoning that a second charge naming a different customer
+    /// is a sign something is wrong and adopting it would strand the cards saved on the first.
+    /// The first half is true; the conclusion was backwards. Refusing does not keep those cards
+    /// reachable — it leaves the account naming a customer that no later payment writes to,
+    /// while the card that was actually charged sits on the new one. A renewal then presents a
+    /// card the shopper has removed, a month after the divergence, with nothing logged at the
+    /// time. Following the money is the recoverable choice; noticing in silence was not.
+    /// </para>
     /// </remarks>
     /// <param name="providerOrganizationId">
     /// The organization whose merchant configuration took the card, which is what later charges
     /// resolve the provider under — see <see cref="Entities.BillingAccount.ProviderOrganizationId"/>.
     /// </param>
-    Task<bool> TrySetProviderCustomerAsync(
+    Task<SetProviderCustomerOutcome> TrySetProviderCustomerAsync(
         string tenantId,
         string billingAccountId,
         string providerCustomerId,

--- a/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
@@ -252,7 +252,7 @@ public sealed class SubscriptionRepositoryIntegrationTests
     }
 
     [Fact]
-    public async Task A_provider_customer_is_recorded_once_and_never_replaced()
+    public async Task A_provider_customer_that_changes_is_followed_and_reported()
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
@@ -261,21 +261,43 @@ public sealed class SubscriptionRepositoryIntegrationTests
             CancellationToken.None);
 
         (await _accounts.TrySetProviderCustomerAsync(
-            tenantId, account.ItemId, "cus_first", "pm_1", "default",
-            CancellationToken.None)).Should().BeTrue();
+                tenantId, account.ItemId, "cus_first", "pm_1", "default",
+                CancellationToken.None))
+            .Should().Be(SetProviderCustomerOutcome.Recorded);
 
         (await _accounts.TrySetProviderCustomerAsync(
-                tenantId, account.ItemId, "cus_other", null, "default",
+                tenantId, account.ItemId, "cus_first", "pm_1", "default",
                 CancellationToken.None))
-            .Should().BeFalse("adopting a second customer would strand every saved card on " +
-                              "the first");
+            .Should().Be(SetProviderCustomerOutcome.Unchanged);
+
+        // Refusing here used to look like the careful choice. It left the account naming a
+        // customer that no later payment writes to, and the card it pointed at unreachable —
+        // which a renewal only discovers a whole billing period afterwards.
+        (await _accounts.TrySetProviderCustomerAsync(
+                tenantId, account.ItemId, "cus_other", "pm_2", "default",
+                CancellationToken.None))
+            .Should().Be(SetProviderCustomerOutcome.Repointed);
 
         var stored = await _accounts.GetAsync(
             tenantId,
             account.ItemId,
             CancellationToken.None);
 
-        stored!.ProviderCustomerId.Should().Be("cus_first");
+        stored!.ProviderCustomerId.Should().Be("cus_other");
+        stored.DefaultPaymentMethodId.Should().Be(
+            "pm_2",
+            "the card a renewal presents must be the one the latest charge actually saved");
+    }
+
+    [Fact]
+    public async Task Recording_against_an_account_that_is_not_there_says_so()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        (await _accounts.TrySetProviderCustomerAsync(
+                tenantId, "missing", "cus_first", "pm_1", "default",
+                CancellationToken.None))
+            .Should().Be(SetProviderCustomerOutcome.AccountMissing);
     }
 
     [Fact]

--- a/server/XUnitTest/Payment/HostedCheckoutInitiationServiceTests.cs
+++ b/server/XUnitTest/Payment/HostedCheckoutInitiationServiceTests.cs
@@ -58,6 +58,10 @@ public sealed class HostedCheckoutInitiationServiceTests
         _storedPaymentMethods.Setup(s => s.ListActiveAsync(
                 "tenant", It.IsAny<IReadOnlyCollection<StoredPaymentMethodLookupScope>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
+        _storedPaymentMethods.Setup(s => s.FindProviderPayerReferenceAsync(
+                "tenant", It.IsAny<IReadOnlyCollection<StoredPaymentMethodLookupScope>>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
         _callbackStateProtector.Setup(p => p.Create("tenant", It.IsAny<string>(), "pay-1", "provider", It.IsAny<TimeSpan>(), It.IsAny<string>()))
             .Returns(new ProtectedCheckoutCallbackState("token", new CheckoutCallbackState("tenant", "pay-1", "provider", DateTime.UtcNow, DateTime.UtcNow.AddMinutes(30), "nonce")));
         _sessionClients.Setup(r => r.Resolve("provider")).Returns(_sessionClient.Object);
@@ -254,6 +258,44 @@ public sealed class HostedCheckoutInitiationServiceTests
         await CreateService().RecoverAsync(_payment, CancellationToken.None);
 
         _stateTransitions.Verify(s => s.ApplyProviderResultAsync(claimed, It.IsAny<ProviderSessionCreationResult>(), It.IsAny<string>(), "corr", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// A shopper who removed their last card is still the same shopper. Asked only about active
+    /// cards, checkout decided they were new, Stripe minted a second customer, and the billing
+    /// account a renewal reads was left naming the first — with the charged card on the other.
+    /// </summary>
+    [Fact]
+    public async Task A_returning_shopper_is_recognised_from_a_card_they_have_since_removed()
+    {
+        _storedPaymentMethods.Setup(s => s.FindProviderPayerReferenceAsync(
+                "tenant", It.IsAny<IReadOnlyCollection<StoredPaymentMethodLookupScope>>(), "provider",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync("cus_existing");
+
+        await RunAsync();
+
+        _requestFactory.Verify(
+            f => f.Create(
+                It.IsAny<MakePaymentRequest>(), It.IsAny<PaymentExecutionContext>(), It.IsAny<PaymentDetail>(),
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                "cus_existing", It.IsAny<bool>(), It.IsAny<long>()),
+            Times.Once,
+            "naming the customer is what stops a second one being created for the same shopper");
+    }
+
+    [Fact]
+    public async Task A_shopper_with_no_history_is_left_for_the_provider_to_create()
+    {
+        await RunAsync();
+
+        _requestFactory.Verify(
+            f => f.Create(
+                It.IsAny<MakePaymentRequest>(), It.IsAny<PaymentExecutionContext>(), It.IsAny<PaymentDetail>(),
+                It.IsAny<PaymentProvider>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                null, It.IsAny<bool>(), It.IsAny<long>()),
+            Times.Once,
+            "an unresolved reference must never block a payment — it simply means a new customer");
     }
 
     private delegate void ShopperCallback(string tenantId, string actorId, string key, out string reference);


### PR DESCRIPTION
## What went wrong

A subscription paid successfully on 18 Aug, went `Active`, and its entitlements answered correctly. Its billing account was still `Version: 1` from 16 Aug, pointing `DefaultPaymentMethodId` at a card whose status is `Removed`.

The renewal a month later would have presented that card, on a Stripe customer no payment had written to since.

## Two defects, one chain

**The shopper stopped being recognised.** `ResolveProviderPayerReferenceAsync` looked for the provider's customer id among the shopper's **active** cards. The card that established it was removed on 17 Aug, so the lookup came back empty, checkout named no customer, and Stripe minted a new one. Three checkouts produced three customers for one shopper.

**The billing account then refused to follow.** `TrySetProviderCustomerAsync` only filled a blank customer id, never replaced one — on the reasoning that a second charge naming a different customer means something is wrong and adopting it would strand the cards saved on the first.

That premise is right. The conclusion was backwards: refusing does not make those cards reachable. It leaves the account naming a dead customer while the card actually charged sits on the live one. And the `bool` saying which happened was **discarded by its only caller**, so nothing logged at the time.

Every surface read healthy. The failure was scheduled for a month later.

## The fix

Provider identity now comes from any card the shopper has ever saved in the same shopper-and-organization scope, removed ones included — the same scope pairing, so it reveals nothing a caller could not already list, and only the identifier is returned.

`TrySetProviderCustomerAsync` returns `Recorded` / `Unchanged` / `Repointed` / `AccountMissing` instead of a bool, adopts a changed customer, and activation warns on the last two.

Fixing the first alone would have been enough for this case; both are here because a customer *can* legitimately change, and when it does the account should follow it and say so rather than diverge in silence.

## Verification

`dotnet test --filter "FullyQualifiedName!~Integration"` — **2151 passed, 0 failed, 1 skipped**.

New tests: a returning shopper is recognised from a removed card; no history still leaves customer creation to the provider; the billing account reports `Recorded` then `Unchanged` then `Repointed` and keeps the newest card.

Rewritten: `A_provider_customer_is_recorded_once_and_never_replaced` asserted exactly the behaviour that caused this, and is now `A_provider_customer_that_changes_is_followed_and_reported`.

Live verification of an actual renewal follows on dev, against the subscription this was found on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
