### PR TITLE
Expose pending checkout from current subscription

### DIFF
--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -867,10 +867,10 @@ stateDiagram-v2
         </li>
         <li>
           <p class="step-title">Wait for activation</p>
-          <p>Poll <code>GET /api/subscriptions/current</code> until it returns <code>200</code>. It
-          returns <code>404 subscription_not_found</code> while checkout is still
-          <code>Incomplete</code>; normally the activation webhook changes that within seconds.
-          Treat this short 404 as pending after checkout, not as a payment failure.</p>
+          <p>Poll <code>GET /api/subscriptions/current</code>. While payment is outstanding it
+          returns <code>200</code> with <code>status: "Incomplete"</code> and the pending
+          <code>checkoutUrl</code>. Normally the activation webhook changes the status within
+          seconds; continue only when it becomes <code>Active</code> or <code>Trialing</code>.</p>
         </li>
         <li>
           <p class="step-title">Gate features on entitlements</p>
@@ -1127,9 +1127,11 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscriptions/current</span></div>
         <div class="endpoint-body">
           <p>
-            Returns the authenticated caller's current subscription when its status is
-            <code>Trialing</code>, <code>Active</code>, or <code>PastDue</code>. It deliberately does
-            not return <code>Incomplete</code>, <code>Unpaid</code>, or ended subscriptions.
+            Returns the authenticated caller's current or pending subscription. Granting states
+            (<code>Trialing</code>, <code>Active</code>, or <code>PastDue</code>) take priority. When
+            checkout has started but payment has not completed, it returns
+            <code>status: "Incomplete"</code> and the still-valid <code>checkoutUrl</code> when one
+            is available. It does not return <code>Unpaid</code> or ended subscriptions.
           </p>
           <h4>Query</h4>
           <p>
@@ -1169,10 +1171,9 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
 }</code></pre>
           <h4>Returns</h4>
           <p>
-            <code>200</code> with the subscription above · <code>404</code>
-            <code>subscription_not_found</code> when the organization has no subscription in a
-            live status. Immediately after paid checkout, poll through this 404 until the
-            activation webhook completes. · <code>401</code> unauthenticated.
+            <code>200</code> with a granting or <code>Incomplete</code> subscription ·
+            <code>404 subscription_not_found</code> only when the organization has neither a
+            granting subscription nor an incomplete checkout · <code>401</code> unauthenticated.
           </p>
         </div>
       </div>

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -130,28 +130,12 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
             return null;
         }
 
-        var link = await _links.FindBySubscriptionAsync(
+        var checkoutUrl = await GetPendingCheckoutUrlAsync(
             context.TenantId,
             subscription.ItemId,
             cancellationToken);
 
-        if (link is null || link.State != SubscriptionPaymentLinkState.Pending)
-        {
-            return PendingCheckoutConflict(subscription, null, correlationId);
-        }
-
-        // The link is already tenant- and organization-scoped. Read the linked payment directly:
-        // PaymentService's caller-facing lookup scopes by the merchant OrganizationId, while a
-        // subscription payment belongs to the subscriber through CustomerOrganizationId.
-        var payment = await _paymentRepository.GetByIdAsync(
-            context.TenantId,
-            link.PaymentDetailId,
-            cancellationToken);
-        var checkoutUrl = payment?.RedirectUrl;
-
-        if (payment is null ||
-            string.IsNullOrWhiteSpace(checkoutUrl) ||
-            payment.ExpirationDate != default && payment.ExpirationDate <= DateTime.UtcNow)
+        if (string.IsNullOrWhiteSpace(checkoutUrl))
         {
             return PendingCheckoutConflict(subscription, null, correlationId);
         }
@@ -173,6 +157,36 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         return SubscriptionOperationResult<SubscriptionResponse>.Success(
             _mapper.ToResponse(subscription, checkoutUrl),
             correlationId);
+    }
+
+    private async Task<string?> GetPendingCheckoutUrlAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken)
+    {
+        var link = await _links.FindBySubscriptionAsync(
+            tenantId,
+            subscriptionId,
+            cancellationToken);
+
+        if (link is null || link.State != SubscriptionPaymentLinkState.Pending)
+        {
+            return null;
+        }
+
+        // The link is already tenant- and organization-scoped. Read the linked payment directly:
+        // PaymentService's caller-facing lookup scopes by the merchant OrganizationId, while a
+        // subscription payment belongs to the subscriber through CustomerOrganizationId.
+        var payment = await _paymentRepository.GetByIdAsync(
+            tenantId,
+            link.PaymentDetailId,
+            cancellationToken);
+
+        return payment is null ||
+               string.IsNullOrWhiteSpace(payment.RedirectUrl) ||
+               payment.ExpirationDate != default && payment.ExpirationDate <= DateTime.UtcNow
+            ? null
+            : payment.RedirectUrl;
     }
 
     private static bool MatchesPendingTerms(
@@ -244,15 +258,35 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
             context.OrganizationId,
             cancellationToken);
 
-        return subscription is null
-            ? SubscriptionOperationResult<SubscriptionResponse>.Failure(
-                PaymentFailureKind.NotFound,
-                "subscription_not_found",
-                "This organization has no active subscription.",
-                correlationId)
-            : SubscriptionOperationResult<SubscriptionResponse>.Success(
+        if (subscription is not null)
+        {
+            return SubscriptionOperationResult<SubscriptionResponse>.Success(
                 _mapper.ToResponse(subscription),
                 correlationId);
+        }
+
+        subscription = await _subscriptions.GetIncompleteAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        if (subscription is not null)
+        {
+            var checkoutUrl = await GetPendingCheckoutUrlAsync(
+                context.TenantId,
+                subscription.ItemId,
+                cancellationToken);
+
+            return SubscriptionOperationResult<SubscriptionResponse>.Success(
+                _mapper.ToResponse(subscription, checkoutUrl),
+                correlationId);
+        }
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Failure(
+            PaymentFailureKind.NotFound,
+            "subscription_not_found",
+            "This organization has no current or pending subscription.",
+            correlationId);
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -383,6 +383,38 @@ public sealed class SubscriptionCheckoutServiceTests
             "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
+    [Fact]
+    public async Task Current_returns_an_incomplete_subscription_with_its_pending_checkout()
+    {
+        ArrangePendingCheckout();
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Incomplete));
+        result.Value.SubscriptionId.Should().Be(_subscription.ItemId);
+        result.Value.CheckoutUrl.Should().Be("https://checkout.stripe.com/existing");
+    }
+
+    [Fact]
+    public async Task Current_prefers_a_live_subscription_over_any_pending_lookup()
+    {
+        _subscription.Status = SubscriptionStatus.Active;
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_subscription);
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Active));
+        result.Value.CheckoutUrl.Should().BeNull();
+        _subscriptions.Verify(
+            repository => repository.GetIncompleteAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private SubscriptionCheckoutService Service() => new(
         _creation.Object,
         _subscriptions.Object,


### PR DESCRIPTION
## Summary
- make GET /api/subscriptions/current return an Incomplete pending subscription and its valid checkout URL
- prefer Trialing, Active, or PastDue over the pending lookup
- keep 404 only for organizations with neither a granting nor incomplete subscription
- update the integration guide's polling behavior

## Verification
- focused checkout tests: 17 passed
- subscription unit tests: 337 passed

## Base
- created from dev after PR #256 was merged
- contains only the post-merge current-endpoint change