### PR TITLE
Fix duplicate subscription checkout race

### DIFF
--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1065,9 +1065,9 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
           <h4>Returns</h4>
           <p>
             <code>200</code> · <code>400</code> invalid, unknown time zone · <code>404</code> plan or
-            price not found · <code>409</code> <code>subscription_already_active</code> when creation
-            is rejected · <code>502</code>/<code>503</code> provider trouble. Do not rely on that
-            conflict as the only duplicate-signup guard; see the known limitation below.
+            price not found · <code>409</code> <code>subscription_already_active</code> when the
+            organization already has an open signup or live subscription ·
+            <code>502</code>/<code>503</code> provider trouble.
           </p>
         </div>
       </div>
@@ -1337,20 +1337,15 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         JPY has no minor unit; BHD and KWD have three digits.
       </p>
 
-      <h3>Duplicate signup is not currently rejected before payment</h3>
-      <div class="note danger">
-        <span class="note-label">Known limitation</span>
-        <p>
-          A new subscription is stored as <code>Incomplete</code>, while the one-live-subscription
-          index covers only <code>Trialing</code>, <code>Active</code> and <code>PastDue</code>. An
-          organization that already has a live subscription can therefore receive another checkout
-          URL and pay before the conflict is discovered during activation. Check
-          <code>GET /api/subscriptions/current</code> before offering checkout and prevent repeat
-          submissions in your UI. This reduces accidental duplicates but is not concurrency-safe;
-          the server-side reservation must be fixed before callers can rely on
-          <code>subscription_already_active</code> as the final guard.
-        </p>
-      </div>
+      <h3>One open signup or live subscription per organization</h3>
+      <p>
+        Enforced atomically by a unique reservation index covering <code>Incomplete</code>,
+        <code>Trialing</code>, <code>Active</code> and <code>PastDue</code>. The reservation is taken
+        before checkout is created, so concurrent requests cannot both reach payment. A later
+        attempt receives <code>409 subscription_already_active</code>. Once an abandoned attempt
+        becomes <code>IncompleteExpired</code>, or a subscription ends, the organization may
+        subscribe again.
+      </p>
 
       <h3>Periods follow the customer's calendar</h3>
       <p>
@@ -1376,4 +1371,3 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
 </div>
 </body>
 </html>
-

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -8,11 +8,13 @@ public interface ISubscriptionRepository
     Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Inserts a subscription, returning false when the organization already has a live one.
+    /// Inserts a subscription, returning false when the organization already has an open signup
+    /// or a live subscription.
     /// </summary>
     /// <remarks>
