### PR TITLE
fix: renewal invoices were created in the wrong currency and collected nothing

### DIFF
--- a/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/IStripeInvoiceClient.cs
@@ -43,10 +43,25 @@ public interface IStripeInvoiceClient
     /// whichever card the customer happens to default to, which is not necessarily the one the
     /// billing account recorded.
     /// </param>
+    /// <param name="currencyCode">
+    /// The subscription's currency, stated rather than inferred.
+    /// </param>
+    /// <remarks>
+    /// Naming the currency is not optional. The invoice is created before the line item that
+    /// belongs to it, so at creation there is nothing for Stripe to read a currency from and it
+    /// falls back to the customer's history, then to the merchant account's own default. A line
+    /// item in any other currency cannot then attach, and the invoice is left empty and unusable.
+    /// <para>
+    /// This fails silently in the one direction that matters: a shopper whose earlier invoices
+    /// were already in the right currency inherits it and works, so the defect only appears for
+    /// customers with no history — which is every genuinely new subscriber.
+    /// </para>
+    /// </remarks>
     Task<StripeInvoiceCallResult> CreateInvoiceAsync(
         PaymentProvider provider,
         string customerId,
         string defaultPaymentMethodId,
+        string currencyCode,
         string idempotencyKey,
         CancellationToken cancellationToken);
 

--- a/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInvoiceClient.cs
@@ -63,11 +63,19 @@ public sealed class StripeInvoiceClient : IStripeInvoiceClient
         PaymentProvider provider,
         string customerId,
         string defaultPaymentMethodId,
+        string currencyCode,
         string idempotencyKey,
         CancellationToken cancellationToken)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(currencyCode);
+
         var form = new StripeForm()
             .Add("customer", customerId)
+            // Stated, never inferred. The line item is added after this call, so there is
+            // nothing here for Stripe to read a currency from: it reaches for the customer's
+            // history and then the merchant account's default, and an item in any other
+            // currency cannot attach to what comes back.
+            .Add("currency", currencyCode.ToLowerInvariant())
             .Add("collection_method", "charge_automatically")
             // Blocks decides when this advances, not Stripe's own background job — the same
             // discipline that keeps this off a second billing clock. It does not stop the

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -156,10 +156,15 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
         // pending for the next invoice to sweep up, and recent Stripe API versions default
         // pending_invoice_items_behavior to exclude — the invoice then finalizes at zero, reads
         // as paid because nothing is owed, and the renewal completes having collected nothing.
+        //
+        // Which is why the currency has to be passed: creating the invoice first means Stripe
+        // has no line to infer it from, so it guesses from the customer's history or the
+        // merchant's default, and the line item is then refused for disagreeing with the guess.
         var invoice = await _invoices.CreateInvoiceAsync(
             provider,
             request.ProviderCustomerId!,
             paymentMethodId,
+            request.CurrencyCode,
             $"{idempotencyKey}:invoice",
             cancellationToken);
 

