### PR TITLE
Make subscription catalogues client-ready

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -41,7 +41,7 @@ import { StepUsageLimits } from "./step-usage-limits";
 const STEPS: Steps = [
   { id: 1, title: "Identity" },
   { id: 2, title: "Pricing model" },
-  { id: 3, title: "Usage limits" },
+  { id: 3, title: "What the plan grants" },
   { id: 4, title: "Trial" },
   { id: 5, title: "Review" },
 ];

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -84,7 +84,10 @@ export const PlanPriceFields = ({
                 key={price.priceId}
                 className="flex items-center justify-between gap-3 text-sm"
               >
-                <span>{formatPrice(price)}</span>
+                <span>
+                  {formatPrice(price)}
+                  {price.displayPriceNote && <span className="ml-2 text-xs text-muted-foreground">{price.displayPriceNote}</span>}
+                </span>
                 {onRetirePrice && (
                   <Button
                     type="button"
@@ -202,6 +205,20 @@ export const PlanPriceFields = ({
                 )}
               />
             </div>
+
+            <FormField
+              control={control}
+              name={`prices.${index}.displayPriceNote`}
+              render={({ field: inputField }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">Display price note (optional)</FormLabel>
+                  <FormControl>
+                    <Input {...inputField} placeholder="$17/month, billed annually" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
             <FormField
               control={control}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-identity.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-identity.tsx
@@ -149,6 +149,31 @@ export const StepIdentity = ({ isEditing = false }: { isEditing?: boolean }) => 
             </FormItem>
           )}
         />
+
+        <FormField
+          control={control}
+          name="familyCode"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Family code (optional)</FormLabel>
+              <FormControl><Input {...field} placeholder="claude-max" /></FormControl>
+              <FormDescription>Plans with the same family code are levels of one product.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={control}
+          name="familyRank"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Family rank</FormLabel>
+              <FormControl><Input {...field} type="number" min={0} placeholder="10" /></FormControl>
+              <FormDescription>Lower levels sort first; required when family code is set.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
       </div>
 
       <Collapsible>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -1,6 +1,6 @@
-import { Gauge, Layers, Plus } from "lucide-react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
-import { Card } from "@/components/ui-kits/card/card";
+import { ChevronDown } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui-kits/collapsible/collapsible";
 import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import {
   FormControl,
@@ -17,34 +17,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui-kits/select/select";
-import { METER_AGGREGATION_OPTIONS } from "../../constants/subscription.constants";
+import { BILLING_INTERVAL_OPTIONS, METER_AGGREGATION_OPTIONS } from "../../constants/subscription.constants";
 import type { PlanPrice } from "../../models/subscription-plan.model";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 import { CardListItem, CardListShell } from "./card-list-shell";
 import { MeterRateTableFields } from "./meter-rate-table-fields";
 import { PlanPriceFields } from "./plan-price-fields";
 import { ThresholdChipInput } from "./threshold-chip-input";
-
-const PRICING_SHAPES = [
-  {
-    value: "seats" as const,
-    icon: Layers,
-    title: "Per seat or unit",
-    description: "Charge per seat, user, or unit — e.g. $12 per user, per month.",
-  },
-  {
-    value: "usage" as const,
-    icon: Gauge,
-    title: "Usage-based",
-    description: "Charge for what's used — e.g. $0.01 per API call, with a free allowance.",
-  },
-  {
-    value: "both" as const,
-    icon: Plus,
-    title: "Both",
-    description: "A base seat charge plus metered usage on top.",
-  },
-];
 
 export const StepPricingModel = ({
   isEditing = false,
@@ -57,8 +36,7 @@ export const StepPricingModel = ({
   onRetirePrice?: (priceId: string) => void;
   retiringPriceId?: string | null;
 }) => {
-  const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
-  const pricingShape = useWatch({ control, name: "pricingShape" });
+  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
 
   const quantityItems = useFieldArray({ control, name: "quantityItems" });
   const meters = useFieldArray({ control, name: "meters" });
@@ -66,40 +44,20 @@ export const StepPricingModel = ({
   // itself changes — see step-usage-limits for the same trap.
   const meterValues = useWatch({ control, name: "meters" });
 
-  const showSeats = pricingShape === "seats" || pricingShape === "both";
-  const showUsage = pricingShape === "usage" || pricingShape === "both";
-
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-lg font-semibold">Pricing model</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          How does this plan charge? Pick the shape that fits — you can change this later.
+          Add any quantity and usage dimensions this plan needs. A flat-fee plan needs neither.
         </p>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-3">
-        {PRICING_SHAPES.map((shape) => (
-          <button
-            key={shape.value}
-            type="button"
-            onClick={() => setValue("pricingShape", shape.value, { shouldDirty: true })}
-            className={`rounded-xl border p-4 text-left transition ${
-              pricingShape === shape.value
-                ? "border-blocks-primary-500 bg-blocks-primary-shades-50"
-                : "hover:border-blocks-primary-300"
-            }`}
-          >
-            <shape.icon className="h-5 w-5 text-blocks-primary-600" />
-            <p className="mt-2 font-medium">{shape.title}</p>
-            <p className="mt-1 text-xs text-muted-foreground">{shape.description}</p>
-          </button>
-        ))}
-      </div>
-
-      {showSeats && (
-        <div className="space-y-3">
-          <h3 className="text-sm font-semibold">Quantity items</h3>
+      <OptionalSection
+        title="Quantity items"
+        description="Use these when price scales with seats, users, or another selected quantity."
+        defaultOpen={quantityItems.fields.length > 0}
+      >
           <CardListShell
             addLabel="Add quantity item"
             onAdd={() =>
@@ -170,12 +128,13 @@ export const StepPricingModel = ({
               </CardListItem>
             ))}
           </CardListShell>
-        </div>
-      )}
+      </OptionalSection>
 
-      {showUsage && (
-        <div className="space-y-3">
-          <h3 className="text-sm font-semibold">Meters</h3>
+      <OptionalSection
+        title="Meters"
+        description="Use meters to track an allowance and optionally bill usage beyond it."
+        defaultOpen={meters.fields.length > 0}
+      >
           <CardListShell
             addLabel="Add meter"
             onAdd={() =>
@@ -323,25 +282,69 @@ export const StepPricingModel = ({
               </CardListItem>
             ))}
           </CardListShell>
-        </div>
-      )}
+          {(meterValues?.length ?? 0) > 0 && (
+            <div className="grid gap-2 rounded-lg border p-3 sm:grid-cols-2">
+              <FormField
+                control={control}
+                name="usageInterval"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Allowance resets every</FormLabel>
+                    <Select value={String(field.value)} onValueChange={(value) => field.onChange(Number(value))}>
+                      <FormControl><SelectTrigger><SelectValue /></SelectTrigger></FormControl>
+                      <SelectContent>
+                        {BILLING_INTERVAL_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={String(option.value)}>{option.label}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name="usageIntervalCount"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">How many</FormLabel>
+                    <FormControl><Input {...field} type="number" min={1} max={100} /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          )}
+      </OptionalSection>
 
       {/* Last in the step because a price may multiply a quantity item, which is defined above
           it. Not gated on the pricing shape: every plan needs a price, whatever its shape. */}
-      {pricingShape && (
-        <PlanPriceFields
+      <PlanPriceFields
           isEditing={isEditing}
           existingPrices={existingPrices}
           onRetirePrice={onRetirePrice}
           retiringPriceId={retiringPriceId}
-        />
-      )}
-
-      {!pricingShape && (
-        <Card className="flex flex-col items-center gap-2 rounded-xl py-8 text-center text-sm text-muted-foreground">
-          Choose a pricing shape above to continue.
-        </Card>
-      )}
+      />
     </div>
   );
 };
+
+const OptionalSection = ({
+  title,
+  description,
+  defaultOpen,
+  children,
+}: {
+  title: string;
+  description: string;
+  defaultOpen: boolean;
+  children: React.ReactNode;
+}) => (
+  <Collapsible defaultOpen={defaultOpen} className="rounded-xl border p-4">
+    <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
+      <span><span className="block text-sm font-semibold">{title}</span><span className="block text-xs text-muted-foreground">{description}</span></span>
+      <ChevronDown className="h-4 w-4 shrink-0" />
+    </CollapsibleTrigger>
+    <CollapsibleContent className="space-y-3 pt-4">{children}</CollapsibleContent>
+  </Collapsible>
+);

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
@@ -1,5 +1,7 @@
 import { AlertTriangle } from "lucide-react";
+import { useState } from "react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Button } from "@/components/ui-kits/button/button";
 import {
   FormControl,
   FormField,
@@ -29,11 +31,12 @@ export const StepUsageLimits = () => {
   // the list itself changes, so editing a card's own Kind would never reveal the fields that
   // depend on it.
   const entitlementValues = useWatch({ control, name: "entitlements" });
+  const [limitOverrides, setLimitOverrides] = useState<Record<number, boolean>>({});
 
   return (
     <div className="space-y-5">
       <div>
-        <h2 className="text-lg font-semibold">Usage limits</h2>
+        <h2 className="text-lg font-semibold">What the plan grants</h2>
         <p className="mt-1 text-sm text-muted-foreground">
           What a subscriber on this plan is allowed to do — separate from what they&apos;re billed for.
           Skip this if the plan just grants everything.
@@ -52,6 +55,13 @@ export const StepUsageLimits = () => {
         {entitlements.fields.map((field, index) => {
           const limitKind = entitlementValues?.[index]?.limitKind ?? field.limitKind;
           const draft = entitlementValues?.[index];
+          const selectedMeter = (meters ?? []).find(
+            (meter) => meter.meterKey && meter.meterKey === draft?.meterKey,
+          );
+          const limitIsOverridden =
+            limitOverrides[index] ??
+            (selectedMeter !== undefined && draft?.limit !== undefined &&
+              draft.limit !== selectedMeter.includedQuantity);
           const mismatch = draft
             ? describeEntitlementMeterMismatch(
                 {
@@ -130,7 +140,17 @@ export const StepUsageLimits = () => {
                     render={({ field: inputField }) => (
                       <FormItem>
                         <FormLabel className="text-xs">Draws down which meter</FormLabel>
-                        <Select value={inputField.value ?? ""} onValueChange={inputField.onChange}>
+                        <Select
+                          value={inputField.value ?? ""}
+                          onValueChange={(meterKey) => {
+                            inputField.onChange(meterKey);
+                            const meter = (meters ?? []).find((item) => item.meterKey === meterKey);
+                            setValue(`entitlements.${index}.limit`, meter?.includedQuantity ?? 0, {
+                              shouldDirty: true,
+                            });
+                            setLimitOverrides((current) => ({ ...current, [index]: false }));
+                          }}
+                        >
                           <FormControl>
                             <SelectTrigger>
                               <SelectValue placeholder="Choose a meter" />
@@ -155,9 +175,32 @@ export const StepUsageLimits = () => {
                     name={`entitlements.${index}.limit`}
                     render={({ field: inputField }) => (
                       <FormItem>
-                        <FormLabel className="text-xs">Limit</FormLabel>
+                        <div className="flex items-center justify-between gap-2">
+                          <FormLabel className="text-xs">
+                            Limit{selectedMeter && !limitIsOverridden ? " (inherited from meter)" : ""}
+                          </FormLabel>
+                          {selectedMeter && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-6 px-2 text-xs"
+                              onClick={() => {
+                                const override = !limitIsOverridden;
+                                setLimitOverrides((current) => ({ ...current, [index]: override }));
+                                if (!override) {
+                                  setValue(`entitlements.${index}.limit`, selectedMeter.includedQuantity, {
+                                    shouldDirty: true,
+                                  });
+                                }
+                              }}
+                            >
+                              {limitIsOverridden ? "Use meter allowance" : "Override"}
+                            </Button>
+                          )}
+                        </div>
                         <FormControl>
-                          <Input {...inputField} type="number" min={0} />
+                          <Input {...inputField} type="number" min={0} disabled={Boolean(selectedMeter) && !limitIsOverridden} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/client/app/cross-modules/utilities/subscription/index.ts
+++ b/client/app/cross-modules/utilities/subscription/index.ts
@@ -3,3 +3,4 @@ export { SubscriptionPlanDetailPage } from "./pages/subscription-plan-detail-pag
 export { CreateSubscriptionPlanPage } from "./pages/create-subscription-plan-page";
 export { CreateSubscriptionPricePage } from "./pages/create-subscription-price-page";
 export { EditSubscriptionPlanPage } from "./pages/edit-subscription-plan-page";
+export { SubscriptionDiscountsPage } from "./pages/subscription-discounts-page";

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -84,6 +84,7 @@ export interface PlanPrice {
   /** Response DTOs carry this as a string name (e.g. "Month"); requests send the numeric value. */
   interval: BillingIntervalName;
   intervalCount: number;
+  displayPriceNote?: string | null;
   quantityItemKey: string | null;
 }
 
@@ -92,6 +93,10 @@ export interface SubscriptionPlan {
   code: string;
   displayName: string;
   description: string | null;
+  familyCode?: string | null;
+  familyRank?: number | null;
+  usageInterval?: BillingIntervalName;
+  usageIntervalCount?: number;
   featuresJson: string | null;
   organizationId: string | null;
   trialDays: number | null;
@@ -159,6 +164,10 @@ export interface CreateSubscriptionPlanRequest {
   organizationId?: string;
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
+  usageInterval: number;
+  usageIntervalCount: number;
+  familyCode?: string;
+  familyRank?: number;
   quantityItems: CreatePlanQuantityItemRequest[];
   meters: CreatePlanMeterRequest[];
   entitlements: CreatePlanEntitlementRequest[];
@@ -177,6 +186,10 @@ export interface UpdateSubscriptionPlanRequest {
   organizationId?: string;
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
+  usageInterval: number;
+  usageIntervalCount: number;
+  familyCode?: string;
+  familyRank?: number;
   quantityItems: CreatePlanQuantityItemRequest[];
   meters: CreatePlanMeterRequest[];
   entitlements: CreatePlanEntitlementRequest[];
@@ -191,5 +204,34 @@ export interface CreateSubscriptionPriceRequest {
   unitAmountMinor: number;
   interval: number;
   intervalCount: number;
+  displayPriceNote?: string;
   quantityItemKey?: string;
+}
+
+export interface SubscriptionDiscount {
+  discountId: string;
+  organizationId: string | null;
+  code: string;
+  displayName: string;
+  kind: "Percent" | "FixedAmount";
+  percentBasisPoints: number | null;
+  amountMinor: number | null;
+  currencyCode: string | null;
+  durationPeriods: number | null;
+  expiresAtUtc: string | null;
+  applicablePlanCodes: string[];
+  status: "Active" | "Archived";
+}
+
+export interface CreateSubscriptionDiscountRequest {
+  organizationId?: string;
+  code: string;
+  displayName: string;
+  kind: number;
+  percentBasisPoints?: number;
+  amountMinor?: number;
+  currencyCode?: string;
+  durationPeriods?: number;
+  expiresAtUtc?: string;
+  applicablePlanCodes: string[];
 }

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
@@ -1,25 +1,33 @@
-import { useNavigate, useParams } from "react-router";
+import { useMemo } from "react";
+import { useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "@/hooks/use-toast";
 import { PlanBuilder } from "../components/plan-builder/plan-builder";
 import { useCreateSubscriptionPlan } from "../hooks/use-create-subscription-plan";
 import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-price";
 import { withOrganizationScope } from "../hooks/use-organization-scope";
 import { defaultSubscriptionPlanFormValues } from "../schemas/subscription-plan.schema";
-import { toCreatePlanRequest } from "../utilities/plan-form-mapping";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+import { planToFormValues, toCreatePlanRequest } from "../utilities/plan-form-mapping";
 import { submitPlanWithPrices } from "../utilities/submit-plan-with-prices";
 
 export const CreateSubscriptionPlanPage = () => {
   const { itemId } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const { mutateAsync: createPlan, isPending } = useCreateSubscriptionPlan();
   const { mutateAsync: createPrice, isPending: isPricing } = useCreateSubscriptionPrice();
   const listPath = `/app/${itemId ?? ""}/subscription/plans`;
+  const duplicatePlan = (location.state as { duplicatePlan?: SubscriptionPlan } | null)?.duplicatePlan;
+  const initialValues = useMemo(
+    () => duplicatePlan ? { ...planToFormValues(duplicatePlan), code: "" } : defaultSubscriptionPlanFormValues,
+    [duplicatePlan],
+  );
 
   return (
     <PlanBuilder
       mode="create"
-      defaultValues={defaultSubscriptionPlanFormValues}
-      title="Create subscription plan"
+      defaultValues={initialValues}
+      title={duplicatePlan ? `Duplicate ${duplicatePlan.displayName}` : "Create subscription plan"}
       description="A guided walkthrough — nothing is created until you review and confirm at the end."
       backTo={listPath}
       submitLabel="Create plan"

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-price-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-price-page.tsx
@@ -76,6 +76,7 @@ export const CreateSubscriptionPricePage = () => {
       unitAmountMinor: toMinorUnits(values.amount, values.currencyCode),
       interval: values.interval,
       intervalCount: values.intervalCount,
+      displayPriceNote: values.displayPriceNote?.trim() || undefined,
       quantityItemKey:
         values.quantityItemKey === FLAT_FEE ? undefined : values.quantityItemKey,
     };

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui-kits/select/select";
+import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { useOrganizationScope } from "../hooks/use-organization-scope";
+import { subscriptionService } from "../services/subscription.service";
+
+export const SubscriptionDiscountsPage = () => {
+  const { itemId } = useParams();
+  const organizationId = useOrganizationScope();
+  const queryClient = useQueryClient();
+  const [code, setCode] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [percent, setPercent] = useState("10");
+  const [kind, setKind] = useState<"percent" | "fixed">("percent");
+  const [amountMinor, setAmountMinor] = useState("");
+  const [currencyCode, setCurrencyCode] = useState("USD");
+  const [durationPeriods, setDurationPeriods] = useState("");
+  const [expiresAtUtc, setExpiresAtUtc] = useState("");
+  const [plans, setPlans] = useState("");
+
+  const discounts = useQuery({
+    queryKey: ["subscription-discounts", organizationId],
+    queryFn: () => subscriptionService.listDiscounts(organizationId),
+  });
+  const create = useMutation({
+    mutationFn: () => subscriptionService.createDiscount({
+      organizationId,
+      code: code.trim(),
+      displayName: displayName.trim(),
+      kind: kind === "percent" ? 0 : 1,
+      percentBasisPoints: kind === "percent" ? Math.round(Number(percent) * 100) : undefined,
+      amountMinor: kind === "fixed" ? Number(amountMinor) : undefined,
+      currencyCode: kind === "fixed" ? currencyCode : undefined,
+      durationPeriods: durationPeriods ? Number(durationPeriods) : undefined,
+      expiresAtUtc: expiresAtUtc ? new Date(expiresAtUtc).toISOString() : undefined,
+      applicablePlanCodes: plans.split(",").map((value) => value.trim()).filter(Boolean),
+    }),
+    onSuccess: async () => {
+      setCode(""); setDisplayName(""); setPlans("");
+      await queryClient.invalidateQueries({ queryKey: ["subscription-discounts"] });
+    },
+  });
+  const archive = useMutation({
+    mutationFn: (discountId: string) => subscriptionService.archiveDiscount(discountId, organizationId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["subscription-discounts"] }),
+  });
+
+  return (
+    <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
+      <SubscriptionPlanPageHeader
+        title="Subscription discounts"
+        description="Reusable discount codes are validated at signup and copied onto each subscription."
+        backTo={`/app/${itemId ?? ""}/subscription/plans`}
+      />
+      <Card className="space-y-4 rounded-xl">
+        <h2 className="font-semibold">Create discount</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div><Label htmlFor="discount-code">Code</Label><Input id="discount-code" value={code} onChange={(event) => setCode(event.target.value)} placeholder="launch25" /></div>
+          <div><Label htmlFor="discount-name">Display name</Label><Input id="discount-name" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Launch offer" /></div>
+          <div><Label>Kind</Label><Select value={kind} onValueChange={(value) => setKind(value as "percent" | "fixed")}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="percent">Percentage</SelectItem><SelectItem value="fixed">Fixed amount</SelectItem></SelectContent></Select></div>
+          {kind === "percent" ? <div><Label htmlFor="discount-percent">Percent off</Label><Input id="discount-percent" type="number" min={0.01} max={100} value={percent} onChange={(event) => setPercent(event.target.value)} /></div> : <div className="grid grid-cols-2 gap-2"><div><Label htmlFor="discount-amount">Minor units off</Label><Input id="discount-amount" type="number" min={1} value={amountMinor} onChange={(event) => setAmountMinor(event.target.value)} /></div><div><Label htmlFor="discount-currency">Currency</Label><Input id="discount-currency" maxLength={3} value={currencyCode} onChange={(event) => setCurrencyCode(event.target.value.toUpperCase())} /></div></div>}
+          <div><Label htmlFor="discount-plans">Plan codes (optional)</Label><Input id="discount-plans" value={plans} onChange={(event) => setPlans(event.target.value)} placeholder="pro, max-5x" /></div>
+          <div><Label htmlFor="discount-duration">Duration in billing periods (optional)</Label><Input id="discount-duration" type="number" min={1} value={durationPeriods} onChange={(event) => setDurationPeriods(event.target.value)} /></div>
+          <div><Label htmlFor="discount-expiry">Expires at (optional)</Label><Input id="discount-expiry" type="datetime-local" value={expiresAtUtc} onChange={(event) => setExpiresAtUtc(event.target.value)} /></div>
+        </div>
+        {create.error && <p className="text-sm text-destructive">{create.error.message}</p>}
+        <Button disabled={!code.trim() || !displayName.trim() || create.isPending} onClick={() => create.mutate()}>{create.isPending ? "Creating…" : "Create discount"}</Button>
+      </Card>
+      <Card className="rounded-xl p-0">
+        <div className="border-b p-4 font-semibold">Discount catalogue</div>
+        <div className="divide-y">
+          {(discounts.data ?? []).map((discount) => (
+            <div key={discount.discountId} className="flex items-center justify-between gap-4 p-4">
+              <div><p className="font-medium">{discount.displayName} <code className="text-xs">{discount.code}</code></p><p className="text-xs text-muted-foreground">{discount.percentBasisPoints ? `${discount.percentBasisPoints / 100}% off` : `${discount.amountMinor} ${discount.currencyCode} minor units off`} · {discount.status}</p></div>
+              {discount.status === "Active" && <Button variant="ghost" size="sm" onClick={() => archive.mutate(discount.discountId)}>Retire</Button>}
+            </div>
+          ))}
+          {!discounts.isLoading && !(discounts.data?.length) && <p className="p-4 text-sm text-muted-foreground">No discounts authored yet.</p>}
+        </div>
+      </Card>
+    </main>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -132,6 +132,15 @@ export const SubscriptionPlanDetailPage = () => {
         backTo={listPath}
         actions={
           <div className="flex flex-wrap gap-2">
+            <Button variant="outline" asChild>
+              <Link
+                to={withOrganizationScope(`${basePath}/create`, plan.organizationId)}
+                state={{ duplicatePlan: plan }}
+              >
+                <Copy className="mr-2 h-4 w-4" />
+                Duplicate plan
+              </Link>
+            </Button>
             {/* Disabled rather than hidden: someone looking for the edit button needs to be told
                 why it is gone, not left to wonder whether it was ever there. */}
             {plan.hasSubscribers ? (
@@ -257,6 +266,7 @@ export const SubscriptionPlanDetailPage = () => {
                 {plan.prices.map((price) => (
                   <Card key={price.priceId} className="rounded-lg">
                     <p className="font-medium">{formatPrice(price)}</p>
+                    {price.displayPriceNote && <p className="text-xs text-muted-foreground">{price.displayPriceNote}</p>}
                     {/* Subscribing names the price by this id, so leaving it off the page meant
                         nobody could subscribe without reading the API first. */}
                     <IdentifierField label="Price id" value={price.priceId} />

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
@@ -75,6 +75,19 @@ export const SubscriptionPlanListPage = () => {
     );
   }, [plans, search]);
 
+  const catalogueGroups = useMemo(() => {
+    const groups = new Map<string, typeof filteredPlans>();
+    filteredPlans.forEach((plan) => {
+      const key = plan.familyCode ? `family:${plan.familyCode}` : `plan:${plan.planId}`;
+      groups.set(key, [...(groups.get(key) ?? []), plan]);
+    });
+    return [...groups.entries()].map(([key, levels]) => ({
+      key,
+      familyCode: key.startsWith("family:") ? key.slice(7) : null,
+      levels: levels.sort((left, right) => (left.familyRank ?? 0) - (right.familyRank ?? 0)),
+    }));
+  }, [filteredPlans]);
+
   return (
     <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
       <SubscriptionPlanPageHeader
@@ -82,6 +95,11 @@ export const SubscriptionPlanListPage = () => {
         description="What your tenant sells — configure once here, then subscribe organizations to it from your own product."
         actions={
           <>
+            <Button variant="outline" asChild>
+              <Link to={withOrganizationScope(`/app/${itemId ?? ""}/subscription/discounts`, organizationScope)}>
+                Discounts
+              </Link>
+            </Button>
             <Button
               variant="outline"
               className="bg-background/80"
@@ -195,20 +213,29 @@ export const SubscriptionPlanListPage = () => {
               )}
             </div>
           ) : (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {filteredPlans.map((plan) => (
-                <PlanCard
-                  key={plan.planId}
-                  plan={plan}
-                  organizationLabel={organizationName(plan.organizationId)}
-                  // The plan's own organization, not the current filter: a tenant-wide plan
-                  // needs no scope, and an organization's plan stays reachable however it
-                  // was reached.
-                  detailPath={withOrganizationScope(
-                    `${basePath}/${encodeURIComponent(plan.planId)}`,
-                    plan.organizationId,
+            <div className="space-y-4">
+              {catalogueGroups.map((group) => (
+                <section key={group.key} className={group.familyCode ? "rounded-xl border p-4" : ""}>
+                  {group.familyCode && (
+                    <div className="mb-3">
+                      <h3 className="font-semibold">{group.levels[0]?.displayName}</h3>
+                      <p className="text-xs text-muted-foreground">{group.familyCode} · {group.levels.length} levels</p>
+                    </div>
                   )}
-                />
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {group.levels.map((plan) => (
+                      <PlanCard
+                        key={plan.planId}
+                        plan={plan}
+                        organizationLabel={organizationName(plan.organizationId)}
+                        detailPath={withOrganizationScope(
+                          `${basePath}/${encodeURIComponent(plan.planId)}`,
+                          plan.organizationId,
+                        )}
+                      />
+                    ))}
+                  </div>
+                </section>
               ))}
             </div>
           )}

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -121,9 +121,6 @@ const trialGrantSchema = z.object({
   includedQuantity: z.coerce.number().int().min(0),
 });
 
-export const PRICING_SHAPE_OPTIONS = ["seats", "usage", "both"] as const;
-export type PricingShape = (typeof PRICING_SHAPE_OPTIONS)[number];
-
 /** What identifies a price to the server, so two rows that would collide can be caught here. */
 const priceTerms = (price: z.infer<typeof subscriptionPriceFieldsSchema>) =>
   `${price.currencyCode}|${price.interval}|${price.intervalCount}|${price.quantityItemKey}`;
@@ -161,7 +158,13 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
     organizationId: z.string().min(1, "Choose an organization."),
     trialDays: z.coerce.number().int().min(1).max(365).optional(),
     trialRequiresPaymentMethod: z.boolean(),
-    pricingShape: z.enum(PRICING_SHAPE_OPTIONS).optional(),
+    usageInterval: z.coerce.number().int().min(0).max(3),
+    usageIntervalCount: z.coerce.number().int().min(1).max(100),
+    familyCode: z.string().trim().max(SUBSCRIPTION_KEY_MAX_LENGTH).optional().or(z.literal("")),
+    familyRank: z.preprocess(
+      (value) => value === "" ? undefined : value,
+      z.coerce.number().int().min(0).optional(),
+    ),
     quantityItems: z.array(quantityItemSchema),
     meters: z.array(meterSchema),
     entitlements: z.array(entitlementSchema),
@@ -174,6 +177,14 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
         code: z.ZodIssueCode.custom,
         path: ["featuresJson"],
         message: "Features must be a valid JSON object, e.g. {\"betaAccess\": true}.",
+      });
+    }
+
+    if (Boolean(plan.familyCode) !== (plan.familyRank !== undefined)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [plan.familyCode ? "familyRank" : "familyCode"],
+        message: "Family code and rank must be supplied together.",
       });
     }
 
@@ -248,7 +259,10 @@ export const defaultSubscriptionPlanFormValues: CreateSubscriptionPlanFormValues
   organizationId: TENANT_WIDE_ORGANIZATION,
   trialDays: undefined,
   trialRequiresPaymentMethod: true,
-  pricingShape: undefined,
+  usageInterval: 2,
+  usageIntervalCount: 1,
+  familyCode: "",
+  familyRank: undefined,
   quantityItems: [],
   meters: [],
   entitlements: [],

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
@@ -22,6 +22,7 @@ export const subscriptionPriceFieldsSchema = z.object({
   amount: z.coerce.number().min(0, "Enter an amount of zero or more."),
   interval: z.coerce.number().int().min(0).max(3),
   intervalCount: z.coerce.number().int().min(1).max(36),
+  displayPriceNote: z.string().trim().max(200).optional().or(z.literal("")),
   quantityItemKey: z.string().min(1),
 });
 
@@ -34,5 +35,6 @@ export const defaultSubscriptionPriceFormValues: CreateSubscriptionPriceFormValu
   amount: 0,
   interval: 2,
   intervalCount: 1,
+  displayPriceNote: "",
   quantityItemKey: FLAT_FEE,
 };

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
@@ -6,6 +6,8 @@ import {
 import type {
   CreateSubscriptionPlanRequest,
   CreateSubscriptionPriceRequest,
+  CreateSubscriptionDiscountRequest,
+  SubscriptionDiscount,
   SubscriptionPlan,
   UpdateSubscriptionPlanRequest,
 } from "../models/subscription-plan.model";
@@ -142,6 +144,32 @@ class SubscriptionService {
       );
     }
 
+    return response.data;
+  }
+
+  async listDiscounts(organizationId?: string): Promise<SubscriptionDiscount[]> {
+    const query = organizationId ? `?organizationId=${encodeURIComponent(organizationId)}` : "";
+    const response = await serviceInstances.utitlitiesService.get<SubscriptionApiResponse<SubscriptionDiscount[]>>(
+      `/api/subscription-discounts${query}`,
+    );
+    if (!response.success || !response.data) throw new Error(response.error?.message || "Discounts could not be loaded.");
+    return response.data;
+  }
+
+  async createDiscount(request: CreateSubscriptionDiscountRequest): Promise<SubscriptionDiscount> {
+    const response = await serviceInstances.utitlitiesService.post<SubscriptionApiResponse<SubscriptionDiscount>>(
+      "/api/subscription-discounts", request,
+    );
+    if (!response.success || !response.data) throw new Error(response.error?.message || "The discount could not be created.");
+    return response.data;
+  }
+
+  async archiveDiscount(discountId: string, organizationId?: string): Promise<SubscriptionDiscount> {
+    const query = organizationId ? `?organizationId=${encodeURIComponent(organizationId)}` : "";
+    const response = await serviceInstances.utitlitiesService.put<SubscriptionApiResponse<SubscriptionDiscount>>(
+      `/api/subscription-discounts/${encodeURIComponent(discountId)}/archive${query}`, {},
+    );
+    if (!response.success || !response.data) throw new Error(response.error?.message || "The discount could not be retired.");
     return response.data;
   }
 }

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -81,12 +81,6 @@ describe("planToFormValues", () => {
     ]);
   });
 
-  it("opens on a pricing shape that reveals what the plan actually has", () => {
-    expect(planToFormValues(storedPlan()).pricingShape).toBe("both");
-    expect(planToFormValues(storedPlan({ quantityItems: [] })).pricingShape).toBe("usage");
-    expect(planToFormValues(storedPlan({ meters: [] })).pricingShape).toBe("seats");
-  });
-
   it("starts with no price rows, because saving does not touch existing prices", () => {
     expect(planToFormValues(storedPlan()).prices).toEqual([]);
   });

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -1,5 +1,6 @@
 import { TENANT_WIDE_ORGANIZATION } from "../constants/subscription.constants";
 import {
+  BILLING_INTERVAL,
   ENTITLEMENT_LIMIT_KIND,
   METER_AGGREGATION,
   type CreateSubscriptionPlanRequest,
@@ -19,6 +20,10 @@ const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
   featuresJson: values.featuresJson?.trim() || undefined,
   trialDays: values.trialDays,
   trialRequiresPaymentMethod: values.trialRequiresPaymentMethod,
+  usageInterval: values.usageInterval,
+  usageIntervalCount: values.usageIntervalCount,
+  familyCode: values.familyCode?.trim() || undefined,
+  familyRank: values.familyRank,
   quantityItems: values.quantityItems.map((item) => ({
     itemKey: item.itemKey.trim(),
     unitLabel: item.unitLabel.trim(),
@@ -99,14 +104,12 @@ export const planToFormValues = (
   organizationId: plan.organizationId ?? TENANT_WIDE_ORGANIZATION,
   trialDays: plan.trialDays ?? undefined,
   trialRequiresPaymentMethod: plan.trialRequiresPaymentMethod,
-  // The step reveals its sections from this, so a plan with meters has to open on the shape that
-  // shows them — otherwise editing a usage plan starts by looking like it has no meters at all.
-  pricingShape:
-    plan.quantityItems.length > 0 && plan.meters.length > 0
-      ? "both"
-      : plan.meters.length > 0
-        ? "usage"
-        : "seats",
+  usageInterval: plan.usageInterval
+    ? (BILLING_INTERVAL[plan.usageInterval] ?? BILLING_INTERVAL.Month)
+    : BILLING_INTERVAL.Month,
+  usageIntervalCount: plan.usageIntervalCount ?? 1,
+  familyCode: plan.familyCode ?? "",
+  familyRank: plan.familyRank ?? undefined,
   quantityItems: plan.quantityItems.map((item) => ({
     itemKey: item.itemKey,
     unitLabel: item.unitLabel,

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
@@ -48,7 +48,8 @@ export const submitPlanWithPrices = async <TPlanRequest,>({
         currencyCode: price.currencyCode,
         unitAmountMinor: toMinorUnits(price.amount, price.currencyCode),
         interval: price.interval,
-        intervalCount: price.intervalCount,
+          intervalCount: price.intervalCount,
+          displayPriceNote: price.displayPriceNote?.trim() || undefined,
         quantityItemKey:
           price.quantityItemKey === FLAT_FEE ? undefined : price.quantityItemKey,
       });

--- a/client/app/router.tsx
+++ b/client/app/router.tsx
@@ -14,6 +14,7 @@ import SubscriptionPlanCreateRoute from "./routes/dashboard/subscription-plan-cr
 import SubscriptionPlanDetailRoute from "./routes/dashboard/subscription-plan-detail";
 import SubscriptionPlanPriceCreateRoute from "./routes/dashboard/subscription-plan-price-create";
 import SubscriptionPlanEditRoute from "./routes/dashboard/subscription-plan-edit";
+import SubscriptionDiscountsRoute from "./routes/dashboard/subscription-discounts";
 import {
   AuthResolver,
   PublicGuard,
@@ -136,6 +137,10 @@ export const router = createBrowserRouter([
                   {
                     path: "subscription/plans/create",
                     element: <SubscriptionPlanCreateRoute />,
+                  },
+                  {
+                    path: "subscription/discounts",
+                    element: <SubscriptionDiscountsRoute />,
                   },
                   {
                     path: "subscription/plans/:planId",

--- a/client/app/routes/dashboard/subscription-discounts.tsx
+++ b/client/app/routes/dashboard/subscription-discounts.tsx
@@ -1,0 +1,5 @@
+import { SubscriptionDiscountsPage } from "@blocks-utilities/subscription";
+
+export default function SubscriptionDiscountsRoute() {
+  return <SubscriptionDiscountsPage />;
+}

--- a/server/Api/Controllers/SubscriptionDiscountsController.cs
+++ b/server/Api/Controllers/SubscriptionDiscountsController.cs
@@ -1,0 +1,35 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+
+namespace Api.Controllers;
+
+[ApiController, Authorize, Route("subscription-discounts")]
+public sealed class SubscriptionDiscountsController : ControllerBase
+{
+    private readonly IDiscountCatalogueService _catalogue;
+    public SubscriptionDiscountsController(IDiscountCatalogueService catalogue) => _catalogue = catalogue;
+
+    [HttpGet]
+    public async Task<IActionResult> List([FromQuery] string? organizationId, CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        return (await _catalogue.ListAsync(organizationId, correlationId, cancellationToken)).ToActionResult(correlationId);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateDiscountRequest request, CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        return (await _catalogue.CreateAsync(request, correlationId, cancellationToken)).ToActionResult(correlationId);
+    }
+
+    [HttpPut("{discountId}/archive")]
+    public async Task<IActionResult> Archive(string discountId, [FromQuery] string? organizationId, CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        return (await _catalogue.ArchiveAsync(discountId, organizationId, correlationId, cancellationToken)).ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -585,6 +585,8 @@
             <tr><td>code</td><td class="type">string</td><td class="prose">The stable key <strong>you</strong> subscribe by. Lowercase letters, digits, hyphens, underscores. Never changes.</td></tr>
             <tr><td>displayName</td><td class="type">string</td><td class="prose">Shown to subscribers.</td></tr>
             <tr><td>description</td><td class="type">string?</td><td class="prose">Free text.</td></tr>
+            <tr><td>familyCode / familyRank</td><td class="type">string? / int?</td><td class="prose">Optional product family and ordered level. Each level remains an ordinary plan.</td></tr>
+            <tr><td>usageInterval / usageIntervalCount</td><td class="type">string / int</td><td class="prose">The single allowance reset window, independent of price cadence. Defaults to one month.</td></tr>
             <tr><td>organizationId</td><td class="type">string?</td><td class="prose">Which organization the plan is sold to. <code>null</code> means the whole tenant.</td></tr>
             <tr><td>featuresJson</td><td class="type">string?</td><td class="prose">Arbitrary JSON, stored verbatim and returned untouched. Nothing interprets it — this is where your product puts its own flags.</td></tr>
             <tr><td>trialDays</td><td class="type">int?</td><td class="prose">Trial length. <code>null</code> means no trial.</td></tr>
@@ -611,6 +613,7 @@
             <tr><td>unitAmountMinor</td><td class="type">long</td><td class="prose">Minor units — <code>300</code> is EUR 3.00. Never a decimal: the exponent belongs to the currency.</td></tr>
             <tr><td>interval</td><td class="type">string</td><td class="prose"><code>Day</code>, <code>Week</code>, <code>Month</code>, <code>Year</code>.</td></tr>
             <tr><td>intervalCount</td><td class="type">int</td><td class="prose">Paired with the interval. <code>3</code> + <code>Month</code> is quarterly.</td></tr>
+            <tr><td>displayPriceNote</td><td class="type">string?</td><td class="prose">Authored presentation such as "$17/month, billed annually"; clients should display it rather than recompute it.</td></tr>
             <tr><td>quantityItemKey</td><td class="type">string?</td><td class="prose"><code>null</code> is a flat fee. Otherwise the amount is multiplied by that item's quantity.</td></tr>
             <tr><td>taxRateBasisPoints</td><td class="type">int?</td><td class="prose">Authoring only. Basis points out of 10,000 — <code>770</code> is 7.7%. Applied after discount, before credit.</td></tr>
           </tbody>
@@ -1019,6 +1022,25 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         </div>
       </div>
 
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">PUT</span><span class="path">/api/subscription-plans/prices/{priceId}/archive</span></div>
+        <div class="endpoint-body"><p>Retires a price without changing subscriptions that already hold its snapshot.</p></div>
+      </div>
+
+      <h3>Discount catalogue</h3>
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscription-discounts</span></div>
+        <div class="endpoint-body"><p>Authors a tenant-wide or organization-scoped percentage/fixed discount. Optional plan-code applicability, expiry and duration are validated at subscribe time.</p></div>
+      </div>
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscription-discounts</span></div>
+        <div class="endpoint-body"><p>Lists the visible discount catalogue. Organization-owned codes override tenant-wide codes of the same name.</p></div>
+      </div>
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">PUT</span><span class="path">/api/subscription-discounts/{discountId}/archive</span></div>
+        <div class="endpoint-body"><p>Retires the code for future subscriptions. Existing subscriptions keep their copied discount terms.</p></div>
+      </div>
+
       <h3 id="api-subs">Subscriptions</h3>
 
       <div class="endpoint">
@@ -1092,8 +1114,9 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
 }</code></pre>
           <h4>Returns</h4>
           <p>
-            <code>200</code> · <code>400</code> · <code>404</code> · <code>409</code> currency or
-            interval mismatch, no stored payment method, or not eligible.
+            <code>200</code> · <code>400</code> · <code>404</code> · <code>409</code> currency
+            mismatch, no stored payment method, or not eligible. Billing interval changes are
+            allowed and rebuild both schedules from the change instant.
           </p>
         </div>
       </div>
@@ -1119,7 +1142,8 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       <div class="endpoint">
         <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscriptions/invoices</span></div>
         <div class="endpoint-body">
-          <p>Lists the caller's settled renewal invoices, newest first. Every item includes an authenticated PDF download URL; provider invoice identifiers and Stripe's permanent bearer-style document links are never exposed.</p>
+          <p>Lists the caller's settled renewal, plan-change and usage invoices, newest first. Every item includes an authenticated PDF download URL; provider invoice identifiers and Stripe's permanent bearer-style document links are never exposed.</p>
+          <p><strong>The first payment is not an invoice.</strong> Signup remains a Stripe Checkout session backed by a PaymentIntent, so invoice history begins with the first renewal. Clients must not promise a signup invoice or treat an empty history immediately after checkout as an error.</p>
           <h4>Query</h4>
           <div class="table-wrap">
             <table>
@@ -1161,6 +1185,12 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       </div>
 
       <h3 id="api-usage">Usage</h3>
+      <div class="callout">
+        <strong>Independent allowance windows.</strong> A plan declares <code>usageInterval</code>
+        and <code>usageIntervalCount</code> (monthly by default). Meter allowances reset on that
+        cadence even when the recurring price bills on another cadence. Both schedules are
+        snapshotted and rebuilt when a subscriber changes plan.
+      </div>
 
       <div class="endpoint">
         <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscription-usage</span></div>
@@ -1321,7 +1351,6 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <tr><td>subscription_quantity_duplicated</td><td class="prose">The same <code>itemKey</code> appears twice.</td></tr>
             <tr><td>subscription_quantity_item_unknown</td><td class="prose">A quantity the plan does not define.</td></tr>
             <tr><td>subscription_plan_change_currency_mismatch</td><td class="prose">Target price is in another currency.</td></tr>
-            <tr><td>subscription_plan_change_interval_mismatch</td><td class="prose">Target price bills on another cadence.</td></tr>
             <tr><td>subscription_plan_change_no_payment_method</td><td class="prose">An upgrade needs a stored card to charge the difference.</td></tr>
             <tr><td>subscription_plan_in_use</td><td class="prose">Editing a plan somebody has subscribed to.</td></tr>
             <tr><td>subscription_organization_missing</td><td class="prose">The caller's organization could not be resolved.</td></tr>

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -813,7 +813,13 @@ stateDiagram-v2
         An upgrade is charged straight away for the prorated difference. A downgrade is
         <strong>credited toward future renewals rather than refunded</strong>. A trial has paid nothing
         yet, so its plan simply swaps with no charge or credit either way. Both plans must share a
-        currency and interval.
+        currency; changing interval is allowed.
+      </p>
+      <p class="callout">
+        A plan change starts a full target billing period immediately. Monthly → annual therefore
+        charges the full new annual period at the change instant, less the unused value of the old
+        monthly period and any banked credit. The outgoing usage window is closed and rated under
+        its original allowance and rates before usage continues in the target plan's new window.
       </p>
 
       <h3>6 · Renewal succeeds, or enters dunning</h3>
@@ -1116,7 +1122,9 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
           <p>
             <code>200</code> · <code>400</code> · <code>404</code> · <code>409</code> currency
             mismatch, no stored payment method, or not eligible. Billing interval changes are
-            allowed and rebuild both schedules from the change instant.
+            allowed and rebuild both schedules from the change instant. The complete target period
+            is charged immediately, less unused old-period value; the outgoing usage window is
+            queued atomically for rating under its original terms.
           </p>
         </div>
       </div>

--- a/server/Payment.DomainService/Models/PaymentQueryRecord.cs
+++ b/server/Payment.DomainService/Models/PaymentQueryRecord.cs
@@ -8,5 +8,7 @@ public sealed class PaymentQueryRecord
     public string CurrencyCode { get; init; } = string.Empty;
     public DateTime PaymentDateUtc { get; init; }
     public string PaymentStatus { get; init; } = string.Empty;
+    public string PaymentFlow { get; init; } = string.Empty;
+    public bool HasInvoice { get; init; }
     public bool HasPendingRefund { get; init; }
 }

--- a/server/Payment.DomainService/Repositories/PaymentQueryRepository.cs
+++ b/server/Payment.DomainService/Repositories/PaymentQueryRepository.cs
@@ -43,6 +43,8 @@ public sealed class PaymentQueryRepository :
                 CurrencyCode = payment.CurrencyCode,
                 PaymentDateUtc = payment.PaymentDate,
                 PaymentStatus = payment.PaymentStatus,
+                PaymentFlow = payment.PaymentFlow,
+                HasInvoice = payment.ProviderInvoiceId != null && payment.ProviderInvoiceId != "",
                 HasPendingRefund =
                     (payment.Refunds ??
                      new List<PaymentRefund>())
@@ -98,10 +100,11 @@ public sealed class PaymentQueryRepository :
         // deliberately; see PaymentQueryCriteria.RequestedOrganizationId.
         if (!string.IsNullOrWhiteSpace(criteria.RequestedOrganizationId))
         {
-            filters.Add(
+            filters.Add(Builders<PaymentDetail>.Filter.Or(
                 Builders<PaymentDetail>.Filter.Eq(
-                    payment => payment.OrganizationId,
-                    criteria.RequestedOrganizationId));
+                    payment => payment.OrganizationId, criteria.RequestedOrganizationId),
+                Builders<PaymentDetail>.Filter.Eq(
+                    payment => payment.CustomerOrganizationId, criteria.RequestedOrganizationId)));
         }
 
         // Otherwise an organization sees its own payments and the ones made before
@@ -116,6 +119,9 @@ public sealed class PaymentQueryRepository :
                 Builders<PaymentDetail>.Filter.Or(
                     Builders<PaymentDetail>.Filter.Eq(
                         payment => payment.OrganizationId,
+                        criteria.OrganizationId),
+                    Builders<PaymentDetail>.Filter.Eq(
+                        payment => payment.CustomerOrganizationId,
                         criteria.OrganizationId),
                     Builders<PaymentDetail>.Filter.Eq(
                         payment => payment.OrganizationId,

--- a/server/Payment.DomainService/Responses/PaymentListItemResponse.cs
+++ b/server/Payment.DomainService/Responses/PaymentListItemResponse.cs
@@ -8,5 +8,7 @@ public sealed class PaymentListItemResponse
     public string CurrencyCode { get; init; } = string.Empty;
     public DateTime PaymentDateUtc { get; init; }
     public string PaymentStatus { get; init; } = string.Empty;
+    public string PaymentFlow { get; init; } = string.Empty;
+    public bool HasInvoice { get; init; }
     public bool HasPendingRefund { get; init; }
 }

--- a/server/Payment.DomainService/Services/PaymentQueryResponseMapper.cs
+++ b/server/Payment.DomainService/Services/PaymentQueryResponseMapper.cs
@@ -27,6 +27,8 @@ public sealed class PaymentQueryResponseMapper :
                 CurrencyCode = record.CurrencyCode,
                 PaymentDateUtc = record.PaymentDateUtc.ToUniversalTime(),
                 PaymentStatus = record.PaymentStatus,
+                PaymentFlow = record.PaymentFlow,
+                HasInvoice = record.HasInvoice,
                 HasPendingRefund = record.HasPendingRefund
             })
             .ToArray();

--- a/server/Subscription.DomainService/Entities/Discount.cs
+++ b/server/Subscription.DomainService/Entities/Discount.cs
@@ -1,0 +1,20 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+[BsonIgnoreExtraElements]
+public sealed class Discount
+{
+    [BsonId] public string ItemId { get; set; } = Guid.NewGuid().ToString();
+    public string TenantId { get; set; } = string.Empty;
+    public string? OrganizationId { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public CatalogueStatus Status { get; set; } = CatalogueStatus.Active;
+    public DiscountTerms Terms { get; set; } = new();
+    public string? CurrencyCode { get; set; }
+    public List<string> ApplicablePlanCodes { get; set; } = [];
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Entities/DiscountTerms.cs
+++ b/server/Subscription.DomainService/Entities/DiscountTerms.cs
@@ -7,7 +7,8 @@ namespace Subscription.DomainService.Entities;
 /// A reduction applied to this subscription's charges.
 /// </summary>
 /// <remarks>
-/// Held as data in phase 1 and applied to the first charge. Percentages are basis points so a
+/// Snapshotted from the discount catalogue and applied to signup, renewal and proration.
+/// Percentages are basis points so a
 /// third off is exact rather than 33.33 rounded somewhere unpredictable.
 /// </remarks>
 [BsonIgnoreExtraElements]

--- a/server/Subscription.DomainService/Entities/PendingUsagePeriod.cs
+++ b/server/Subscription.DomainService/Entities/PendingUsagePeriod.cs
@@ -1,0 +1,16 @@
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// Immutable rating terms for a usage window cut short by a plan change.
+/// Stored on the subscription in the same compare-and-set that installs the new schedule.
+/// </summary>
+public sealed class PendingUsagePeriod
+{
+    public string PeriodKey { get; set; } = string.Empty;
+    public DateTime PeriodStartUtc { get; set; }
+    public DateTime PeriodEndUtc { get; set; }
+    public PlanSnapshot Plan { get; set; } = new();
+    public PriceSnapshot Price { get; set; } = new();
+    public string CurrencyCode { get; set; } = string.Empty;
+    public string CorrelationId { get; set; } = string.Empty;
+}

--- a/server/Subscription.DomainService/Entities/Plan.cs
+++ b/server/Subscription.DomainService/Entities/Plan.cs
@@ -30,6 +30,14 @@ public sealed class Plan
 
     public string? Description { get; set; }
 
+    public string? FamilyCode { get; set; }
+
+    public int? FamilyRank { get; set; }
+
+    public BillingInterval UsageInterval { get; set; } = BillingInterval.Month;
+
+    public int UsageIntervalCount { get; set; } = 1;
+
     public CatalogueStatus Status { get; set; } = CatalogueStatus.Draft;
 
     /// <summary>

--- a/server/Subscription.DomainService/Entities/PlanSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PlanSnapshot.cs
@@ -1,4 +1,5 @@
 using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
 
 namespace Subscription.DomainService.Entities;
 
@@ -22,6 +23,10 @@ public sealed class PlanSnapshot
     public string DisplayName { get; set; } = string.Empty;
 
     public string? FeaturesJson { get; set; }
+
+    public BillingInterval UsageInterval { get; set; } = BillingInterval.Month;
+
+    public int UsageIntervalCount { get; set; } = 1;
 
     public List<PlanEntitlement> Entitlements { get; set; } = [];
 

--- a/server/Subscription.DomainService/Entities/Price.cs
+++ b/server/Subscription.DomainService/Entities/Price.cs
@@ -32,6 +32,8 @@ public sealed class Price
 
     public int IntervalCount { get; set; } = 1;
 
+    public string? DisplayPriceNote { get; set; }
+
     /// <summary>
     /// Which quantity item this price charges for. Null is a flat fee that does not multiply.
     /// </summary>

--- a/server/Subscription.DomainService/Entities/PriceSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PriceSnapshot.cs
@@ -23,6 +23,8 @@ public sealed class PriceSnapshot
 
     public int IntervalCount { get; set; } = 1;
 
+    public string? DisplayPriceNote { get; set; }
+
     public string? QuantityItemKey { get; set; }
 
     public int? TaxRateBasisPoints { get; set; }

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -100,6 +100,12 @@ public sealed class SubscriptionDetail
 
     public DateTime? NextUsageBillingAtUtc { get; set; }
 
+    /// <summary>
+    /// Usage windows atomically detached by plan changes and still awaiting rating under their
+    /// original plan terms. This prevents both lost overage and a free allowance reset.
+    /// </summary>
+    public List<PendingUsagePeriod> PendingUsagePeriods { get; set; } = [];
+
     public DateTime? ActivatedAtUtc { get; set; }
 
     /// <summary>Whether cancellation has been requested but not yet taken effect.</summary>

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -91,6 +91,32 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     {
         var periodsClosed = 0;
 
+        // A plan change detaches its outgoing window atomically with the schedule swap. Rate
+        // those snapshots first: their counters are still addressed by the old period key and
+        // their price/allowance must come from the old plan, not the newly installed one.
+        foreach (var pending in subscription.PendingUsagePeriods.ToList())
+        {
+            var ratingSubscription = new SubscriptionDetail
+            {
+                ItemId = subscription.ItemId,
+                TenantId = subscription.TenantId,
+                OrganizationId = subscription.OrganizationId,
+                BillingAccountId = subscription.BillingAccountId,
+                Plan = pending.Plan,
+                Price = pending.Price,
+                CurrencyCode = pending.CurrencyCode,
+                CorrelationId = pending.CorrelationId
+            };
+
+            await EnsureInvoiceAsync(ratingSubscription, pending.PeriodKey, cancellationToken);
+            await _subscriptions.TryRemovePendingUsagePeriodAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                pending.PeriodKey,
+                cancellationToken);
+            periodsClosed++;
+        }
+
         for (var iteration = 0; iteration < MaximumPeriodsPerSweep; iteration++)
         {
             if (subscription.CurrentUsagePeriodEndUtc > now)
@@ -99,7 +125,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             }
 
             var periodKey = PeriodKey.Create(
-                BillingInterval.Month,
+                subscription.UsageSchedule.Interval,
                 subscription.CurrentUsagePeriodStartUtc);
 
             await EnsureInvoiceAsync(subscription, periodKey, cancellationToken);

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -504,6 +504,33 @@ The sweep only matters at the first renewal, a whole billing period later.
 
 ## Settings
 
+## Catalogue capabilities
+
+Plans may declare one usage allowance cadence independently of their fee cadence through
+`UsageInterval` and `UsageIntervalCount`. Both values are copied to `PlanSnapshot`; changing the
+catalogue later cannot move an existing subscriber's reset window. Plan changes rebuild both the
+fee and usage schedules from the change instant and permit monthly/annual moves when currency is
+unchanged.
+
+`FamilyCode` and `FamilyRank` group ordinary plans into ordered product levels. A level remains a
+plan—there is no second tier entity. Prices may carry `DisplayPriceNote` for authored presentation
+such as "$17/month, billed annually".
+
+Discounts are authored at `/api/subscription-discounts`, optionally scoped to an organization and
+optionally restricted to plan codes. Unknown, retired, expired, inapplicable, and wrong-currency
+fixed discounts are rejected. Accepted terms are copied onto the subscription, so retiring the
+catalogue entry never changes an existing subscriber's renewal.
+
+## Invoice boundary
+
+The signup payment remains a hosted checkout/PaymentIntent and has no Stripe invoice. Invoice
+history therefore begins at the first settled renewal (and also includes later plan-change and
+usage invoices). `GET /api/subscriptions/invoices` returns authenticated PDF download links; the
+provider's permanent document URL is never exposed.
+
+`PUT /api/subscription-plans/prices/{priceId}/archive` retires a price without changing any
+subscription that already holds its snapshot.
+
 Under the `Subscription` section. The ones whose default is a decision:
 
 | Setting | Default | Why it matters |

--- a/server/Subscription.DomainService/Repositories/ISubscriptionDiscountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionDiscountRepository.cs
@@ -1,0 +1,11 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionDiscountRepository
+{
+    Task<bool> TryCreateAsync(Discount discount, CancellationToken cancellationToken);
+    Task<Discount?> FindActiveByCodeAsync(string tenantId, string? organizationId, string code, CancellationToken cancellationToken);
+    Task<IReadOnlyList<Discount>> ListAsync(string tenantId, string? organizationId, CancellationToken cancellationToken);
+    Task<bool> TryArchiveAsync(string tenantId, string discountId, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -85,6 +85,7 @@ public interface ISubscriptionRepository
         PlanSnapshot newPlan,
         PriceSnapshot newPrice,
         List<SubscriptionQuantityItem> newQuantityItems,
+        SubscriptionPlanSchedule newSchedule,
         long newCreditBalanceMinor,
         string? planChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -86,9 +86,16 @@ public interface ISubscriptionRepository
         PriceSnapshot newPrice,
         List<SubscriptionQuantityItem> newQuantityItems,
         SubscriptionPlanSchedule newSchedule,
+        PendingUsagePeriod outgoingUsagePeriod,
         long newCreditBalanceMinor,
         string? planChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
+        CancellationToken cancellationToken);
+
+    Task<bool> TryRemovePendingUsagePeriodAsync(
+        string tenantId,
+        string subscriptionId,
+        string periodKey,
         CancellationToken cancellationToken);
 
     /// <summary>Whether anything has ever subscribed to a plan, whatever became of it since.</summary>

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -15,6 +15,7 @@ internal static class SubscriptionCollections
 {
     public const string Plans = "SubscriptionPlans";
     public const string Prices = "SubscriptionPrices";
+    public const string Discounts = "SubscriptionDiscounts";
     public const string BillingAccounts = "SubscriptionBillingAccounts";
     public const string Subscriptions = "Subscriptions";
     public const string UsageRecords = "SubscriptionUsageRecords";

--- a/server/Subscription.DomainService/Repositories/SubscriptionDiscountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionDiscountRepository.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionDiscountRepository : ISubscriptionDiscountRepository
+{
+    private readonly IDbContextProvider _db;
+    private readonly ConcurrentDictionary<string, byte> _indexed = new();
+
+    public SubscriptionDiscountRepository(IDbContextProvider db) => _db = db;
+
+    public async Task<bool> TryCreateAsync(Discount discount, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await EnsureIndexesAsync(discount.TenantId, cancellationToken);
+            await Collection(discount.TenantId).InsertOneAsync(discount, cancellationToken: cancellationToken);
+            return true;
+        }
+        catch (MongoWriteException exception) when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            return false;
+        }
+    }
+
+    public async Task<Discount?> FindActiveByCodeAsync(
+        string tenantId, string? organizationId, string code, CancellationToken cancellationToken)
+    {
+        var baseFilter = Builders<Discount>.Filter.And(
+            Builders<Discount>.Filter.Eq(item => item.TenantId, tenantId),
+            Builders<Discount>.Filter.Eq(item => item.Code, code),
+            Builders<Discount>.Filter.Eq(item => item.Status, CatalogueStatus.Active));
+
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            var owned = await Collection(tenantId).Find(Builders<Discount>.Filter.And(
+                baseFilter,
+                Builders<Discount>.Filter.Eq(item => item.OrganizationId, organizationId)))
+                .FirstOrDefaultAsync(cancellationToken);
+            if (owned is not null) return owned;
+        }
+
+        return await Collection(tenantId).Find(Builders<Discount>.Filter.And(
+            baseFilter,
+            Builders<Discount>.Filter.Eq(item => item.OrganizationId, null)))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Discount>> ListAsync(
+        string tenantId, string? organizationId, CancellationToken cancellationToken)
+    {
+        var scope = string.IsNullOrWhiteSpace(organizationId)
+            ? Builders<Discount>.Filter.Eq(item => item.OrganizationId, null)
+            : Builders<Discount>.Filter.In(item => item.OrganizationId, new string?[] { null, organizationId });
+        return await Collection(tenantId).Find(Builders<Discount>.Filter.And(
+                Builders<Discount>.Filter.Eq(item => item.TenantId, tenantId), scope))
+            .SortBy(item => item.Code).ToListAsync(cancellationToken);
+    }
+
+    public async Task<bool> TryArchiveAsync(string tenantId, string discountId, CancellationToken cancellationToken)
+    {
+        var result = await Collection(tenantId).UpdateOneAsync(
+            Builders<Discount>.Filter.And(
+                Builders<Discount>.Filter.Eq(item => item.TenantId, tenantId),
+                Builders<Discount>.Filter.Eq(item => item.ItemId, discountId),
+                Builders<Discount>.Filter.Eq(item => item.Status, CatalogueStatus.Active)),
+            Builders<Discount>.Update
+                .Set(item => item.Status, CatalogueStatus.Archived)
+                .Set(item => item.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+        return result.ModifiedCount == 1;
+    }
+
+    private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexed.ContainsKey(tenantId)) return;
+        await Collection(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateDiscountIndexes(), cancellationToken);
+        _indexed.TryAdd(tenantId, 0);
+    }
+
+    private IMongoCollection<Discount> Collection(string tenantId) =>
+        SubscriptionCollections.Of<Discount>(_db, tenantId, SubscriptionCollections.Discounts);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -41,6 +41,7 @@ public static class SubscriptionIndexDefinitions
 
     public const string PricePlanIndexName =
         "ix_subscription_price_tenant_plan";
+    public const string DiscountCodeIndexName = "ux_subscription_discount_tenant_org_code";
 
     public const string BillingAccountIndexName =
         "ux_subscription_account_tenant_org_provider";
@@ -147,6 +148,16 @@ public static class SubscriptionIndexDefinitions
                 .Ascending(price => price.TenantId)
                 .Ascending(price => price.PlanId),
             new CreateIndexOptions { Name = PricePlanIndexName })
+    ];
+
+    public static IReadOnlyCollection<CreateIndexModel<Discount>> CreateDiscountIndexes() =>
+    [
+        new(
+            Builders<Discount>.IndexKeys
+                .Ascending(discount => discount.TenantId)
+                .Ascending(discount => discount.OrganizationId)
+                .Ascending(discount => discount.Code),
+            new CreateIndexOptions { Unique = true, Name = DiscountCodeIndexName })
     ];
 
     public static IReadOnlyCollection<CreateIndexModel<BillingAccount>> CreateBillingAccountIndexes() =>

--- a/server/Subscription.DomainService/Repositories/SubscriptionPlanSchedule.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionPlanSchedule.cs
@@ -1,0 +1,13 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed record SubscriptionPlanSchedule(
+    BillingSchedule FeeSchedule,
+    DateTime CurrentPeriodStartUtc,
+    DateTime CurrentPeriodEndUtc,
+    DateTime NextFeeBillingAtUtc,
+    BillingSchedule UsageSchedule,
+    DateTime CurrentUsagePeriodStartUtc,
+    DateTime CurrentUsagePeriodEndUtc,
+    DateTime NextUsageBillingAtUtc);

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -202,6 +202,7 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         PlanSnapshot newPlan,
         PriceSnapshot newPrice,
         List<SubscriptionQuantityItem> newQuantityItems,
+        SubscriptionPlanSchedule newSchedule,
         long newCreditBalanceMinor,
         string? planChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
@@ -210,6 +211,7 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         ArgumentNullException.ThrowIfNull(newPlan);
         ArgumentNullException.ThrowIfNull(newPrice);
         ArgumentNullException.ThrowIfNull(newQuantityItems);
+        ArgumentNullException.ThrowIfNull(newSchedule);
         ArgumentNullException.ThrowIfNull(outboxEvent);
 
         var filter = Builders<SubscriptionDetail>.Filter.And(
@@ -225,6 +227,14 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             .Set(subscription => subscription.Plan, newPlan)
             .Set(subscription => subscription.Price, newPrice)
             .Set(subscription => subscription.QuantityItems, newQuantityItems)
+            .Set(subscription => subscription.FeeSchedule, newSchedule.FeeSchedule)
+            .Set(subscription => subscription.CurrentPeriodStartUtc, newSchedule.CurrentPeriodStartUtc)
+            .Set(subscription => subscription.CurrentPeriodEndUtc, newSchedule.CurrentPeriodEndUtc)
+            .Set(subscription => subscription.NextFeeBillingAtUtc, newSchedule.NextFeeBillingAtUtc)
+            .Set(subscription => subscription.UsageSchedule, newSchedule.UsageSchedule)
+            .Set(subscription => subscription.CurrentUsagePeriodStartUtc, newSchedule.CurrentUsagePeriodStartUtc)
+            .Set(subscription => subscription.CurrentUsagePeriodEndUtc, newSchedule.CurrentUsagePeriodEndUtc)
+            .Set(subscription => subscription.NextUsageBillingAtUtc, newSchedule.NextUsageBillingAtUtc)
             .Set(subscription => subscription.CreditBalanceMinor, newCreditBalanceMinor)
             .Inc(subscription => subscription.Version, 1)
             .Set(subscription => subscription.LastUpdatedDateUtc, DateTime.UtcNow)

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -203,6 +203,7 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         PriceSnapshot newPrice,
         List<SubscriptionQuantityItem> newQuantityItems,
         SubscriptionPlanSchedule newSchedule,
+        PendingUsagePeriod outgoingUsagePeriod,
         long newCreditBalanceMinor,
         string? planChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
@@ -212,6 +213,7 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         ArgumentNullException.ThrowIfNull(newPrice);
         ArgumentNullException.ThrowIfNull(newQuantityItems);
         ArgumentNullException.ThrowIfNull(newSchedule);
+        ArgumentNullException.ThrowIfNull(outgoingUsagePeriod);
         ArgumentNullException.ThrowIfNull(outboxEvent);
 
         var filter = Builders<SubscriptionDetail>.Filter.And(
@@ -236,6 +238,7 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             .Set(subscription => subscription.CurrentUsagePeriodEndUtc, newSchedule.CurrentUsagePeriodEndUtc)
             .Set(subscription => subscription.NextUsageBillingAtUtc, newSchedule.NextUsageBillingAtUtc)
             .Set(subscription => subscription.CreditBalanceMinor, newCreditBalanceMinor)
+            .Push(subscription => subscription.PendingUsagePeriods, outgoingUsagePeriod)
             .Inc(subscription => subscription.Version, 1)
             .Set(subscription => subscription.LastUpdatedDateUtc, DateTime.UtcNow)
             .Push(subscription => subscription.OutboxEvents, outboxEvent);
@@ -250,6 +253,24 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         var result = await Subscriptions(tenantId).UpdateOneAsync(
             filter,
             update,
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<bool> TryRemovePendingUsagePeriodAsync(
+        string tenantId,
+        string subscriptionId,
+        string periodKey,
+        CancellationToken cancellationToken)
+    {
+        var result = await Subscriptions(tenantId).UpdateOneAsync(
+            Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(subscription => subscription.ItemId, subscriptionId)),
+            Builders<SubscriptionDetail>.Update.PullFilter(
+                subscription => subscription.PendingUsagePeriods,
+                pending => pending.PeriodKey == periodKey),
             cancellationToken: cancellationToken);
 
         return result.ModifiedCount == 1;
@@ -310,12 +331,14 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
                 // Explicitly excludes null rather than relying on how $lte treats it — same
                 // reasoning as the renewal due-query: an immediately-canceled subscription
                 // clears this field on purpose.
-                Builders<SubscriptionDetail>.Filter.Ne(
-                    subscription => subscription.NextUsageBillingAtUtc,
-                    null),
-                Builders<SubscriptionDetail>.Filter.Lte(
-                    subscription => subscription.NextUsageBillingAtUtc,
-                    asOfUtc)))
+                Builders<SubscriptionDetail>.Filter.Or(
+                    Builders<SubscriptionDetail>.Filter.SizeGt(
+                        subscription => subscription.PendingUsagePeriods, 0),
+                    Builders<SubscriptionDetail>.Filter.And(
+                        Builders<SubscriptionDetail>.Filter.Ne(
+                            subscription => subscription.NextUsageBillingAtUtc, null),
+                        Builders<SubscriptionDetail>.Filter.Lte(
+                            subscription => subscription.NextUsageBillingAtUtc, asOfUtc)))))
             .Limit(limit)
             .ToListAsync(cancellationToken);
 

--- a/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
@@ -1,0 +1,17 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Requests;
+
+public sealed class CreateDiscountRequest
+{
+    public string? OrganizationId { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
+    public DiscountKind Kind { get; set; }
+    public int? PercentBasisPoints { get; set; }
+    public long? AmountMinor { get; set; }
+    public string? CurrencyCode { get; set; }
+    public int? DurationPeriods { get; set; }
+    public DateTime? ExpiresAtUtc { get; set; }
+    public List<string> ApplicablePlanCodes { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -26,6 +26,8 @@ public sealed class CreatePriceRequest
     /// <summary>Paired with the interval, so three months is a quarter and no enum grows.</summary>
     public int IntervalCount { get; set; } = 1;
 
+    public string? DisplayPriceNote { get; set; }
+
     /// <summary>Which quantity item this multiplies. Null is a flat fee.</summary>
     public string? QuantityItemKey { get; set; }
 

--- a/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
+++ b/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
@@ -1,5 +1,7 @@
 namespace Subscription.DomainService.Requests;
 
+using Subscription.DomainService.Enums;
+
 /// <summary>
 /// What a plan sells, shared by authoring one and editing one.
 /// </summary>
@@ -25,6 +27,14 @@ public abstract class PlanDefinitionRequest
     public int? TrialDays { get; set; }
 
     public bool TrialRequiresPaymentMethod { get; set; } = true;
+
+    public BillingInterval UsageInterval { get; set; } = BillingInterval.Month;
+
+    public int UsageIntervalCount { get; set; } = 1;
+
+    public string? FamilyCode { get; set; }
+
+    public int? FamilyRank { get; set; }
 
     public List<PlanQuantityItemRequest> QuantityItems { get; set; } = [];
 

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -1,0 +1,17 @@
+namespace Subscription.DomainService.Responses;
+
+public sealed class DiscountResponse
+{
+    public string DiscountId { get; init; } = string.Empty;
+    public string? OrganizationId { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string Kind { get; init; } = string.Empty;
+    public int? PercentBasisPoints { get; init; }
+    public long? AmountMinor { get; init; }
+    public string? CurrencyCode { get; init; }
+    public int? DurationPeriods { get; init; }
+    public DateTime? ExpiresAtUtc { get; init; }
+    public List<string> ApplicablePlanCodes { get; init; } = [];
+    public string Status { get; init; } = string.Empty;
+}

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -18,6 +18,14 @@ public sealed class PlanResponse
 
     public string? Description { get; init; }
 
+    public string? FamilyCode { get; init; }
+
+    public int? FamilyRank { get; init; }
+
+    public string UsageInterval { get; init; } = string.Empty;
+
+    public int UsageIntervalCount { get; init; }
+
     /// <summary>
     /// The organization this plan is scoped to, or null when the tenant sells it to everyone.
     /// Returned so a caller that can see plans from more than one organization — the console —
@@ -146,6 +154,8 @@ public sealed class PlanPriceResponse
     public string Interval { get; init; } = string.Empty;
 
     public int IntervalCount { get; init; }
+
+    public string? DisplayPriceNote { get; init; }
 
     public string? QuantityItemKey { get; init; }
 }

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -21,6 +21,8 @@ public sealed class SubscriptionResponse
 
     public int IntervalCount { get; init; }
 
+    public string? DisplayPriceNote { get; init; }
+
     public List<SubscriptionQuantityResponse> Quantities { get; init; } = [];
 
     public DateTime CurrentPeriodStartUtc { get; init; }

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -1,0 +1,99 @@
+using FluentValidation;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public sealed class DiscountCatalogueService : IDiscountCatalogueService
+{
+    private readonly ISubscriptionDiscountRepository _discounts;
+    private readonly ISubscriptionContextResolver _context;
+    private readonly IValidator<CreateDiscountRequest> _validator;
+
+    public DiscountCatalogueService(
+        ISubscriptionDiscountRepository discounts,
+        ISubscriptionContextResolver context,
+        IValidator<CreateDiscountRequest> validator)
+    {
+        _discounts = discounts;
+        _context = context;
+        _validator = validator;
+    }
+
+    public async Task<SubscriptionOperationResult<DiscountResponse>> CreateAsync(
+        CreateDiscountRequest request, string correlationId, CancellationToken cancellationToken)
+    {
+        var resolution = await _context.ResolveAsync(correlationId, null, cancellationToken);
+        if (!resolution.IsSuccess) return resolution.ToFailure<DiscountResponse>(correlationId);
+        var invalid = await SubscriptionValidation.CheckAsync<CreateDiscountRequest, DiscountResponse>(
+            _validator, request, "subscription_discount_invalid", "The discount is invalid.",
+            correlationId, cancellationToken);
+        if (invalid is not null) return invalid;
+
+        var context = resolution.Context!;
+        var discount = new Discount
+        {
+            TenantId = context.TenantId,
+            OrganizationId = string.IsNullOrWhiteSpace(request.OrganizationId) ? null : request.OrganizationId,
+            Code = request.Code.Trim().ToLowerInvariant(),
+            DisplayName = request.DisplayName.Trim(),
+            CurrencyCode = request.CurrencyCode?.Trim().ToUpperInvariant(),
+            ApplicablePlanCodes = request.ApplicablePlanCodes.Distinct(StringComparer.Ordinal).ToList(),
+            Terms = new DiscountTerms
+            {
+                Code = request.Code.Trim().ToLowerInvariant(),
+                Kind = request.Kind,
+                PercentBasisPoints = request.PercentBasisPoints,
+                AmountMinor = request.AmountMinor,
+                DurationPeriods = request.DurationPeriods,
+                ExpiresAtUtc = request.ExpiresAtUtc
+            }
+        };
+
+        if (!await _discounts.TryCreateAsync(discount, cancellationToken))
+            return SubscriptionOperationResult<DiscountResponse>.Failure(
+                PaymentFailureKind.Conflict, "subscription_discount_exists",
+                "A discount with this code already exists at this scope.", correlationId);
+        return SubscriptionOperationResult<DiscountResponse>.Success(Map(discount), correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<IReadOnlyList<DiscountResponse>>> ListAsync(
+        string? organizationId, string correlationId, CancellationToken cancellationToken)
+    {
+        var resolution = await _context.ResolveAsync(correlationId, organizationId, cancellationToken);
+        if (!resolution.IsSuccess) return resolution.ToFailure<IReadOnlyList<DiscountResponse>>(correlationId);
+        var context = resolution.Context!;
+        var items = await _discounts.ListAsync(context.TenantId, context.OrganizationId, cancellationToken);
+        return SubscriptionOperationResult<IReadOnlyList<DiscountResponse>>.Success(items.Select(Map).ToList(), correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<DiscountResponse>> ArchiveAsync(
+        string discountId, string? organizationId, string correlationId, CancellationToken cancellationToken)
+    {
+        var resolution = await _context.ResolveAsync(correlationId, organizationId, cancellationToken);
+        if (!resolution.IsSuccess) return resolution.ToFailure<DiscountResponse>(correlationId);
+        var context = resolution.Context!;
+        var item = (await _discounts.ListAsync(context.TenantId, context.OrganizationId, cancellationToken))
+            .FirstOrDefault(discount => discount.ItemId == discountId);
+        if (item is null || !await _discounts.TryArchiveAsync(context.TenantId, discountId, cancellationToken))
+            return SubscriptionOperationResult<DiscountResponse>.Failure(
+                PaymentFailureKind.NotFound, "subscription_discount_not_found",
+                "The discount does not exist or is already retired.", correlationId);
+        item.Status = CatalogueStatus.Archived;
+        return SubscriptionOperationResult<DiscountResponse>.Success(Map(item), correlationId);
+    }
+
+    private static DiscountResponse Map(Discount item) => new()
+    {
+        DiscountId = item.ItemId, OrganizationId = item.OrganizationId, Code = item.Code,
+        DisplayName = item.DisplayName, Kind = item.Terms.Kind.ToString(),
+        PercentBasisPoints = item.Terms.PercentBasisPoints, AmountMinor = item.Terms.AmountMinor,
+        CurrencyCode = item.CurrencyCode, DurationPeriods = item.Terms.DurationPeriods,
+        ExpiresAtUtc = item.Terms.ExpiresAtUtc, ApplicablePlanCodes = [.. item.ApplicablePlanCodes],
+        Status = item.Status.ToString()
+    };
+}

--- a/server/Subscription.DomainService/Services/IDiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IDiscountCatalogueService.cs
@@ -1,0 +1,11 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+public interface IDiscountCatalogueService
+{
+    Task<SubscriptionOperationResult<DiscountResponse>> CreateAsync(CreateDiscountRequest request, string correlationId, CancellationToken cancellationToken);
+    Task<SubscriptionOperationResult<IReadOnlyList<DiscountResponse>>> ListAsync(string? organizationId, string correlationId, CancellationToken cancellationToken);
+    Task<SubscriptionOperationResult<DiscountResponse>> ArchiveAsync(string discountId, string? organizationId, string correlationId, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -253,6 +253,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             UnitAmountMinor = request.UnitAmountMinor,
             Interval = request.Interval,
             IntervalCount = request.IntervalCount,
+            DisplayPriceNote = request.DisplayPriceNote,
             QuantityItemKey = request.QuantityItemKey,
             TaxRateBasisPoints = request.TaxRateBasisPoints,
             Status = CatalogueStatus.Active
@@ -467,6 +468,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         TenantId = tenantId,
         DisplayName = request.DisplayName,
         Description = request.Description,
+        FamilyCode = request.FamilyCode,
+        FamilyRank = request.FamilyRank,
+        UsageInterval = request.UsageInterval,
+        UsageIntervalCount = request.UsageIntervalCount,
         FeaturesJson = request.FeaturesJson,
         Status = CatalogueStatus.Active,
         TrialDays = request.TrialDays,

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -27,6 +27,10 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
             Code = plan.Code,
             DisplayName = plan.DisplayName,
             Description = plan.Description,
+            FamilyCode = plan.FamilyCode,
+            FamilyRank = plan.FamilyRank,
+            UsageInterval = plan.UsageInterval.ToString(),
+            UsageIntervalCount = plan.UsageIntervalCount,
             OrganizationId = plan.OrganizationId,
             FeaturesJson = plan.FeaturesJson,
             TrialDays = plan.TrialDays,
@@ -93,6 +97,7 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     UnitAmountMinor = price.UnitAmountMinor,
                     Interval = price.Interval.ToString(),
                     IntervalCount = price.IntervalCount,
+                    DisplayPriceNote = price.DisplayPriceNote,
                     QuantityItemKey = price.QuantityItemKey
                 })
                 .ToList()

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -169,6 +169,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                 CurrencyCode = subscription.CurrencyCode,
                 OrderId = subscription.OrderId,
                 Description = $"{subscription.Plan.DisplayName} subscription",
+                CustomerOrganizationId = subscription.OrganizationId,
                 // The renewal in a month charges this card with nobody present, which the
                 // provider only permits if the mandate was established when it was saved.
                 SavePaymentMethod = true

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -19,6 +19,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
     private readonly ISubscriptionCatalogueRepository _catalogue;
     private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionDiscountRepository _discounts;
     private readonly IBillingAccountRepository _billingAccounts;
     private readonly IValidator<CreateSubscriptionRequest> _validator;
     private readonly ILogger<SubscriptionCreationService> _logger;
@@ -27,6 +28,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
     public SubscriptionCreationService(
         ISubscriptionCatalogueRepository catalogue,
         ISubscriptionRepository subscriptions,
+        ISubscriptionDiscountRepository discounts,
         IBillingAccountRepository billingAccounts,
         IValidator<CreateSubscriptionRequest> validator,
         ILogger<SubscriptionCreationService> logger,
@@ -34,6 +36,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
     {
         _catalogue = catalogue;
         _subscriptions = subscriptions;
+        _discounts = discounts;
         _billingAccounts = billingAccounts;
         _validator = validator;
         _logger = logger;
@@ -71,6 +74,8 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         }
 
         var (plan, price) = terms.Value;
+        var discount = await ResolveDiscountAsync(request, context, plan, price, correlationId, cancellationToken);
+        if (!discount.IsSuccess) return discount.ToFailure<SubscriptionDetail>();
         var quantities = SubscriptionQuantityBuilder.Build(request.Quantities, plan, price);
 
         if (quantities is null)
@@ -91,8 +96,8 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 request.TimeZoneId,
                 out var feeSchedule) ||
             !BillingPeriodCalculator.TryCreateSchedule(
-                BillingInterval.Month,
-                1,
+                plan.UsageInterval,
+                plan.UsageIntervalCount,
                 now,
                 request.TimeZoneId,
                 out var usageSchedule))
@@ -123,6 +128,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             account,
             feeSchedule,
             usageSchedule,
+            discount.Value,
             now,
             correlationId);
 
@@ -201,6 +207,67 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             correlationId);
     }
 
+    private async Task<SubscriptionOperationResult<DiscountTerms?>> ResolveDiscountAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        Plan plan,
+        Price price,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.DiscountCode))
+            return SubscriptionOperationResult<DiscountTerms?>.Success(null, correlationId);
+
+        var discount = await _discounts.FindActiveByCodeAsync(
+            context.TenantId,
+            context.OrganizationId,
+            request.DiscountCode.Trim().ToLowerInvariant(),
+            cancellationToken);
+
+        if (discount is null)
+            return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_discount_not_found",
+                "The discount code does not exist or is retired.",
+                correlationId);
+
+        if (discount.Terms.ExpiresAtUtc is { } expiry && expiry <= _time.GetUtcNow().UtcDateTime)
+            return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_discount_expired",
+                "The discount code has expired.",
+                correlationId);
+
+        if (discount.ApplicablePlanCodes.Count > 0 &&
+            !discount.ApplicablePlanCodes.Contains(plan.Code, StringComparer.Ordinal))
+            return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_discount_not_applicable",
+                "The discount does not apply to this plan.",
+                correlationId);
+
+        if (discount.Terms.Kind == DiscountKind.FixedAmount &&
+            !string.Equals(discount.CurrencyCode, price.CurrencyCode, StringComparison.Ordinal))
+            return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_discount_currency_mismatch",
+                "The fixed discount is denominated in another currency.",
+                correlationId);
+
+        var terms = discount.Terms;
+        return SubscriptionOperationResult<DiscountTerms?>.Success(
+            new DiscountTerms
+            {
+                Code = terms.Code,
+                Kind = terms.Kind,
+                PercentBasisPoints = terms.PercentBasisPoints,
+                AmountMinor = terms.AmountMinor,
+                DurationPeriods = terms.DurationPeriods,
+                ExpiresAtUtc = terms.ExpiresAtUtc
+            },
+            correlationId);
+    }
+
     private static SubscriptionDetail BuildSubscription(
         SubscriptionContext context,
         Plan plan,
@@ -209,6 +276,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         BillingAccount account,
         BillingSchedule feeSchedule,
         BillingSchedule usageSchedule,
+        DiscountTerms? discount,
         DateTime now,
         string correlationId)
     {
@@ -227,6 +295,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             QuantityItems = quantities,
             FeeSchedule = feeSchedule,
             UsageSchedule = usageSchedule,
+            Discount = discount,
             Trial = BuildTrial(plan, now),
             OrderId = SubscriptionConstants.OrderIdFor(subscriptionId),
             CorrelationId = correlationId,

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -262,6 +262,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
     {
         var previousPlanCode = subscription.Plan.Code;
         var expectedVersion = subscription.Version;
+        var outgoingUsagePeriod = SnapshotOutgoingUsagePeriod(subscription, correlationId);
 
         subscription.Plan = newPlan;
         subscription.Price = newPrice;
@@ -284,6 +285,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             newPrice,
             quantities,
             newSchedule,
+            outgoingUsagePeriod,
             newCreditBalanceMinor,
             paymentDetailId,
             _events.CreatePlanChanged(subscription, previousPlanCode, correlationId),
@@ -395,6 +397,21 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             usagePeriod.EndUtc);
         return true;
     }
+
+    private static PendingUsagePeriod SnapshotOutgoingUsagePeriod(
+        SubscriptionDetail subscription,
+        string correlationId) => new()
+    {
+        PeriodKey = PeriodKey.Create(
+            subscription.UsageSchedule.Interval,
+            subscription.CurrentUsagePeriodStartUtc),
+        PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
+        PeriodEndUtc = subscription.CurrentUsagePeriodEndUtc,
+        Plan = subscription.Plan,
+        Price = subscription.Price,
+        CurrencyCode = subscription.CurrencyCode,
+        CorrelationId = correlationId
+    };
 
     private static SubscriptionOperationResult<SubscriptionResponse> Failure(
         PaymentFailureKind kind,

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -22,9 +22,8 @@ namespace Subscription.DomainService.Services;
 /// is the seam's third caller, after the renewal service and (indirectly) the checkout service's
 /// sibling money path.
 /// <para>
-/// Restricted to a same-currency, same-billing-interval target price. A different interval would
-/// mean rebuilding the fee schedule and the current period boundaries mid-flight — a separate,
-/// harder problem this does not attempt.
+/// The target cadence starts at the change instant. Both fee and usage schedules are rebuilt so
+/// changing a monthly subscription to annual cannot leave a monthly renewal clock behind.
 /// </para>
 /// </remarks>
 public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeService
@@ -152,13 +151,24 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         var newPlan = SubscriptionSnapshotBuilder.SnapshotOf(plan);
         var newPrice = SubscriptionSnapshotBuilder.SnapshotOf(price);
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (!TryBuildSchedule(subscription, newPlan, newPrice, now, out var newSchedule))
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_schedule_invalid",
+                "The target plan's schedules could not be derived.",
+                correlationId);
+        }
 
         return subscription.Status == SubscriptionStatus.Trialing
             ? await ApplyAsync(
-                subscription, newPlan, newPrice, quantities,
+                subscription, newPlan, newPrice, quantities, newSchedule,
                 subscription.CreditBalanceMinor, null, correlationId, cancellationToken)
             : await ChargeAndApplyAsync(
-                subscription, newPlan, newPrice, quantities, correlationId, cancellationToken);
+                subscription, newPlan, newPrice, quantities, newSchedule, now,
+                correlationId, cancellationToken);
     }
 
     private async Task<SubscriptionOperationResult<SubscriptionResponse>> ChargeAndApplyAsync(
@@ -166,16 +176,23 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         PlanSnapshot newPlan,
         PriceSnapshot newPrice,
         List<SubscriptionQuantityItem> quantities,
+        SubscriptionPlanSchedule newSchedule,
+        DateTime now,
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var now = _time.GetUtcNow().UtcDateTime;
-        var outcome = SubscriptionProrationCalculator.Calculate(subscription, newPrice, quantities, now);
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            newPrice,
+            quantities,
+            now,
+            newSchedule.CurrentPeriodStartUtc,
+            newSchedule.CurrentPeriodEndUtc);
 
         if (outcome.ChargeMinor <= 0)
         {
             return await ApplyAsync(
-                subscription, newPlan, newPrice, quantities,
+                subscription, newPlan, newPrice, quantities, newSchedule,
                 outcome.NewCreditBalanceMinor, null, correlationId, cancellationToken);
         }
 
@@ -228,7 +245,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         }
 
         return await ApplyAsync(
-            subscription, newPlan, newPrice, quantities,
+            subscription, newPlan, newPrice, quantities, newSchedule,
             outcome.NewCreditBalanceMinor, charge.Value, correlationId, cancellationToken);
     }
 
@@ -237,6 +254,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         PlanSnapshot newPlan,
         PriceSnapshot newPrice,
         List<SubscriptionQuantityItem> quantities,
+        SubscriptionPlanSchedule newSchedule,
         long newCreditBalanceMinor,
         string? paymentDetailId,
         string correlationId,
@@ -248,6 +266,14 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         subscription.Plan = newPlan;
         subscription.Price = newPrice;
         subscription.QuantityItems = quantities;
+        subscription.FeeSchedule = newSchedule.FeeSchedule;
+        subscription.CurrentPeriodStartUtc = newSchedule.CurrentPeriodStartUtc;
+        subscription.CurrentPeriodEndUtc = newSchedule.CurrentPeriodEndUtc;
+        subscription.NextFeeBillingAtUtc = newSchedule.NextFeeBillingAtUtc;
+        subscription.UsageSchedule = newSchedule.UsageSchedule;
+        subscription.CurrentUsagePeriodStartUtc = newSchedule.CurrentUsagePeriodStartUtc;
+        subscription.CurrentUsagePeriodEndUtc = newSchedule.CurrentUsagePeriodEndUtc;
+        subscription.NextUsageBillingAtUtc = newSchedule.NextUsageBillingAtUtc;
         subscription.CreditBalanceMinor = newCreditBalanceMinor;
 
         var applied = await _subscriptions.TryChangePlanAsync(
@@ -257,6 +283,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             newPlan,
             newPrice,
             quantities,
+            newSchedule,
             newCreditBalanceMinor,
             paymentDetailId,
             _events.CreatePlanChanged(subscription, previousPlanCode, correlationId),
@@ -334,17 +361,39 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 correlationId);
         }
 
-        if (price.Interval != subscription.Price.Interval ||
-            price.IntervalCount != subscription.Price.IntervalCount)
+        return SubscriptionOperationResult<(Plan, Price)>.Success((plan, price), correlationId);
+    }
+
+    private static bool TryBuildSchedule(
+        SubscriptionDetail subscription,
+        PlanSnapshot targetPlan,
+        PriceSnapshot targetPrice,
+        DateTime now,
+        out SubscriptionPlanSchedule schedule)
+    {
+        schedule = null!;
+        var timeZoneId = subscription.FeeSchedule.TimeZoneId;
+
+        if (!BillingPeriodCalculator.TryCreateSchedule(
+                targetPrice.Interval, targetPrice.IntervalCount, now, timeZoneId, out var fee) ||
+            !BillingPeriodCalculator.TryGetPeriod(fee, now, out var feePeriod) ||
+            !BillingPeriodCalculator.TryCreateSchedule(
+                targetPlan.UsageInterval, targetPlan.UsageIntervalCount, now, timeZoneId, out var usage) ||
+            !BillingPeriodCalculator.TryGetPeriod(usage, now, out var usagePeriod))
         {
-            return SubscriptionOperationResult<(Plan, Price)>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_plan_change_interval_mismatch",
-                "A subscription cannot change to a price with a different billing interval.",
-                correlationId);
+            return false;
         }
 
-        return SubscriptionOperationResult<(Plan, Price)>.Success((plan, price), correlationId);
+        schedule = new SubscriptionPlanSchedule(
+            fee,
+            feePeriod.StartUtc,
+            feePeriod.EndUtc,
+            feePeriod.EndUtc,
+            usage,
+            usagePeriod.StartUtc,
+            usagePeriod.EndUtc,
+            usagePeriod.EndUtc);
+        return true;
     }
 
     private static SubscriptionOperationResult<SubscriptionResponse> Failure(

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -22,8 +22,8 @@ public static class SubscriptionProrationCalculator
         PriceSnapshot targetPrice,
         IReadOnlyList<SubscriptionQuantityItem> targetQuantityItems,
         DateTime nowUtc,
-        DateTime? targetPeriodStartUtc = null,
-        DateTime? targetPeriodEndUtc = null)
+        DateTime targetPeriodStartUtc,
+        DateTime targetPeriodEndUtc)
     {
         ArgumentNullException.ThrowIfNull(subscription);
         ArgumentNullException.ThrowIfNull(targetPrice);
@@ -69,12 +69,11 @@ public static class SubscriptionProrationCalculator
             targetPrice.TaxRateBasisPoints);
 
         var oldRemainingValue = Prorate(oldTaxInclusive, remainingTicks, totalTicks);
-        var targetTotalTicks = targetPeriodStartUtc.HasValue && targetPeriodEndUtc.HasValue
-            ? (targetPeriodEndUtc.Value - targetPeriodStartUtc.Value).Ticks
-            : totalTicks;
-        var targetRemainingTicks = targetPeriodEndUtc.HasValue
-            ? Math.Clamp((targetPeriodEndUtc.Value - nowUtc).Ticks, 0, targetTotalTicks)
-            : remainingTicks;
+        var targetTotalTicks = (targetPeriodEndUtc - targetPeriodStartUtc).Ticks;
+        var targetRemainingTicks = Math.Clamp(
+            (targetPeriodEndUtc - nowUtc).Ticks,
+            0,
+            Math.Max(0, targetTotalTicks));
         var newRemainingCost = targetTotalTicks <= 0
             ? 0
             : Prorate(newTaxInclusive, targetRemainingTicks, targetTotalTicks);

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -21,7 +21,9 @@ public static class SubscriptionProrationCalculator
         SubscriptionDetail subscription,
         PriceSnapshot targetPrice,
         IReadOnlyList<SubscriptionQuantityItem> targetQuantityItems,
-        DateTime nowUtc)
+        DateTime nowUtc,
+        DateTime? targetPeriodStartUtc = null,
+        DateTime? targetPeriodEndUtc = null)
     {
         ArgumentNullException.ThrowIfNull(subscription);
         ArgumentNullException.ThrowIfNull(targetPrice);
@@ -67,7 +69,15 @@ public static class SubscriptionProrationCalculator
             targetPrice.TaxRateBasisPoints);
 
         var oldRemainingValue = Prorate(oldTaxInclusive, remainingTicks, totalTicks);
-        var newRemainingCost = Prorate(newTaxInclusive, remainingTicks, totalTicks);
+        var targetTotalTicks = targetPeriodStartUtc.HasValue && targetPeriodEndUtc.HasValue
+            ? (targetPeriodEndUtc.Value - targetPeriodStartUtc.Value).Ticks
+            : totalTicks;
+        var targetRemainingTicks = targetPeriodEndUtc.HasValue
+            ? Math.Clamp((targetPeriodEndUtc.Value - nowUtc).Ticks, 0, targetTotalTicks)
+            : remainingTicks;
+        var newRemainingCost = targetTotalTicks <= 0
+            ? 0
+            : Prorate(newTaxInclusive, targetRemainingTicks, targetTotalTicks);
 
         var rawDelta = newRemainingCost - oldRemainingValue;
         var netAfterCredit = rawDelta - subscription.CreditBalanceMinor;

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -21,6 +21,7 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             UnitAmountMinor = subscription.Price.UnitAmountMinor,
             Interval = subscription.Price.Interval.ToString(),
             IntervalCount = subscription.Price.IntervalCount,
+            DisplayPriceNote = subscription.Price.DisplayPriceNote,
             Quantities = subscription.QuantityItems
                 .Select(item => new SubscriptionQuantityResponse
                 {

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -22,6 +22,8 @@ internal static class SubscriptionSnapshotBuilder
             Code = plan.Code,
             DisplayName = plan.DisplayName,
             FeaturesJson = plan.FeaturesJson,
+            UsageInterval = plan.UsageInterval,
+            UsageIntervalCount = plan.UsageIntervalCount,
             PlanVersion = plan.Version,
             Entitlements = plan.Entitlements
                 .Select(entitlement => new PlanEntitlement
@@ -82,6 +84,7 @@ internal static class SubscriptionSnapshotBuilder
             UnitAmountMinor = price.UnitAmountMinor,
             Interval = price.Interval,
             IntervalCount = price.IntervalCount,
+            DisplayPriceNote = price.DisplayPriceNote,
             QuantityItemKey = price.QuantityItemKey,
             TaxRateBasisPoints = price.TaxRateBasisPoints,
             PriceVersion = price.Version

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             ISubscriptionInvoiceHistoryRepository,
             SubscriptionInvoiceHistoryRepository>();
+        services.AddSingleton<ISubscriptionDiscountRepository, SubscriptionDiscountRepository>();
 
         // Singleton so the cache is actually shared. Scoped, every request would get an empty
         // one and the hot path would read the database every time regardless.
@@ -83,6 +84,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<
             IValidator<CreateSubscriptionRequest>,
             CreateSubscriptionRequestValidator>();
+        services.AddTransient<IValidator<CreateDiscountRequest>, CreateDiscountRequestValidator>();
         services.AddTransient<
             IValidator<ChangeSubscriptionPlanRequest>,
             ChangeSubscriptionPlanRequestValidator>();
@@ -95,6 +97,7 @@ public static class ApplicationServiceCollectionExtensions
             ISubscriptionContextResolver,
             SubscriptionContextResolver>();
         services.AddScoped<IPlanCatalogueService, PlanCatalogueService>();
+        services.AddScoped<IDiscountCatalogueService, DiscountCatalogueService>();
         services.AddScoped<
             ISubscriptionCreationService,
             SubscriptionCreationService>();

--- a/server/Subscription.DomainService/Validators/CreateDiscountRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreateDiscountRequestValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Validators;
+
+public sealed class CreateDiscountRequestValidator : AbstractValidator<CreateDiscountRequest>
+{
+    public CreateDiscountRequestValidator()
+    {
+        RuleFor(request => request.Code).NotEmpty().MaximumLength(64).Matches("^[a-z0-9_-]+$");
+        RuleFor(request => request.DisplayName).NotEmpty().MaximumLength(200);
+        RuleFor(request => request.PercentBasisPoints).NotNull().InclusiveBetween(1, 10_000)
+            .When(request => request.Kind == DiscountKind.Percent);
+        RuleFor(request => request.AmountMinor).NotNull().GreaterThan(0)
+            .When(request => request.Kind == DiscountKind.FixedAmount);
+        RuleFor(request => request.CurrencyCode).NotEmpty().Length(3)
+            .When(request => request.Kind == DiscountKind.FixedAmount);
+        RuleFor(request => request.DurationPeriods).GreaterThan(0)
+            .When(request => request.DurationPeriods.HasValue);
+        RuleForEach(request => request.ApplicablePlanCodes).NotEmpty().MaximumLength(64);
+        RuleFor(request => request).Must(request =>
+            request.Kind != DiscountKind.Percent || request.AmountMinor is null)
+            .WithMessage("A percentage discount cannot also define a fixed amount.");
+        RuleFor(request => request).Must(request =>
+            request.Kind != DiscountKind.FixedAmount || request.PercentBasisPoints is null)
+            .WithMessage("A fixed discount cannot also define a percentage.");
+    }
+}

--- a/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
@@ -20,6 +20,7 @@ public sealed class CreatePriceRequestValidator : AbstractValidator<CreatePriceR
         RuleFor(request => request.UnitAmountMinor).GreaterThanOrEqualTo(0);
 
         RuleFor(request => request.IntervalCount).InclusiveBetween(1, 36);
+        RuleFor(request => request.DisplayPriceNote).MaximumLength(200);
 
         RuleFor(request => request.TaxRateBasisPoints!.Value)
             .InclusiveBetween(0, 10_000)

--- a/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
@@ -25,6 +25,14 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
             .InclusiveBetween(1, 365)
             .When(request => request.TrialDays.HasValue);
 
+        RuleFor(request => request.UsageIntervalCount).InclusiveBetween(1, 100);
+        RuleFor(request => request.FamilyCode).MaximumLength(64);
+        RuleFor(request => request.FamilyRank).GreaterThanOrEqualTo(0)
+            .When(request => request.FamilyRank.HasValue);
+        RuleFor(request => request)
+            .Must(request => string.IsNullOrWhiteSpace(request.FamilyCode) == !request.FamilyRank.HasValue)
+            .WithMessage("Family code and family rank must be supplied together.");
+
         RuleFor(request => request.FeaturesJson)
             .Must(BeAJsonObject)
             .When(request => !string.IsNullOrWhiteSpace(request.FeaturesJson))

--- a/server/XUnitTest/Payment/PaymentQueryOrganizationFilterTests.cs
+++ b/server/XUnitTest/Payment/PaymentQueryOrganizationFilterTests.cs
@@ -28,9 +28,10 @@ public sealed class PaymentQueryOrganizationFilterTests
         var alternatives = OrganizationAlternatives(
             Render(organizationId: "organization-1"));
 
-        alternatives.Should().HaveCount(2);
-        alternatives.Should().Contain(value => value == "organization-1");
-        alternatives.Should().Contain(value => value == null);
+        alternatives.Should().HaveCount(3);
+        alternatives.Should().Contain(("OrganizationId", "organization-1"));
+        alternatives.Should().Contain(("CustomerOrganizationId", "organization-1"));
+        alternatives.Should().Contain(("OrganizationId", (string?)null));
     }
 
     [Fact]
@@ -39,7 +40,7 @@ public sealed class PaymentQueryOrganizationFilterTests
         var alternatives = OrganizationAlternatives(
             Render(organizationId: "organization-1"));
 
-        alternatives.Should().NotContain(value => value == "organization-2");
+        alternatives.Should().NotContain(value => value.Value == "organization-2");
     }
 
     /// <summary>
@@ -68,10 +69,10 @@ public sealed class PaymentQueryOrganizationFilterTests
 
         rendered.ToString().Should().Contain("CHF");
         rendered["TenantId"].AsString.Should().Be("tenant-1");
-        OrganizationAlternatives(rendered).Should().HaveCount(2);
+        OrganizationAlternatives(rendered).Should().HaveCount(3);
     }
 
-    private static List<string?> OrganizationAlternatives(BsonDocument rendered)
+    private static List<(string Field, string? Value)> OrganizationAlternatives(BsonDocument rendered)
     {
         var clause = rendered.Contains("$or")
             ? rendered["$or"]
@@ -82,9 +83,9 @@ public sealed class PaymentQueryOrganizationFilterTests
         return clause.AsBsonArray
             .Select(alternative =>
             {
-                var value = alternative.AsBsonDocument["OrganizationId"];
-
-                return value.IsBsonNull ? null : value.AsString;
+                var document = alternative.AsBsonDocument;
+                var field = document.GetElement(0);
+                return (field.Name, field.Value.IsBsonNull ? null : field.Value.AsString);
             })
             .ToList();
     }
@@ -104,8 +105,10 @@ public sealed class PaymentQueryOrganizationFilterTests
         rendered.ToString().Should().Contain("organization-2");
         rendered.ToString().Should()
             .NotContain("organization-1", "the request decides the scope, not the context");
-        rendered.ToString().Should()
-            .NotContain("$or", "the pre-organization history belongs to the caller's own scope");
+        var alternatives = OrganizationAlternatives(rendered);
+        alternatives.Should().Contain(("OrganizationId", "organization-2"));
+        alternatives.Should().Contain(("CustomerOrganizationId", "organization-2"));
+        alternatives.Should().NotContain(("OrganizationId", null));
     }
 
     /// <summary>

--- a/server/XUnitTest/Payment/PaymentQueryResponseMapperTests.cs
+++ b/server/XUnitTest/Payment/PaymentQueryResponseMapperTests.cs
@@ -19,6 +19,8 @@ public sealed class PaymentQueryResponseMapperTests
 
         response.Items.Should().ContainSingle();
         response.Items.Single().HasPendingRefund.Should().BeTrue();
+        response.Items.Single().PaymentFlow.Should().Be(PaymentFlows.SubscriptionInvoice);
+        response.Items.Single().HasInvoice.Should().BeTrue();
         response.PageInfo.HasNextPage.Should().BeTrue();
         response.PageInfo.HasPreviousPage.Should().BeFalse();
         response.PageInfo.StartCursor.Should().NotBeNullOrWhiteSpace();
@@ -76,6 +78,8 @@ public sealed class PaymentQueryResponseMapperTests
             CurrencyCode = "CHF",
             PaymentDateUtc = DateTime.UtcNow,
             PaymentStatus = PaymentStatuses.Authorized,
+            PaymentFlow = PaymentFlows.SubscriptionInvoice,
+            HasInvoice = true,
             HasPendingRefund = true
         };
 }

--- a/server/XUnitTest/Subscription/CreateDiscountRequestValidatorTests.cs
+++ b/server/XUnitTest/Subscription/CreateDiscountRequestValidatorTests.cs
@@ -1,0 +1,42 @@
+using FluentAssertions;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Validators;
+
+namespace XUnitTest.Subscription;
+
+public sealed class CreateDiscountRequestValidatorTests
+{
+    private readonly CreateDiscountRequestValidator _validator = new();
+
+    [Fact]
+    public async Task A_percentage_discount_requires_basis_points()
+    {
+        var result = await _validator.ValidateAsync(new CreateDiscountRequest
+        {
+            Code = "launch", DisplayName = "Launch", Kind = DiscountKind.Percent
+        });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_fixed_discount_requires_amount_and_currency()
+    {
+        var result = await _validator.ValidateAsync(new CreateDiscountRequest
+        {
+            Code = "five-off", DisplayName = "Five off", Kind = DiscountKind.FixedAmount
+        });
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_scoped_percentage_discount_is_valid()
+    {
+        var result = await _validator.ValidateAsync(new CreateDiscountRequest
+        {
+            Code = "launch25", DisplayName = "Launch", Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2500, ApplicablePlanCodes = ["professional"]
+        });
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -113,6 +113,15 @@ public sealed class SubscriptionCheckoutServiceTests
     }
 
     [Fact]
+    public async Task The_initial_charge_is_attributed_to_the_subscriber_organization()
+    {
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        _paymentRequest!.CustomerOrganizationId.Should().Be(OrganizationId);
+    }
+
+    [Fact]
     public async Task The_charge_carries_the_subscriptions_own_order_id_and_idempotency_key()
     {
         await Service().SubscribeAsync(

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -23,6 +23,7 @@ public sealed class SubscriptionCreationServiceTests
 
     private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
     private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
     private readonly Mock<IBillingAccountRepository> _accounts = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero));
@@ -140,25 +141,47 @@ public sealed class SubscriptionCreationServiceTests
     }
 
     [Fact]
-    public async Task Usage_is_metered_monthly_even_on_a_yearly_plan()
+    public async Task A_weekly_usage_window_stays_weekly_while_fees_bill_monthly()
     {
-        _catalogue
-            .Setup(repository => repository.GetPriceAsync(
-                TenantId, "price-1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
-            {
-                var price = NewPrice();
-                price.Interval = BillingInterval.Year;
-
-                return price;
-            });
+        _plan.UsageInterval = BillingInterval.Week;
+        _plan.UsageIntervalCount = 1;
 
         await Service().CreateAsync(
             NewRequest(), Context(), "corr-1", CancellationToken.None);
 
-        _created!.FeeSchedule.Interval.Should().Be(BillingInterval.Year);
-        _created.UsageSchedule.Interval.Should().Be(BillingInterval.Month,
-            "waiting a year to settle metered usage is a year of unsecured credit");
+        _created!.FeeSchedule.Interval.Should().Be(BillingInterval.Month);
+        _created.UsageSchedule.Interval.Should().Be(BillingInterval.Week);
+        _created.NextUsageBillingAtUtc.Should().BeBefore(_created.NextFeeBillingAtUtc!.Value);
+    }
+
+    [Fact]
+    public async Task An_unknown_discount_code_is_refused_instead_of_ignored()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "missing";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_not_found");
+        _created.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_catalogue_discount_is_copied_to_the_subscription()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "launch25";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "launch25", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms { Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2500 }
+            });
+
+        await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        _created!.Discount.Should().NotBeNull();
+        _created.Discount!.PercentBasisPoints.Should().Be(2500);
     }
 
     [Fact]
@@ -359,6 +382,7 @@ public sealed class SubscriptionCreationServiceTests
     private SubscriptionCreationService Service() => new(
         _catalogue.Object,
         _subscriptions.Object,
+        _discounts.Object,
         _accounts.Object,
         new CreateSubscriptionRequestValidator(),
         NullLogger<SubscriptionCreationService>.Instance,

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -60,6 +60,7 @@ public sealed class SubscriptionPlanChangeServiceTests
                 It.IsAny<PlanSnapshot>(),
                 It.IsAny<PriceSnapshot>(),
                 It.IsAny<List<SubscriptionQuantityItem>>(),
+                It.IsAny<SubscriptionPlanSchedule>(),
                 It.IsAny<long>(),
                 It.IsAny<string?>(),
                 It.IsAny<SubscriptionOutboxEvent>(),
@@ -122,7 +123,7 @@ public sealed class SubscriptionPlanChangeServiceTests
             repository => repository.TryChangePlanAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
-                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<long>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(), It.IsAny<long>(),
                 It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -167,6 +168,7 @@ public sealed class SubscriptionPlanChangeServiceTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
                 It.IsAny<List<SubscriptionQuantityItem>>(),
+                It.IsAny<SubscriptionPlanSchedule>(),
                 0L,
                 It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()),
             Times.Once);
@@ -187,7 +189,7 @@ public sealed class SubscriptionPlanChangeServiceTests
     }
 
     [Fact]
-    public async Task A_different_billing_interval_is_refused()
+    public async Task A_different_billing_interval_rebuilds_the_fee_schedule()
     {
         var price = NewPrice(2_000);
         price.Interval = BillingInterval.Year;
@@ -199,7 +201,23 @@ public sealed class SubscriptionPlanChangeServiceTests
         var result = await Service().ChangePlanAsync(
             "sub-1", Request(), "corr-1", CancellationToken.None);
 
-        result.ErrorCode.Should().Be("subscription_plan_change_interval_mismatch");
+        result.IsSuccess.Should().BeTrue();
+        _subscription.FeeSchedule.Interval.Should().Be(BillingInterval.Year);
+    }
+
+    [Fact]
+    public async Task Annual_to_monthly_rebuilds_the_fee_schedule_in_the_other_direction()
+    {
+        _subscription.Price.Interval = BillingInterval.Year;
+        _subscription.FeeSchedule.Interval = BillingInterval.Year;
+        _subscription.CurrentPeriodEndUtc = new DateTime(2027, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _subscription.FeeSchedule.Interval.Should().Be(BillingInterval.Month);
+        _subscription.CurrentPeriodStartUtc.Should().Be(_time.GetUtcNow().UtcDateTime);
     }
 
     [Theory]
@@ -223,7 +241,7 @@ public sealed class SubscriptionPlanChangeServiceTests
             .Setup(repository => repository.TryChangePlanAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
-                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<long>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(), It.IsAny<long>(),
                 It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -61,6 +61,7 @@ public sealed class SubscriptionPlanChangeServiceTests
                 It.IsAny<PriceSnapshot>(),
                 It.IsAny<List<SubscriptionQuantityItem>>(),
                 It.IsAny<SubscriptionPlanSchedule>(),
+                It.IsAny<PendingUsagePeriod>(),
                 It.IsAny<long>(),
                 It.IsAny<string?>(),
                 It.IsAny<SubscriptionOutboxEvent>(),
@@ -123,7 +124,8 @@ public sealed class SubscriptionPlanChangeServiceTests
             repository => repository.TryChangePlanAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
-                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(), It.IsAny<long>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(),
+                It.IsAny<PendingUsagePeriod>(), It.IsAny<long>(),
                 It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
@@ -169,6 +171,7 @@ public sealed class SubscriptionPlanChangeServiceTests
                 It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
                 It.IsAny<List<SubscriptionQuantityItem>>(),
                 It.IsAny<SubscriptionPlanSchedule>(),
+                It.IsAny<PendingUsagePeriod>(),
                 0L,
                 It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()),
             Times.Once);
@@ -220,6 +223,32 @@ public sealed class SubscriptionPlanChangeServiceTests
         _subscription.CurrentPeriodStartUtc.Should().Be(_time.GetUtcNow().UtcDateTime);
     }
 
+    [Fact]
+    public async Task A_change_atomically_queues_the_outgoing_usage_window_for_rating()
+    {
+        _subscription.CurrentUsagePeriodStartUtc = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        _subscription.CurrentUsagePeriodEndUtc = new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Utc);
+        _subscription.Plan.Meters = [new PlanMeter { MeterKey = "requests", IncludedQuantity = 100 }];
+
+        await Service().ChangePlanAsync("sub-1", Request(), "corr-1", CancellationToken.None);
+
+        _subscriptions.Verify(repository => repository.TryChangePlanAsync(
+            TenantId,
+            "sub-1",
+            It.IsAny<int>(),
+            It.IsAny<PlanSnapshot>(),
+            It.IsAny<PriceSnapshot>(),
+            It.IsAny<List<SubscriptionQuantityItem>>(),
+            It.IsAny<SubscriptionPlanSchedule>(),
+            It.Is<PendingUsagePeriod>(period =>
+                period.PeriodStartUtc == new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc) &&
+                period.Plan.Meters[0].IncludedQuantity == 100),
+            It.IsAny<long>(),
+            It.IsAny<string?>(),
+            It.IsAny<SubscriptionOutboxEvent>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Theory]
     [InlineData(SubscriptionStatus.PastDue)]
     [InlineData(SubscriptionStatus.Unpaid)]
@@ -241,7 +270,8 @@ public sealed class SubscriptionPlanChangeServiceTests
             .Setup(repository => repository.TryChangePlanAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
-                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(), It.IsAny<long>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(),
+                It.IsAny<PendingUsagePeriod>(), It.IsAny<long>(),
                 It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 

--- a/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
@@ -17,7 +17,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var subscription = NewSubscription(oldAmountMinor: 1_000);
         var targetPrice = NewPrice(2_000);
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodStart);
 
         outcome.ChargeMinor.Should().Be(1_000);
@@ -30,7 +30,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var subscription = NewSubscription(oldAmountMinor: 1_000);
         var targetPrice = NewPrice(2_000);
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodEnd);
 
         outcome.ChargeMinor.Should().Be(0);
@@ -44,7 +44,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var targetPrice = NewPrice(1_000);
         var halfway = PeriodStart.AddDays(15);
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], halfway);
 
         outcome.ChargeMinor.Should().Be(0);
@@ -57,7 +57,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var subscription = NewSubscription(oldAmountMinor: 1_000, creditBalanceMinor: 1_000);
         var targetPrice = NewPrice(2_000);
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodStart);
 
         // The full 1,000 difference is covered by the existing 1,000 credit.
@@ -71,7 +71,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var subscription = NewSubscription(oldAmountMinor: 1_000, creditBalanceMinor: 5_000);
         var targetPrice = NewPrice(2_000);
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodStart);
 
         outcome.ChargeMinor.Should().Be(0);
@@ -86,7 +86,7 @@ public sealed class SubscriptionProrationCalculatorTests
             discount: new DiscountTerms { Kind = DiscountKind.Percent, PercentBasisPoints = 5_000 });
         var targetPrice = NewPrice(2_000);
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodStart);
 
         // Without the discount this would be 1,000 (2,000 - 1,000); halved on both sides it is
@@ -100,7 +100,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var subscription = NewSubscription(oldAmountMinor: 1_000);
         var targetPrice = NewPrice(1_000);
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodStart.AddDays(10));
 
         outcome.ChargeMinor.Should().Be(0);
@@ -115,7 +115,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var targetPrice = NewPrice(2_000);
         targetPrice.TaxRateBasisPoints = 1_000;
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodStart);
 
         // Old side: 1,000 + 10% = 1,100. New side: 2,000 + 10% = 2,200. Delta = 1,100.
@@ -130,7 +130,7 @@ public sealed class SubscriptionProrationCalculatorTests
         var targetPrice = NewPrice(1_000);
         targetPrice.TaxRateBasisPoints = 2_000; // new price carries 20% tax
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        var outcome = Calculate(
             subscription, targetPrice, [], PeriodStart);
 
         // Old side stays 1,000 (no tax). New side is 1,000 + 20% = 1,200. Delta = 200.
@@ -152,4 +152,16 @@ public sealed class SubscriptionProrationCalculatorTests
 
     private static PriceSnapshot NewPrice(long unitAmountMinor) =>
         new() { UnitAmountMinor = unitAmountMinor };
+
+    private static ProrationOutcome Calculate(
+        SubscriptionDetail subscription,
+        PriceSnapshot targetPrice,
+        IReadOnlyList<SubscriptionQuantityItem> quantities,
+        DateTime nowUtc) => SubscriptionProrationCalculator.Calculate(
+            subscription,
+            targetPrice,
+            quantities,
+            nowUtc,
+            PeriodStart,
+            PeriodEnd);
 }

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -47,6 +47,11 @@ public sealed class SubscriptionUsageRatingProcessorTests
             .ReturnsAsync(true);
 
         _subscriptions
+            .Setup(repository => repository.TryRemovePendingUsagePeriodAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _subscriptions
             .Setup(repository => repository.GetByIdAsync(
                 TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string tenantId, string subscriptionId, CancellationToken _) =>
@@ -132,6 +137,38 @@ public sealed class SubscriptionUsageRatingProcessorTests
         _createdInvoice.TotalAmountMinor.Should().Be(2_000);
         _createdInvoice.Lines.Should().ContainSingle(line => line.MeterKey == "screening");
         _createdInvoice.NextAttemptAtUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task A_plan_change_rates_the_detached_window_under_its_original_allowance()
+    {
+        var subscription = NewSubscription("sub-1");
+        var oldPlan = subscription.Plan;
+        subscription.Plan = new PlanSnapshot { Meters = [] };
+        subscription.CurrentUsagePeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc);
+        subscription.PendingUsagePeriods =
+        [
+            new PendingUsagePeriod
+            {
+                PeriodKey = "M20260801T000000Z",
+                Plan = oldPlan,
+                Price = subscription.Price,
+                CurrencyCode = "CHF",
+                CorrelationId = "change-1"
+            }
+        ];
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 700)]);
+
+        var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        closed.Should().Be(1);
+        _createdInvoice!.TotalAmountMinor.Should().Be(2_000);
+        _subscriptions.Verify(repository => repository.TryRemovePendingUsagePeriodAsync(
+            TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Makes the subscription catalogue usable by client applications and implements the seven agreed workstreams.

- removes the fictional pricing-shape choice, separates quantity items and meters, inherits entitlement limits, renames the grant step, and adds plan duplication
- adds configurable, snapshotted usage windows independent of fee cadence
- allows cross-interval plan changes and atomically rebuilds fee and usage schedules with proration
- adds plan-family metadata, family catalogue grouping, ranks, and display price notes
- implements a scoped discount catalogue with validation, retirement, subscription-time lookup, and immutable subscription snapshots
- makes subscription payments visible to subscriber organizations, attributes checkout payments consistently, and exposes payment flow/invoice availability
- updates the maintained subscription documentation, including price archival, discounts, invoices, and the first-checkout invoice boundary

## Impact

Clients can express flat-fee, per-seat, metered, mixed, family-tiered, and discounted catalogues without relying on inferred UI state. Subscription schedules now follow stored plan terms, cadence changes are safe, and subscriber payment lists can render invoice download actions without probing each payment.

## Verification

- `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName!~Integration" --no-restore --verbosity minimal -p:WarningLevel=0` — 2,179 passed, 1 skipped
- subscription/payment focused server tests — 328 passed
- client TypeScript typecheck — passed
- client ESLint for changed subscription/router files — passed
- `vitest run app/cross-modules/utilities/subscription --maxWorkers=1` — 106 passed
- `git diff --check` — passed

The repository-wide client `npm test` command was attempted with default workers and one worker, but hangs after unrelated zero-test/jsdom canvas suites; the focused subscription suite is clean.

Integration tests were not run because they require a local MongoDB instance.

## Known repository boundary

This client package has no subscriber checkout/subscribe form. The server now validates and applies `discountCode`, and the client includes discount catalogue authoring; a checkout UI in its owning application can pass the existing request field.