### PR TITLE
Send subscription usage threshold emails

### DIFF
--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -644,7 +644,7 @@
             <tr><td>aggregation</td><td class="type">string</td><td class="prose">How recordings combine. <code>Sum</code> adds them up — the supported mode. <code>Max</code> and <code>LastValue</code> exist in the enum but the rater rejects them with <code>subscription_meter_aggregation_unsupported</code>.</td></tr>
             <tr><td>includedQuantity</td><td class="type">long</td><td class="prose">The allowance per period.</td></tr>
             <tr><td>overageAllowed</td><td class="type">bool</td><td class="prose"><code>false</code> blocks past the allowance. <code>true</code> permits and records it.</td></tr>
-            <tr><td>thresholdPercents</td><td class="type">int[]</td><td class="prose">Percentages that raise an event the first time they are crossed — 80, 100.</td></tr>
+            <tr><td>thresholdPercents</td><td class="type">int[]</td><td class="prose">Percentages that raise a <code>UsageThresholdReached</code> event once per usage period — for example 80 and 100. The worker forwards the event to the Blocks OS mail module using the subscription billing contact.</td></tr>
             <tr><td>rateTables</td><td class="type">array</td><td class="prose">What overage costs, per currency. <strong>Empty means overage is billed nothing.</strong></td></tr>
           </tbody>
         </table>

