### PR TITLE
Add persistent meter allowances

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -142,6 +142,7 @@ const PlanBuilderWizard = ({
       displayName: meter?.displayName ?? "",
       unitLabel: meter?.unitLabel ?? "",
       includedQuantity: meter?.includedQuantity ?? 0,
+      resetPolicy: meter?.resetPolicy ?? 0,
       overageAllowed: meter?.overageAllowed ?? false,
       // Only the currency matters to the summary — its presence is what decides whether
       // overage reads as billed or given away.

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -1,6 +1,10 @@
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { ChevronDown } from "lucide-react";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui-kits/collapsible/collapsible";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui-kits/collapsible/collapsible";
 import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import {
   FormControl,
@@ -17,7 +21,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui-kits/select/select";
-import { BILLING_INTERVAL_OPTIONS, METER_AGGREGATION_OPTIONS } from "../../constants/subscription.constants";
+import {
+  BILLING_INTERVAL_OPTIONS,
+  METER_AGGREGATION_OPTIONS,
+  METER_RESET_POLICY_OPTIONS,
+} from "../../constants/subscription.constants";
 import type { PlanPrice } from "../../models/subscription-plan.model";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 import { CardListItem, CardListShell } from "./card-list-shell";
@@ -36,7 +44,7 @@ export const StepPricingModel = ({
   onRetirePrice?: (priceId: string) => void;
   retiringPriceId?: string | null;
 }) => {
-  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
 
   const quantityItems = useFieldArray({ control, name: "quantityItems" });
   const meters = useFieldArray({ control, name: "meters" });
@@ -58,147 +66,52 @@ export const StepPricingModel = ({
         description="Use these when price scales with seats, users, or another selected quantity."
         defaultOpen={quantityItems.fields.length > 0}
       >
-          <CardListShell
-            addLabel="Add quantity item"
-            onAdd={() =>
-              quantityItems.append({
-                itemKey: "",
-                unitLabel: "",
-                minQuantity: 1,
-                defaultQuantity: 1,
-              })
-            }
-          >
-            {quantityItems.fields.map((field, index) => (
-              <CardListItem key={field.id} onRemove={() => quantityItems.remove(index)}>
+        <CardListShell
+          addLabel="Add quantity item"
+          onAdd={() =>
+            quantityItems.append({
+              itemKey: "",
+              unitLabel: "",
+              minQuantity: 1,
+              defaultQuantity: 1,
+            })
+          }
+        >
+          {quantityItems.fields.map((field, index) => (
+            <CardListItem key={field.id} onRemove={() => quantityItems.remove(index)}>
+              <FormField
+                control={control}
+                name={`quantityItems.${index}.itemKey`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Item key</FormLabel>
+                    <FormControl>
+                      <Input {...inputField} placeholder="seat" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name={`quantityItems.${index}.unitLabel`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Unit label</FormLabel>
+                    <FormControl>
+                      <Input {...inputField} placeholder="seat" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="grid grid-cols-2 gap-2">
                 <FormField
                   control={control}
-                  name={`quantityItems.${index}.itemKey`}
+                  name={`quantityItems.${index}.defaultQuantity`}
                   render={({ field: inputField }) => (
                     <FormItem>
-                      <FormLabel className="text-xs">Item key</FormLabel>
-                      <FormControl>
-                        <Input {...inputField} placeholder="seat" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={control}
-                  name={`quantityItems.${index}.unitLabel`}
-                  render={({ field: inputField }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Unit label</FormLabel>
-                      <FormControl>
-                        <Input {...inputField} placeholder="seat" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <div className="grid grid-cols-2 gap-2">
-                  <FormField
-                    control={control}
-                    name={`quantityItems.${index}.defaultQuantity`}
-                    render={({ field: inputField }) => (
-                      <FormItem>
-                        <FormLabel className="text-xs">Default qty</FormLabel>
-                        <FormControl>
-                          <Input {...inputField} type="number" min={0} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={control}
-                    name={`quantityItems.${index}.maxQuantity`}
-                    render={({ field: inputField }) => (
-                      <FormItem>
-                        <FormLabel className="text-xs">Max (optional)</FormLabel>
-                        <FormControl>
-                          <Input {...inputField} type="number" min={0} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-              </CardListItem>
-            ))}
-          </CardListShell>
-      </OptionalSection>
-
-      <OptionalSection
-        title="Meters"
-        description="Use meters to track an allowance and optionally bill usage beyond it."
-        defaultOpen={meters.fields.length > 0}
-      >
-          <CardListShell
-            addLabel="Add meter"
-            onAdd={() =>
-              meters.append({
-                meterKey: "",
-                displayName: "",
-                unitLabel: "",
-                aggregation: 0,
-                includedQuantity: 0,
-                overageAllowed: true,
-                thresholdPercents: [],
-                rateTables: [],
-              })
-            }
-          >
-            {meters.fields.map((field, index) => (
-              <CardListItem key={field.id} onRemove={() => meters.remove(index)}>
-                <FormField
-                  control={control}
-                  name={`meters.${index}.displayName`}
-                  render={({ field: inputField }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Display name</FormLabel>
-                      <FormControl>
-                        <Input {...inputField} placeholder="API calls" />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <div className="grid grid-cols-2 gap-2">
-                  <FormField
-                    control={control}
-                    name={`meters.${index}.meterKey`}
-                    render={({ field: inputField }) => (
-                      <FormItem>
-                        <FormLabel className="text-xs">Meter key</FormLabel>
-                        <FormControl>
-                          <Input {...inputField} placeholder="api-calls" />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={control}
-                    name={`meters.${index}.unitLabel`}
-                    render={({ field: inputField }) => (
-                      <FormItem>
-                        <FormLabel className="text-xs">Unit label</FormLabel>
-                        <FormControl>
-                          <Input {...inputField} placeholder="call" />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <FormField
-                  control={control}
-                  name={`meters.${index}.includedQuantity`}
-                  render={({ field: inputField }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Included per period</FormLabel>
+                      <FormLabel className="text-xs">Default qty</FormLabel>
                       <FormControl>
                         <Input {...inputField} type="number" min={0} />
                       </FormControl>
@@ -208,31 +121,169 @@ export const StepPricingModel = ({
                 />
                 <FormField
                   control={control}
-                  name={`meters.${index}.aggregation`}
+                  name={`quantityItems.${index}.maxQuantity`}
                   render={({ field: inputField }) => (
                     <FormItem>
-                      <FormLabel className="text-xs">How usage is measured</FormLabel>
-                      <Select
-                        value={String(inputField.value)}
-                        onValueChange={(value) => inputField.onChange(Number(value))}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {METER_AGGREGATION_OPTIONS.map((option) => (
-                            <SelectItem key={option.value} value={String(option.value)}>
-                              {option.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel className="text-xs">Max (optional)</FormLabel>
+                      <FormControl>
+                        <Input {...inputField} type="number" min={0} />
+                      </FormControl>
                       <FormMessage />
                     </FormItem>
                   )}
                 />
+              </div>
+            </CardListItem>
+          ))}
+        </CardListShell>
+      </OptionalSection>
+
+      <OptionalSection
+        title="Meters"
+        description="Use meters to track an allowance and optionally bill usage beyond it."
+        defaultOpen={meters.fields.length > 0}
+      >
+        <CardListShell
+          addLabel="Add meter"
+          onAdd={() =>
+            meters.append({
+              meterKey: "",
+              displayName: "",
+              unitLabel: "",
+              aggregation: 0,
+              resetPolicy: 0,
+              includedQuantity: 0,
+              overageAllowed: true,
+              thresholdPercents: [],
+              rateTables: [],
+            })
+          }
+        >
+          {meters.fields.map((field, index) => (
+            <CardListItem key={field.id} onRemove={() => meters.remove(index)}>
+              <FormField
+                control={control}
+                name={`meters.${index}.displayName`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Display name</FormLabel>
+                    <FormControl>
+                      <Input {...inputField} placeholder="API calls" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="grid grid-cols-2 gap-2">
+                <FormField
+                  control={control}
+                  name={`meters.${index}.meterKey`}
+                  render={({ field: inputField }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs">Meter key</FormLabel>
+                      <FormControl>
+                        <Input {...inputField} placeholder="api-calls" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={control}
+                  name={`meters.${index}.unitLabel`}
+                  render={({ field: inputField }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs">Unit label</FormLabel>
+                      <FormControl>
+                        <Input {...inputField} placeholder="call" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <FormField
+                control={control}
+                name={`meters.${index}.includedQuantity`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">
+                      {meterValues?.[index]?.resetPolicy === 1
+                        ? "Included for subscription lifetime"
+                        : "Included per period"}
+                    </FormLabel>
+                    <FormControl>
+                      <Input {...inputField} type="number" min={0} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name={`meters.${index}.resetPolicy`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Allowance resets</FormLabel>
+                    <Select
+                      value={String(inputField.value)}
+                      onValueChange={(value) => {
+                        const policy = Number(value);
+                        inputField.onChange(policy);
+                        if (policy === 1) {
+                          setValue(`meters.${index}.overageAllowed`, false);
+                          setValue(`meters.${index}.rateTables`, []);
+                        }
+                      }}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {METER_RESET_POLICY_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={String(option.value)}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      Choose Never for capacity that must remain consumed after renewal.
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name={`meters.${index}.aggregation`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">How usage is measured</FormLabel>
+                    <Select
+                      value={String(inputField.value)}
+                      onValueChange={(value) => inputField.onChange(Number(value))}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {METER_AGGREGATION_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={String(option.value)}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {meterValues?.[index]?.resetPolicy !== 1 ? (
                 <FormField
                   control={control}
                   name={`meters.${index}.overageAllowed`}
@@ -252,78 +303,92 @@ export const StepPricingModel = ({
                     </FormItem>
                   )}
                 />
-                <FormField
-                  control={control}
-                  name={`meters.${index}.thresholdPercents`}
-                  render={({ field: inputField }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Notify at</FormLabel>
-                      <ThresholdChipInput
-                        value={inputField.value}
-                        onChange={inputField.onChange}
-                      />
-                    </FormItem>
-                  )}
-                />
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Lifetime capacity stops at its included amount and is not billed as monthly
+                  overage.
+                </p>
+              )}
+              <FormField
+                control={control}
+                name={`meters.${index}.thresholdPercents`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Notify at</FormLabel>
+                    <ThresholdChipInput value={inputField.value} onChange={inputField.onChange} />
+                  </FormItem>
+                )}
+              />
 
-                {/* Only meaningful where overage is permitted: a blocked meter never produces
+              {/* Only meaningful where overage is permitted: a blocked meter never produces
                     billable units, so there is nothing to price. */}
-                {meterValues?.[index]?.overageAllowed ? (
-                  <FormItem>
-                    <FormLabel className="text-xs">Overage pricing</FormLabel>
-                    {meterValues[index]?.rateTables?.length ? null : (
-                      <p className="text-xs text-muted-foreground">
-                        No price set, so usage past the allowance is billed nothing.
-                      </p>
-                    )}
-                    <MeterRateTableFields meterIndex={index} />
-                  </FormItem>
-                ) : null}
-              </CardListItem>
-            ))}
-          </CardListShell>
-          {(meterValues?.length ?? 0) > 0 && (
-            <div className="grid gap-2 rounded-lg border p-3 sm:grid-cols-2">
-              <FormField
-                control={control}
-                name="usageInterval"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-xs">Allowance resets every</FormLabel>
-                    <Select value={String(field.value)} onValueChange={(value) => field.onChange(Number(value))}>
-                      <FormControl><SelectTrigger><SelectValue /></SelectTrigger></FormControl>
-                      <SelectContent>
-                        {BILLING_INTERVAL_OPTIONS.map((option) => (
-                          <SelectItem key={option.value} value={String(option.value)}>{option.label}</SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={control}
-                name="usageIntervalCount"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-xs">How many</FormLabel>
-                    <FormControl><Input {...field} type="number" min={1} max={100} /></FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          )}
+              {meterValues?.[index]?.overageAllowed ? (
+                <FormItem>
+                  <FormLabel className="text-xs">Overage pricing</FormLabel>
+                  {meterValues[index]?.rateTables?.length ? null : (
+                    <p className="text-xs text-muted-foreground">
+                      No price set, so usage past the allowance is billed nothing.
+                    </p>
+                  )}
+                  <MeterRateTableFields meterIndex={index} />
+                </FormItem>
+              ) : null}
+            </CardListItem>
+          ))}
+        </CardListShell>
+        {(meterValues ?? []).some((meter) => meter.resetPolicy !== 1) && (
+          <div className="grid gap-2 rounded-lg border p-3 sm:grid-cols-2">
+            <FormField
+              control={control}
+              name="usageInterval"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">Allowance resets every</FormLabel>
+                  <Select
+                    value={String(field.value)}
+                    onValueChange={(value) => field.onChange(Number(value))}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {BILLING_INTERVAL_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={String(option.value)}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={control}
+              name="usageIntervalCount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">How many</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="number" min={1} max={100} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        )}
       </OptionalSection>
 
       {/* Last in the step because a price may multiply a quantity item, which is defined above
           it. Not gated on the pricing shape: every plan needs a price, whatever its shape. */}
       <PlanPriceFields
-          isEditing={isEditing}
-          existingPrices={existingPrices}
-          onRetirePrice={onRetirePrice}
-          retiringPriceId={retiringPriceId}
+        isEditing={isEditing}
+        existingPrices={existingPrices}
+        onRetirePrice={onRetirePrice}
+        retiringPriceId={retiringPriceId}
       />
     </div>
   );
@@ -342,7 +407,10 @@ const OptionalSection = ({
 }) => (
   <Collapsible defaultOpen={defaultOpen} className="rounded-xl border p-4">
     <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
-      <span><span className="block text-sm font-semibold">{title}</span><span className="block text-xs text-muted-foreground">{description}</span></span>
+      <span>
+        <span className="block text-sm font-semibold">{title}</span>
+        <span className="block text-xs text-muted-foreground">{description}</span>
+      </span>
       <ChevronDown className="h-4 w-4 shrink-0" />
     </CollapsibleTrigger>
     <CollapsibleContent className="space-y-3 pt-4">{children}</CollapsibleContent>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -77,8 +77,9 @@ export const StepTrial = () => {
         <div className="space-y-3">
           <h3 className="text-sm font-semibold">Trial grants</h3>
           <p className="text-xs text-muted-foreground">
-            Give a trial its own allowance for a meter instead of the plan&apos;s normal one — useful
-            when the regular allowance would be an open invitation to sign up, consume and leave.
+            Give a trial its own allowance for a meter instead of the plan&apos;s normal one —
+            useful when the regular allowance would be an open invitation to sign up, consume and
+            leave.
           </p>
           <CardListShell
             addLabel="Add trial grant"
@@ -100,7 +101,7 @@ export const StepTrial = () => {
                         </FormControl>
                         <SelectContent>
                           {(meters ?? [])
-                            .filter((meter) => meter.meterKey)
+                            .filter((meter) => meter.meterKey && meter.resetPolicy !== 1)
                             .map((meter) => (
                               <SelectItem key={meter.meterKey} value={meter.meterKey}>
                                 {meter.displayName || meter.meterKey}

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -26,6 +26,7 @@ export interface PlanSummaryData {
     displayName: string;
     unitLabel: string;
     includedQuantity: number;
+    resetPolicy?: number | string;
     overageAllowed: boolean;
     /** Drives whether overage is described as billed or given away. */
     rateTables?: { currencyCode: string }[];
@@ -72,9 +73,7 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
       <CardHeader className="gap-2">
         <div className="flex flex-wrap items-center gap-2">
           <CardTitle>{plan.displayName || "Untitled plan"}</CardTitle>
-          {plan.trialDays ? (
-            <Badge variant="info">{plan.trialDays}-day trial</Badge>
-          ) : null}
+          {plan.trialDays ? <Badge variant="info">{plan.trialDays}-day trial</Badge> : null}
         </div>
         <p className="text-xs text-muted-foreground">
           {plan.code || "no-code-yet"} · {plan.organizationLabel}
@@ -110,10 +109,12 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
               {plan.meters.map((meter, index) => (
                 <p key={index}>
                   {meter.displayName}:{" "}
-                  {formatTrialAllowance(
-                    meter,
-                    plan.trialGrants.find((grant) => grant.meterKey === meter.meterKey),
-                  )}
+                  {meter.resetPolicy === 1 || meter.resetPolicy === "Never"
+                    ? `${formatMeterAllowance(meter)} for the subscription lifetime`
+                    : formatTrialAllowance(
+                        meter,
+                        plan.trialGrants.find((grant) => grant.meterKey === meter.meterKey),
+                      )}
                 </p>
               ))}
             </div>
@@ -131,9 +132,7 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
                   {/* The ceiling is part of what the plan sells — a buyer choosing between
                       tiers needs to see it, and it is the one quantity rule that refuses a
                       subscription outright rather than just costing more. */}
-                  {item.maxQuantity === null
-                    ? ""
-                    : `, up to ${item.maxQuantity.toLocaleString()}`}
+                  {item.maxQuantity === null ? "" : `, up to ${item.maxQuantity.toLocaleString()}`}
                 </p>
               ))}
             </div>
@@ -147,7 +146,10 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
               {plan.meters.map((meter, index) => (
                 <p key={index}>
                   <span className="font-medium">{meter.displayName}:</span>{" "}
-                  {formatMeterAllowance(meter)}
+                  {formatMeterAllowance(meter)} ·{" "}
+                  {meter.resetPolicy === 1 || meter.resetPolicy === "Never"
+                    ? "never resets"
+                    : "resets each allowance period"}
                 </p>
               ))}
             </div>
@@ -167,9 +169,7 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
                       <span className="font-medium">{entitlement.key}:</span>{" "}
                       {formatEntitlementLimit(entitlement)}
                     </p>
-                    {mismatch && (
-                      <p className="text-xs text-warning-700">{mismatch}</p>
-                    )}
+                    {mismatch && <p className="text-xs text-warning-700">{mismatch}</p>}
                   </div>
                 );
               })}

--- a/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
+++ b/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
@@ -19,6 +19,11 @@ export const METER_AGGREGATION_OPTIONS = [
   { value: 2, label: "Last value — only the most recent recording" },
 ] as const;
 
+export const METER_RESET_POLICY_OPTIONS = [
+  { value: 0, label: "Every allowance period — tokens, requests, generations" },
+  { value: 1, label: "Never — persistent capacity such as storage" },
+] as const;
+
 export const ENTITLEMENT_LIMIT_KIND_OPTIONS = [
   { value: 0, label: "Boolean — granted or not, no number attached" },
   { value: 1, label: "Count — a numeric limit, drawn from a meter" },

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -18,6 +18,11 @@ export const METER_AGGREGATION = {
   LastValue: 2,
 } as const;
 
+export const METER_RESET_POLICY = {
+  Periodic: 0,
+  Never: 1,
+} as const;
+
 export const ENTITLEMENT_LIMIT_KIND = {
   Boolean: 0,
   Count: 1,
@@ -31,6 +36,7 @@ export const BILLING_INTERVAL_NAMES = ["Day", "Week", "Month", "Year"] as const;
 
 export type BillingIntervalName = keyof typeof BILLING_INTERVAL;
 export type MeterAggregationName = keyof typeof METER_AGGREGATION;
+export type MeterResetPolicyName = keyof typeof METER_RESET_POLICY;
 export type EntitlementLimitKindName = keyof typeof ENTITLEMENT_LIMIT_KIND;
 
 export interface PlanQuantityItem {
@@ -57,6 +63,8 @@ export interface PlanMeter {
   unitLabel: string;
   /** Response DTOs carry this as a string name (e.g. "Sum"); requests send the numeric value. */
   aggregation: MeterAggregationName;
+  /** Periodic meters reset with the plan window; Never meters keep one lifetime balance. */
+  resetPolicy?: MeterResetPolicyName;
   includedQuantity: number;
   overageAllowed: boolean;
   thresholdPercents: number[];
@@ -133,6 +141,7 @@ export interface CreatePlanMeterRequest {
   displayName: string;
   unitLabel: string;
   aggregation: number;
+  resetPolicy: number;
   includedQuantity: number;
   overageAllowed: boolean;
   thresholdPercents: number[];

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -15,7 +15,11 @@ import { useArchiveSubscriptionPrice } from "../hooks/use-archive-subscription-p
 import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
 import { describeEntitlementMeterMismatch } from "../utilities/plan-consistency";
-import { formatEntitlementLimit, formatMeterAllowance, formatPrice } from "../utilities/subscription-format";
+import {
+  formatEntitlementLimit,
+  formatMeterAllowance,
+  formatPrice,
+} from "../utilities/subscription-format";
 
 export const SubscriptionPlanDetailPage = () => {
   const { itemId, planId } = useParams();
@@ -23,10 +27,7 @@ export const SubscriptionPlanDetailPage = () => {
   const basePath = `/app/${itemId ?? ""}/subscription/plans`;
   const listPath = withOrganizationScope(basePath, organizationScope);
 
-  const { data: plan, error, isError, isLoading } = useSubscriptionPlan(
-    planId,
-    organizationScope,
-  );
+  const { data: plan, error, isError, isLoading } = useSubscriptionPlan(planId, organizationScope);
 
   const { mutateAsync: archivePrice } = useArchiveSubscriptionPrice();
   const [retiringPriceId, setRetiringPriceId] = useState<string | null>(null);
@@ -154,14 +155,24 @@ export const SubscriptionPlanDetailPage = () => {
               </Button>
             ) : (
               <Button variant="outline" asChild>
-                <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/edit`, plan.organizationId)}>
+                <Link
+                  to={withOrganizationScope(
+                    `${basePath}/${encodeURIComponent(plan.planId)}/edit`,
+                    plan.organizationId,
+                  )}
+                >
                   <Pencil className="mr-2 h-4 w-4" />
                   Edit
                 </Link>
               </Button>
             )}
             <Button asChild>
-              <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`, plan.organizationId)}>
+              <Link
+                to={withOrganizationScope(
+                  `${basePath}/${encodeURIComponent(plan.planId)}/prices/create`,
+                  plan.organizationId,
+                )}
+              >
                 <Plus className="mr-2 h-4 w-4" />
                 Add price
               </Link>
@@ -181,8 +192,7 @@ export const SubscriptionPlanDetailPage = () => {
                     <p className="text-sm text-muted-foreground">
                       {item.defaultQuantity.toLocaleString()} {item.unitLabel}
                       {item.defaultQuantity === 1 ? "" : "s"} by default
-                      {item.maxQuantity !== null &&
-                        ` (max ${item.maxQuantity.toLocaleString()})`}
+                      {item.maxQuantity !== null && ` (max ${item.maxQuantity.toLocaleString()})`}
                     </p>
                   </Card>
                 ))}
@@ -202,6 +212,11 @@ export const SubscriptionPlanDetailPage = () => {
                     <IdentifierField label="Meter key" value={meter.meterKey} />
                     <p className="mt-2 text-sm text-muted-foreground">
                       {formatMeterAllowance(meter)}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {meter.resetPolicy === "Never"
+                        ? "Lifetime allowance — usage survives renewals"
+                        : "Resets with the plan allowance period"}
                     </p>
                     {/* Optional-chained deliberately: a plan stored before the response
                         carried thresholds has no array here at all, and reading length off
@@ -255,7 +270,12 @@ export const SubscriptionPlanDetailPage = () => {
                   No price yet — subscribers cannot check out until one exists.
                 </p>
                 <Button asChild size="sm">
-                  <Link to={withOrganizationScope(`${basePath}/${encodeURIComponent(plan.planId)}/prices/create`, plan.organizationId)}>
+                  <Link
+                    to={withOrganizationScope(
+                      `${basePath}/${encodeURIComponent(plan.planId)}/prices/create`,
+                      plan.organizationId,
+                    )}
+                  >
                     <Plus className="mr-2 h-4 w-4" />
                     Add price
                   </Link>
@@ -266,7 +286,9 @@ export const SubscriptionPlanDetailPage = () => {
                 {plan.prices.map((price) => (
                   <Card key={price.priceId} className="rounded-lg">
                     <p className="font-medium">{formatPrice(price)}</p>
-                    {price.displayPriceNote && <p className="text-xs text-muted-foreground">{price.displayPriceNote}</p>}
+                    {price.displayPriceNote && (
+                      <p className="text-xs text-muted-foreground">{price.displayPriceNote}</p>
+                    )}
                     {/* Subscribing names the price by this id, so leaving it off the page meant
                         nobody could subscribe without reading the API first. */}
                     <IdentifierField label="Price id" value={price.priceId} />

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
@@ -188,6 +188,48 @@ describe("createSubscriptionPlanSchema", () => {
     }
   });
 
+  it("accepts lifetime capacity when overage is blocked", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [
+        {
+          meterKey: "storage",
+          displayName: "Storage",
+          unitLabel: "byte",
+          aggregation: 0,
+          resetPolicy: 1,
+          includedQuantity: 5_368_709_120,
+          overageAllowed: false,
+          thresholdPercents: [80, 100],
+          rateTables: [],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects monthly overage pricing on lifetime capacity", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [
+        {
+          meterKey: "storage",
+          displayName: "Storage",
+          unitLabel: "byte",
+          aggregation: 0,
+          resetPolicy: 1,
+          includedQuantity: 5_368_709_120,
+          overageAllowed: true,
+          thresholdPercents: [],
+          rateTables: [],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("refuses a plan with no price, which nobody could subscribe to", () => {
     const result = createSubscriptionPlanSchema.safeParse({ ...validPlan, prices: [] });
 

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -41,11 +41,7 @@ const meterTierSchema = z.object({
 
 const meterRateTableSchema = z
   .object({
-    currencyCode: z
-      .string()
-      .trim()
-      .length(3, "Use a three-letter currency code.")
-      .toUpperCase(),
+    currencyCode: z.string().trim().length(3, "Use a three-letter currency code.").toUpperCase(),
     tiers: z.array(meterTierSchema).min(1, "Add at least one tier."),
   })
   .superRefine((table, context) => {
@@ -79,6 +75,7 @@ const meterSchema = z.object({
   displayName: z.string().trim().min(1, "Enter a display name.").max(200),
   unitLabel: key("unit label"),
   aggregation: z.coerce.number().int().min(0).max(2),
+  resetPolicy: z.coerce.number().int().min(0).max(1).default(0),
   includedQuantity: z.coerce.number().int().min(0),
   overageAllowed: z.boolean(),
   thresholdPercents: z.array(z.number().int().min(1).max(100)),
@@ -93,10 +90,10 @@ const quantityItemSchema = z
     maxQuantity: z.coerce.number().int().positive().optional(),
     defaultQuantity: z.coerce.number().int().min(0),
   })
-  .refine(
-    (item) => item.maxQuantity === undefined || item.maxQuantity >= item.minQuantity,
-    { message: "The maximum cannot be below the minimum.", path: ["maxQuantity"] },
-  );
+  .refine((item) => item.maxQuantity === undefined || item.maxQuantity >= item.minQuantity, {
+    message: "The maximum cannot be below the minimum.",
+    path: ["maxQuantity"],
+  });
 
 const entitlementSchema = z
   .object({
@@ -133,119 +130,136 @@ const priceTerms = (price: z.infer<typeof subscriptionPriceFieldsSchema>) =>
  */
 export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: boolean }) =>
   z
-  .object({
-    code: z
-      .string()
-      .trim()
-      .min(1, "Enter a plan code.")
-      .max(SUBSCRIPTION_PLAN_CODE_MAX_LENGTH)
-      .regex(
-        /^[a-z0-9_-]+$/,
-        "Use only lowercase letters, digits, hyphens and underscores.",
+    .object({
+      code: z
+        .string()
+        .trim()
+        .min(1, "Enter a plan code.")
+        .max(SUBSCRIPTION_PLAN_CODE_MAX_LENGTH)
+        .regex(/^[a-z0-9_-]+$/, "Use only lowercase letters, digits, hyphens and underscores."),
+      displayName: z
+        .string()
+        .trim()
+        .min(1, "Enter a display name.")
+        .max(SUBSCRIPTION_DISPLAY_NAME_MAX_LENGTH),
+      description: z.string().trim().max(2000).optional().or(z.literal("")),
+      featuresJson: z
+        .string()
+        .trim()
+        .max(SUBSCRIPTION_FEATURES_JSON_MAX_LENGTH)
+        .optional()
+        .or(z.literal("")),
+      organizationId: z.string().min(1, "Choose an organization."),
+      trialDays: z.coerce.number().int().min(1).max(365).optional(),
+      trialRequiresPaymentMethod: z.boolean(),
+      usageInterval: z.coerce.number().int().min(0).max(3),
+      usageIntervalCount: z.coerce.number().int().min(1).max(100),
+      familyCode: z.string().trim().max(SUBSCRIPTION_KEY_MAX_LENGTH).optional().or(z.literal("")),
+      familyRank: z.preprocess(
+        (value) => (value === "" ? undefined : value),
+        z.coerce.number().int().min(0).optional(),
       ),
-    displayName: z
-      .string()
-      .trim()
-      .min(1, "Enter a display name.")
-      .max(SUBSCRIPTION_DISPLAY_NAME_MAX_LENGTH),
-    description: z.string().trim().max(2000).optional().or(z.literal("")),
-    featuresJson: z
-      .string()
-      .trim()
-      .max(SUBSCRIPTION_FEATURES_JSON_MAX_LENGTH)
-      .optional()
-      .or(z.literal("")),
-    organizationId: z.string().min(1, "Choose an organization."),
-    trialDays: z.coerce.number().int().min(1).max(365).optional(),
-    trialRequiresPaymentMethod: z.boolean(),
-    usageInterval: z.coerce.number().int().min(0).max(3),
-    usageIntervalCount: z.coerce.number().int().min(1).max(100),
-    familyCode: z.string().trim().max(SUBSCRIPTION_KEY_MAX_LENGTH).optional().or(z.literal("")),
-    familyRank: z.preprocess(
-      (value) => value === "" ? undefined : value,
-      z.coerce.number().int().min(0).optional(),
-    ),
-    quantityItems: z.array(quantityItemSchema),
-    meters: z.array(meterSchema),
-    entitlements: z.array(entitlementSchema),
-    trialGrants: z.array(trialGrantSchema),
-    prices: z.array(subscriptionPriceFieldsSchema),
-  })
-  .superRefine((plan, context) => {
-    if (plan.featuresJson && !isJsonObject(plan.featuresJson)) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["featuresJson"],
-        message: "Features must be a valid JSON object, e.g. {\"betaAccess\": true}.",
+      quantityItems: z.array(quantityItemSchema),
+      meters: z.array(meterSchema),
+      entitlements: z.array(entitlementSchema),
+      trialGrants: z.array(trialGrantSchema),
+      prices: z.array(subscriptionPriceFieldsSchema),
+    })
+    .superRefine((plan, context) => {
+      if (plan.featuresJson && !isJsonObject(plan.featuresJson)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["featuresJson"],
+          message: 'Features must be a valid JSON object, e.g. {"betaAccess": true}.',
+        });
+      }
+
+      if (Boolean(plan.familyCode) !== (plan.familyRank !== undefined)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [plan.familyCode ? "familyRank" : "familyCode"],
+          message: "Family code and rank must be supplied together.",
+        });
+      }
+
+      const meterKeys = new Set(plan.meters.map((meter) => meter.meterKey));
+      const lifetimeMeterKeys = new Set(
+        plan.meters.filter((meter) => meter.resetPolicy === 1).map((meter) => meter.meterKey),
+      );
+
+      plan.meters.forEach((meter, index) => {
+        if (meter.resetPolicy === 1 && (meter.overageAllowed || meter.rateTables.length > 0)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["meters", index, "resetPolicy"],
+            message:
+              "Lifetime capacity must stop at its allowance; it cannot use monthly overage billing.",
+          });
+        }
       });
-    }
 
-    if (Boolean(plan.familyCode) !== (plan.familyRank !== undefined)) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: [plan.familyCode ? "familyRank" : "familyCode"],
-        message: "Family code and rank must be supplied together.",
+      plan.entitlements.forEach((entitlement, index) => {
+        if (entitlement.meterKey && !meterKeys.has(entitlement.meterKey)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["entitlements", index, "meterKey"],
+            message: "This meter is not defined on this plan.",
+          });
+        }
       });
-    }
 
-    const meterKeys = new Set(plan.meters.map((meter) => meter.meterKey));
-
-    plan.entitlements.forEach((entitlement, index) => {
-      if (entitlement.meterKey && !meterKeys.has(entitlement.meterKey)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["entitlements", index, "meterKey"],
-          message: "This meter is not defined on this plan.",
-        });
-      }
-    });
-
-    plan.trialGrants.forEach((grant, index) => {
-      if (!meterKeys.has(grant.meterKey)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["trialGrants", index, "meterKey"],
-          message: "This meter is not defined on this plan.",
-        });
-      }
-    });
-
-    if (requirePrice && plan.prices.length === 0) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["prices"],
-        message: "Add at least one price — nobody can subscribe to a plan that has none.",
+      plan.trialGrants.forEach((grant, index) => {
+        if (!meterKeys.has(grant.meterKey)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["trialGrants", index, "meterKey"],
+            message: "This meter is not defined on this plan.",
+          });
+        } else if (lifetimeMeterKeys.has(grant.meterKey)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["trialGrants", index, "meterKey"],
+            message: "A lifetime capacity cannot have a separate trial allowance.",
+          });
+        }
       });
-    }
 
-    const itemKeys = new Set(plan.quantityItems.map((item) => item.itemKey));
-    const seenTerms = new Set<string>();
-
-    plan.prices.forEach((price, index) => {
-      if (price.quantityItemKey !== FLAT_FEE && !itemKeys.has(price.quantityItemKey)) {
+      if (requirePrice && plan.prices.length === 0) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ["prices", index, "quantityItemKey"],
-          message: "This plan does not define that quantity item.",
+          path: ["prices"],
+          message: "Add at least one price — nobody can subscribe to a plan that has none.",
         });
       }
 
-      // The server rejects a second price with the same terms, and it is rejected after the plan
-      // itself has been created — so catching it here is the difference between fixing a field
-      // and being left with a half-priced plan.
-      const terms = priceTerms(price);
+      const itemKeys = new Set(plan.quantityItems.map((item) => item.itemKey));
+      const seenTerms = new Set<string>();
 
-      if (seenTerms.has(terms)) {
-        context.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["prices", index, "currencyCode"],
-          message: "Another price already charges on exactly these terms.",
-        });
-      }
+      plan.prices.forEach((price, index) => {
+        if (price.quantityItemKey !== FLAT_FEE && !itemKeys.has(price.quantityItemKey)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["prices", index, "quantityItemKey"],
+            message: "This plan does not define that quantity item.",
+          });
+        }
 
-      seenTerms.add(terms);
+        // The server rejects a second price with the same terms, and it is rejected after the plan
+        // itself has been created — so catching it here is the difference between fixing a field
+        // and being left with a half-priced plan.
+        const terms = priceTerms(price);
+
+        if (seenTerms.has(terms)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["prices", index, "currencyCode"],
+            message: "Another price already charges on exactly these terms.",
+          });
+        }
+
+        seenTerms.add(terms);
+      });
     });
-  });
 
 export const createSubscriptionPlanSchema = buildSubscriptionPlanSchema({ requirePrice: true });
 

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -30,6 +30,7 @@ const storedPlan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan
       displayName: "Simple Signatures",
       unitLabel: "signature",
       aggregation: "Sum",
+      resetPolicy: "Periodic",
       includedQuantity: 150,
       overageAllowed: true,
       thresholdPercents: [80, 100],
@@ -72,7 +73,20 @@ describe("planToFormValues", () => {
     const values = planToFormValues(storedPlan());
 
     expect(values.meters[0].aggregation).toBe(0);
+    expect(values.meters[0].resetPolicy).toBe(0);
     expect(values.entitlements[0].limitKind).toBe(1);
+  });
+
+  it("maps a never-reset response to the numeric request enum", () => {
+    const plan = storedPlan();
+    plan.meters[0] = {
+      ...plan.meters[0],
+      resetPolicy: "Never",
+      overageAllowed: false,
+      rateTables: [],
+    };
+
+    expect(planToFormValues(plan).meters[0].resetPolicy).toBe(1);
   });
 
   it("keeps trial grants, which an edit would otherwise drop", () => {
@@ -142,11 +156,10 @@ describe("toUpdatePlanRequest", () => {
     expect(request.meters[0]).toMatchObject({
       meterKey: "ses-signatures",
       aggregation: 0,
+      resetPolicy: 0,
       includedQuantity: 150,
       thresholdPercents: [80, 100],
     });
-    expect(request.trialGrants).toEqual([
-      { meterKey: "ses-signatures", includedQuantity: 5 },
-    ]);
+    expect(request.trialGrants).toEqual([{ meterKey: "ses-signatures", includedQuantity: 5 }]);
   });
 });

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -3,6 +3,7 @@ import {
   BILLING_INTERVAL,
   ENTITLEMENT_LIMIT_KIND,
   METER_AGGREGATION,
+  METER_RESET_POLICY,
   type CreateSubscriptionPlanRequest,
   type SubscriptionPlan,
   type UpdateSubscriptionPlanRequest,
@@ -36,6 +37,7 @@ const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
     displayName: meter.displayName.trim(),
     unitLabel: meter.unitLabel.trim(),
     aggregation: meter.aggregation,
+    resetPolicy: meter.resetPolicy,
     includedQuantity: meter.includedQuantity,
     overageAllowed: meter.overageAllowed,
     thresholdPercents: meter.thresholdPercents,
@@ -82,6 +84,9 @@ export const toUpdatePlanRequest = (
 const aggregationValue = (name: string): number =>
   METER_AGGREGATION[name as keyof typeof METER_AGGREGATION] ?? METER_AGGREGATION.Sum;
 
+const resetPolicyValue = (name?: string): number =>
+  METER_RESET_POLICY[name as keyof typeof METER_RESET_POLICY] ?? METER_RESET_POLICY.Periodic;
+
 const limitKindValue = (name: string): number =>
   ENTITLEMENT_LIMIT_KIND[name as keyof typeof ENTITLEMENT_LIMIT_KIND] ??
   ENTITLEMENT_LIMIT_KIND.Boolean;
@@ -93,9 +98,7 @@ const limitKindValue = (name: string): number =>
  * the plan already has are left where they are and anything listed here is a new price to create.
  * Showing them as editable rows would promise an edit that cannot happen.
  */
-export const planToFormValues = (
-  plan: SubscriptionPlan,
-): CreateSubscriptionPlanFormValues => ({
+export const planToFormValues = (plan: SubscriptionPlan): CreateSubscriptionPlanFormValues => ({
   ...defaultSubscriptionPlanFormValues,
   code: plan.code,
   displayName: plan.displayName,
@@ -122,6 +125,7 @@ export const planToFormValues = (
     displayName: meter.displayName,
     unitLabel: meter.unitLabel,
     aggregation: aggregationValue(meter.aggregation),
+    resetPolicy: resetPolicyValue(meter.resetPolicy),
     includedQuantity: meter.includedQuantity,
     overageAllowed: meter.overageAllowed,
     thresholdPercents: meter.thresholdPercents ?? [],

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -645,13 +645,23 @@
             <tr><td>displayName</td><td class="type">string</td><td class="prose">Human name.</td></tr>
             <tr><td>unitLabel</td><td class="type">string</td><td class="prose">signature, call, export.</td></tr>
             <tr><td>aggregation</td><td class="type">string</td><td class="prose">How recordings combine. <code>Sum</code> adds them up — the supported mode. <code>Max</code> and <code>LastValue</code> exist in the enum but the rater rejects them with <code>subscription_meter_aggregation_unsupported</code>.</td></tr>
-            <tr><td>includedQuantity</td><td class="type">long</td><td class="prose">The allowance per period.</td></tr>
-            <tr><td>overageAllowed</td><td class="type">bool</td><td class="prose"><code>false</code> blocks past the allowance. <code>true</code> permits and records it.</td></tr>
-            <tr><td>thresholdPercents</td><td class="type">int[]</td><td class="prose">Percentages that raise a <code>UsageThresholdReached</code> event once per usage period — for example 80 and 100. The worker forwards the event to the Blocks OS mail module using the subscription billing contact.</td></tr>
+            <tr><td>resetPolicy</td><td class="type">string</td><td class="prose"><code>Periodic</code> starts a fresh balance each plan usage window. <code>Never</code> keeps one balance for the subscription lifetime, suitable for persistent capacity such as storage. Requests send <code>0</code> or <code>1</code>.</td></tr>
+            <tr><td>includedQuantity</td><td class="type">long</td><td class="prose">The allowance per period, or the lifetime allowance when <code>resetPolicy</code> is <code>Never</code>.</td></tr>
+            <tr><td>overageAllowed</td><td class="type">bool</td><td class="prose"><code>false</code> blocks past the allowance. <code>true</code> permits and records it. Must be <code>false</code> for a <code>Never</code> meter.</td></tr>
+            <tr><td>thresholdPercents</td><td class="type">int[]</td><td class="prose">Percentages that raise a <code>UsageThresholdReached</code> event once per usage period, or once per subscription for a <code>Never</code> meter — for example 80 and 100. The worker forwards the event to the Blocks OS mail module using the subscription billing contact.</td></tr>
             <tr><td>rateTables</td><td class="type">array</td><td class="prose">What overage costs, per currency. <strong>Empty means overage is billed nothing.</strong></td></tr>
           </tbody>
         </table>
       </div>
+      <p class="callout">
+        Reset policy belongs to each meter. A plan can therefore include one million tokens with
+        <code>Periodic</code> reset and 5 GB storage with <code>Never</code> reset. If the subscriber
+        has consumed 3 GB when renewal runs, the storage balance remains 3 GB and only 2 GB is
+        available; renewal does not grant another 5 GB. Existing meters default to
+        <code>Periodic</code>. Record uploads as positive byte quantities and deletions as negative
+        quantities. Negative usage is accepted only for <code>Never</code> meters and cannot reduce
+        their balance below zero.
+      </p>
       <p>Each rate table holds <code>currencyCode</code> and a list of tiers:</p>
       <div class="table-wrap">
         <table>
@@ -923,6 +933,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         "displayName": "Simple Signatures (SES)",
         "unitLabel": "signature",
         "aggregation": "Sum",
+        "resetPolicy": "Periodic",
         "includedQuantity": 150,
         "overageAllowed": false,
         "thresholdPercents": [80, 100],
@@ -976,6 +987,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
     "displayName": "Simple Signatures (SES)",
     "unitLabel": "signature",
     "aggregation": 0,                 // integer, not "Sum"
+    "resetPolicy": 0,                 // 0 = Periodic, 1 = Never
     "includedQuantity": 150,
     "overageAllowed": false,
     "thresholdPercents": [80, 100],

--- a/server/Subscription.DomainService/Entities/PlanMeter.cs
+++ b/server/Subscription.DomainService/Entities/PlanMeter.cs
@@ -22,7 +22,10 @@ public sealed class PlanMeter
 
     public MeterAggregation Aggregation { get; set; } = MeterAggregation.Sum;
 
-    /// <summary>How much of this meter the plan includes each usage period.</summary>
+    /// <summary>Periodic by default; Never keeps one lifetime balance across renewals.</summary>
+    public MeterResetPolicy ResetPolicy { get; set; } = MeterResetPolicy.Periodic;
+
+    /// <summary>How much the plan includes per period, or for its lifetime when reset is Never.</summary>
     public long IncludedQuantity { get; set; }
 
     /// <summary>Whether usage past the included quantity is permitted and billed.</summary>

--- a/server/Subscription.DomainService/Enums/MeterResetPolicy.cs
+++ b/server/Subscription.DomainService/Enums/MeterResetPolicy.cs
@@ -1,0 +1,11 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>Whether a meter starts over with each usage window or accumulates for the subscription lifetime.</summary>
+public enum MeterResetPolicy
+{
+    /// <summary>Default behavior: a new counter is addressed for every usage period.</summary>
+    Periodic = 0,
+
+    /// <summary>One stable counter survives renewals and usage-window boundaries.</summary>
+    Never = 1
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -202,7 +202,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 planMeter => string.Equals(
                     planMeter.MeterKey,
                     counter.MeterKey,
-                    StringComparison.Ordinal));
+                    StringComparison.Ordinal) &&
+                    planMeter.ResetPolicy == MeterResetPolicy.Periodic);
 
             // The meter was removed from the plan after this usage was recorded — nothing left
             // to rate it against. Not expected in practice; skipped rather than blocking every

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -506,6 +506,13 @@ The sweep only matters at the first renewal, a whole billing period later.
 
 ## Catalogue capabilities
 
+Meters choose their reset behavior independently. `MeterResetPolicy.Periodic` is the backward-
+compatible default and addresses a counter by the configured usage window. `Never` addresses the
+stable `LIFETIME` counter instead, so persistent capacity such as storage remains consumed across
+fee renewals and usage-window boundaries. Monthly rating only prices periodic counters.
+Positive recordings consume lifetime capacity; negative recordings release it and are rejected
+for periodic meters or when they would take the lifetime balance below zero.
+
 Plans may declare one usage allowance cadence independently of their fee cadence through
 `UsageInterval` and `UsageIntervalCount`. Both values are copied to `PlanSnapshot`; changing the
 catalogue later cannot move an existing subscriber's reset window. Plan changes rebuild both the

--- a/server/Subscription.DomainService/Requests/PlanPartRequests.cs
+++ b/server/Subscription.DomainService/Requests/PlanPartRequests.cs
@@ -26,6 +26,8 @@ public sealed class PlanMeterRequest
 
     public MeterAggregation Aggregation { get; set; } = MeterAggregation.Sum;
 
+    public MeterResetPolicy ResetPolicy { get; set; } = MeterResetPolicy.Periodic;
+
     public long IncludedQuantity { get; set; }
 
     public bool OverageAllowed { get; set; } = true;

--- a/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
+++ b/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
@@ -5,7 +5,9 @@ public sealed class RecordUsageRequest
     /// <summary>The meter's key, in the calling product's own vocabulary.</summary>
     public string MeterKey { get; set; } = string.Empty;
 
-    /// <summary>How much was used. One, usually.</summary>
+    /// <summary>
+    /// How much was used. A negative value releases capacity only on a Never-reset meter.
+    /// </summary>
     public long Quantity { get; set; } = 1;
 
     /// <summary>

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -97,6 +97,8 @@ public sealed class PlanMeterResponse
     /// <summary>How recordings combine, as its name — see <c>MeterAggregation</c>.</summary>
     public string Aggregation { get; init; } = string.Empty;
 
+    public string ResetPolicy { get; init; } = string.Empty;
+
     public long IncludedQuantity { get; init; }
 
     public bool OverageAllowed { get; init; }

--- a/server/Subscription.DomainService/Services/EntitlementService.cs
+++ b/server/Subscription.DomainService/Services/EntitlementService.cs
@@ -138,19 +138,21 @@ public sealed class EntitlementService : IEntitlementService
     {
         var balances = new Dictionary<string, long>(StringComparer.Ordinal);
 
-        if (!BillingPeriodCalculator.TryGetPeriod(
-                subscription.UsageSchedule,
-                _time.GetUtcNow().UtcDateTime,
-                out var period))
-        {
-            return balances;
-        }
+        var now = _time.GetUtcNow().UtcDateTime;
 
         foreach (var meterKey in subscription.Plan.Entitlements
                      .Where(entitlement => entitlement.MeterKey is { Length: > 0 })
                      .Select(entitlement => entitlement.MeterKey!)
                      .Distinct(StringComparer.Ordinal))
         {
+            var meter = subscription.Plan.Meters.Find(candidate =>
+                string.Equals(candidate.MeterKey, meterKey, StringComparison.Ordinal));
+
+            if (meter is null || !MeterPeriodResolver.TryGetPeriod(subscription, meter, now, out var period))
+            {
+                continue;
+            }
+
             var counter = await _usage.GetCounterAsync(
                 subscription.TenantId,
                 SubscriptionUsageCounter.CreateId(

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -493,6 +493,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
                 DisplayName = meter.DisplayName,
                 UnitLabel = meter.UnitLabel,
                 Aggregation = meter.Aggregation,
+                ResetPolicy = meter.ResetPolicy,
                 IncludedQuantity = meter.IncludedQuantity,
                 OverageAllowed = meter.OverageAllowed,
                 ThresholdPercents = meter.ThresholdPercents.Distinct().Order().ToList(),

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -54,6 +54,7 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     DisplayName = meter.DisplayName,
                     UnitLabel = meter.UnitLabel,
                     Aggregation = meter.Aggregation.ToString(),
+                    ResetPolicy = meter.ResetPolicy.ToString(),
                     IncludedQuantity = meter.IncludedQuantity,
                     OverageAllowed = meter.OverageAllowed,
                     ThresholdPercents = [.. meter.ThresholdPercents],

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -42,6 +42,7 @@ internal static class SubscriptionSnapshotBuilder
                     DisplayName = meter.DisplayName,
                     UnitLabel = meter.UnitLabel,
                     Aggregation = meter.Aggregation,
+                    ResetPolicy = meter.ResetPolicy,
                     IncludedQuantity = meter.IncludedQuantity,
                     OverageAllowed = meter.OverageAllowed,
                     ThresholdPercents = [.. meter.ThresholdPercents],

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -119,10 +119,20 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 correlationId);
         }
 
+        if (request.Quantity < 0 && meter.ResetPolicy != MeterResetPolicy.Never)
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_usage_reduction_not_allowed",
+                "Only a never-reset capacity meter accepts negative usage adjustments.",
+                correlationId);
+        }
+
         var occurredAt = request.OccurredAtUtc ?? _time.GetUtcNow().UtcDateTime;
 
-        if (!BillingPeriodCalculator.TryGetPeriod(
-                subscription.UsageSchedule,
+        if (!MeterPeriodResolver.TryGetPeriod(
+                subscription,
+                meter,
                 occurredAt,
                 out var period))
         {
@@ -177,36 +187,32 @@ public sealed class UsageRecordingService : IUsageRecordingService
 
         var now = _time.GetUtcNow().UtcDateTime;
 
-        if (!BillingPeriodCalculator.TryGetPeriod(
-                subscription.UsageSchedule,
-                now,
-                out var period))
+        var responses = new List<UsageResponse>();
+
+        foreach (var meter in subscription.Plan.Meters)
         {
-            return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
-                PaymentFailureKind.Unavailable,
-                "subscription_schedule_unavailable",
-                "The usage period could not be determined.",
-                correlationId);
-        }
+            if (!MeterPeriodResolver.TryGetPeriod(subscription, meter, now, out var period))
+            {
+                return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
+                    PaymentFailureKind.Unavailable,
+                    "subscription_schedule_unavailable",
+                    "The usage period could not be determined.",
+                    correlationId);
+            }
 
-        var counters = await _usage.ListCountersAsync(
-            context.TenantId,
-            subscription.ItemId,
-            period.Key,
-            cancellationToken);
+            var counter = await _usage.GetCounterAsync(
+                context.TenantId,
+                SubscriptionUsageCounter.CreateId(subscription.ItemId, meter.MeterKey, period.Key),
+                cancellationToken);
 
-        var responses = subscription.Plan.Meters
-            .Select(meter => Describe(
+            responses.Add(Describe(
                 meter,
                 period,
-                counters.FirstOrDefault(counter => string.Equals(
-                    counter.MeterKey,
-                    meter.MeterKey,
-                    StringComparison.Ordinal))?.Balance ?? 0,
+                counter?.Balance ?? 0,
                 AllowanceFor(subscription, meter),
                 allowed: true,
-                replayed: false))
-            .ToList();
+                replayed: false));
+        }
 
         return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Success(
             responses,
@@ -258,6 +264,19 @@ public sealed class UsageRecordingService : IUsageRecordingService
             cancellationToken);
 
         var withinAllowance = counter.Balance <= allowance;
+
+        if (counter.Balance < 0)
+        {
+            return await RefuseAsync(
+                record,
+                context,
+                subscription,
+                meter,
+                period,
+                allowance,
+                correlationId,
+                cancellationToken);
+        }
 
         if (request.Enforce && !withinAllowance && !meter.OverageAllowed)
         {
@@ -342,7 +361,7 @@ public sealed class UsageRecordingService : IUsageRecordingService
             cancellationToken);
 
         _logger.LogInformation(
-            "Usage refused because the allowance is exhausted TenantHash={TenantHash} " +
+            "Usage refused because the resulting balance is outside its allowed range TenantHash={TenantHash} " +
             "SubscriptionHash={SubscriptionHash} Meter={Meter} Balance={Balance} " +
             "Included={Included} CorrelationId={CorrelationId}",
             PaymentLogValue.Hash(context.TenantId),
@@ -432,8 +451,9 @@ public sealed class UsageRecordingService : IUsageRecordingService
         LimitSnapshot = allowance,
         PeriodStartUtc = period.StartUtc,
         PeriodEndUtc = period.EndUtc,
-        ExpiresAtUtc = period.EndUtc.AddDays(
-            Math.Max(1, _options.CurrentValue.CounterRetentionDays))
+        ExpiresAtUtc = meter.ResetPolicy == MeterResetPolicy.Never
+            ? DateTime.MaxValue
+            : period.EndUtc.AddDays(Math.Max(1, _options.CurrentValue.CounterRetentionDays))
     };
 
     private static PlanMeter? FindMeter(SubscriptionDetail subscription, string meterKey) =>

--- a/server/Subscription.DomainService/Utilities/MeterPeriodResolver.cs
+++ b/server/Subscription.DomainService/Utilities/MeterPeriodResolver.cs
@@ -1,0 +1,32 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>Chooses the counter address for a meter from its reset policy.</summary>
+public static class MeterPeriodResolver
+{
+    public const string LifetimePeriodKey = "LIFETIME";
+
+    public static bool TryGetPeriod(
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        DateTime occurredAtUtc,
+        out BillingPeriod period)
+    {
+        if (meter.ResetPolicy == MeterResetPolicy.Never)
+        {
+            period = new BillingPeriod(
+                0,
+                subscription.CreatedAtUtc,
+                DateTime.MaxValue,
+                LifetimePeriodKey);
+            return true;
+        }
+
+        return BillingPeriodCalculator.TryGetPeriod(
+            subscription.UsageSchedule,
+            occurredAtUtc,
+            out period);
+    }
+}

--- a/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
@@ -62,6 +62,15 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
                 meter.RuleFor(definition => definition.UnitLabel).NotEmpty().MaximumLength(64);
                 meter.RuleFor(definition => definition.IncludedQuantity)
                     .GreaterThanOrEqualTo(0);
+                meter.RuleFor(definition => definition.ResetPolicy).IsInEnum();
+                meter.RuleFor(definition => definition)
+                    .Must(definition =>
+                        definition.ResetPolicy != MeterResetPolicy.Never ||
+                        (!definition.OverageAllowed && definition.RateTables.Count == 0))
+                    .WithMessage(
+                        "A never-reset meter is persistent capacity: block at its allowance " +
+                        "instead of configuring periodic overage billing.")
+                    .WithErrorCode("subscription_lifetime_meter_overage_invalid");
                 meter.RuleForEach(definition => definition.ThresholdPercents)
                     .InclusiveBetween(1, 100);
                 meter.RuleFor(definition => definition.RateTables)
@@ -100,6 +109,15 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
             .WithName(nameof(PlanDefinitionRequest.TrialGrants))
             .WithMessage("A trial grant names a meter the plan does not define.")
             .WithErrorCode("subscription_trial_grant_meter_unknown");
+
+        RuleFor(request => request)
+            .Must(request => request.TrialGrants.All(grant =>
+                request.Meters.Any(meter =>
+                    string.Equals(meter.MeterKey, grant.MeterKey, StringComparison.Ordinal) &&
+                    meter.ResetPolicy == MeterResetPolicy.Periodic)))
+            .WithName(nameof(PlanDefinitionRequest.TrialGrants))
+            .WithMessage("Trial allowances can only replace periodic meters, not lifetime capacity.")
+            .WithErrorCode("subscription_lifetime_meter_trial_grant_invalid");
     }
 
     private static bool BeAJsonObject(string? featuresJson)

--- a/server/Subscription.DomainService/Validators/RecordUsageRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/RecordUsageRequestValidator.cs
@@ -22,10 +22,10 @@ public sealed class RecordUsageRequestValidator : AbstractValidator<RecordUsageR
             .WithErrorCode("subscription_usage_idempotency_key_required");
 
         RuleFor(request => request.Quantity)
-            .GreaterThan(0)
+            .NotEqual(0)
             .WithMessage(
-                "Usage must be positive. A correction is recorded as its own reversal so the " +
-                "ledger can still explain the bill.");
+                "Usage cannot be zero. Negative adjustments are accepted only by never-reset " +
+                "capacity meters, where they release previously consumed capacity.");
 
         RuleFor(request => request.Metadata)
             .Must(metadata =>

--- a/server/XUnitTest/Subscription/EntitlementServiceTests.cs
+++ b/server/XUnitTest/Subscription/EntitlementServiceTests.cs
@@ -127,6 +127,24 @@ public sealed class EntitlementServiceTests
     }
 
     [Fact]
+    public async Task A_lifetime_entitlement_reads_the_counter_that_survives_renewal()
+    {
+        _subscription!.Plan.Meters[0].ResetPolicy = MeterResetPolicy.Never;
+        _balance = 300;
+
+        var result = await Service().GetAsync(false, null, "corr-1", CancellationToken.None);
+
+        result.Value!.Entitlements.Single().Remaining.Should().Be(200);
+        _usage.Verify(repository => repository.GetCounterAsync(
+            TenantId,
+            SubscriptionUsageCounter.CreateId(
+                _subscription.ItemId,
+                "screening",
+                MeterPeriodResolver.LifetimePeriodKey),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task A_counted_entitlement_at_its_limit_reports_the_reason()
     {
         _balance = 500;

--- a/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
+++ b/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Validators;
+
+namespace XUnitTest.Subscription;
+
+public sealed class PlanDefinitionRequestValidatorTests
+{
+    [Fact]
+    public async Task A_lifetime_capacity_without_overage_is_valid()
+    {
+        var request = RequestWithLifetimeMeter();
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_lifetime_capacity_cannot_promise_monthly_overage_billing()
+    {
+        var request = RequestWithLifetimeMeter();
+        request.Meters[0].OverageAllowed = true;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_lifetime_meter_overage_invalid");
+    }
+
+    [Fact]
+    public async Task A_lifetime_capacity_cannot_have_a_separate_trial_allowance()
+    {
+        var request = RequestWithLifetimeMeter();
+        request.TrialGrants = [new TrialGrantRequest { MeterKey = "storage", IncludedQuantity = 1_000 }];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_lifetime_meter_trial_grant_invalid");
+    }
+
+    private static UpdatePlanRequest RequestWithLifetimeMeter() => new()
+    {
+        DisplayName = "Storage plan",
+        Meters =
+        [
+            new PlanMeterRequest
+            {
+                MeterKey = "storage",
+                DisplayName = "Storage",
+                UnitLabel = "byte",
+                IncludedQuantity = 5_368_709_120,
+                ResetPolicy = MeterResetPolicy.Never,
+                OverageAllowed = false
+            }
+        ]
+    };
+}

--- a/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
@@ -51,6 +51,17 @@ public sealed class PlanResponseMapperTests
             "a client that has to know 0 means summed is coupled to our storage format");
     }
 
+    [Fact]
+    public void A_meter_reports_its_reset_policy_by_name()
+    {
+        var plan = Plan("organization-1");
+        plan.Meters[0].ResetPolicy = MeterResetPolicy.Never;
+
+        var response = _mapper.ToResponse(plan, []);
+
+        response.Meters[0].ResetPolicy.Should().Be(nameof(MeterResetPolicy.Never));
+    }
+
     /// <summary>
     /// Overage that cannot be priced is charged nothing, so an author has to be able to see
     /// whether a meter permitting overage actually has a table behind it.

--- a/server/XUnitTest/Subscription/SubscriptionEntitySerializationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionEntitySerializationTests.cs
@@ -53,6 +53,18 @@ public sealed class SubscriptionEntitySerializationTests
     }
 
     [Fact]
+    public void A_meter_stored_before_reset_policy_defaults_to_periodic()
+    {
+        var document = NewSubscription().ToBsonDocument();
+        var meter = document["Plan"].AsBsonDocument["Meters"].AsBsonArray[0].AsBsonDocument;
+        meter.Remove("ResetPolicy");
+
+        var restored = BsonSerializer.Deserialize<SubscriptionDetail>(document);
+
+        restored.Plan.Meters[0].ResetPolicy.Should().Be(MeterResetPolicy.Periodic);
+    }
+
+    [Fact]
     public void A_usage_counter_id_is_composed_from_its_scope()
     {
         SubscriptionUsageCounter

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -140,6 +140,24 @@ public sealed class SubscriptionUsageRatingProcessorTests
     }
 
     [Fact]
+    public async Task A_monthly_closeout_never_rates_a_lifetime_capacity_meter()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.Plan.Meters[0].ResetPolicy = MeterResetPolicy.Never;
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 700)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        _createdInvoice!.State.Should().Be(SubscriptionUsageInvoiceState.NoCharge);
+        _createdInvoice.Lines.Should().BeEmpty(
+            "a lifetime capacity is enforced continuously, not sold again as monthly overage");
+    }
+
+    [Fact]
     public async Task A_plan_change_rates_the_detached_window_under_its_original_allowance()
     {
         var subscription = NewSubscription("sub-1");

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -256,6 +256,94 @@ public sealed class UsageRecordingServiceTests
     }
 
     [Fact]
+    public async Task A_never_reset_meter_keeps_one_counter_across_month_boundaries()
+    {
+        _subscription.Plan.Meters[0].ResetPolicy = MeterResetPolicy.Never;
+
+        var july = NewRequest("storage-july");
+        july.OccurredAtUtc = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc);
+        var august = NewRequest("storage-august");
+        august.OccurredAtUtc = new DateTime(2026, 8, 20, 9, 0, 0, DateTimeKind.Utc);
+
+        var first = await Service().RecordAsync(july, "corr-1", CancellationToken.None);
+        var second = await Service().RecordAsync(august, "corr-2", CancellationToken.None);
+
+        first.Value!.PeriodKey.Should().Be(MeterPeriodResolver.LifetimePeriodKey);
+        second.Value!.PeriodKey.Should().Be(MeterPeriodResolver.LifetimePeriodKey);
+        second.Value.Used.Should().Be(2, "renewal must not create a fresh storage allowance");
+        _ledger.Select(record => record.PeriodKey).Should().OnlyContain(
+            key => key == MeterPeriodResolver.LifetimePeriodKey);
+    }
+
+    [Fact]
+    public async Task Deleting_storage_releases_lifetime_capacity()
+    {
+        _subscription.Plan.Meters[0].ResetPolicy = MeterResetPolicy.Never;
+        _balance = 300;
+        var request = NewRequest("storage-delete");
+        request.Quantity = -100;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Used.Should().Be(200);
+        result.Value.Remaining.Should().Be(300);
+    }
+
+    [Fact]
+    public async Task A_periodic_consumption_meter_rejects_negative_usage()
+    {
+        var request = NewRequest("token-reduction");
+        request.Quantity = -1;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_usage_reduction_not_allowed");
+        _ledger.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task A_capacity_reduction_cannot_take_the_balance_below_zero()
+    {
+        _subscription.Plan.Meters[0].ResetPolicy = MeterResetPolicy.Never;
+        _balance = 50;
+        var request = NewRequest("storage-delete");
+        request.Quantity = -100;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.Value!.Allowed.Should().BeFalse();
+        result.Value.Used.Should().Be(50);
+        _ledger.Should().HaveCount(2);
+        _ledger[1].EntryType.Should().Be(UsageEntryType.Reversal);
+        _ledger[1].Delta.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task Current_usage_reads_periodic_and_lifetime_meters_from_different_counters()
+    {
+        _subscription.Plan.Meters.Add(new PlanMeter
+        {
+            MeterKey = "storage",
+            UnitLabel = "byte",
+            IncludedQuantity = 5_000,
+            ResetPolicy = MeterResetPolicy.Never
+        });
+
+        await Service().GetCurrentUsageAsync(null, "corr-1", CancellationToken.None);
+
+        _usage.Verify(repository => repository.GetCounterAsync(
+            TenantId,
+            SubscriptionUsageCounter.CreateId(
+                "sub-1", "storage", MeterPeriodResolver.LifetimePeriodKey),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _usage.Verify(repository => repository.GetCounterAsync(
+            TenantId,
+            It.Is<string>(id => id.StartsWith("sub-1:screening:M", StringComparison.Ordinal)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task A_requested_organization_is_forwarded_to_context_resolution()
     {
         var request = NewRequest("usage-1");


### PR DESCRIPTION
## Summary

Adds a per-meter reset policy so one plan can combine periodically replenished usage with persistent lifetime capacity.

- adds `MeterResetPolicy.Periodic` and `MeterResetPolicy.Never`, with `Periodic` as the backward-compatible default
- stores and snapshots the policy with each plan meter and returns it from catalogue APIs
- routes `Never` meters to one stable `LIFETIME` counter across usage windows and fee renewals
- keeps periodic meters on the configured plan usage schedule
- reads lifetime balances consistently from usage and entitlement endpoints
- excludes lifetime capacity from monthly usage-rating invoices
- supports negative adjustments on lifetime meters for storage deletion, while rejecting periodic reductions and below-zero balances
- prevents lifetime meters from configuring monthly overage pricing or separate trial allowances
- adds the reset selector, validation, summaries, detail display, and trial filtering to the plan builder
- documents mixed token/storage plans and request/response enum values

## Example

A plan can configure tokens as `Periodic` and 5 GB storage as `Never`. If renewal occurs after 3 GB has been consumed, tokens receive a new period counter while storage continues at 3 GB used and 2 GB remaining.

## Verification

- focused server tests: 66 passed
- client TypeScript: passed
- client schema/mapping tests: 30 passed
- full non-integration server run: 2,191 passed, 1 skipped; two known `PeriodicPingBackgroundServiceTests` timing flakes failed in the combined run and all 8 affected cases passed in isolation
- `git diff --check`: passed

The broader subscription Vitest invocation can intermittently time out starting workers in this Windows worktree; the directly affected suites pass using the thread pool.