### PR TITLE
feat(subscription): add subscription simulation module

### DIFF
--- a/client/app/constants/navigation-menus.ts
+++ b/client/app/constants/navigation-menus.ts
@@ -1,6 +1,7 @@
 import {
   CirclePlus,
   CreditCard,
+  FlaskConical,
   Home,
   Layers,
   Package,
@@ -80,6 +81,13 @@ export const navigationMenus: Menu[] = [
         name: "Plans",
         path: "/app/subscription/plans",
         icon: Layers,
+      },
+      {
+        id: "subscription-simulation",
+        type: "menu",
+        name: "Simulation",
+        path: "/app/subscription/simulation",
+        icon: FlaskConical,
       },
     ],
   },

--- a/client/app/cross-modules/utilities/subscription-simulation/components/cancel-subscription-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/cancel-subscription-dialog.tsx
@@ -1,0 +1,124 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Label } from "@/components/ui-kits/label/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui-kits/radio-group/radio-group";
+import { Textarea } from "@/components/ui-kits/textarea/textarea";
+import { toast } from "@/hooks/use-toast";
+import { useCancelSubscription } from "../hooks/use-cancel-subscription";
+import type { SimulatedSubscription } from "../models/subscription-simulation.model";
+
+export const CancelSubscriptionDialog = ({
+  subscription,
+  open,
+  onOpenChange,
+}: {
+  subscription: SimulatedSubscription;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { mutateAsync, isPending } = useCancelSubscription();
+
+  const [immediately, setImmediately] = useState(false);
+  const [reason, setReason] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setFormError(null);
+
+    try {
+      const canceled = await mutateAsync({
+        subscriptionId: subscription.subscriptionId,
+        immediately,
+        reason: reason.trim() || undefined,
+      });
+
+      toast({
+        variant: "success",
+        title: "Cancellation sent",
+        description: immediately
+          ? "The subscription stopped granting immediately."
+          : `Access continues until ${new Date(canceled.currentPeriodEndUtc).toLocaleString()}.`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "The subscription could not be canceled.",
+      );
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Cancel {subscription.planName}</DialogTitle>
+          <DialogDescription>
+            Sends <code>DELETE /api/subscriptions/{subscription.subscriptionId}</code> exactly as
+            an integrating application would.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <RadioGroup
+            value={immediately ? "immediately" : "period-end"}
+            onValueChange={(value) => setImmediately(value === "immediately")}
+          >
+            <div className="flex items-start gap-2">
+              <RadioGroupItem value="period-end" id="cancel-period-end" className="mt-1" />
+              <Label htmlFor="cancel-period-end" className="font-normal">
+                Cancel at period end — keeps granting until{" "}
+                {new Date(subscription.currentPeriodEndUtc).toLocaleDateString()}, then stops
+                renewing.
+              </Label>
+            </div>
+            <div className="flex items-start gap-2">
+              <RadioGroupItem value="immediately" id="cancel-immediately" className="mt-1" />
+              <Label htmlFor="cancel-immediately" className="font-normal">
+                Cancel immediately — stops granting right now.
+              </Label>
+            </div>
+          </RadioGroup>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cancel-reason">Reason (optional)</Label>
+            <Textarea
+              id="cancel-reason"
+              value={reason}
+              onChange={(event) => setReason(event.target.value)}
+              placeholder="Recorded on the cancellation event."
+            />
+          </div>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Back
+          </Button>
+          <Button variant="destructive" onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Cancel subscription
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -1,0 +1,237 @@
+import { Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui-kits/badge/badge";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { toast } from "@/hooks/use-toast";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { formatPrice } from "../../subscription/utilities/subscription-format";
+import { useChangeSubscriptionPlan } from "../hooks/use-change-subscription-plan";
+import type {
+  SimulatedSubscription,
+  SubscriptionQuantity,
+} from "../models/subscription-simulation.model";
+import { labelPlanChange } from "../utilities/plan-change-label";
+
+export const ChangePlanDialog = ({
+  subscription,
+  currentPlan,
+  plans,
+  open,
+  onOpenChange,
+}: {
+  subscription: SimulatedSubscription;
+  currentPlan: SubscriptionPlan | undefined;
+  plans: SubscriptionPlan[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { mutateAsync, isPending } = useChangeSubscriptionPlan();
+
+  const [targetPlanId, setTargetPlanId] = useState(currentPlan?.planId ?? "");
+  const [priceId, setPriceId] = useState("");
+  const [quantities, setQuantities] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const targetPlan = useMemo(
+    () => plans.find((plan) => plan.planId === targetPlanId),
+    [plans, targetPlanId],
+  );
+
+  const selectedPrice = useMemo(
+    () => targetPlan?.prices.find((price) => price.priceId === priceId),
+    [targetPlan, priceId],
+  );
+
+  const moveLabel = targetPlan ? labelPlanChange(currentPlan, targetPlan) : null;
+  const currencyMismatch = Boolean(
+    selectedPrice && selectedPrice.currencyCode !== subscription.currencyCode,
+  );
+
+  const selectTargetPlan = (planId: string) => {
+    setTargetPlanId(planId);
+    const plan = plans.find((candidate) => candidate.planId === planId);
+    setPriceId(plan?.prices[0]?.priceId ?? "");
+    setQuantities(
+      Object.fromEntries(
+        (plan?.quantityItems ?? []).map((item) => [item.itemKey, String(item.defaultQuantity)]),
+      ),
+    );
+    setFormError(null);
+  };
+
+  const submit = async () => {
+    setFormError(null);
+
+    if (!targetPlan || !priceId) {
+      setFormError("Choose a target plan and price.");
+      return;
+    }
+
+    if (currencyMismatch) {
+      setFormError(
+        "This price is in a different currency. A currency change needs a cancel and a fresh subscription, not a plan change.",
+      );
+      return;
+    }
+
+    const parsedQuantities: SubscriptionQuantity[] = [];
+    for (const item of targetPlan.quantityItems) {
+      const raw = quantities[item.itemKey] ?? "";
+      const quantity = Number(raw);
+
+      if (!raw || !Number.isFinite(quantity) || quantity < item.minQuantity) {
+        setFormError(`${item.unitLabel} must be at least ${item.minQuantity}.`);
+        return;
+      }
+
+      if (item.maxQuantity != null && quantity > item.maxQuantity) {
+        setFormError(`${item.unitLabel} can be at most ${item.maxQuantity}.`);
+        return;
+      }
+
+      parsedQuantities.push({ itemKey: item.itemKey, quantity });
+    }
+
+    try {
+      await mutateAsync({
+        subscriptionId: subscription.subscriptionId,
+        request: { priceId, quantities: parsedQuantities },
+      });
+
+      toast({
+        variant: "success",
+        title: `${moveLabel ?? "Plan changed"}`,
+        description: `Now on ${targetPlan.displayName}.`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : "The plan could not be changed.");
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Change plan</DialogTitle>
+          <DialogDescription>
+            Sends <code>PUT /api/subscriptions/{subscription.subscriptionId}/plan</code> — the
+            server follows the chosen price back to its plan and rebuilds billing from there.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="change-plan-target">Target plan</Label>
+            <Select value={targetPlanId} onValueChange={selectTargetPlan}>
+              <SelectTrigger id="change-plan-target">
+                <SelectValue placeholder="Choose a plan" />
+              </SelectTrigger>
+              <SelectContent>
+                {plans.map((plan) => (
+                  <SelectItem key={plan.planId} value={plan.planId}>
+                    {plan.displayName}
+                    {plan.planId === currentPlan?.planId ? " (current)" : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {targetPlan && (
+            <div className="space-y-1.5">
+              <Label htmlFor="change-plan-price">Target price</Label>
+              <Select value={priceId} onValueChange={setPriceId}>
+                <SelectTrigger id="change-plan-price">
+                  <SelectValue placeholder="Choose a price" />
+                </SelectTrigger>
+                <SelectContent>
+                  {targetPlan.prices.map((price) => (
+                    <SelectItem key={price.priceId} value={price.priceId}>
+                      {price.displayPriceNote ?? formatPrice(price)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {moveLabel && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">This is labelled as</span>
+              <Badge variant="info" className="font-normal">
+                {moveLabel}
+              </Badge>
+              {currencyMismatch && (
+                <Badge variant="error" className="font-normal">
+                  Currency mismatch
+                </Badge>
+              )}
+            </div>
+          )}
+
+          {targetPlan?.quantityItems.map((item) => (
+            <div className="space-y-1.5" key={item.itemKey}>
+              <Label htmlFor={`change-quantity-${item.itemKey}`}>{item.unitLabel}</Label>
+              <Input
+                id={`change-quantity-${item.itemKey}`}
+                type="number"
+                min={item.minQuantity}
+                max={item.maxQuantity ?? undefined}
+                value={quantities[item.itemKey] ?? ""}
+                onChange={(event) =>
+                  setQuantities((current) => ({
+                    ...current,
+                    [item.itemKey]: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          ))}
+
+          <p className="text-xs text-muted-foreground">
+            The change takes effect immediately and starts a full target billing period — an
+            upgrade may charge immediately, a downgrade becomes credit toward future renewals.
+          </p>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Confirm change
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
@@ -1,0 +1,132 @@
+import { AlertCircle, CalendarClock, ExternalLink, Inbox } from "lucide-react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import { formatPrice } from "../../subscription/utilities/subscription-format";
+import type { SimulatedSubscription } from "../models/subscription-simulation.model";
+import { SubscriptionStatusBadge } from "./subscription-status-badge";
+
+const formatDate = (isoDate: string | null) =>
+  isoDate ? new Date(isoDate).toLocaleString() : "—";
+
+const CANCELABLE_STATUSES = new Set(["Incomplete", "Trialing", "Active", "PastDue"]);
+// Incomplete has not paid yet, so it is not eligible to change plan — the doc has you continue
+// or cancel that checkout instead.
+const CHANGEABLE_STATUSES = new Set(["Trialing", "Active", "PastDue"]);
+
+export const CurrentSubscriptionCard = ({
+  subscription,
+  isLoading,
+  isError,
+  error,
+  scopeLabel,
+  onRetry,
+  onCancel,
+  onChangePlan,
+}: {
+  subscription: SimulatedSubscription | null | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  error: unknown;
+  scopeLabel: string;
+  onRetry: () => void;
+  onCancel: () => void;
+  onChangePlan: () => void;
+}) => {
+  if (isLoading) {
+    return <Skeleton className="h-28 w-full rounded-xl" />;
+  }
+
+  if (isError) {
+    return (
+      <Card className="flex flex-col items-start gap-2 rounded-xl border-destructive/30 bg-destructive/5 p-4">
+        <div className="flex items-center gap-2 text-destructive">
+          <AlertCircle className="h-4 w-4" />
+          <span className="font-medium">Current subscription could not be loaded</span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {error instanceof Error ? error.message : "Try again in a moment."}
+        </p>
+        <Button size="sm" variant="outline" onClick={onRetry}>
+          Try again
+        </Button>
+      </Card>
+    );
+  }
+
+  if (!subscription) {
+    return (
+      <Card className="flex items-center gap-3 rounded-xl p-4 text-sm text-muted-foreground">
+        <Inbox className="h-5 w-5 shrink-0" />
+        <span>
+          <strong className="text-foreground">{scopeLabel}</strong> has no subscription yet.
+          Subscribe to a plan below to start one.
+        </span>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="rounded-xl p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold">{subscription.planName}</h3>
+            <SubscriptionStatusBadge status={subscription.status} />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {scopeLabel} · {subscription.planCode} ·{" "}
+            {formatPrice({
+              currencyCode: subscription.currencyCode,
+              unitAmountMinor: subscription.unitAmountMinor,
+              interval: subscription.interval,
+              intervalCount: subscription.intervalCount,
+              quantityItemKey: subscription.quantities[0]?.itemKey ?? null,
+            })}
+          </p>
+        </div>
+
+        <div className="flex gap-2">
+          {subscription.checkoutUrl && (
+            <Button size="sm" asChild>
+              <a href={subscription.checkoutUrl} target="_blank" rel="noreferrer">
+                Continue checkout
+                <ExternalLink className="ml-2 h-3.5 w-3.5" />
+              </a>
+            </Button>
+          )}
+          {CHANGEABLE_STATUSES.has(subscription.status) && (
+            <Button size="sm" variant="outline" onClick={onChangePlan}>
+              Change plan
+            </Button>
+          )}
+          {CANCELABLE_STATUSES.has(subscription.status) && (
+            <Button size="sm" variant="destructive-outline" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <CalendarClock className="h-3.5 w-3.5" />
+          Current period ends {formatDate(subscription.currentPeriodEndUtc)}
+        </span>
+        {subscription.trialEndsAtUtc && (
+          <span>Trial ends {formatDate(subscription.trialEndsAtUtc)}</span>
+        )}
+        {subscription.cancelAtPeriodEnd && (
+          <span className="text-warning-800">Cancels at period end</span>
+        )}
+        {subscription.quantities.length > 0 && (
+          <span>
+            {subscription.quantities
+              .map((quantity) => `${quantity.itemKey} × ${quantity.quantity}`)
+              .join(", ")}
+          </span>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/simulated-plan-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/simulated-plan-card.tsx
@@ -1,0 +1,79 @@
+import { Gauge, Layers } from "lucide-react";
+import { Badge } from "@/components/ui-kits/badge/badge";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { formatPrice } from "../../subscription/utilities/subscription-format";
+
+export const SimulatedPlanCard = ({
+  plan,
+  organizationLabel,
+  hasActiveSubscription,
+  onSubscribe,
+}: {
+  plan: SubscriptionPlan;
+  organizationLabel: string;
+  hasActiveSubscription: boolean;
+  onSubscribe: () => void;
+}) => {
+  const cheapestPrice = plan.prices.reduce<SubscriptionPlan["prices"][number] | null>(
+    (cheapest, price) =>
+      cheapest === null || price.unitAmountMinor < cheapest.unitAmountMinor
+        ? price
+        : cheapest,
+    null,
+  );
+
+  return (
+    <Card className="flex h-full flex-col justify-between rounded-xl">
+      <div>
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h3 className="font-semibold">{plan.displayName}</h3>
+            <p className="text-xs text-muted-foreground">{plan.code}</p>
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          <Badge variant="outline" className="font-normal">
+            {organizationLabel}
+          </Badge>
+          {plan.trialDays ? (
+            <Badge variant="info" className="font-normal">
+              {plan.trialDays}-day trial
+            </Badge>
+          ) : null}
+          {plan.quantityItems.length > 0 && (
+            <Badge variant="secondary" className="gap-1 font-normal">
+              <Layers className="h-3 w-3" />
+              {plan.quantityItems.length} quantity item
+              {plan.quantityItems.length === 1 ? "" : "s"}
+            </Badge>
+          )}
+          {plan.meters.length > 0 && (
+            <Badge variant="secondary" className="gap-1 font-normal">
+              <Gauge className="h-3 w-3" />
+              {plan.meters.length} meter{plan.meters.length === 1 ? "" : "s"}
+            </Badge>
+          )}
+        </div>
+
+        <p className="mt-3 text-sm text-muted-foreground">
+          {cheapestPrice ? `From ${formatPrice(cheapestPrice)}` : "No price configured yet"}
+        </p>
+      </div>
+
+      <Button
+        className="mt-4"
+        disabled={!cheapestPrice || hasActiveSubscription}
+        onClick={onSubscribe}
+      >
+        {hasActiveSubscription
+          ? "Already subscribed"
+          : cheapestPrice
+            ? "Subscribe"
+            : "No price to subscribe on"}
+      </Button>
+    </Card>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
@@ -1,0 +1,216 @@
+import { Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { toast } from "@/hooks/use-toast";
+import { detectBrowserTimeZone } from "../constants/subscription-simulation.constants";
+import { useSubscribeToPlan } from "../hooks/use-subscribe-to-plan";
+import type { SubscriptionQuantity } from "../models/subscription-simulation.model";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { formatPrice } from "../../subscription/utilities/subscription-format";
+
+export const SubscribeDialog = ({
+  plan,
+  organizationId,
+  open,
+  onOpenChange,
+  onSubscribed,
+}: {
+  plan: SubscriptionPlan;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubscribed: (checkoutUrl: string | null) => void;
+}) => {
+  const { mutateAsync, isPending } = useSubscribeToPlan();
+
+  const [priceId, setPriceId] = useState(plan.prices[0]?.priceId ?? "");
+  const [quantities, setQuantities] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      plan.quantityItems.map((item) => [item.itemKey, String(item.defaultQuantity)]),
+    ),
+  );
+  const [discountCode, setDiscountCode] = useState("");
+  const [billingEmail, setBillingEmail] = useState("");
+  const [billingName, setBillingName] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const selectedPrice = useMemo(
+    () => plan.prices.find((price) => price.priceId === priceId),
+    [plan.prices, priceId],
+  );
+
+  const submit = async () => {
+    setFormError(null);
+
+    if (!priceId) {
+      setFormError("Choose a price to subscribe on.");
+      return;
+    }
+
+    const parsedQuantities: SubscriptionQuantity[] = [];
+    for (const item of plan.quantityItems) {
+      const raw = quantities[item.itemKey] ?? "";
+      const quantity = Number(raw);
+
+      if (!raw || !Number.isFinite(quantity) || quantity < item.minQuantity) {
+        setFormError(`${item.unitLabel} must be at least ${item.minQuantity}.`);
+        return;
+      }
+
+      if (item.maxQuantity != null && quantity > item.maxQuantity) {
+        setFormError(`${item.unitLabel} can be at most ${item.maxQuantity}.`);
+        return;
+      }
+
+      parsedQuantities.push({ itemKey: item.itemKey, quantity });
+    }
+
+    try {
+      const subscription = await mutateAsync({
+        planCode: plan.code,
+        priceId,
+        quantities: parsedQuantities,
+        timeZoneId: detectBrowserTimeZone(),
+        discountCode: discountCode.trim() || undefined,
+        billingEmail: billingEmail.trim() || undefined,
+        billingName: billingName.trim() || undefined,
+        organizationId,
+      });
+
+      toast({
+        variant: "success",
+        title: "Subscription started",
+        description: subscription.checkoutUrl
+          ? "Continue to checkout to activate it."
+          : `Status: ${subscription.status}.`,
+      });
+
+      onOpenChange(false);
+      onSubscribed(subscription.checkoutUrl);
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "The subscription could not be started.",
+      );
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Subscribe to {plan.displayName}</DialogTitle>
+          <DialogDescription>
+            Sends <code>POST /api/subscriptions</code> exactly as an integrating application
+            would.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="subscribe-price">Price</Label>
+            <Select value={priceId} onValueChange={setPriceId}>
+              <SelectTrigger id="subscribe-price">
+                <SelectValue placeholder="Choose a price" />
+              </SelectTrigger>
+              <SelectContent>
+                {plan.prices.map((price) => (
+                  <SelectItem key={price.priceId} value={price.priceId}>
+                    {price.displayPriceNote ?? formatPrice(price)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {plan.quantityItems.map((item) => (
+            <div className="space-y-1.5" key={item.itemKey}>
+              <Label htmlFor={`quantity-${item.itemKey}`}>
+                {item.unitLabel}
+                {selectedPrice?.quantityItemKey === item.itemKey && " (price multiplier)"}
+              </Label>
+              <Input
+                id={`quantity-${item.itemKey}`}
+                type="number"
+                min={item.minQuantity}
+                max={item.maxQuantity ?? undefined}
+                value={quantities[item.itemKey] ?? ""}
+                onChange={(event) =>
+                  setQuantities((current) => ({
+                    ...current,
+                    [item.itemKey]: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          ))}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="subscribe-discount">Discount code (optional)</Label>
+            <Input
+              id="subscribe-discount"
+              value={discountCode}
+              onChange={(event) => setDiscountCode(event.target.value)}
+              placeholder="e.g. LAUNCH20"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="subscribe-email">Billing email (optional)</Label>
+              <Input
+                id="subscribe-email"
+                type="email"
+                value={billingEmail}
+                onChange={(event) => setBillingEmail(event.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="subscribe-name">Billing name (optional)</Label>
+              <Input
+                id="subscribe-name"
+                value={billingName}
+                onChange={(event) => setBillingName(event.target.value)}
+              />
+            </div>
+          </div>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Subscribe
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscription-status-badge.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscription-status-badge.tsx
@@ -1,0 +1,19 @@
+import { Badge, type BadgeProps } from "@/components/ui-kits/badge/badge";
+import type { SubscriptionStatus } from "../models/subscription-simulation.model";
+
+/** Mirrors the lifecycle in the integration guide: only three states actually grant anything. */
+const STATUS_VARIANT: Record<SubscriptionStatus, BadgeProps["variant"]> = {
+  Trialing: "info",
+  Active: "success",
+  PastDue: "info",
+  Incomplete: "secondary",
+  IncompleteExpired: "error",
+  Unpaid: "error",
+  Canceled: "secondary",
+};
+
+export const SubscriptionStatusBadge = ({ status }: { status: SubscriptionStatus }) => (
+  <Badge variant={STATUS_VARIANT[status]} className="font-normal">
+    {status}
+  </Badge>
+);

--- a/client/app/cross-modules/utilities/subscription-simulation/components/usage-meter-row.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/usage-meter-row.tsx
@@ -1,0 +1,167 @@
+import { CheckCircle2, Loader2, ShieldAlert } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Input } from "@/components/ui-kits/input/input";
+import { toast } from "@/hooks/use-toast";
+import { useRecordUsage } from "../hooks/use-record-usage";
+import type { EntitlementDecision } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+import type { PlanMeter } from "../../subscription/models/subscription-plan.model";
+
+/**
+ * One meter's consume control.
+ *
+ * Deliberately two steps, matching how an integrator would naturally reach for the API: read the
+ * entitlement right before acting, decide client-side, then record. The docs are explicit that
+ * this check is advisory rather than a lock — two callers a unit under the limit can both read
+ * `allowed: true` — so the record call still carries `enforce: true` as the real gate. Watching
+ * the "checked" and "recorded" balances diverge under fast repeated clicks is the point of
+ * simulating it this way rather than only calling the usage endpoint directly.
+ */
+export const UsageMeterRow = ({
+  meter,
+  entitlementKey,
+  initialDecision,
+  organizationId,
+}: {
+  meter: PlanMeter;
+  /** The plan entitlement that gates this meter, if the plan defines one. */
+  entitlementKey: string | undefined;
+  initialDecision: EntitlementDecision | undefined;
+  organizationId: string | undefined;
+}) => {
+  const { mutateAsync: recordUsage } = useRecordUsage();
+
+  const [quantity, setQuantity] = useState("1");
+  const [phase, setPhase] = useState<"idle" | "checking" | "recording">("idle");
+  const [lastCheck, setLastCheck] = useState<EntitlementDecision | undefined>(initialDecision);
+  const [lastResult, setLastResult] = useState<
+    { message: string; tone: "success" | "blocked" | "error" } | null
+  >(null);
+
+  const consume = async () => {
+    const parsedQuantity = Number(quantity);
+    if (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0) {
+      setLastResult({ message: "Enter a quantity greater than zero.", tone: "error" });
+      return;
+    }
+
+    setLastResult(null);
+
+    try {
+      if (entitlementKey) {
+        // Step 1 — check: read the entitlement fresh, right before acting.
+        setPhase("checking");
+        const checked = await subscriptionSimulationService.getEntitlement(
+          entitlementKey,
+          organizationId,
+        );
+        setLastCheck(checked);
+
+        if (!checked.allowed) {
+          setLastResult({
+            message: `Blocked before recording — ${checked.reason}.`,
+            tone: "blocked",
+          });
+          return;
+        }
+
+        if (
+          checked.limitKind === "Count" &&
+          checked.remaining != null &&
+          checked.remaining < parsedQuantity
+        ) {
+          setLastResult({
+            message: `Blocked before recording — only ${checked.remaining} ${meter.unitLabel}${checked.remaining === 1 ? "" : "s"} remaining.`,
+            tone: "blocked",
+          });
+          return;
+        }
+      }
+
+      // Step 2/3 — the check passed (or none applies), so record. `enforce: true` is the real
+      // gate: the check above cannot see this exact quantity landing at the same instant another
+      // one does.
+      setPhase("recording");
+
+      const result = await recordUsage({
+        meterKey: meter.meterKey,
+        quantity: parsedQuantity,
+        idempotencyKey: crypto.randomUUID(),
+        enforce: true,
+        organizationId,
+      });
+
+      setLastResult({
+        message: result.allowed
+          ? `Recorded. ${result.used}/${result.included} ${result.unitLabel} used this period, ${result.remaining} remaining${result.overage ? `, ${result.overage} over` : ""}.`
+          : "Refused by the usage call — the allowance was exhausted between the check and this call.",
+        tone: result.allowed ? "success" : "blocked",
+      });
+
+      if (!result.allowed) {
+        toast({
+          variant: "destructive",
+          title: "Usage refused",
+          description: `${meter.displayName} has no remaining allowance.`,
+        });
+      }
+    } catch (error) {
+      setLastResult({
+        message: error instanceof Error ? error.message : "The usage call failed.",
+        tone: "error",
+      });
+    } finally {
+      setPhase("idle");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border-b py-3 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{meter.displayName}</p>
+        <p className="text-xs text-muted-foreground">
+          {lastCheck?.limitKind === "Count"
+            ? `${lastCheck.used ?? 0}/${lastCheck.limit ?? meter.includedQuantity} ${meter.unitLabel}${meter.includedQuantity === 1 ? "" : "s"} used this period`
+            : entitlementKey
+              ? `Entitlement: ${entitlementKey}`
+              : `No entitlement gates this meter — recording goes straight through.`}
+        </p>
+        {lastResult && (
+          <p
+            className={
+              "mt-1 flex items-center gap-1 text-xs " +
+              (lastResult.tone === "success"
+                ? "text-green-700"
+                : lastResult.tone === "blocked"
+                  ? "text-warning-800"
+                  : "text-destructive")
+            }
+          >
+            {lastResult.tone === "success" ? (
+              <CheckCircle2 className="h-3.5 w-3.5" />
+            ) : (
+              <ShieldAlert className="h-3.5 w-3.5" />
+            )}
+            {lastResult.message}
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Input
+          type="number"
+          min={1}
+          value={quantity}
+          onChange={(event) => setQuantity(event.target.value)}
+          className="w-20"
+          aria-label={`Quantity to consume for ${meter.displayName}`}
+        />
+        <Button size="sm" onClick={consume} disabled={phase !== "idle"}>
+          {phase !== "idle" && <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />}
+          {phase === "checking" ? "Checking…" : phase === "recording" ? "Recording…" : "Consume"}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/usage-section.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/usage-section.tsx
@@ -1,0 +1,87 @@
+import { AlertCircle, Gauge } from "lucide-react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { useEntitlements } from "../hooks/use-entitlements";
+import { UsageMeterRow } from "./usage-meter-row";
+
+export const UsageSection = ({
+  plan,
+  organizationId,
+}: {
+  plan: SubscriptionPlan | undefined;
+  organizationId: string | undefined;
+}) => {
+  const {
+    data: entitlements,
+    error,
+    isError,
+    isLoading,
+    refetch,
+  } = useEntitlements(organizationId);
+
+  return (
+    <Card className="rounded-xl p-0">
+      <div className="border-b p-4 sm:p-5">
+        <h2 className="font-semibold">Usage</h2>
+        <p className="text-xs text-muted-foreground">
+          Each consume checks{" "}
+          <code className="mx-1 rounded bg-muted px-1">GET /api/entitlements/{"{key}"}</code>{" "}
+          first and decides from that answer, then records with{" "}
+          <code className="mx-1 rounded bg-muted px-1">POST /api/subscription-usage</code>,
+          which is the call that actually enforces.
+        </p>
+      </div>
+
+      <div className="p-4 sm:p-5">
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-14 w-full rounded-lg" />
+            <Skeleton className="h-14 w-full rounded-lg" />
+          </div>
+        ) : isError ? (
+          <div className="flex flex-col items-start gap-2">
+            <div className="flex items-center gap-2 text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span className="font-medium">Entitlements could not be loaded</span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {error instanceof Error ? error.message : "Try again in a moment."}
+            </p>
+            <Button size="sm" variant="outline" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </div>
+        ) : !plan || !plan.meters.length ? (
+          <div className="flex min-h-32 flex-col items-center justify-center text-center text-sm text-muted-foreground">
+            <Gauge className="mb-2 h-6 w-6" />
+            This plan has no metered usage to consume.
+          </div>
+        ) : (
+          <div>
+            {plan.meters.map((meter) => {
+              // The entitlement that gates this meter, found through the plan's own authored
+              // link (entitlement.meterKey), not by assuming the two keys match.
+              const entitlementKey = plan.entitlements.find(
+                (candidate) => candidate.meterKey === meter.meterKey,
+              )?.key;
+
+              return (
+                <UsageMeterRow
+                  key={meter.meterKey}
+                  meter={meter}
+                  entitlementKey={entitlementKey}
+                  initialDecision={entitlements?.entitlements.find(
+                    (decision) => decision.key === entitlementKey,
+                  )}
+                  organizationId={organizationId}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
@@ -1,0 +1,11 @@
+export const SUBSCRIPTIONS_ENDPOINT = "/api/subscriptions";
+export const SUBSCRIPTIONS_CURRENT_ENDPOINT = "/api/subscriptions/current";
+export const ENTITLEMENTS_ENDPOINT = "/api/entitlements";
+export const SUBSCRIPTION_USAGE_ENDPOINT = "/api/subscription-usage";
+
+/**
+ * The browser's own IANA zone. Periods turn over on this clock, so simulating from wherever the
+ * tester happens to sit is the closest stand-in for a real subscriber's timezone.
+ */
+export const detectBrowserTimeZone = (): string =>
+  Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-cancel-subscription.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-cancel-subscription.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { CancelSubscriptionRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+export const useCancelSubscription = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CancelSubscriptionRequest) =>
+      subscriptionSimulationService.cancel(request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-change-subscription-plan.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-change-subscription-plan.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { ChangeSubscriptionPlanRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+export const useChangeSubscriptionPlan = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: ChangeSubscriptionPlanRequest;
+    }) => subscriptionSimulationService.changePlan(subscriptionId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] });
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-entitlements"] });
+    },
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-current-simulated-subscription.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-current-simulated-subscription.ts
@@ -1,0 +1,13 @@
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { useQuery } from "@tanstack/react-query";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+export const useCurrentSimulatedSubscription = (organizationId?: string) => {
+  const tenantId = useProjectStore()?.selectedProject?.tenantId || "";
+
+  return useQuery({
+    queryKey: ["subscription-simulation-current", tenantId, organizationId ?? null],
+    queryFn: () => subscriptionSimulationService.getCurrentSubscription(organizationId),
+    staleTime: 5_000,
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-entitlements.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-entitlements.ts
@@ -1,0 +1,14 @@
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { useQuery } from "@tanstack/react-query";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/** The once-per-session summary read, for the entitlements list. */
+export const useEntitlements = (organizationId?: string) => {
+  const tenantId = useProjectStore()?.selectedProject?.tenantId || "";
+
+  return useQuery({
+    queryKey: ["subscription-simulation-entitlements", tenantId, organizationId ?? null],
+    queryFn: () => subscriptionSimulationService.getEntitlements(organizationId),
+    staleTime: 5_000,
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-record-usage.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-record-usage.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { RecordUsageRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+export const useRecordUsage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: RecordUsageRequest) =>
+      subscriptionSimulationService.recordUsage(request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ["subscription-simulation-entitlements"],
+      }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-subscribe-to-plan.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-subscribe-to-plan.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { SubscribeToPlanRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+export const useSubscribeToPlan = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: SubscribeToPlanRequest) =>
+      subscriptionSimulationService.subscribe(request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/index.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/index.ts
@@ -1,0 +1,1 @@
+export { SubscriptionSimulationPage } from "./pages/subscription-simulation-page";

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -1,0 +1,130 @@
+import type { BillingIntervalName } from "../../subscription/models/subscription-plan.model";
+
+export type SubscriptionStatus =
+  | "Incomplete"
+  | "IncompleteExpired"
+  | "Trialing"
+  | "Active"
+  | "PastDue"
+  | "Unpaid"
+  | "Canceled";
+
+export interface SubscriptionQuantity {
+  itemKey: string;
+  quantity: number;
+}
+
+export interface SimulatedSubscription {
+  subscriptionId: string;
+  status: SubscriptionStatus;
+  planCode: string;
+  planName: string;
+  currencyCode: string;
+  unitAmountMinor: number;
+  interval: BillingIntervalName;
+  intervalCount: number;
+  displayPriceNote: string | null;
+  quantities: SubscriptionQuantity[];
+  currentPeriodStartUtc: string;
+  currentPeriodEndUtc: string;
+  nextPaymentAtUtc: string | null;
+  trialEndsAtUtc: string | null;
+  cancelAtPeriodEnd: boolean;
+  canceledAtUtc: string | null;
+  /** Only present while payment is outstanding; null once activated. */
+  checkoutUrl: string | null;
+  version: number;
+}
+
+export interface SubscribeToPlanRequest {
+  /** The plan's stable code, not its planId — sending the id reads as "plan not found". */
+  planCode: string;
+  priceId: string;
+  quantities: SubscriptionQuantity[];
+  timeZoneId: string;
+  discountCode?: string;
+  billingEmail?: string;
+  billingName?: string;
+  /**
+   * Honoured only because this portal calls the API as the platform console acting on the
+   * chosen organization's behalf. Omitted entirely for the tenant-wide scope, the same way plan
+   * authoring omits it — an ordinary integrator's token already carries its own organization and
+   * this field is silently ignored for it.
+   */
+  organizationId?: string;
+}
+
+export interface CancelSubscriptionRequest {
+  subscriptionId: string;
+  /** Default false — keeps granting until the paid period ends. True stops right away. */
+  immediately: boolean;
+  reason?: string;
+}
+
+/**
+ * A client never sends a target planCode. It sends the target price; the server follows
+ * `priceId → Price.PlanId → Plan` on its own, applies the new snapshots atomically, and handles
+ * proration.
+ */
+export interface ChangeSubscriptionPlanRequest {
+  priceId: string;
+  quantities: SubscriptionQuantity[];
+}
+
+export type PlanChangeLabel =
+  | "Upgrade"
+  | "Downgrade"
+  | "Switch plan"
+  | "Change billing cadence";
+
+/**
+ * A single entitlement's live decision. Reading one is a check, not enforcement — two callers
+ * both a unit under the limit can both read `allowed: true`, and only the usage call below tells
+ * them apart. `used`/`remaining` are present only for a `Count` entitlement.
+ */
+export interface EntitlementDecision {
+  key: string;
+  allowed: boolean;
+  reason: "Allowed" | "NoSubscription" | "SubscriptionNotActive" | "NotInPlan" | "LimitReached";
+  limitKind: "Boolean" | "Count" | "Unlimited";
+  limit: number | null;
+  used?: number | null;
+  remaining?: number | null;
+  unitLabel: string | null;
+}
+
+export interface EntitlementsSnapshot {
+  hasSubscription: boolean;
+  status?: SubscriptionStatus;
+  planCode?: string;
+  currentPeriodEndUtc?: string | null;
+  trialEndsAtUtc?: string | null;
+  quantities: SubscriptionQuantity[];
+  entitlements: EntitlementDecision[];
+  featuresJson: string | null;
+}
+
+export interface RecordUsageRequest {
+  meterKey: string;
+  quantity: number;
+  /** Mandatory — at-least-once delivery makes a retried call a certainty, and it must not double-count. */
+  idempotencyKey: string;
+  /** Refuses and rolls back once the allowance is exhausted, but only for a meter with no overage. */
+  enforce: boolean;
+  /** Honoured only for this portal acting as the platform console; see SubscribeToPlanRequest. */
+  organizationId?: string;
+}
+
+export interface RecordUsageResult {
+  allowed: boolean;
+  meterKey: string;
+  unitLabel: string;
+  periodKey: string;
+  periodStartUtc: string;
+  periodEndUtc: string;
+  included: number;
+  used: number;
+  remaining: number;
+  overage: number;
+  replayed: boolean;
+}

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from "react";
+import { AlertCircle, FlaskConical, Layers, RefreshCw } from "lucide-react";
+import { useSearchParams } from "react-router";
+import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import { toast } from "@/hooks/use-toast";
+import {
+  ORGANIZATION_PAGE_SIZE,
+  ORGANIZATION_QUERY_PARAM,
+  TENANT_WIDE_ORGANIZATION,
+} from "../../subscription/constants/subscription.constants";
+import { SubscriptionPlanPageHeader } from "../../subscription/components/subscription-plan-page-header";
+import { useSubscriptionPlans } from "../../subscription/hooks/use-subscription-plans";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { CancelSubscriptionDialog } from "../components/cancel-subscription-dialog";
+import { ChangePlanDialog } from "../components/change-plan-dialog";
+import { CurrentSubscriptionCard } from "../components/current-subscription-card";
+import { SimulatedPlanCard } from "../components/simulated-plan-card";
+import { SubscribeDialog } from "../components/subscribe-dialog";
+import { UsageSection } from "../components/usage-section";
+import { useCurrentSimulatedSubscription } from "../hooks/use-current-simulated-subscription";
+
+// Reserves the organization's one open signup or live subscription slot — includes Incomplete.
+const GRANTING_STATUSES = new Set(["Incomplete", "Trialing", "Active", "PastDue"]);
+// Actually grants entitlements per the lifecycle: Incomplete has not paid yet and grants nothing.
+const ENTITLED_STATUSES = new Set(["Trialing", "Active", "PastDue"]);
+
+export const SubscriptionSimulationPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const organizationScope = searchParams.get(ORGANIZATION_QUERY_PARAM) ?? undefined;
+  const [subscribingTo, setSubscribingTo] = useState<SubscriptionPlan | null>(null);
+  const [isCanceling, setIsCanceling] = useState(false);
+  const [isChangingPlan, setIsChangingPlan] = useState(false);
+
+  const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
+  const { data: organizationsData } = useGetOrganizations({
+    projectKey: tenantId,
+    page: 0,
+    pageSize: ORGANIZATION_PAGE_SIZE,
+  });
+  const organizations = organizationsData?.organizations ?? [];
+
+  const scopeLabel = useMemo(() => {
+    if (!organizationScope) {
+      return "Tenant-wide";
+    }
+    return (
+      organizationsData?.organizations?.find(
+        (organization) => organization.itemId === organizationScope,
+      )?.name ?? organizationScope
+    );
+  }, [organizationsData, organizationScope]);
+
+  const {
+    data: plans,
+    error: plansError,
+    isError: isPlansError,
+    isFetching: isFetchingPlans,
+    isLoading: isLoadingPlans,
+    refetch: refetchPlans,
+  } = useSubscriptionPlans(organizationScope);
+
+  const {
+    data: currentSubscription,
+    error: currentError,
+    isError: isCurrentError,
+    isLoading: isLoadingCurrent,
+    refetch: refetchCurrent,
+  } = useCurrentSimulatedSubscription(organizationScope);
+
+  const hasActiveSubscription = Boolean(
+    currentSubscription && GRANTING_STATUSES.has(currentSubscription.status),
+  );
+  const isEntitled = Boolean(
+    currentSubscription && ENTITLED_STATUSES.has(currentSubscription.status),
+  );
+  const currentPlan = plans?.find((plan) => plan.code === currentSubscription?.planCode);
+
+  const refresh = () => {
+    refetchPlans();
+    refetchCurrent();
+  };
+
+  return (
+    <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
+      <SubscriptionPlanPageHeader
+        title="Subscription simulation"
+        description="Exercise the Subscription module's client-facing API as an integrating application would — pick an organization, subscribe it to a plan, and watch the result."
+        icon={<FlaskConical className="h-6 w-6" />}
+        actions={
+          <Button
+            variant="outline"
+            className="bg-background/80"
+            onClick={refresh}
+            disabled={isFetchingPlans}
+          >
+            <RefreshCw className={`mr-2 h-4 w-4 ${isFetchingPlans ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        }
+      />
+
+      <Card className="rounded-xl p-0">
+        <div className="flex flex-col gap-3 border-b p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+          <div>
+            <h2 className="font-semibold">Acting as</h2>
+            <p className="text-xs text-muted-foreground">
+              Every action below is scoped to this organization, exactly as it would be for a
+              real integration.
+            </p>
+          </div>
+
+          <Select
+            value={organizationScope ?? TENANT_WIDE_ORGANIZATION}
+            onValueChange={(value) =>
+              setSearchParams(
+                value === TENANT_WIDE_ORGANIZATION ? {} : { [ORGANIZATION_QUERY_PARAM]: value },
+              )
+            }
+          >
+            <SelectTrigger className="sm:w-64" aria-label="Organization">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={TENANT_WIDE_ORGANIZATION}>Tenant-wide only</SelectItem>
+              {organizations.map((organization) => (
+                <SelectItem key={organization.itemId} value={organization.itemId}>
+                  {organization.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2 p-4 sm:p-5">
+          <h3 className="text-sm font-medium text-muted-foreground">Current subscription</h3>
+          <CurrentSubscriptionCard
+            subscription={currentSubscription}
+            isLoading={isLoadingCurrent}
+            isError={isCurrentError}
+            error={currentError}
+            scopeLabel={scopeLabel}
+            onRetry={() => refetchCurrent()}
+            onCancel={() => setIsCanceling(true)}
+            onChangePlan={() => setIsChangingPlan(true)}
+          />
+        </div>
+      </Card>
+
+      <Card className="rounded-xl p-0">
+        <div className="border-b p-4 sm:p-5">
+          <h2 className="font-semibold">Plan catalogue</h2>
+          <p className="text-xs text-muted-foreground">
+            Every plan visible to <strong>{scopeLabel}</strong> — the same list a
+            <code className="mx-1 rounded bg-muted px-1">
+              GET /api/subscription-plans
+            </code>
+            call returns.
+          </p>
+        </div>
+
+        <div className="p-4 sm:p-5">
+          {isLoadingPlans ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-label="Loading plans">
+              {Array.from({ length: 3 }, (_, index) => (
+                <Skeleton key={index} className="h-44 w-full rounded-xl" />
+              ))}
+            </div>
+          ) : isPlansError ? (
+            <div className="flex min-h-72 flex-col items-center justify-center text-center">
+              <span className="rounded-full bg-destructive/10 p-4 text-destructive">
+                <AlertCircle className="h-7 w-7" />
+              </span>
+              <h3 className="mt-4 text-lg font-semibold">Plans could not be loaded</h3>
+              <p className="mt-1 max-w-md text-sm text-muted-foreground">
+                {plansError instanceof Error ? plansError.message : "Try loading the plan list again."}
+              </p>
+              <Button className="mt-5" variant="outline" onClick={() => refetchPlans()}>
+                Try again
+              </Button>
+            </div>
+          ) : !plans?.length ? (
+            <div className="flex min-h-72 flex-col items-center justify-center text-center">
+              <span className="rounded-full bg-muted p-4 text-muted-foreground">
+                <Layers className="h-7 w-7" />
+              </span>
+              <h3 className="mt-4 text-lg font-semibold">No plan on sale for this scope</h3>
+              <p className="mt-1 max-w-md text-sm text-muted-foreground">
+                Author one from the subscription plans screen, or choose a different
+                organization.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {plans.map((plan) => (
+                <SimulatedPlanCard
+                  key={plan.planId}
+                  plan={plan}
+                  organizationLabel={
+                    plan.organizationId ? scopeLabel : "Tenant-wide"
+                  }
+                  hasActiveSubscription={hasActiveSubscription}
+                  onSubscribe={() => setSubscribingTo(plan)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </Card>
+
+      {isEntitled && (
+        <UsageSection plan={currentPlan} organizationId={organizationScope} />
+      )}
+
+      {subscribingTo && (
+        <SubscribeDialog
+          plan={subscribingTo}
+          organizationId={organizationScope}
+          open={Boolean(subscribingTo)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setSubscribingTo(null);
+            }
+          }}
+          onSubscribed={(checkoutUrl) => {
+            if (checkoutUrl) {
+              toast({
+                title: "Checkout ready",
+                description: "Open the checkout link from the current subscription card above.",
+              });
+            }
+          }}
+        />
+      )}
+
+      {isCanceling && currentSubscription && (
+        <CancelSubscriptionDialog
+          subscription={currentSubscription}
+          open={isCanceling}
+          onOpenChange={setIsCanceling}
+        />
+      )}
+
+      {isChangingPlan && currentSubscription && (
+        <ChangePlanDialog
+          subscription={currentSubscription}
+          currentPlan={currentPlan}
+          plans={plans ?? []}
+          open={isChangingPlan}
+          onOpenChange={setIsChangingPlan}
+        />
+      )}
+    </main>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -1,0 +1,173 @@
+import { HttpError } from "@seliseblocks/genesis-os/lib";
+import { serviceInstances } from "@/lib/http-client";
+import {
+  ENTITLEMENTS_ENDPOINT,
+  SUBSCRIPTION_USAGE_ENDPOINT,
+  SUBSCRIPTIONS_CURRENT_ENDPOINT,
+  SUBSCRIPTIONS_ENDPOINT,
+} from "../constants/subscription-simulation.constants";
+import type {
+  CancelSubscriptionRequest,
+  ChangeSubscriptionPlanRequest,
+  EntitlementDecision,
+  EntitlementsSnapshot,
+  RecordUsageRequest,
+  RecordUsageResult,
+  SimulatedSubscription,
+  SubscribeToPlanRequest,
+} from "../models/subscription-simulation.model";
+
+interface SimulationApiError {
+  code: string;
+  message: string;
+  fields?: Record<string, string[]> | null;
+}
+
+interface SimulationApiResponse<T> {
+  success: boolean;
+  data: T | null;
+  error: SimulationApiError | null;
+}
+
+class SubscriptionSimulationService {
+  async getCurrentSubscription(
+    organizationId?: string,
+  ): Promise<SimulatedSubscription | null> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+
+    try {
+      const response = await serviceInstances.utitlitiesService.get<
+        SimulationApiResponse<SimulatedSubscription>
+      >(`${SUBSCRIPTIONS_CURRENT_ENDPOINT}${query}`);
+
+      return response.success ? response.data : null;
+    } catch (error) {
+      // No granting or pending subscription for this scope is an ordinary empty state for a
+      // simulation screen, not a failure worth reporting as one.
+      if (error instanceof HttpError && error.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  async subscribe(request: SubscribeToPlanRequest): Promise<SimulatedSubscription> {
+    const response = await serviceInstances.utitlitiesService.post<
+      SimulationApiResponse<SimulatedSubscription>
+    >(SUBSCRIPTIONS_ENDPOINT, request);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "The subscription could not be started.");
+    }
+
+    return response.data;
+  }
+
+  async cancel(request: CancelSubscriptionRequest): Promise<SimulatedSubscription> {
+    const query = new URLSearchParams();
+    query.set("immediately", String(request.immediately));
+    if (request.reason) {
+      query.set("reason", request.reason);
+    }
+
+    const response = await serviceInstances.utitlitiesService.delete<
+      SimulationApiResponse<SimulatedSubscription>
+    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(request.subscriptionId)}?${query}`);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "The subscription could not be canceled.");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * Moves an existing subscription to another price. The server resolves
+   * `priceId → Price.PlanId → Plan` itself — the client never names a target plan directly.
+   */
+  async changePlan(
+    subscriptionId: string,
+    request: ChangeSubscriptionPlanRequest,
+  ): Promise<SimulatedSubscription> {
+    const response = await serviceInstances.utitlitiesService.put<
+      SimulationApiResponse<SimulatedSubscription>
+    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan`, request);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "The plan could not be changed.");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * The cached-once-per-session read: every entitlement in one call, for the summary list.
+   * `fresh` bypasses the short cache — counters are never cached regardless.
+   */
+  async getEntitlements(
+    organizationId?: string,
+    fresh = false,
+  ): Promise<EntitlementsSnapshot> {
+    const query = new URLSearchParams();
+    if (organizationId) {
+      query.set("organizationId", organizationId);
+    }
+    if (fresh) {
+      query.set("fresh", "true");
+    }
+    const queryString = query.toString();
+    const suffix = queryString ? `?${queryString}` : "";
+
+    const response = await serviceInstances.utitlitiesService.get<
+      SimulationApiResponse<EntitlementsSnapshot>
+    >(`${ENTITLEMENTS_ENDPOINT}${suffix}`);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "Entitlements could not be loaded.");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * The point-of-use read for one entitlement, always fresh. This is the "may they do this right
+   * now" check a real integration runs immediately before letting an action proceed — it is
+   * advisory, not enforcement, since nothing stops a second call from reading the same answer a
+   * moment later.
+   */
+  async getEntitlement(
+    entitlementKey: string,
+    organizationId?: string,
+  ): Promise<EntitlementDecision> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+
+    const response = await serviceInstances.utitlitiesService.get<
+      SimulationApiResponse<EntitlementDecision>
+    >(`${ENTITLEMENTS_ENDPOINT}/${encodeURIComponent(entitlementKey)}${query}`);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "The entitlement could not be checked.");
+    }
+
+    return response.data;
+  }
+
+  /** The authoritative gate — the figures returned include this call. */
+  async recordUsage(request: RecordUsageRequest): Promise<RecordUsageResult> {
+    const response = await serviceInstances.utitlitiesService.post<
+      SimulationApiResponse<RecordUsageResult>
+    >(SUBSCRIPTION_USAGE_ENDPOINT, request);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "The usage could not be recorded.");
+    }
+
+    return response.data;
+  }
+}
+
+export const subscriptionSimulationService = new SubscriptionSimulationService();

--- a/client/app/cross-modules/utilities/subscription-simulation/utilities/plan-change-label.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/utilities/plan-change-label.ts
@@ -1,0 +1,34 @@
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import type { PlanChangeLabel } from "../models/subscription-simulation.model";
+
+/**
+ * Labelled from product family metadata, not price — a lower amount is not necessarily a
+ * downgrade once discounts, quantities and monthly-versus-annual billing are in play.
+ */
+export const labelPlanChange = (
+  currentPlan: SubscriptionPlan | undefined,
+  targetPlan: SubscriptionPlan,
+): PlanChangeLabel => {
+  if (currentPlan && currentPlan.planId === targetPlan.planId) {
+    return "Change billing cadence";
+  }
+
+  if (
+    currentPlan?.familyCode &&
+    targetPlan.familyCode &&
+    currentPlan.familyCode === targetPlan.familyCode
+  ) {
+    const currentRank = currentPlan.familyRank ?? 0;
+    const targetRank = targetPlan.familyRank ?? 0;
+
+    if (targetRank > currentRank) {
+      return "Upgrade";
+    }
+    if (targetRank < currentRank) {
+      return "Downgrade";
+    }
+    return "Change billing cadence";
+  }
+
+  return "Switch plan";
+};

--- a/client/app/router.tsx
+++ b/client/app/router.tsx
@@ -15,6 +15,7 @@ import SubscriptionPlanDetailRoute from "./routes/dashboard/subscription-plan-de
 import SubscriptionPlanPriceCreateRoute from "./routes/dashboard/subscription-plan-price-create";
 import SubscriptionPlanEditRoute from "./routes/dashboard/subscription-plan-edit";
 import SubscriptionDiscountsRoute from "./routes/dashboard/subscription-discounts";
+import SubscriptionSimulationRoute from "./routes/dashboard/subscription-simulation";
 import {
   AuthResolver,
   PublicGuard,
@@ -153,6 +154,10 @@ export const router = createBrowserRouter([
                   {
                     path: "subscription/plans/:planId/prices/create",
                     element: <SubscriptionPlanPriceCreateRoute />,
+                  },
+                  {
+                    path: "subscription/simulation",
+                    element: <SubscriptionSimulationRoute />,
                   },
                   { path: "magic-url", element: <MagicUrlPage /> },
                   {

--- a/client/app/routes/dashboard/subscription-simulation.tsx
+++ b/client/app/routes/dashboard/subscription-simulation.tsx
@@ -1,0 +1,5 @@
+import { SubscriptionSimulationPage } from "@blocks-utilities/subscription-simulation";
+
+export default function SubscriptionSimulationRoute() {
+  return <SubscriptionSimulationPage />;
+}


### PR DESCRIPTION
## Summary
- Adds a new client-facing "Subscription simulation" screen (`/app/subscription/simulation`) that exercises the Subscription module's client-facing API exactly as an integrating application would, scoped to a chosen organization or tenant-wide.
- **Plans & subscribe**: lists the organization's plan catalogue (`GET /api/subscription-plans`) and subscribes via `POST /api/subscriptions`, collecting price, quantities, discount code and billing details.
- **Current subscription**: shows the live subscription (`GET /api/subscriptions/current`), including checkout continuation when payment is outstanding.
- **Cancel**: cancels at period end or immediately (`DELETE /api/subscriptions/{id}`), with an optional reason.
- **Usage**: for each metered item on the current plan, checks the entitlement (`GET /api/entitlements/{key}`) right before acting, decides locally, then records with the authoritative gate (`POST /api/subscription-usage`, `enforce: true`) — deliberately built as two steps to make the check-vs-enforce distinction from the integration docs visible.
- **Change plan**: moves to another price (`PUT /api/subscriptions/{id}/plan`), labelling the move as Upgrade/Downgrade/Switch plan/Change billing cadence from product family metadata, with a client-side currency-mismatch guard.
- Reuses the existing subscription module's organization-scope hook, plan list hook, and formatting utilities rather than duplicating them.
- Registers the route in `router.tsx` and adds a "Simulation" entry under the Subscriptions nav menu.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` (scoped to the new module) passes clean
- [ ] Manual smoke test against a live Blocks Utilities backend: subscribe, consume usage past/under the allowance, cancel, and change plan for both an organization scope and tenant-wide scope (not run in this environment — no backend credentials/browser automation available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)