### PR TITLE
Resume incomplete subscription checkout on retry

### DIFF
--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1109,8 +1109,16 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
           <p>
             <code>200</code> · <code>400</code> invalid, unknown time zone · <code>404</code> plan or
             price not found · <code>409</code> <code>subscription_already_active</code> when the
-            organization already has an open signup or live subscription ·
+            organization already has a live subscription ·
             <code>502</code>/<code>503</code> provider trouble.
+          </p>
+          <p>
+            Retrying the same plan, price, discount, time zone and quantities while its checkout
+            is still incomplete returns <code>200</code> with the original subscription and checkout
+            URL; it does not create another payment. Asking for different terms returns
+            <code>409 subscription_checkout_pending</code>. Its error fields include the pending
+            <code>subscriptionId</code> and, when still usable, <code>checkoutUrl</code>, so the client
+            can continue that checkout or cancel it before trying again.
           </p>
         </div>
       </div>
@@ -1412,6 +1420,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <tr><td>subscription_plan_not_found</td><td class="prose">Wrong <code>planCode</code>, or the plan belongs to another organization. Check you sent the code, not the planId.</td></tr>
             <tr><td>subscription_price_not_found</td><td class="prose">The <code>priceId</code> is unknown or belongs to a different plan.</td></tr>
             <tr><td>subscription_already_active</td><td class="prose">This organization already has a live subscription. Cancel or change plan instead.</td></tr>
+            <tr><td>subscription_checkout_pending</td><td class="prose">This organization has an unpaid checkout for different terms. The error fields contain its <code>subscriptionId</code> and, when recoverable, <code>checkoutUrl</code>; continue it or cancel it before subscribing again.</td></tr>
             <tr><td>subscription_already_ended</td><td class="prose">Cancelling something already cancelled.</td></tr>
             <tr><td>subscription_not_found</td><td class="prose">No subscription for this organization.</td></tr>
             <tr><td>subscription_time_zone_unknown</td><td class="prose">Not a valid IANA identifier. Refused here rather than at the first renewal.</td></tr>

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -39,6 +39,12 @@ public interface ISubscriptionRepository
         string organizationId,
         CancellationToken cancellationToken);
 
+    /// <summary>The organization's checkout that has not activated yet, if any.</summary>
+    Task<SubscriptionDetail?> GetIncompleteAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken);
+
     Task<SubscriptionDetail?> GetByOrderIdAsync(
         string tenantId,
         string orderId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -101,6 +101,21 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             .Find(BuildLiveFilter(tenantId, organizationId))
             .FirstOrDefaultAsync(cancellationToken);
 
+    public async Task<SubscriptionDetail?> GetIncompleteAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.OrganizationId,
+                    organizationId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.Status,
+                    SubscriptionStatus.Incomplete)))
+            .FirstOrDefaultAsync(cancellationToken);
+
     public async Task<SubscriptionDetail?> GetByOrderIdAsync(
         string tenantId,
         string orderId,

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
 using Payment.DomainService.Requests;
 using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
@@ -30,6 +31,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     private readonly ISubscriptionOutboxEventFactory _events;
     private readonly ISubscriptionResponseMapper _mapper;
     private readonly IPaymentService _payments;
+    private readonly IPaymentRepository _paymentRepository;
     private readonly ICurrencyMinorUnitResolver _currency;
     private readonly ILogger<SubscriptionCheckoutService> _logger;
 
@@ -41,6 +43,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         ISubscriptionOutboxEventFactory events,
         ISubscriptionResponseMapper mapper,
         IPaymentService payments,
+        IPaymentRepository paymentRepository,
         ICurrencyMinorUnitResolver currency,
         ILogger<SubscriptionCheckoutService> logger)
     {
@@ -51,6 +54,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         _events = events;
         _mapper = mapper;
         _payments = payments;
+        _paymentRepository = paymentRepository;
         _currency = currency;
         _logger = logger;
     }
@@ -80,6 +84,23 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
 
         if (!created.IsSuccess)
         {
+            if (string.Equals(
+                    created.ErrorCode,
+                    "subscription_already_active",
+                    StringComparison.Ordinal))
+            {
+                var resumed = await TryResumeIncompleteCheckoutAsync(
+                    request,
+                    context,
+                    correlationId,
+                    cancellationToken);
+
+                if (resumed is not null)
+                {
+                    return resumed;
+                }
+            }
+
             return created.ToFailure<SubscriptionResponse>();
         }
 