--- a/server/Subscription.DomainService/Messaging/SendMail.cs
+++ b/server/Subscription.DomainService/Messaging/SendMail.cs
@@ -1,0 +1,29 @@
+namespace Subscription.DomainService.Messaging;
+
+/// <summary>
+/// Wire contract accepted by the Blocks OS mail listener.
+/// </summary>
+/// <remarks>
+/// Keep property names and shapes compatible with <c>DomainService.Dtos.SendMail</c> in
+/// blocks-os. This project intentionally does not take a source dependency on that application.
+/// </remarks>
+public sealed class SendMail
+{
+    public Dictionary<string, string> SubjectDataContext { get; set; } = [];
+
+    public IEnumerable<string> To { get; set; } = [];
+
+    public IEnumerable<string> Bcc { get; set; } = [];
+
+    public IEnumerable<string> Cc { get; set; } = [];
+
+    public string Purpose { get; set; } = string.Empty;
+
+    public string Language { get; set; } = string.Empty;
+
+    public IEnumerable<string> ReplyTo { get; set; } = [];
+
+    public IEnumerable<string> Attachments { get; set; } = [];
+
+    public Dictionary<string, string> BodyDataContext { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
@@ -1,4 +1,5 @@
 using Blocks.Genesis;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Payment.DomainService.Utilities;
@@ -111,11 +112,17 @@ public sealed class SubscriptionOutboxProcessor : ISubscriptionOutboxProcessor
 
         try
         {
+            var payload = JsonSerializer.Deserialize<SubscriptionLifecycleEvent>(
+                claimed.Payload,
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true }) ??
+                throw new InvalidOperationException(
+                    $"Subscription event {claimed.EventId} has an empty payload.");
+
             await _messageClient.SendToMassConsumerAsync(
-                new ConsumerMessage<string>
+                new ConsumerMessage<SubscriptionLifecycleEvent>
                 {
                     ConsumerName = SubscriptionConstants.LifecycleTopic,
-                    Payload = claimed.Payload
+                    Payload = payload
                 });
 
             await _subscriptions.MarkEventPublishedAsync(

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -442,10 +442,15 @@ so publishing inline would drop events precisely when something went wrong.
 `SubscriptionPastDue`, `SubscriptionUnpaid`, `SubscriptionPlanChanged`, `UsageRated`,
 `UsageRatingFailed`.
 
-> **Nothing consumes this topic, and there is no email path in this repository** —
-> `Notification.DomainService` and `Mail.DomainService` contain only build output, no source. A
-> quota threshold raises an event and has no user-visible effect in this phase. That is the
-> intended shape: the platform states the fact, each product decides what it means.
+The worker consumes `UsageThresholdReached`. It resolves the subscription's billing account and
+queues a Blocks OS mail command to `blocks_email_listener` for `BillingEmail`, using purpose
+`subscription_usage_threshold` and language `en-US`. The configured mail template can use these
+subject/body context values: `DisplayName`, `PlanName`, `PlanCode`, `MeterKey`,
+`ThresholdPercent`, `Balance`, and `Limit`. Blocks OS must have a template with that purpose for
+the email to render and send.
+
+Other lifecycle events remain facts for integrating products to consume; this repository does
+not turn them into customer notifications.
 
 Every event carries a correlation id, persisted at write time, because publication happens later
 in another process. Without it the trace ends at the queue.

--- a/server/Subscription.DomainService/Services/IUsageThresholdEmailService.cs
+++ b/server/Subscription.DomainService/Services/IUsageThresholdEmailService.cs
@@ -1,0 +1,10 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+public interface IUsageThresholdEmailService
+{
+    Task SendAsync(
+        SubscriptionLifecycleEvent lifecycleEvent,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/UsageThresholdEmailService.cs
+++ b/server/Subscription.DomainService/Services/UsageThresholdEmailService.cs
@@ -1,0 +1,121 @@
+using System.Globalization;
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Messaging;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Converts a usage-threshold lifecycle event into the mail command understood by Blocks OS.
+/// </summary>
+public sealed class UsageThresholdEmailService : IUsageThresholdEmailService
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly IBillingAccountRepository _billingAccounts;
+    private readonly IMessageClient _messageClient;
+    private readonly ILogger<UsageThresholdEmailService> _logger;
+
+    public UsageThresholdEmailService(
+        ISubscriptionRepository subscriptions,
+        IBillingAccountRepository billingAccounts,
+        IMessageClient messageClient,
+        ILogger<UsageThresholdEmailService> logger)
+    {
+        _subscriptions = subscriptions;
+        _billingAccounts = billingAccounts;
+        _messageClient = messageClient;
+        _logger = logger;
+    }
+
+    public async Task SendAsync(
+        SubscriptionLifecycleEvent lifecycleEvent,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(lifecycleEvent);
+
+        if (lifecycleEvent.EventType != SubscriptionConstants.UsageThresholdReached)
+        {
+            return;
+        }
+
+        var subscription = await _subscriptions.GetByIdAsync(
+            lifecycleEvent.TenantId,
+            lifecycleEvent.SubscriptionId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            _logger.LogWarning(
+                "Usage threshold email skipped because the subscription was not found " +
+                "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} EventId={EventId}",
+                PaymentLogValue.Hash(lifecycleEvent.TenantId),
+                PaymentLogValue.Hash(lifecycleEvent.SubscriptionId),
+                lifecycleEvent.EventId);
+            return;
+        }
+
+        var account = await _billingAccounts.GetAsync(
+            lifecycleEvent.TenantId,
+            subscription.BillingAccountId,
+            cancellationToken);
+
+        if (account is null || string.IsNullOrWhiteSpace(account.BillingEmail))
+        {
+            _logger.LogWarning(
+                "Usage threshold email skipped because the billing account has no recipient " +
+                "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} EventId={EventId}",
+                PaymentLogValue.Hash(lifecycleEvent.TenantId),
+                PaymentLogValue.Hash(lifecycleEvent.SubscriptionId),
+                lifecycleEvent.EventId);
+            return;
+        }
+
+        var threshold = Number(lifecycleEvent.ThresholdPercent);
+        var balance = Number(lifecycleEvent.Balance);
+        var limit = Number(lifecycleEvent.Limit);
+        var displayName = string.IsNullOrWhiteSpace(account.BillingName)
+            ? account.BillingEmail
+            : account.BillingName;
+
+        var context = new Dictionary<string, string>
+        {
+            ["DisplayName"] = displayName,
+            ["PlanName"] = subscription.Plan.DisplayName,
+            ["PlanCode"] = subscription.Plan.Code,
+            ["MeterKey"] = lifecycleEvent.MeterKey ?? string.Empty,
+            ["ThresholdPercent"] = threshold,
+            ["Balance"] = balance,
+            ["Limit"] = limit
+        };
+
+        await _messageClient.SendToConsumerAsync(
+            new ConsumerMessage<SendMail>
+            {
+                ConsumerName = SubscriptionConstants.MailQueue,
+                Payload = new SendMail
+                {
+                    To = [account.BillingEmail.Trim().ToLowerInvariant()],
+                    Purpose = SubscriptionConstants.UsageThresholdMailPurpose,
+                    Language = SubscriptionConstants.DefaultMailLanguage,
+                    SubjectDataContext = new Dictionary<string, string>(context),
+                    BodyDataContext = context
+                }
+            });
+
+        _logger.LogInformation(
+            "Usage threshold email queued TenantHash={TenantHash} " +
+            "SubscriptionHash={SubscriptionHash} ThresholdPercent={ThresholdPercent} " +
+            "EventId={EventId}",
+            PaymentLogValue.Hash(lifecycleEvent.TenantId),
+            PaymentLogValue.Hash(lifecycleEvent.SubscriptionId),
+            lifecycleEvent.ThresholdPercent,
+            lifecycleEvent.EventId);
+    }
+
+    private static string Number(long? value) =>
+        value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -110,6 +110,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();
+        services.AddScoped<IUsageThresholdEmailService, UsageThresholdEmailService>();
         services.AddScoped<
             ISubscriptionActivationProcessor,
             SubscriptionActivationProcessor>();

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -6,12 +6,18 @@ namespace Subscription.DomainService.Utilities;
 public static class SubscriptionConstants
 {
     /// <summary>
-    /// Where subscription domain events are published. Nothing in this repository consumes it:
-    /// the platform states what happened and each product decides what that means, which is why
-    /// a quota alert is an event here rather than an email.
+    /// Where subscription domain events are published. The worker consumes usage-threshold
+    /// events from this topic and forwards a mail command to the platform mail module.
     /// </summary>
     public const string LifecycleTopic =
         "blocks_subscription_lifecycle_topic";
+
+    public const string UsageThresholdEmailQueue =
+        "blocks_subscription_usage_threshold_email_listener";
+    public const string MailQueue = "blocks_email_listener";
+    public const string UsageThresholdMailPurpose =
+        "subscription_usage_threshold";
+    public const string DefaultMailLanguage = "en-US";
 
     public const string SubscriptionCreated = "SubscriptionCreated";
     public const string SubscriptionTrialStarted =

--- a/server/Worker/Consumers/Subscription/UsageThresholdReachedConsumer.cs
+++ b/server/Worker/Consumers/Subscription/UsageThresholdReachedConsumer.cs
@@ -1,0 +1,28 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.DependencyInjection;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Services;
+
+namespace Worker.Consumers.Subscription;
+
+/// <summary>
+/// Turns subscription threshold facts into mail requests while leaving all other lifecycle
+/// events available to their own consumers.
+/// </summary>
+public sealed class UsageThresholdReachedConsumer :
+    IConsumer<SubscriptionLifecycleEvent>
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+
+    public UsageThresholdReachedConsumer(IServiceScopeFactory scopeFactory) =>
+        _scopeFactory = scopeFactory;
+
+    public async Task Consume(SubscriptionLifecycleEvent lifecycleEvent)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var emails = scope.ServiceProvider.GetRequiredService<
+            IUsageThresholdEmailService>();
+
+        await emails.SendAsync(lifecycleEvent, CancellationToken.None);
+    }
+}

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -12,6 +12,8 @@ using Subscription.DomainService.Utilities;
 using Worker;
 using Worker.Configuration;
 using Worker.Consumers.Payment;
+using Worker.Consumers.Subscription;
+using Subscription.DomainService.Entities;
 
 const string _serviceName = "blocks-utilities-worker";
 
@@ -64,6 +66,9 @@ IHostBuilder CreateHostBuilder(string[] args) =>
             services.AddSingleton<
                 IConsumer<ProcessPaymentWorkCommand>,
                 PaymentWorkCommandConsumer>();
+            services.AddSingleton<
+                IConsumer<SubscriptionLifecycleEvent>,
+                UsageThresholdReachedConsumer>();
             // Register the test consumer
             services.RegisterUtilityServices();
             services.AddSingleton<IVault>(_ => paymentVault);
@@ -100,7 +105,10 @@ static MessageConfiguration GetCombinedMessageConfiguration(string connectionStr
                     ..pdfGenerator.RabbitMqConfiguration?.ConsumerSubscriptions ?? [],
                     ..templateEngine.RabbitMqConfiguration?.ConsumerSubscriptions ?? [],
                     ConsumerSubscription.BindToQueue(
-                        PaymentConstants.PaymentWorkQueue)
+                        PaymentConstants.PaymentWorkQueue),
+                    ConsumerSubscription.BindToQueueViaExchange(
+                        SubscriptionConstants.UsageThresholdEmailQueue,
+                        SubscriptionConstants.LifecycleTopic)
                 ]
             }
         };
@@ -124,7 +132,8 @@ static MessageConfiguration GetCombinedMessageConfiguration(string connectionStr
                 ..helper.AzureServiceBusConfiguration?.Topics ?? [],
                 ..pdfGenerator.AzureServiceBusConfiguration?.Topics ?? [],
                 ..templateEngine.AzureServiceBusConfiguration?.Topics ?? [],
-                PaymentConstants.LifecycleTopic
+                PaymentConstants.LifecycleTopic,
+                SubscriptionConstants.LifecycleTopic
             ]
         }
     };