--- a/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
+++ b/server/XUnitTest/Payment/StripeInvoiceClientTests.cs
@@ -57,9 +57,54 @@ public sealed class StripeInvoiceClientTests
             .ReturnsAsync((new StripeInvoice { Id = "in_1", Status = "draft" }, (string?)null));
 
         var result = await Client(http.Object).CreateInvoiceAsync(
-            Provider(), "cus_123", "pm_456", "idem-1", CancellationToken.None);
+            Provider(), "cus_123", "pm_456", "USD", "idem-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The invoice is created before the line item that belongs to it, so nothing on it tells
+    /// Stripe what currency it is in. Left unsaid, Stripe takes the customer's history or the
+    /// merchant's default, and the line item is refused for disagreeing — leaving an empty draft
+    /// and a renewal that collected nothing.
+    /// </summary>
+    /// <remarks>
+    /// Only bites customers with no invoice history, so anyone already billed in the right
+    /// currency inherits it and passes. That is precisely every new subscriber, and precisely
+    /// why this went unnoticed against an account whose earlier test invoices happened to match.
+    /// </remarks>
+    [Fact]
+    public async Task Creating_an_invoice_states_the_currency_rather_than_letting_stripe_guess()
+    {
+        var http = new Mock<IHttpService>(MockBehavior.Strict);
+        http.Setup(service => service.SendFormUrlEncoded<StripeInvoice>(
+                HttpMethod.Post,
+                It.Is<Dictionary<string, string>>(form => form["currency"] == "usd"),
+                "https://api.stripe.com/v1/invoices",
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()))
+            .ReturnsAsync((new StripeInvoice { Id = "in_1", Status = "draft" }, (string?)null));
+
+        var result = await Client(http.Object).CreateInvoiceAsync(
+            Provider(), "cus_123", "pm_456", "USD", "idem-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        http.VerifyAll();
+    }
+
+    [Fact]
+    public async Task An_invoice_without_a_currency_is_refused_before_stripe_is_called()
+    {
+        var http = new Mock<IHttpService>(MockBehavior.Strict);
+
+        await Client(http.Object)
+            .Invoking(client => client.CreateInvoiceAsync(
+                Provider(), "cus_123", "pm_456", " ", "idem-1", CancellationToken.None))
+            .Should().ThrowAsync<ArgumentException>(
+                "an invoice whose currency Stripe had to guess is the defect this prevents");
+
+        http.VerifyNoOtherCalls();
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -84,7 +84,8 @@ public sealed class StripeInvoiceBillingGatewayTests
 
         _invoices
             .Setup(client => client.CreateInvoiceAsync(
-                It.IsAny<PaymentProvider>(), "cus_123", "pm_456", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<PaymentProvider>(), "cus_123", "pm_456", It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new StripeInvoiceCallResult(StripeInvoiceOutcome.Success, "in_1", "draft"));
 
         _invoices
@@ -296,9 +297,10 @@ public sealed class StripeInvoiceBillingGatewayTests
         // which need not be the one this renewal resolved.
         _invoices.Verify(
             client => client.CreateInvoiceAsync(
-                It.IsAny<PaymentProvider>(), "cus_123", "pm_456", "idem-1:invoice",
+                It.IsAny<PaymentProvider>(), "cus_123", "pm_456", "CHF", "idem-1:invoice",
                 It.IsAny<CancellationToken>()),
-            Times.Once);
+            Times.Once,
+            "the currency must reach the invoice, or its line item cannot attach to it");
     }
 
     [Fact]


### PR DESCRIPTION
## The evidence

Three renewal attempts on dev produced three Stripe invoices — 10:11, 10:27, 10:43 — every one of them a **CHF 0.00 draft** for a **USD $20.00** subscription. Nothing was collected, no `PaymentDetail` was written, and the subscription walked to `DunningAttemptCount: 3`.

## Cause

`CreateInvoiceAsync` sent no `currency`. Stripe assigned one itself — the merchant account's default, CHF — and the USD line item added immediately afterwards could not attach to a CHF invoice. The item call failed, the invoice was abandoned as an empty draft, and the gateway reported failure.

This is a consequence of creating the invoice **before** its line item. That order is deliberate and stays: the reverse leaves the line pending, and current Stripe API versions default `pending_invoice_items_behavior` to `exclude`, so the invoice finalizes at zero and reads as paid having collected nothing. But creating the invoice first means there is no line for Stripe to infer the currency from, and nothing replaced that inference.

## Why it wasn't caught

Stripe falls back to the customer's invoice history before the account default. A shopper already billed in the right currency inherits it and succeeds — so this only bites customers with **no** history, which is every genuinely new subscriber.

An earlier EUR renewal on this same account passed for exactly that reason: that customer had two prior EUR invoices. It worked on currency history, not on correctness.

## The fix

`currencyCode` is now a required parameter, sent as `currency`, and rejected before the HTTP call when blank. The billing gateway passes the subscription's own currency — the same value the line item uses, so the two cannot disagree.

## Verification

`dotnet test --filter "FullyQualifiedName!~Integration"` — **2153 passed, 0 failed, 1 skipped**.

Two new tests: the create-invoice form carries `currency=usd`; a blank currency throws before Stripe is called. The existing gateway test now asserts the currency reaches `CreateInvoiceAsync` rather than accepting any string.

Live re-test on dev follows once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
