### PR TITLE
Add subscription invoice history

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -588,6 +588,11 @@
             </para>
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.GetInvoiceHistory(Subscription.DomainService.Requests.GetSubscriptionInvoicesRequest,System.Threading.CancellationToken)">
+            <summary>
+            Lists the calling organization's settled subscription invoices, newest first.
+            </summary>
+        </member>
         <member name="T:Api.Controllers.SubscriptionUsageController">
             <summary>
             Metered usage. Served under <c>/api/subscription-usage</c>.

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -27,17 +27,20 @@ public sealed class SubscriptionsController : ControllerBase
     private readonly ISubscriptionCancellationService _cancellation;
     private readonly ISubscriptionPlanChangeService _planChange;
     private readonly ISubscriptionInvoiceDocumentService _invoiceDocuments;
+    private readonly ISubscriptionInvoiceHistoryService _invoiceHistory;
 
     public SubscriptionsController(
         ISubscriptionCheckoutService checkout,
         ISubscriptionCancellationService cancellation,
         ISubscriptionPlanChangeService planChange,
-        ISubscriptionInvoiceDocumentService invoiceDocuments)
+        ISubscriptionInvoiceDocumentService invoiceDocuments,
+        ISubscriptionInvoiceHistoryService invoiceHistory)
     {
         _checkout = checkout;
         _cancellation = cancellation;
         _planChange = planChange;
         _invoiceDocuments = invoiceDocuments;
+        _invoiceHistory = invoiceHistory;
     }
 
     [HttpPost]
@@ -187,5 +190,29 @@ public sealed class SubscriptionsController : ControllerBase
         }
 
         return File(document.Content, document.ContentType, document.FileName);