--- a/server/XUnitTest/Subscription/UsageThresholdEmailServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageThresholdEmailServiceTests.cs
@@ -1,0 +1,127 @@
+using Blocks.Genesis;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Messaging;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+public sealed class UsageThresholdEmailServiceTests
+{
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+    private readonly Mock<IMessageClient> _messages = new();
+
+    [Fact]
+    public async Task Threshold_event_queues_mail_for_the_subscription_billing_contact()
+    {
+        var subscription = Subscription();
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                "tenant-1", "subscription-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _accounts
+            .Setup(repository => repository.GetAsync(
+                "tenant-1", "account-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                BillingEmail = " Owner@Example.com ",
+                BillingName = "Ada Lovelace"
+            });
+
+        ConsumerMessage<SendMail>? queued = null;
+        _messages
+            .Setup(client => client.SendToConsumerAsync(
+                It.IsAny<ConsumerMessage<SendMail>>()))
+            .Callback<ConsumerMessage<SendMail>>(message => queued = message)
+            .Returns(Task.CompletedTask);
+
+        await Service().SendAsync(ThresholdEvent(), CancellationToken.None);
+
+        queued.Should().NotBeNull();
+        queued!.ConsumerName.Should().Be(SubscriptionConstants.MailQueue);
+        queued.Payload.Purpose.Should().Be(
+            SubscriptionConstants.UsageThresholdMailPurpose);
+        queued.Payload.Language.Should().Be("en-US");
+        queued.Payload.To.Should().Equal("owner@example.com");
+        queued.Payload.BodyDataContext.Should().Contain(new Dictionary<string, string>
+        {
+            ["DisplayName"] = "Ada Lovelace",
+            ["PlanName"] = "Claude Pro",
+            ["PlanCode"] = "claude-pro",
+            ["MeterKey"] = "tokens",
+            ["ThresholdPercent"] = "80",
+            ["Balance"] = "800",
+            ["Limit"] = "1000"
+        });
+    }
+
+    [Fact]
+    public async Task Non_threshold_event_is_ignored()
+    {
+        var lifecycleEvent = ThresholdEvent();
+        lifecycleEvent.EventType = SubscriptionConstants.SubscriptionActivated;
+
+        await Service().SendAsync(lifecycleEvent, CancellationToken.None);
+
+        _subscriptions.VerifyNoOtherCalls();
+        _messages.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Missing_billing_email_does_not_queue_an_invalid_mail()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                "tenant-1", "subscription-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Subscription());
+        _accounts
+            .Setup(repository => repository.GetAsync(
+                "tenant-1", "account-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount());
+
+        await Service().SendAsync(ThresholdEvent(), CancellationToken.None);
+
+        _messages.Verify(
+            client => client.SendToConsumerAsync(
+                It.IsAny<ConsumerMessage<SendMail>>()),
+            Times.Never);
+    }
+
+    private UsageThresholdEmailService Service() => new(
+        _subscriptions.Object,
+        _accounts.Object,
+        _messages.Object,
+        NullLogger<UsageThresholdEmailService>.Instance);
+
+    private static SubscriptionDetail Subscription() => new()
+    {
+        ItemId = "subscription-1",
+        TenantId = "tenant-1",
+        OrganizationId = "organization-1",
+        BillingAccountId = "account-1",
+        Plan = new PlanSnapshot
+        {
+            Code = "claude-pro",
+            DisplayName = "Claude Pro"
+        }
+    };
+
+    private static SubscriptionLifecycleEvent ThresholdEvent() => new()
+    {
+        EventId = "event-1",
+        EventType = SubscriptionConstants.UsageThresholdReached,
+        TenantId = "tenant-1",
+        OrganizationId = "organization-1",
+        SubscriptionId = "subscription-1",
+        PlanCode = "claude-pro",
+        MeterKey = "tokens",
+        ThresholdPercent = 80,
+        Balance = 800,
+        Limit = 1000
+    };
+}


### PR DESCRIPTION
## What changed

- publish subscription lifecycle outbox payloads as typed events
- consume UsageThresholdReached in the worker for Azure Service Bus and RabbitMQ
- resolve the subscription billing contact and queue a blocks-os SendMail command
- document the subscription_usage_threshold template purpose and available context values
- add focused email-service coverage

## Why

Configured usage thresholds previously produced an event but no customer-visible warning. This connects that event to the Blocks OS mail module while preserving the subscription outbox boundary.

## Validation

- 316 subscription and service-registration tests passed
- Worker project builds successfully

## Deployment dependency

Blocks OS must contain an en-US mail template whose purpose is subscription_usage_threshold.