### PR TITLE
fix: invoice PDF downloads were blocked by our own SSRF guard

### DIFF
--- a/server/Payment.DomainService/Providers/Stripe/StripeFileUrl.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeFileUrl.cs
@@ -4,19 +4,33 @@ namespace Payment.DomainService.Providers.Stripe;
 /// Checks that a file link taken from a Stripe response is served by Stripe.
 /// </summary>
 /// <remarks>
-/// Invoice PDFs come from <c>files.stripe.com</c>, not the API host, so
-/// <see cref="StripeEndpointPolicy"/> — which guards the API base URL — says nothing about them.
-/// A URL read out of a response body is still input: without this the credential-bearing fetch
-/// would follow wherever that body pointed, which is the shape of a server-side request forgery
-/// even when the response is genuinely Stripe's.
+/// Invoice PDFs do not come from the API host, so <see cref="StripeEndpointPolicy"/> — which
+/// guards the API base URL — says nothing about them. A URL read out of a response body is still
+/// input: without this the credential-bearing fetch would follow wherever that body pointed,
+/// which is the shape of a server-side request forgery even when the response is genuinely
+/// Stripe's.
+/// <para>
+/// Matched as "any host within stripe.com" rather than a list of named hosts. The first version
+/// named <c>files.stripe.com</c>, which is where File objects live — invoice PDFs are served from
+/// <c>pay.stripe.com</c>, so every real invoice download was refused while a unit test using a
+/// made-up <c>files.stripe.com</c> URL agreed it should be allowed. Enumerating Stripe's hosts
+/// means being wrong again the next time they add one, and the property actually worth checking
+/// is the domain.
+/// </para>
 /// </remarks>
 public static class StripeFileUrl
 {
-    private const string FileHost = "files.stripe.com";
+    private const string Domain = "stripe.com";
+
+    /// <summary>
+    /// The leading dot is what makes this a subdomain test rather than a suffix test:
+    /// <c>notstripe.com</c> and <c>files.stripe.com.evil.test</c> both fail it.
+    /// </summary>
+    private const string DomainSuffix = "." + Domain;
 
     public static bool IsStripeHosted(string? url) =>
         Uri.TryCreate(url, UriKind.Absolute, out var parsed) &&
         parsed.Scheme == Uri.UriSchemeHttps &&
-        (parsed.Host.Equals(FileHost, StringComparison.OrdinalIgnoreCase) ||
-         parsed.Host.Equals(StripeConstants.ApiHost, StringComparison.OrdinalIgnoreCase));
+        (parsed.Host.Equals(Domain, StringComparison.OrdinalIgnoreCase) ||
+         parsed.Host.EndsWith(DomainSuffix, StringComparison.OrdinalIgnoreCase));
 }

--- a/server/XUnitTest/Payment/StripeFileUrlTests.cs
+++ b/server/XUnitTest/Payment/StripeFileUrlTests.cs
@@ -7,18 +7,27 @@ namespace XUnitTest.Payment;
 public sealed class StripeFileUrlTests
 {
     [Theory]
+    // The shape Stripe actually serves an invoice PDF from. This is the case the first version
+    // refused: it allowed files.stripe.com, which is where File objects live, and every real
+    // invoice download failed the check while a test using a fabricated files.stripe.com URL
+    // reported the guard working.
+    [InlineData("https://pay.stripe.com/invoice/acct_1Ty96e/test_YWNjd/pdf?s=ap")]
+    [InlineData("https://invoice.stripe.com/i/acct_1Ty96e/test_YWNjd/pdf")]
     [InlineData("https://files.stripe.com/links/abc")]
     [InlineData("https://FILES.STRIPE.COM/links/abc")]
     [InlineData("https://api.stripe.com/v1/invoices/in_1/pdf")]
-    public void Stripes_own_file_hosts_are_followed(string url) =>
+    [InlineData("https://stripe.com/anything")]
+    public void Stripes_own_hosts_are_followed(string url) =>
         StripeFileUrl.IsStripeHosted(url).Should().BeTrue();
 
     [Theory]
     // The credential travels on this fetch, so a link pointing elsewhere is a request forgery
     // waiting to happen — including hosts that merely end in Stripe's domain.
     [InlineData("https://files.stripe.com.evil.test/links/abc")]
+    [InlineData("https://notstripe.com/links/abc")]
     [InlineData("https://evil.test/files.stripe.com")]
     [InlineData("http://files.stripe.com/links/abc")]
+    [InlineData("http://pay.stripe.com/invoice/abc/pdf")]
     [InlineData("https://localhost/links/abc")]
     [InlineData("https://169.254.169.254/latest/meta-data")]
     [InlineData("file:///etc/passwd")]


### PR DESCRIPTION
## Evidence

```
[12:28:37] Received HTTP response headers after 135ms - 200
[12:28:37 ERR] A Stripe invoice PDF link pointed somewhere unexpected and was not followed
```

The invoice read succeeded. The download was then refused by our own SSRF guard.

## Cause

`StripeFileUrl` allowed `files.stripe.com` and `api.stripe.com`. `files.stripe.com` is where **File objects** live. Stripe serves an invoice PDF from **`pay.stripe.com`**:

```
https://pay.stripe.com/invoice/acct_.../.../pdf?s=ap
```

So every genuine invoice download was rejected. The endpoint had never been run end to end against a real Stripe invoice, so nothing contradicted the assumption.

## Why the test didn't catch it

`StripeFileUrlTests` asserted that `https://files.stripe.com/links/abc` is allowed. That is true, and irrelevant — no case used the URL shape Stripe actually returns. The test was written from the same wrong belief as the code, so it agreed with it.

A guard exercised only against URLs invented to match it confirms the author's model of the provider, not the provider.

## Fix

Matched as **any host within `stripe.com`** rather than a list of named hosts. Enumerating them means being wrong again the next time Stripe adds one, and the domain is the property actually worth checking.

The security properties are unchanged:

- HTTPS still required — `http://pay.stripe.com/...` is refused
- The suffix carries a leading dot, so it is a subdomain test, not a string-suffix test: `notstripe.com` and `files.stripe.com.evil.test` both fail
- Non-Stripe hosts, link-local addresses, `localhost`, `file://` and relative URLs all still refused

## Verification

`dotnet test --filter "FullyQualifiedName!~Integration"` — **2158 passed, 0 failed, 1 skipped**.

Positive cases now lead with the real `pay.stripe.com` invoice shape and `invoice.stripe.com`, keeping `files.stripe.com` and `api.stripe.com`. Negative cases gain `notstripe.com` and an HTTP `pay.stripe.com` to pin both halves of the subdomain rule.

Live download re-tested on dev against invoice `in_1U5lypRykTBerLEudXvU50Yu` once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