+    }
+
+    /// <summary>
+    /// Lists the calling organization's settled subscription invoices, newest first.
+    /// </summary>
+    [HttpGet("invoices")]
+    [ProducesResponseType(
+        typeof(ApiResponse<SubscriptionInvoiceHistoryResponse>),
+        StatusCodes.Status200OK)]
+    [ProducesResponseType(
+        typeof(ApiResponse<SubscriptionInvoiceHistoryResponse>),
+        StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetInvoiceHistory(
+        [FromQuery] GetSubscriptionInvoicesRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _invoiceHistory.ListAsync(
+            request,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
     }
 }

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1116,6 +1116,50 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         </div>
       </div>
 
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscriptions/invoices</span></div>
+        <div class="endpoint-body">
+          <p>Lists the caller's settled renewal invoices, newest first. Every item includes an authenticated PDF download URL; provider invoice identifiers and Stripe's permanent bearer-style document links are never exposed.</p>
+          <h4>Query</h4>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Param</th><th>Type</th><th>Meaning</th></tr></thead>
+              <tbody>
+                <tr><td>pageSize</td><td class="type">int</td><td class="prose">Default 25; minimum 1, maximum 100.</td></tr>
+                <tr><td>after</td><td class="type">string?</td><td class="prose">The <code>nextCursor</code> returned by the previous page.</td></tr>
+                <tr><td>organizationId</td><td class="type">string?</td><td class="prose">Honored only for the platform console. Application callers are always scoped by their token.</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <h4>Sample item</h4>
+          <pre><code>{
+  "paymentDetailId": "payment-123",
+  "subscriptionId": "subscription-123",
+  "invoiceType": "Renewal",
+  "periodKey": "2026-08-01T00:00:00.0000000Z",
+  "providerName": "STRIPE",
+  "description": "Personal renewal",
+  "amount": 3.00,
+  "refundedAmount": 0,
+  "currencyCode": "EUR",
+  "status": "CAPTURED",
+  "issuedAtUtc": "2026-08-16T16:29:00Z",
+  "downloadUrl": "/api/subscriptions/invoices/payment-123/pdf"
+}</code></pre>
+          <h4>Returns</h4>
+          <p><code>200</code> · <code>400</code> invalid page size or cursor · <code>401</code>.</p>
+        </div>
+      </div>
+
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscriptions/invoices/{paymentDetailId}/pdf</span></div>
+        <div class="endpoint-body">
+          <p>Downloads one listed invoice as a PDF. The application fetches it from Stripe on demand and keeps the download behind the caller's organization authorization.</p>
+          <h4>Returns</h4>
+          <p><code>200</code> PDF · <code>404</code> absent or not owned · <code>503</code> provider unavailable.</p>
+        </div>
+      </div>
+
       <h3 id="api-usage">Usage</h3>
 
       <div class="endpoint">

--- a/server/Payment.DomainService/Repositories/PaymentIndexDefinitions.cs
+++ b/server/Payment.DomainService/Repositories/PaymentIndexDefinitions.cs
@@ -28,6 +28,9 @@ public static class PaymentIndexDefinitions
     public const string PaymentQueryStatusIndexName =
         "ix_payment_query_tenant_status_id";
 
+    public const string SubscriptionInvoiceHistoryIndexName =
+        "ix_payment_subscription_invoice_history";
+
     public const string ProviderMerchantIndexName =
         "ux_payment_provider_tenant_org_provider_merchant";
 
@@ -117,6 +120,19 @@ public static class PaymentIndexDefinitions
             new CreateIndexOptions
             {
                 Name = PaymentQueryStatusIndexName
+            }),
+        new(
+            Builders<PaymentDetail>.IndexKeys
+                .Ascending(payment => payment.TenantId)
+                .Ascending(payment => payment.CustomerOrganizationId)
+                .Descending(payment => payment.PaymentDate)
+                .Descending(payment => payment.ItemId),
+            new CreateIndexOptions<PaymentDetail>
+            {
+                Name = SubscriptionInvoiceHistoryIndexName,
+                PartialFilterExpression = new BsonDocument(
+                    nameof(PaymentDetail.PaymentFlow),
+                    PaymentFlows.SubscriptionInvoice)
             }),
         new(
             Builders<PaymentDetail>.IndexKeys

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -273,6 +273,13 @@ customer a second time.
 the caller's organization (`?organizationId=` honored only for the console, as everywhere else). The
 `paymentId` is the payment above, never the provider's invoice id.
 
+`GET /api/subscriptions/invoices?pageSize=25&after=...` lists the same organization's settled
+subscription invoices newest first. Each item carries the payment id, subscription, invoice type
+(`Renewal`, `PlanChange`, or `Usage`) and applicable period parsed from the stable order id, amount,
+refund total, status, and an authenticated `downloadUrl`
+pointing at the PDF endpoint above. Pagination is cursor based; cursors are bound to the resolved
+organization and cannot be replayed to move the query into another subscriber's history.
+
 The bytes are proxied rather than the provider's own link returned. A Stripe `invoice_pdf` URL
 carries no authentication and does not expire, so handing one out grants permanent access to a
 billing document and puts it beyond this module's reach. For the same reason the link is read fresh

--- a/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
@@ -1,0 +1,30 @@
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionInvoiceHistoryRepository
+{
+    Task<SubscriptionInvoiceHistoryPage> ListAsync(
+        string tenantId,
+        string organizationId,
+        int pageSize,
+        SubscriptionInvoiceHistoryCursor? after,
+        CancellationToken cancellationToken);
+}
+
+public sealed record SubscriptionInvoiceHistoryCursor(
+    DateTime IssuedAtUtc,
+    string PaymentDetailId);
+
+public sealed record SubscriptionInvoiceHistoryRecord(
+    string PaymentDetailId,
+    string ProviderName,
+    string? OrderId,
+    string? Description,
+    decimal Amount,
+    decimal RefundedAmount,
+    string CurrencyCode,
+    string Status,
+    DateTime IssuedAtUtc);
+
+public sealed record SubscriptionInvoiceHistoryPage(
+    IReadOnlyList<SubscriptionInvoiceHistoryRecord> Items,
+    bool HasMore);

--- a/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
@@ -1,0 +1,131 @@
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// Reads paid subscription invoices by subscriber organization.
+/// </summary>
+/// <remarks>
+/// Renewal payments carry two organizations: <c>OrganizationId</c> is the merchant scope that
+/// took the money, while <c>CustomerOrganizationId</c> is the subscriber that owns the invoice.
+/// An invoice history query must use the latter or console-mediated subscriptions are exposed
+/// to the wrong organization.
+/// </remarks>
+public sealed class SubscriptionInvoiceHistoryRepository :
+    ISubscriptionInvoiceHistoryRepository
+{
+    private static readonly string[] SettledStatuses =
+    [
+        PaymentStatuses.Captured,
+        PaymentStatuses.PartiallyRefunded,
+        PaymentStatuses.Refunded
+    ];
+
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly IPaymentRepository _payments;
+
+    public SubscriptionInvoiceHistoryRepository(
+        IDbContextProvider dbContextProvider,
+        IPaymentRepository payments)
+    {
+        _dbContextProvider = dbContextProvider;
+        _payments = payments;
+    }
+
+    public async Task<SubscriptionInvoiceHistoryPage> ListAsync(
+        string tenantId,
+        string organizationId,
+        int pageSize,
+        SubscriptionInvoiceHistoryCursor? after,
+        CancellationToken cancellationToken)
+    {
+        await _payments.EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var records = await Collection(tenantId)
+            .Find(BuildFilter(tenantId, organizationId, after))
+            .Sort(Builders<PaymentDetail>.Sort
+                .Descending(payment => payment.PaymentDate)
+                .Descending(payment => payment.ItemId))
+            .Limit(pageSize + 1)
+            .Project(payment => new SubscriptionInvoiceHistoryRecord(
+                payment.ItemId,
+                payment.ProviderName,
+                payment.OrderId,
+                payment.Description,
+                payment.PreciseAmount,
+                payment.RefundedAmount,
+                payment.CurrencyCode,
+                payment.PaymentStatus,
+                payment.PaymentDate))
+            .ToListAsync(cancellationToken);
+
+        var hasMore = records.Count > pageSize;
+        if (hasMore)
+        {
+            records.RemoveAt(records.Count - 1);
+        }
+
+        return new SubscriptionInvoiceHistoryPage(records, hasMore);
+    }
+
+    public static FilterDefinition<PaymentDetail> BuildFilter(
+        string tenantId,
+        string organizationId,
+        SubscriptionInvoiceHistoryCursor? after)
+    {
+        var filters = new List<FilterDefinition<PaymentDetail>>
+        {
+            Builders<PaymentDetail>.Filter.Eq(payment => payment.TenantId, tenantId),
+            Builders<PaymentDetail>.Filter.Eq(
+                payment => payment.CustomerOrganizationId,
+                organizationId),
+            Builders<PaymentDetail>.Filter.Eq(
+                payment => payment.PaymentFlow,
+                PaymentFlows.SubscriptionInvoice),
+            Builders<PaymentDetail>.Filter.In(
+                payment => payment.PaymentStatus,
+                SettledStatuses),
+            Builders<PaymentDetail>.Filter.Exists(
+                payment => payment.ProviderInvoiceId,
+                true),
+            Builders<PaymentDetail>.Filter.Ne(
+                payment => payment.ProviderInvoiceId,
+                null),
+            Builders<PaymentDetail>.Filter.Ne(
+                payment => payment.ProviderInvoiceId,
+                string.Empty)
+        };
+
+        if (after is not null)
+        {
+            filters.Add(
+                Builders<PaymentDetail>.Filter.Or(
+                    Builders<PaymentDetail>.Filter.Lt(
+                        payment => payment.PaymentDate,
+                        after.IssuedAtUtc),
+                    Builders<PaymentDetail>.Filter.And(
+                        Builders<PaymentDetail>.Filter.Eq(
+                            payment => payment.PaymentDate,
+                            after.IssuedAtUtc),
+                        Builders<PaymentDetail>.Filter.Lt(
+                            payment => payment.ItemId,
+                            after.PaymentDetailId))));
+        }
+
+        return Builders<PaymentDetail>.Filter.And(filters);
+    }
+
+    private IMongoCollection<PaymentDetail> Collection(string tenantId) =>
+        _dbContextProvider
+            .GetDatabase(Require(tenantId, nameof(tenantId)))
+            .GetCollection<PaymentDetail>("PaymentDetails");
+
+    private static string Require(string value, string parameterName) =>
+        !string.IsNullOrWhiteSpace(value)
+            ? value
+            : throw new ArgumentException("A non-empty value is required.", parameterName);
+}

--- a/server/Subscription.DomainService/Requests/GetSubscriptionInvoicesRequest.cs
+++ b/server/Subscription.DomainService/Requests/GetSubscriptionInvoicesRequest.cs
@@ -1,0 +1,14 @@
+namespace Subscription.DomainService.Requests;
+
+public sealed class GetSubscriptionInvoicesRequest
+{
+    public int PageSize { get; set; } = 25;
+
+    public string? After { get; set; }
+
+    /// <summary>
+    /// Honoured only for the platform console, using the standard subscription organization
+    /// resolution policy.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+}

--- a/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
@@ -1,0 +1,47 @@
+namespace Subscription.DomainService.Responses;
+
+public sealed class SubscriptionInvoiceHistoryResponse
+{
+    public IReadOnlyList<SubscriptionInvoiceHistoryItemResponse> Items { get; init; } = [];
+
+    public SubscriptionInvoiceHistoryPageInfoResponse PageInfo { get; init; } = new();
+}
+
+public sealed class SubscriptionInvoiceHistoryItemResponse
+{
+    public string PaymentDetailId { get; init; } = string.Empty;
+
+    public string? SubscriptionId { get; init; }
+
+    public string InvoiceType { get; init; } = string.Empty;
+
+    public string? PeriodKey { get; init; }
+
+    public string ProviderName { get; init; } = string.Empty;
+
+    public string Description { get; init; } = string.Empty;
+
+    public decimal Amount { get; init; }
+
+    public decimal RefundedAmount { get; init; }
+
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public string Status { get; init; } = string.Empty;
+
+    public DateTime IssuedAtUtc { get; init; }
+
+    /// <summary>
+    /// An authenticated application endpoint, never Stripe's bearer-style document URL.
+    /// </summary>
+    public string DownloadUrl { get; init; } = string.Empty;
+}
+
+public sealed class SubscriptionInvoiceHistoryPageInfoResponse
+{
+    public int PageSize { get; init; }
+
+    public bool HasNextPage { get; init; }
+
+    public string? NextCursor { get; init; }
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionInvoiceHistoryService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionInvoiceHistoryService.cs
@@ -1,0 +1,12 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface ISubscriptionInvoiceHistoryService
+{
+    Task<SubscriptionOperationResult<SubscriptionInvoiceHistoryResponse>> ListAsync(
+        GetSubscriptionInvoicesRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryCursorCodec.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryCursorCodec.cs
@@ -1,0 +1,86 @@
+using System.Text;
+using System.Text.Json;
+using Subscription.DomainService.Repositories;
+
+namespace Subscription.DomainService.Services;
+
+public static class SubscriptionInvoiceHistoryCursorCodec
+{
+    private const int Version = 1;
+    private const int MaximumCursorLength = 2_048;
+    private const int MaximumIdLength = 200;
+
+    public static string Encode(
+        string organizationId,
+        SubscriptionInvoiceHistoryRecord record)
+    {
+        var json = JsonSerializer.Serialize(new CursorPayload
+        {
+            Version = Version,
+            OrganizationId = organizationId,
+            IssuedAtUtc = record.IssuedAtUtc,
+            PaymentDetailId = record.PaymentDetailId
+        });
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    public static bool TryDecode(
+        string? cursor,
+        string organizationId,
+        out SubscriptionInvoiceHistoryCursor? boundary)
+    {
+        boundary = null;
+        if (string.IsNullOrWhiteSpace(cursor) || cursor.Length > MaximumCursorLength)
+        {
+            return false;
+        }
+
+        try
+        {
+            var normalized = cursor.Replace('-', '+').Replace('_', '/');
+            var padded = normalized.PadRight(
+                normalized.Length + ((4 - normalized.Length % 4) % 4),
+                '=');
+            var payload = JsonSerializer.Deserialize<CursorPayload>(
+                Convert.FromBase64String(padded));
+
+            if (payload is null ||
+                payload.Version != Version ||
+                payload.IssuedAtUtc == default ||
+                string.IsNullOrWhiteSpace(payload.PaymentDetailId) ||
+                payload.PaymentDetailId.Length > MaximumIdLength ||
+                !string.Equals(
+                    payload.OrganizationId,
+                    organizationId,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            boundary = new SubscriptionInvoiceHistoryCursor(
+                payload.IssuedAtUtc.ToUniversalTime(),
+                payload.PaymentDetailId);
+            return true;
+        }
+        catch (Exception exception) when (
+            exception is FormatException or JsonException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private sealed class CursorPayload
+    {
+        public int Version { get; set; }
+
+        public string OrganizationId { get; set; } = string.Empty;
+
+        public DateTime IssuedAtUtc { get; set; }
+
+        public string PaymentDetailId { get; set; } = string.Empty;
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
@@ -1,0 +1,164 @@
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+public sealed class SubscriptionInvoiceHistoryService :
+    ISubscriptionInvoiceHistoryService
+{
+    private const int MaximumPageSize = 100;
+
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly ISubscriptionInvoiceHistoryRepository _invoices;
+
+    public SubscriptionInvoiceHistoryService(
+        ISubscriptionContextResolver contextResolver,
+        ISubscriptionInvoiceHistoryRepository invoices)
+    {
+        _contextResolver = contextResolver;
+        _invoices = invoices;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionInvoiceHistoryResponse>> ListAsync(
+        GetSubscriptionInvoicesRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.PageSize is < 1 or > MaximumPageSize)
+        {
+            return Invalid(
+                correlationId,
+                nameof(request.PageSize),
+                $"PageSize must be between 1 and {MaximumPageSize}.");
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            request.OrganizationId,
+            cancellationToken);
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionInvoiceHistoryResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        SubscriptionInvoiceHistoryCursor? after = null;
+        if (request.After is not null &&
+            !SubscriptionInvoiceHistoryCursorCodec.TryDecode(
+                request.After,
+                context.OrganizationId,
+                out after))
+        {
+            return Invalid(correlationId, nameof(request.After), "After is not a valid cursor.");
+        }
+
+        var page = await _invoices.ListAsync(
+            context.TenantId,
+            context.OrganizationId,
+            request.PageSize,
+            after,
+            cancellationToken);
+
+        var items = page.Items
+            .Select(invoice => Map(invoice, request.OrganizationId))
+            .ToArray();
+        var last = page.Items.LastOrDefault();
+
+        return SubscriptionOperationResult<SubscriptionInvoiceHistoryResponse>.Success(
+            new SubscriptionInvoiceHistoryResponse
+            {
+                Items = items,
+                PageInfo = new SubscriptionInvoiceHistoryPageInfoResponse
+                {
+                    PageSize = request.PageSize,
+                    HasNextPage = page.HasMore,
+                    NextCursor = page.HasMore && last is not null
+                        ? SubscriptionInvoiceHistoryCursorCodec.Encode(
+                            context.OrganizationId,
+                            last)
+                        : null
+                }
+            },
+            correlationId);
+    }
+
+    private static SubscriptionInvoiceHistoryItemResponse Map(
+        SubscriptionInvoiceHistoryRecord invoice,
+        string? requestedOrganizationId)
+    {
+        var (subscriptionId, invoiceType, periodKey) = ParseOrderId(invoice.OrderId);
+        var downloadUrl =
+            $"/api/subscriptions/invoices/{Uri.EscapeDataString(invoice.PaymentDetailId)}/pdf";
+        if (!string.IsNullOrWhiteSpace(requestedOrganizationId))
+        {
+            downloadUrl +=
+                $"?organizationId={Uri.EscapeDataString(requestedOrganizationId)}";
+        }
+
+        return new SubscriptionInvoiceHistoryItemResponse
+        {
+            PaymentDetailId = invoice.PaymentDetailId,
+            SubscriptionId = subscriptionId,
+            InvoiceType = invoiceType,
+            PeriodKey = periodKey,
+            ProviderName = invoice.ProviderName,
+            Description = invoice.Description ?? string.Empty,
+            Amount = invoice.Amount,
+            RefundedAmount = invoice.RefundedAmount,
+            CurrencyCode = invoice.CurrencyCode,
+            Status = invoice.Status,
+            IssuedAtUtc = invoice.IssuedAtUtc.ToUniversalTime(),
+            DownloadUrl = downloadUrl
+        };
+    }
+
+    private static (string? SubscriptionId, string InvoiceType, string? PeriodKey) ParseOrderId(
+        string? orderId)
+    {
+        if (string.IsNullOrWhiteSpace(orderId) ||
+            !orderId.StartsWith(SubscriptionConstants.OrderIdPrefix, StringComparison.Ordinal))
+        {
+            return (null, "Unknown", null);
+        }
+
+        var value = orderId[SubscriptionConstants.OrderIdPrefix.Length..];
+        var separator = value.IndexOf(':', StringComparison.Ordinal);
+        if (separator is <= 0 || separator == value.Length - 1)
+        {
+            return (null, "Unknown", null);
+        }
+
+        var subscriptionId = value[..separator];
+        var suffix = value[(separator + 1)..];
+        if (suffix.StartsWith("planchange:", StringComparison.Ordinal))
+        {
+            return (subscriptionId, "PlanChange", null);
+        }
+
+        if (suffix.StartsWith("usage:", StringComparison.Ordinal))
+        {
+            var periodKey = suffix["usage:".Length..];
+            return string.IsNullOrWhiteSpace(periodKey)
+                ? (subscriptionId, "Usage", null)
+                : (subscriptionId, "Usage", periodKey);
+        }
+
+        return (subscriptionId, "Renewal", suffix);
+    }
+
+    private static SubscriptionOperationResult<SubscriptionInvoiceHistoryResponse> Invalid(
+        string correlationId,
+        string field,
+        string message) =>
+        SubscriptionOperationResult<SubscriptionInvoiceHistoryResponse>.Failure(
+            PaymentFailureKind.Validation,
+            "subscription_invoice_query_invalid",
+            "The invoice query is invalid.",
+            correlationId,
+            new Dictionary<string, string[]> { [field] = [message] });
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -46,6 +46,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             ISubscriptionUsageInvoiceRepository,
             SubscriptionUsageInvoiceRepository>();
+        services.AddSingleton<
+            ISubscriptionInvoiceHistoryRepository,
+            SubscriptionInvoiceHistoryRepository>();
 
         // Singleton so the cache is actually shared. Scoped, every request would get an empty
         // one and the hot path would read the database every time regardless.
@@ -107,6 +110,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionInvoiceDocumentService,
             SubscriptionInvoiceDocumentService>();
+        services.AddScoped<
+            ISubscriptionInvoiceHistoryService,
+            SubscriptionInvoiceHistoryService>();
         services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();

--- a/server/XUnitTest/Payment/PaymentQueryIndexDefinitionTests.cs
+++ b/server/XUnitTest/Payment/PaymentQueryIndexDefinitionTests.cs
@@ -17,7 +17,8 @@ public sealed class PaymentQueryIndexDefinitionTests
             PaymentIndexDefinitions.PaymentQueryDateIndexName,
             PaymentIndexDefinitions.PaymentQueryProviderIndexName,
             PaymentIndexDefinitions.PaymentQueryAmountIndexName,
-            PaymentIndexDefinitions.PaymentQueryStatusIndexName
+            PaymentIndexDefinitions.PaymentQueryStatusIndexName,
+            PaymentIndexDefinitions.SubscriptionInvoiceHistoryIndexName
         ]);
     }
 }

--- a/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryFilterTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryFilterTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using Payment.DomainService.Entities;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Subscription;
+
+public sealed class SubscriptionInvoiceHistoryFilterTests
+{
+    [Fact]
+    public void Invoice_history_is_scoped_to_the_subscriber_not_the_merchant()
+    {
+        var rendered = Render();
+        var text = rendered.ToString();
+
+        text.Should().Contain("CustomerOrganizationId");
+        text.Should().Contain("subscriber-1");
+        text.Should().NotContain("\"OrganizationId\"");
+        text.Should().Contain("SUBSCRIPTION_INVOICE");
+        text.Should().Contain("ProviderInvoiceId");
+        text.Should().Contain("CAPTURED");
+        text.Should().Contain("PARTIALLY_REFUNDED");
+        text.Should().Contain("REFUNDED");
+    }
+
+    [Fact]
+    public void Cursor_selects_only_records_after_the_descending_boundary()
+    {
+        var rendered = Render(new SubscriptionInvoiceHistoryCursor(
+            new DateTime(2026, 8, 19, 12, 0, 0, DateTimeKind.Utc),
+            "payment-9"));
+        var text = rendered.ToString();
+
+        text.Should().Contain("$lt");
+        text.Should().Contain("PaymentDate");
+        text.Should().Contain("payment-9");
+    }
+
+    private static BsonDocument Render(SubscriptionInvoiceHistoryCursor? cursor = null)
+    {
+        var serializer = BsonSerializer.SerializerRegistry.GetSerializer<PaymentDetail>();
+        return SubscriptionInvoiceHistoryRepository
+            .BuildFilter("tenant-1", "subscriber-1", cursor)
+            .Render(new RenderArgs<PaymentDetail>(
+                serializer,
+                BsonSerializer.SerializerRegistry));
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryServiceTests.cs
@@ -1,0 +1,193 @@
+using FluentAssertions;
+using Moq;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+public sealed class SubscriptionInvoiceHistoryServiceTests
+{
+    private readonly Mock<ISubscriptionContextResolver> _context = new();
+    private readonly Mock<ISubscriptionInvoiceHistoryRepository> _invoices = new();
+
+    public SubscriptionInvoiceHistoryServiceTests()
+    {
+        _context
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(
+                    "tenant-1",
+                    "subscriber-1",
+                    "actor-1",
+                    "user-1")));
+    }
+
+    [Fact]
+    public async Task History_maps_invoice_metadata_download_links_and_next_cursor()
+    {
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                "tenant-1",
+                "subscriber-1",
+                2,
+                null,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionInvoiceHistoryPage(
+                [Invoice("payment/2", "sub:subscription-2:2026-08"),
+                 Invoice("payment-1", "legacy-order")],
+                true));
+
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest { PageSize = 2 },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().HaveCount(2);
+        result.Value.Items[0].SubscriptionId.Should().Be("subscription-2");
+        result.Value.Items[0].InvoiceType.Should().Be("Renewal");
+        result.Value.Items[0].PeriodKey.Should().Be("2026-08");
+        result.Value.Items[0].DownloadUrl.Should().Be(
+            "/api/subscriptions/invoices/payment%2F2/pdf");
+        result.Value.Items[1].SubscriptionId.Should().BeNull();
+        result.Value.Items[1].InvoiceType.Should().Be("Unknown");
+        result.Value.PageInfo.HasNextPage.Should().BeTrue();
+        result.Value.PageInfo.NextCursor.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Theory]
+    [InlineData("sub:subscription-1:planchange:7", "PlanChange", null)]
+    [InlineData("sub:subscription-1:usage:2026-08", "Usage", "2026-08")]
+    public async Task Non_renewal_invoice_type_is_classified(
+        string orderId,
+        string expectedType,
+        string? expectedPeriod)
+    {
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<SubscriptionInvoiceHistoryCursor?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionInvoiceHistoryPage(
+                [Invoice("payment-1", orderId)],
+                false));
+
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest(),
+            "corr-1",
+            CancellationToken.None);
+
+        result.Value!.Items[0].InvoiceType.Should().Be(expectedType);
+        result.Value.Items[0].PeriodKey.Should().Be(expectedPeriod);
+    }
+
+    [Fact]
+    public async Task Cursor_is_bound_to_the_resolved_organization()
+    {
+        var record = Invoice("payment-1", "sub:subscription-1:2026-07");
+        var cursor = SubscriptionInvoiceHistoryCursorCodec.Encode("subscriber-1", record);
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                "tenant-1",
+                "subscriber-1",
+                25,
+                It.Is<SubscriptionInvoiceHistoryCursor>(boundary =>
+                    boundary.PaymentDetailId == "payment-1" &&
+                    boundary.IssuedAtUtc == record.IssuedAtUtc),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionInvoiceHistoryPage([], false));
+
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest { After = cursor },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        SubscriptionInvoiceHistoryCursorCodec.TryDecode(
+            cursor,
+            "another-organization",
+            out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Console_organization_is_carried_into_download_links()
+    {
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<SubscriptionInvoiceHistoryCursor?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionInvoiceHistoryPage(
+                [Invoice("payment-1", "sub:subscription-1:2026-08")],
+                false));
+
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest
+            {
+                OrganizationId = "subscriber-1"
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.Value!.Items[0].DownloadUrl.Should().Be(
+            "/api/subscriptions/invoices/payment-1/pdf?organizationId=subscriber-1");
+        _context.Verify(resolver => resolver.ResolveAsync(
+            "corr-1",
+            "subscriber-1",
+            It.IsAny<CancellationToken>()));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public async Task Invalid_page_size_is_rejected_without_querying(int pageSize)
+    {
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest { PageSize = pageSize },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_invoice_query_invalid");
+        _invoices.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Invalid_cursor_is_rejected_without_querying()
+    {
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest { After = "not-a-cursor" },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ValidationErrors.Should().ContainKey("After");
+        _invoices.VerifyNoOtherCalls();
+    }
+
+    private SubscriptionInvoiceHistoryService Service() => new(
+        _context.Object,
+        _invoices.Object);
+
+    private static SubscriptionInvoiceHistoryRecord Invoice(
+        string paymentId,
+        string orderId) => new(
+        paymentId,
+        "STRIPE",
+        orderId,
+        "Claude Pro renewal",
+        20m,
+        0m,
+        "USD",
+        "CAPTURED",
+        new DateTime(2026, 8, 19, 12, 0, 0, DateTimeKind.Utc));
+}


### PR DESCRIPTION
## What changed

- adds `GET /api/subscriptions/invoices` with organization-bound cursor pagination
- scopes invoice history by `CustomerOrganizationId`, not the merchant-side payment organization
- returns settled Stripe invoice-backed payments with invoice classification and authenticated PDF download URLs
- adds a supporting MongoDB index, API documentation, service registration, and automated tests

## Why

The generic payment query does not represent subscription invoice ownership: subscription invoices belong to the subscriber organization through `CustomerOrganizationId`. A dedicated endpoint prevents cross-organization or merchant-side query semantics from leaking into customer invoice history.

Initial checkout payments that are only Stripe Checkout/PaymentIntent records are intentionally excluded. Renewal, plan-change, and usage charges that produced real provider invoices are included once settled.

## Validation

- API project builds successfully
- focused invoice history/index/registration tests: 34 passed
- broader subscription/index/registration suite: 327 passed