-    /// The database decides, through a partial unique index, rather than a read followed by a
-    /// write — two concurrent signups would both pass the read.
+    /// The database decides, through a partial unique reservation index that includes
+    /// <see cref="SubscriptionStatus.Incomplete"/>, rather than a read followed by a write — two
+    /// concurrent signups would both pass the read and could otherwise both reach checkout.
     /// </remarks>
     Task<bool> TryCreateAsync(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -16,8 +16,13 @@ namespace Subscription.DomainService.Repositories;
 /// </remarks>
 public static class SubscriptionIndexDefinitions
 {
-    public const string ActiveSubscriptionIndexName =
-        "ux_subscription_tenant_org_live";
+    /// <summary>
+    /// Versioned because MongoDB does not replace an existing named index when its partial
+    /// filter changes. Deploying this alongside the legacy live-only index upgrades existing
+    /// tenant databases as they are first touched.
+    /// </summary>
+    public const string SubscriptionReservationIndexName =
+        "ux_subscription_tenant_org_reserved_v2";
 
     public const string SubscriptionOrganizationIndexName =
         "ix_subscription_tenant_org_status";
@@ -62,12 +67,15 @@ public static class SubscriptionIndexDefinitions
         "ix_subscription_usageinvoice_tenant_state_next_attempt";
 
     /// <summary>
-    /// One live subscription per organization, enforced by the database rather than by a
-    /// read-then-write, so two concurrent signups cannot both succeed.
+    /// One open subscription attempt per organization, enforced before checkout by the database
+    /// rather than by a read-then-write, so two concurrent signups cannot both reach payment.
     /// </summary>
     /// <remarks>
-    /// Partial on the statuses that grant something: ended subscriptions must be allowed to
-    /// accumulate, or an organization could never resubscribe after cancelling.
+    /// Includes <see cref="SubscriptionStatus.Incomplete"/> because that is the status inserted
+    /// before checkout. Restricting the old index to granting statuses allowed another checkout
+    /// while an organization was already subscribed; the conflict appeared only during
+    /// activation, after money had moved. Ended subscriptions remain outside the reservation so
+    /// an organization can subscribe again after the prior attempt or subscription ends.
     /// </remarks>
     public static IReadOnlyCollection<CreateIndexModel<SubscriptionDetail>> CreateSubscriptionIndexes() =>
     [
@@ -78,13 +86,14 @@ public static class SubscriptionIndexDefinitions
             new CreateIndexOptions<SubscriptionDetail>
             {
                 Unique = true,
-                Name = ActiveSubscriptionIndexName,
+                Name = SubscriptionReservationIndexName,
                 PartialFilterExpression = new BsonDocument(
                     nameof(SubscriptionDetail.Status),
                     new BsonDocument(
                         "$in",
                         new BsonArray
                         {
+                            (int)SubscriptionStatus.Incomplete,
                             (int)SubscriptionStatus.Trialing,
                             (int)SubscriptionStatus.Active,
                             (int)SubscriptionStatus.PastDue

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -10,8 +10,9 @@ namespace Subscription.DomainService.Repositories;
 public sealed class SubscriptionRepository : ISubscriptionRepository
 {
     /// <summary>
-    /// Statuses that grant something. The set the live-subscription index is partial on, and the
-    /// one entitlement treats as current.
+    /// Statuses that grant something and that entitlement treats as current. The signup
+    /// reservation index additionally includes Incomplete, since checkout must be exclusive
+    /// before either customer pays.
     /// </summary>
     private static readonly SubscriptionStatus[] LiveStatuses =
     [

--- a/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
@@ -33,7 +33,7 @@ public sealed class SubscriptionRepositoryIntegrationTests
     }
 
     [Fact]
-    public async Task An_organization_cannot_hold_two_live_subscriptions()
+    public async Task An_active_subscription_blocks_a_new_signup_before_checkout()
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
@@ -42,10 +42,27 @@ public sealed class SubscriptionRepositoryIntegrationTests
             CancellationToken.None)).Should().BeTrue();
 
         (await _subscriptions.TryCreateAsync(
-                NewSubscription(tenantId, "org-1", SubscriptionStatus.Trialing),
+                NewSubscription(tenantId, "org-1", SubscriptionStatus.Incomplete),
                 CancellationToken.None))
-            .Should().BeFalse("the database refuses a second live subscription, so two " +
-                              "concurrent signups cannot both succeed");
+            .Should().BeFalse("the incomplete row reserves checkout, so the customer cannot " +
+                              "pay before discovering that the organization is already subscribed");
+    }
+
+    [Fact]
+    public async Task Only_one_of_two_concurrent_signups_reaches_checkout()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var outcomes = await Task.WhenAll(
+            _subscriptions.TryCreateAsync(
+                NewSubscription(tenantId, "org-concurrent", SubscriptionStatus.Incomplete),
+                CancellationToken.None),
+            _subscriptions.TryCreateAsync(
+                NewSubscription(tenantId, "org-concurrent", SubscriptionStatus.Incomplete),
+                CancellationToken.None));
+
+        outcomes.Count(created => created).Should().Be(1,
+            "the database reservation, rather than a pre-read, decides which signup may charge");
     }
 
     [Fact]
@@ -60,7 +77,7 @@ public sealed class SubscriptionRepositoryIntegrationTests
         (await _subscriptions.TryCreateAsync(
                 NewSubscription(tenantId, "org-2", SubscriptionStatus.Active),
                 CancellationToken.None))
-            .Should().BeTrue("the uniqueness rule covers only statuses that grant something");
+            .Should().BeTrue("ended states release the signup reservation");
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionIndexDefinitionsTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionIndexDefinitionsTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Subscription;
+
+public sealed class SubscriptionIndexDefinitionsTests
+{
+    [Fact]
+    public void Signup_reservation_includes_incomplete_before_checkout()
+    {
+        var index = SubscriptionIndexDefinitions.CreateSubscriptionIndexes()
+            .Single(candidate =>
+                candidate.Options.Name ==
+                SubscriptionIndexDefinitions.SubscriptionReservationIndexName);
+
+        index.Options.Unique.Should().BeTrue();
+
+        var partial = index.Options.PartialFilterExpression
+            .Should()
+            .BeOfType<BsonDocumentFilterDefinition<SubscriptionDetail>>()
+            .Subject
+            .Document;
+
+        var reservedStatuses = partial[nameof(SubscriptionDetail.Status)]["$in"]
+            .AsBsonArray
+            .Select(value => value.AsInt32)
+            .ToArray();
+
+        reservedStatuses.Should().BeEquivalentTo(
+        [
+            (int)SubscriptionStatus.Incomplete,
+            (int)SubscriptionStatus.Trialing,
+            (int)SubscriptionStatus.Active,
+            (int)SubscriptionStatus.PastDue
+        ]);
+        reservedStatuses.Should().NotContain((int)SubscriptionStatus.IncompleteExpired);
+        reservedStatuses.Should().NotContain((int)SubscriptionStatus.Unpaid);
+        reservedStatuses.Should().NotContain((int)SubscriptionStatus.Canceled);
+    }
+}


### PR DESCRIPTION
## What changed

- reserve an organization's subscription slot while a subscription is `Incomplete`, before hosted checkout is created
- introduce a versioned MongoDB unique partial index so existing tenant databases receive the corrected definition without replacing the legacy index in place
- return the existing `409 subscription_already_active` result when another open signup or live subscription owns the slot
- update the published integration guide to describe the corrected guarantee
- add index-definition and real-Mongo regression coverage for active-plus-incomplete and concurrent-incomplete inserts

## Root cause

The original unique partial index covered only `Trialing`, `Active`, and `PastDue`. New subscriptions are inserted as `Incomplete`, so their insert never conflicted with an existing live subscription. Both requests could reach checkout; the unique conflict surfaced only during activation, after the second customer payment.

## Impact

The reservation index now covers `Incomplete`, `Trialing`, `Active`, and `PastDue`. Exactly one concurrent signup can be inserted, and duplicate attempts are rejected before the payment flow starts. Terminal states remain outside the index so organizations can resubscribe.

Existing tenant databases containing conflicting open records must be reconciled before the new index can be created; failing index creation blocks another signup rather than allowing another charge.

## Validation

- `dotnet test server/XUnitTest/XUnitTest.csproj --no-restore --filter FullyQualifiedName~XUnitTest.Subscription`: 298 passed
- focused index-definition and creation-service tests: 20 passed
- Mongo integration tests compile, but could not run locally because MongoDB/Docker was not running; CI's Mongo fixture covers the added atomic insertion scenarios