@@ -89,6 +110,116 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         return RequiresPayment(subscription, amountMinor)
             ? await ChargeAsync(subscription, amountMinor, correlationId, cancellationToken)
             : await StartWithoutPaymentAsync(subscription, correlationId, cancellationToken);
+    }
+
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>?> TryResumeIncompleteCheckoutAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var subscription = await _subscriptions.GetIncompleteAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            // A live subscription caused the unique-index collision, or it moved state between
+            // the insert and this read. Preserve the ordinary already-active response.
+            return null;
+        }
+
+        var link = await _links.FindBySubscriptionAsync(
+            context.TenantId,
+            subscription.ItemId,
+            cancellationToken);
+
+        if (link is null || link.State != SubscriptionPaymentLinkState.Pending)
+        {
+            return PendingCheckoutConflict(subscription, null, correlationId);
+        }
+
+        // The link is already tenant- and organization-scoped. Read the linked payment directly:
+        // PaymentService's caller-facing lookup scopes by the merchant OrganizationId, while a
+        // subscription payment belongs to the subscriber through CustomerOrganizationId.
+        var payment = await _paymentRepository.GetByIdAsync(
+            context.TenantId,
+            link.PaymentDetailId,
+            cancellationToken);
+        var checkoutUrl = payment?.RedirectUrl;
+
+        if (payment is null ||
+            string.IsNullOrWhiteSpace(checkoutUrl) ||
+            payment.ExpirationDate != default && payment.ExpirationDate <= DateTime.UtcNow)
+        {
+            return PendingCheckoutConflict(subscription, null, correlationId);
+        }
+
+        if (!MatchesPendingTerms(request, subscription))
+        {
+            return PendingCheckoutConflict(subscription, checkoutUrl, correlationId);
+        }
+
+        _logger.LogInformation(
+            "Existing subscription checkout resumed TenantHash={TenantHash} " +
+            "OrganizationHash={OrganizationHash} SubscriptionHash={SubscriptionHash} " +
+            "CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(context.OrganizationId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Success(
+            _mapper.ToResponse(subscription, checkoutUrl),
+            correlationId);
+    }
+
+    private static bool MatchesPendingTerms(
+        CreateSubscriptionRequest request,
+        SubscriptionDetail subscription)
+    {
+        if (!string.Equals(request.PlanCode, subscription.Plan.Code, StringComparison.Ordinal) ||
+            !string.Equals(request.PriceId, subscription.Price.PriceId, StringComparison.Ordinal) ||
+            !string.Equals(
+                request.DiscountCode?.Trim(),
+                subscription.Discount?.Code,
+                StringComparison.OrdinalIgnoreCase) ||
+            !string.Equals(
+                request.TimeZoneId,
+                subscription.FeeSchedule.TimeZoneId,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return request.Quantities.Count == 0 || request.Quantities.All(requested =>
+            subscription.QuantityItems.Any(existing =>
+                string.Equals(existing.ItemKey, requested.ItemKey, StringComparison.Ordinal) &&
+                existing.Quantity == requested.Quantity));
+    }
+
+    private static SubscriptionOperationResult<SubscriptionResponse> PendingCheckoutConflict(
+        SubscriptionDetail subscription,
+        string? checkoutUrl,
+        string correlationId)
+    {
+        var details = new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["subscriptionId"] = [subscription.ItemId]
+        };
+
+        if (!string.IsNullOrWhiteSpace(checkoutUrl))
+        {
+            details["checkoutUrl"] = [checkoutUrl];
+        }
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Failure(
+            PaymentFailureKind.Conflict,
+            "subscription_checkout_pending",
+            "This organization already has an unpaid checkout. Continue it or cancel it before choosing different terms.",
+            correlationId,
+            details);
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionResponse>> GetCurrentAsync(

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Requests;
+using Payment.DomainService.Repositories;
 using Payment.DomainService.Responses;
 using Payment.DomainService.Services;
 using Subscription.DomainService.Entities;
@@ -29,6 +31,7 @@ public sealed class SubscriptionCheckoutServiceTests
     private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
     private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
     private readonly Mock<IPaymentService> _payments = new();
+    private readonly Mock<IPaymentRepository> _paymentRepository = new();
     private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
 
     private SubscriptionDetail _subscription = NewSubscription();
@@ -183,6 +186,64 @@ public sealed class SubscriptionCheckoutServiceTests
     }
 
     [Fact]
+    public async Task Retrying_the_same_incomplete_subscription_returns_its_existing_checkout()
+    {
+        _creation
+            .Setup(service => service.CreateAsync(
+                It.IsAny<CreateSubscriptionRequest>(),
+                It.IsAny<SubscriptionContext>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<SubscriptionDetail>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_already_active",
+                "This organization already has a live subscription.",
+                "corr-1"));
+        ArrangePendingCheckout();
+
+        var result = await Service().SubscribeAsync(
+            MatchingRequest(), "corr-2", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.SubscriptionId.Should().Be(_subscription.ItemId);
+        result.Value.CheckoutUrl.Should().Be("https://checkout.stripe.com/existing");
+        _payments.Verify(
+            service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "resuming must not create a second provider checkout");
+    }
+
+    [Fact]
+    public async Task Different_terms_report_the_pending_checkout_and_how_to_recover()
+    {
+        _creation
+            .Setup(service => service.CreateAsync(
+                It.IsAny<CreateSubscriptionRequest>(),
+                It.IsAny<SubscriptionContext>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<SubscriptionDetail>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_already_active",
+                "This organization already has a live subscription.",
+                "corr-1"));
+        ArrangePendingCheckout();
+
+        var request = MatchingRequest();
+        request.PriceId = "another-price";
+        var result = await Service().SubscribeAsync(request, "corr-2", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_checkout_pending");
+        result.ValidationErrors!["subscriptionId"].Should().ContainSingle(_subscription.ItemId);
+        result.ValidationErrors["checkoutUrl"].Should()
+            .ContainSingle("https://checkout.stripe.com/existing");
+    }
+
+    [Fact]
     public async Task A_declined_charge_leaves_the_subscription_granting_nothing()
     {
         _payments
@@ -330,8 +391,42 @@ public sealed class SubscriptionCheckoutServiceTests
         new SubscriptionOutboxEventFactory(),
         new SubscriptionResponseMapper(),
         _payments.Object,
+        _paymentRepository.Object,
         _currency.Object,
         NullLogger<SubscriptionCheckoutService>.Instance);
+
+    private void ArrangePendingCheckout()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_subscription);
+        _links
+            .Setup(repository => repository.FindBySubscriptionAsync(
+                TenantId, _subscription.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionPaymentLink
+            {
+                SubscriptionId = _subscription.ItemId,
+                PaymentDetailId = "pay-existing",
+                State = SubscriptionPaymentLinkState.Pending
+            });
+        _paymentRepository
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "pay-existing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "pay-existing",
+                RedirectUrl = "https://checkout.stripe.com/existing",
+                ExpirationDate = DateTime.UtcNow.AddHours(1)
+            });
+    }
+
+    private CreateSubscriptionRequest MatchingRequest() => new()
+    {
+        PlanCode = _subscription.Plan.Code,
+        PriceId = _subscription.Price.PriceId,
+        TimeZoneId = _subscription.FeeSchedule.TimeZoneId
+    };
 
     private static SubscriptionDetail NewSubscription()
     {
@@ -348,10 +443,12 @@ public sealed class SubscriptionCheckoutServiceTests
             Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
             Price = new PriceSnapshot
             {
+                PriceId = "price-1",
                 CurrencyCode = "CHF",
                 UnitAmountMinor = 8900,
                 QuantityItemKey = "seat"
             },
+            FeeSchedule = new BillingSchedule { TimeZoneId = "UTC" },
             QuantityItems =
             [
                 new SubscriptionQuantityItem


### PR DESCRIPTION
## Summary
- resume an existing incomplete checkout when the same subscription terms are submitted again
- return 409 subscription_checkout_pending with recovery details when requested terms differ
- make GET /api/subscriptions/current return an Incomplete pending subscription and its valid checkout URL
- prefer Trialing, Active, or PastDue over the pending lookup
- keep 404 only for organizations with neither a granting nor incomplete subscription
- document retry, polling, and cancellation recovery behavior

## Verification
- focused checkout tests: 17 passed
- subscription unit tests: 337 passed

## Base
- created from dev after PR #253 was merged