### PR TITLE
feat(subscription): author volume discount bands in the plan builder

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.test.tsx
@@ -48,6 +48,11 @@ const Harness = ({
 
   return (
     <FormProvider {...form}>
+      {/* The item's own bounds, registered the way the pricing step registers them. Typing into
+          these is what puts strings in the form state — passing numeric defaults straight in
+          never reproduces what an author actually does. */}
+      <input aria-label="Item minimum" type="number" {...form.register("quantityItems.0.minQuantity")} />
+      <input aria-label="Item maximum" type="number" {...form.register("quantityItems.0.maxQuantity")} />
       <QuantityDiscountTiers itemIndex={0} />
     </FormProvider>
   );
@@ -275,6 +280,62 @@ describe("QuantityDiscountTiers", () => {
       fireEvent.click(screen.getByText("Add band"));
 
       expect(column("minimumQuantity")).toEqual(["1", "3"]);
+    });
+  });
+
+
+  describe("bounds an author typed rather than defaults handed in", () => {
+    it("adds to a typed minimum instead of concatenating onto it", () => {
+      // A number input holds what was typed, so minQuantity arrives as "3". Read raw, "3" + 4 is
+      // "34" and the second band began at 341 — a plan nobody could have meant.
+      render(<Harness />);
+
+      fireEvent.change(screen.getByLabelText("Item minimum"), { target: { value: "3" } });
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      expect(column("minimumQuantity")).toEqual(["3", "8"]);
+      expect(column("maximumQuantity")).toEqual(["7", ""]);
+    });
+
+    it("treats a maximum that was entered and then cleared as no maximum", () => {
+      // Cleared, the input holds "" rather than undefined. Subtracted, that made an unbounded
+      // item look like one with no room at all and disabled the control.
+      render(<Harness />);
+
+      const maximum = screen.getByLabelText("Item maximum");
+
+      fireEvent.change(maximum, { target: { value: "20" } });
+      fireEvent.change(maximum, { target: { value: "" } });
+
+      expect(screen.getByLabelText("Apply volume discounts")).not.toBeDisabled();
+
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      expect(column("maximumQuantity")).toEqual(["5", ""]);
+    });
+
+    it("respects a typed maximum when splitting the range", () => {
+      render(<Harness />);
+
+      fireEvent.change(screen.getByLabelText("Item maximum"), { target: { value: "4" } });
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      expect(column("maximumQuantity")).toEqual(["3", "4"]);
+    });
+
+    it("keeps splitting a band whose bounds are two-digit strings", () => {
+      // Compared as strings, "9" is greater than "10", so a band with room to spare reported
+      // itself unsplittable — and one without room reported the opposite.
+      render(<Harness />);
+
+      fireEvent.change(screen.getByLabelText("Item maximum"), { target: { value: "10" } });
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      expect(screen.getByText("Add band").closest("button")).not.toBeDisabled();
+
+      fireEvent.click(screen.getByText("Add band"));
+
+      expect(column("minimumQuantity")).toEqual(["1", "6", "10"]);
     });
   });
 

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.test.tsx
@@ -1,0 +1,230 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  createSubscriptionPlanSchema,
+  defaultSubscriptionPlanFormValues,
+  type CreateSubscriptionPlanFormValues,
+} from "../../schemas/subscription-plan.schema";
+import { FLAT_FEE } from "../../schemas/subscription-price.schema";
+import { QuantityDiscountTiers } from "./quantity-discount-tiers";
+
+const item = (overrides: Partial<CreateSubscriptionPlanFormValues["quantityItems"][number]> = {}) => ({
+  itemKey: "user",
+  unitLabel: "user",
+  minQuantity: 1,
+  defaultQuantity: 1,
+  quantityDiscountTiers: [],
+  ...overrides,
+});
+
+const Harness = ({
+  quantityItem = item(),
+  priceQuantityItemKey = FLAT_FEE,
+}: {
+  quantityItem?: ReturnType<typeof item>;
+  priceQuantityItemKey?: string;
+}) => {
+  const form = useForm<CreateSubscriptionPlanFormValues>({
+    resolver: zodResolver(createSubscriptionPlanSchema),
+    // The mode the real builder uses, so a message this test expects on blur is a message an
+    // author actually sees on blur.
+    mode: "onBlur",
+    defaultValues: {
+      ...defaultSubscriptionPlanFormValues,
+      quantityItems: [quantityItem],
+      prices: [
+        {
+          currencyCode: "CHF",
+          amount: 145,
+          interval: 2,
+          intervalCount: 1,
+          quantityItemKey: priceQuantityItemKey,
+        },
+      ],
+    },
+  });
+
+  return (
+    <FormProvider {...form}>
+      <QuantityDiscountTiers itemIndex={0} />
+    </FormProvider>
+  );
+};
+
+/**
+ * Read off the rendered inputs rather than the form object: it is what an author actually sees,
+ * and capturing the form would mean assigning to an outer variable during render.
+ */
+const column = (field: string) =>
+  Array.from(
+    document.querySelectorAll<HTMLInputElement>(`input[name$=".${field}"]`),
+  ).map((input) => input.value);
+
+describe("QuantityDiscountTiers", () => {
+  it("shows no bands until volume discounts are asked for", () => {
+    render(<Harness />);
+
+    expect(column("minimumQuantity")).toEqual([]);
+  });
+
+  it("opens with a usable pair rather than one row", () => {
+    // One band is a flat discount, which the unit price already expresses — and the schema
+    // refuses it, so seeding a single row would open the editor already invalid.
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(column("minimumQuantity")).toEqual(["1", "6"]);
+  });
+
+  it("starts the first band where the quantity item starts", () => {
+    render(<Harness quantityItem={item({ minQuantity: 3, defaultQuantity: 3 })} />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(column("minimumQuantity")[0]).toBe("3");
+  });
+
+  /**
+   * The regression this guards: the band being split is the open one, so it has no bound of its
+   * own to build on. Derived from a constant, two bands landed on the same boundary the moment
+   * this was clicked twice — which the server rejects as an overlap.
+   */
+  it("keeps added bands contiguous", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+    fireEvent.click(screen.getByText("Add band"));
+    fireEvent.click(screen.getByText("Add band"));
+
+    const from = column("minimumQuantity");
+    const to = column("maximumQuantity");
+
+    expect(from).toEqual(["1", "6", "11", "16"]);
+    // Every band closes exactly one below the next, and only the last is left open.
+    expect(to).toEqual(["5", "10", "15", ""]);
+  });
+
+  it("leaves the final band open on an item with no maximum", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(column("maximumQuantity").at(-1)).toBe("");
+  });
+
+  it("closes the final band at the item's maximum when it has one", () => {
+    render(<Harness quantityItem={item({ maxQuantity: 30 })} />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(column("maximumQuantity").at(-1)).toBe("30");
+  });
+
+  it("refuses to remove a band while only two remain", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(screen.getByLabelText("Remove band 1")).toBeDisabled();
+  });
+
+  it("removes a band once there are more than two", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+    fireEvent.click(screen.getByText("Add band"));
+    fireEvent.click(screen.getByLabelText("Remove band 1"));
+
+    expect(column("minimumQuantity")).toHaveLength(2);
+  });
+
+  it("clears authored bands only after the author confirms", () => {
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(
+      <Harness
+        quantityItem={item({
+          quantityDiscountTiers: [
+            { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+            { minimumQuantity: 5, discountPercent: 5 },
+          ],
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(confirm).toHaveBeenCalled();
+    // The bands survive a declined confirm.
+    expect(column("minimumQuantity")).toEqual(["1", "5"]);
+
+    confirm.mockRestore();
+  });
+
+  it("does not ask before discarding bands nobody discounted", () => {
+    // A confirm on every toggle trains people to dismiss it, which is how the one that mattered
+    // gets dismissed too.
+    const confirm = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <Harness
+        quantityItem={item({
+          quantityDiscountTiers: [
+            { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+            { minimumQuantity: 5, discountPercent: 0 },
+          ],
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(column("minimumQuantity")).toEqual([]);
+
+    confirm.mockRestore();
+  });
+
+  it("shows what a unit costs inside each band when one price applies", () => {
+    render(<Harness quantityItem={item()} priceQuantityItemKey="user" />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    // CHF 145 at 5% off. Presentation only: the server prices and rounds the charge.
+    expect(screen.getByText(/137\.75/)).toBeInTheDocument();
+  });
+
+  it("shows no money when the item has no price of its own", () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    // With no price written against this item, "the" effective price is a fiction.
+    expect(screen.queryByText(/CHF/)).not.toBeInTheDocument();
+  });
+
+  it("says the discount applies to the whole charge", () => {
+    // Volume pricing, not graduated. An author who reads it the other way prices their catalogue
+    // wrong and finds out from an invoice.
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+    expect(screen.getByText(/applies to the whole charge/)).toBeInTheDocument();
+  });
+
+  it("reports a gap on the band that starts in the wrong place", async () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+    fireEvent.change(screen.getByLabelText("Band 2 from"), { target: { value: "9" } });
+    fireEvent.blur(screen.getByLabelText("Band 2 from"));
+
+    await waitFor(() => {
+      expect(screen.getByText("The next band must begin at 6.")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.test.tsx
@@ -216,6 +216,68 @@ describe("QuantityDiscountTiers", () => {
     expect(screen.getByText(/applies to the whole charge/)).toBeInTheDocument();
   });
 
+
+  describe("narrow finite items", () => {
+    it("splits the range instead of assuming five quantities fit", () => {
+      // min 1 / max 5 used to open as 1-5 followed by 6-5: a second band starting above where it
+      // ends, on an item whose ceiling the first band had already reached.
+      render(<Harness quantityItem={item({ maxQuantity: 5 })} />);
+
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      expect(column("minimumQuantity")).toEqual(["1", "5"]);
+      expect(column("maximumQuantity")).toEqual(["4", "5"]);
+    });
+
+    it("keeps the first band inside an item narrower than the default step", () => {
+      render(<Harness quantityItem={item({ maxQuantity: 3 })} />);
+
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      expect(column("maximumQuantity")).toEqual(["2", "3"]);
+    });
+
+    it("opens valid on the narrowest item that can hold two bands", async () => {
+      render(<Harness quantityItem={item({ maxQuantity: 2 })} />);
+
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      expect(column("minimumQuantity")).toEqual(["1", "2"]);
+      expect(column("maximumQuantity")).toEqual(["1", "2"]);
+
+      // And the schema agrees, which is the point: the editor must not open into a state its own
+      // validation refuses.
+      fireEvent.blur(screen.getByLabelText("Band 2 from"));
+
+      await waitFor(() => {
+        expect(screen.queryByText(/must begin at/)).not.toBeInTheDocument();
+      });
+    });
+
+    it("offers nothing to band on an item that allows one quantity", () => {
+      render(<Harness quantityItem={item({ minQuantity: 5, maxQuantity: 5, defaultQuantity: 5 })} />);
+
+      expect(screen.getByLabelText("Apply volume discounts")).toBeDisabled();
+      expect(screen.getByText(/Raise its maximum/)).toBeInTheDocument();
+    });
+
+    it("stops splitting once the last band covers a single quantity", () => {
+      render(<Harness quantityItem={item({ maxQuantity: 3 })} />);
+
+      fireEvent.click(screen.getByLabelText("Apply volume discounts"));
+
+      // Bands are 1-2 and 3-3. The last covers a single quantity, so splitting it again could
+      // only produce a band starting above where it ends — the control is closed, not merely
+      // guarded after the fact.
+      expect(screen.getByText("Add band").closest("button")).toBeDisabled();
+      expect(screen.getByText(/cannot be split again/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText("Add band"));
+
+      expect(column("minimumQuantity")).toEqual(["1", "3"]);
+    });
+  });
+
   it("reports a gap on the band that starts in the wrong place", async () => {
     render(<Harness />);
 

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.tsx
@@ -1,0 +1,245 @@
+import { Plus, X } from "lucide-react";
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { Button } from "@/components/ui-kits/button/button";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui-kits/form/form";
+import { Input } from "@/components/ui-kits/input/input";
+import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import { formatMoney, toMinorUnits } from "../../utilities/subscription-format";
+
+/**
+ * The volume bands on one quantity item.
+ *
+ * Volume pricing, not graduated pricing, and the difference is the whole reason this needs
+ * explaining on screen: the band is chosen by the total quantity and its discount comes off the
+ * entire charge. Ten users in a 10% band is ten users at 10% off — not four at full price and six
+ * discounted. Authors who assume the graduated reading price their catalogue wrong and only find
+ * out from an invoice.
+ */
+export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
+  const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
+
+  const tiers = useFieldArray({
+    control,
+    name: `quantityItems.${itemIndex}.quantityDiscountTiers`,
+  });
+
+  // Watched rather than read from useFieldArray's snapshot, which only refreshes when the list
+  // itself changes — the same trap the rate-table editor documents.
+  const tierValues = useWatch({ control, name: `quantityItems.${itemIndex}.quantityDiscountTiers` });
+  const item = useWatch({ control, name: `quantityItems.${itemIndex}` });
+  const prices = useWatch({ control, name: "prices" });
+
+  const enabled = tiers.fields.length > 0;
+
+  // Only shown when exactly one price is written against this item: with two, "the" effective
+  // price is a fiction, and quietly picking one of them is worse than showing none.
+  const price = prices?.filter((candidate) => candidate?.quantityItemKey === item?.itemKey);
+  const singlePrice = price?.length === 1 ? price[0] : undefined;
+
+  const toggle = (next: boolean) => {
+    if (next) {
+      // Seeded as a working pair rather than one row: a single band is a flat discount, which the
+      // unit price already expresses, and the schema refuses it.
+      setValue(
+        `quantityItems.${itemIndex}.quantityDiscountTiers`,
+        [
+          {
+            minimumQuantity: item?.minQuantity ?? 1,
+            maximumQuantity: (item?.minQuantity ?? 1) + 4,
+            discountPercent: 0,
+          },
+          {
+            minimumQuantity: (item?.minQuantity ?? 1) + 5,
+            maximumQuantity: item?.maxQuantity,
+            discountPercent: 5,
+          },
+        ],
+        { shouldValidate: false },
+      );
+
+      return;
+    }
+
+    const authored = (tierValues ?? []).some((tier) => (tier?.discountPercent ?? 0) > 0);
+
+    // Only asked when there is something to lose. A confirm on every toggle trains people to
+    // dismiss it, which is how the one that mattered gets dismissed too.
+    if (
+      authored &&
+      !window.confirm("Remove the volume bands on this item? The discounts you entered are lost.")
+    ) {
+      return;
+    }
+
+    setValue(`quantityItems.${itemIndex}.quantityDiscountTiers`, [], { shouldValidate: false });
+  };
+
+  return (
+    <div className="space-y-3">
+      <label className="flex items-center gap-2 text-sm">
+        <Checkbox
+          checked={enabled}
+          onCheckedChange={(checked) => toggle(checked === true)}
+          aria-label="Apply volume discounts"
+        />
+        Apply volume discounts
+      </label>
+
+      {enabled ? (
+        <div className="space-y-3 rounded-md border border-dashed p-3">
+          <div className="grid grid-cols-[1fr_1fr_1fr_auto] items-center gap-2 text-xs text-muted-foreground">
+            <span>From</span>
+            <span>To</span>
+            <span>Discount</span>
+            <span className="sr-only">Remove</span>
+          </div>
+
+          {tiers.fields.map((tier, tierIndex) => {
+            const isLast = tierIndex === tiers.fields.length - 1;
+            const values = tierValues?.[tierIndex];
+
+            return (
+              <div key={tier.id} className="space-y-1">
+                <div className="grid grid-cols-[1fr_1fr_1fr_auto] items-start gap-2">
+                  <FormField
+                    control={control}
+                    name={`quantityItems.${itemIndex}.quantityDiscountTiers.${tierIndex}.minimumQuantity`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="number"
+                            min={1}
+                            aria-label={`Band ${tierIndex + 1} from`}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={control}
+                    name={`quantityItems.${itemIndex}.quantityDiscountTiers.${tierIndex}.maximumQuantity`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            value={field.value ?? ""}
+                            type="number"
+                            min={1}
+                            placeholder={isLast ? "no limit" : ""}
+                            aria-label={`Band ${tierIndex + 1} to`}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={control}
+                    name={`quantityItems.${itemIndex}.quantityDiscountTiers.${tierIndex}.discountPercent`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            type="number"
+                            min={0}
+                            max={100}
+                            step="0.01"
+                            aria-label={`Band ${tierIndex + 1} discount percent`}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => tiers.remove(tierIndex)}
+                    disabled={tiers.fields.length <= 2}
+                    aria-label={`Remove band ${tierIndex + 1}`}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+
+                {singlePrice && values ? (
+                  <p className="text-xs text-muted-foreground">
+                    {effectivePrice(singlePrice, values.discountPercent)} per {item?.unitLabel || "unit"}
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
+
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              const lastIndex = tiers.fields.length - 1;
+              const last = tierValues?.[lastIndex];
+
+              // The band being split is the open one, so it has no bound of its own to build on.
+              // Derived from where it starts, which keeps the list contiguous — a constant put two
+              // bands on the same boundary as soon as this was clicked twice.
+              const boundary = (last?.minimumQuantity ?? item?.minQuantity ?? 1) + 4;
+
+              tiers.update(lastIndex, {
+                minimumQuantity: last?.minimumQuantity ?? item?.minQuantity ?? 1,
+                maximumQuantity: boundary,
+                discountPercent: last?.discountPercent ?? 0,
+              });
+              tiers.append({
+                minimumQuantity: boundary + 1,
+                // Left open when the item is unbounded, which is the only shape the schema
+                // accepts for a final band there.
+                maximumQuantity: item?.maxQuantity,
+                discountPercent: last?.discountPercent ?? 0,
+              });
+            }}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Add band
+          </Button>
+
+          <p className="text-xs text-muted-foreground">
+            The band is chosen by the total quantity, and its discount applies to the whole charge —
+            not only to the units inside the band. A discount code, if one is used, combines
+            according to the plan&apos;s combination policy.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+/**
+ * What one unit costs inside a band. Presentation only — the server prices and rounds the charge,
+ * and showing a figure derived here as though it were authoritative is how a catalogue comes to
+ * disagree with its own invoices.
+ */
+const effectivePrice = (
+  price: { amount?: number; currencyCode?: string },
+  discountPercent: number,
+): string => {
+  const currency = price.currencyCode || "USD";
+  // The builder edits prices in major units; formatMoney speaks minor, and the exponent belongs
+  // to the currency rather than to either of them.
+  const minor = toMinorUnits(price.amount ?? 0, currency);
+  const discounted = Math.round(minor * (1 - (discountPercent || 0) / 100));
+
+  return formatMoney(discounted, currency);
+};

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.tsx
@@ -37,6 +37,23 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
 
   const enabled = tiers.fields.length > 0;
 
+  const minQuantity = item?.minQuantity ?? 1;
+  const maxQuantity = item?.maxQuantity;
+
+  // An item whose whole range is one quantity cannot hold two bands, and two is the fewest that
+  // means anything. Offered anyway, the control opened straight into a configuration the schema
+  // refuses — 1-5 followed by 6-5 on an item capped at five.
+  const span = maxQuantity === undefined ? Infinity : maxQuantity - minQuantity + 1;
+  const canBand = span >= 2;
+
+  // The last band splits only while it has room for two quantities. Left enabled past that, the
+  // button produced a band starting above where it ends.
+  const lastBand = tierValues?.[tiers.fields.length - 1];
+  const canAddBand =
+    lastBand === undefined ||
+    lastBand.maximumQuantity === undefined ||
+    lastBand.maximumQuantity > lastBand.minimumQuantity;
+
   // Only shown when exactly one price is written against this item: with two, "the" effective
   // price is a fiction, and quietly picking one of them is worse than showing none.
   const price = prices?.filter((candidate) => candidate?.quantityItemKey === item?.itemKey);
@@ -45,18 +62,21 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
   const toggle = (next: boolean) => {
     if (next) {
       // Seeded as a working pair rather than one row: a single band is a flat discount, which the
-      // unit price already expresses, and the schema refuses it.
+      // unit price already expresses, and the schema refuses it. The boundary is derived from the
+      // room the item actually has, so a narrow item opens valid rather than opening broken.
+      const boundary = firstBoundary(minQuantity, maxQuantity);
+
       setValue(
         `quantityItems.${itemIndex}.quantityDiscountTiers`,
         [
           {
-            minimumQuantity: item?.minQuantity ?? 1,
-            maximumQuantity: (item?.minQuantity ?? 1) + 4,
+            minimumQuantity: minQuantity,
+            maximumQuantity: boundary,
             discountPercent: 0,
           },
           {
-            minimumQuantity: (item?.minQuantity ?? 1) + 5,
-            maximumQuantity: item?.maxQuantity,
+            minimumQuantity: boundary + 1,
+            maximumQuantity: maxQuantity,
             discountPercent: 5,
           },
         ],
@@ -85,11 +105,19 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
       <label className="flex items-center gap-2 text-sm">
         <Checkbox
           checked={enabled}
+          disabled={!canBand && !enabled}
           onCheckedChange={(checked) => toggle(checked === true)}
           aria-label="Apply volume discounts"
         />
         Apply volume discounts
       </label>
+
+      {!canBand && !enabled ? (
+        <p className="text-xs text-muted-foreground">
+          This item allows only {span <= 0 ? "no" : "one"} quantity, so there is nothing to band.
+          Raise its maximum to offer a volume discount.
+        </p>
+      ) : null}
 
       {enabled ? (
         <div className="space-y-3 rounded-md border border-dashed p-3">
@@ -188,25 +216,29 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
             type="button"
             variant="ghost"
             size="sm"
+            disabled={!canAddBand}
             onClick={() => {
               const lastIndex = tiers.fields.length - 1;
               const last = tierValues?.[lastIndex];
+              const start = last?.minimumQuantity ?? minQuantity;
 
-              // The band being split is the open one, so it has no bound of its own to build on.
-              // Derived from where it starts, which keeps the list contiguous — a constant put two
+              // The band being split is the last one, and when the item is unbounded it has no
+              // bound of its own to build on. Derived from where it starts and from the room left
+              // above it, which keeps the list contiguous and inside the item — a constant put two
               // bands on the same boundary as soon as this was clicked twice.
-              const boundary = (last?.minimumQuantity ?? item?.minQuantity ?? 1) + 4;
+              const boundary = firstBoundary(start, last?.maximumQuantity ?? maxQuantity);
 
               tiers.update(lastIndex, {
-                minimumQuantity: last?.minimumQuantity ?? item?.minQuantity ?? 1,
+                minimumQuantity: start,
                 maximumQuantity: boundary,
                 discountPercent: last?.discountPercent ?? 0,
               });
               tiers.append({
                 minimumQuantity: boundary + 1,
-                // Left open when the item is unbounded, which is the only shape the schema
-                // accepts for a final band there.
-                maximumQuantity: item?.maxQuantity,
+                // Keeps whatever ceiling the band being split had: the item's maximum on a bounded
+                // item, and open on an unbounded one, which is the only shape the schema accepts
+                // for a final band there.
+                maximumQuantity: last?.maximumQuantity ?? maxQuantity,
                 discountPercent: last?.discountPercent ?? 0,
               });
             }}
@@ -214,6 +246,12 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
             <Plus className="mr-2 h-4 w-4" />
             Add band
           </Button>
+
+          {!canAddBand ? (
+            <p className="text-xs text-muted-foreground">
+              The last band covers a single quantity, so it cannot be split again.
+            </p>
+          ) : null}
 
           <p className="text-xs text-muted-foreground">
             The band is chosen by the total quantity, and its discount applies to the whole charge —
@@ -224,6 +262,23 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
       ) : null}
     </div>
   );
+};
+
+/**
+ * Where to close the first of two bands covering everything from <code>from</code> upwards.
+ *
+ * Five quantities where there is room, and half the range where there is not. The constant alone
+ * produced a first band wider than the item it belonged to — 1-5 on an item capped at four — and a
+ * second band starting above where it ended.
+ */
+const firstBoundary = (from: number, upTo: number | undefined): number => {
+  if (upTo === undefined) {
+    return from + 4;
+  }
+
+  // At least one quantity has to be left for the band above, so the boundary stops one short of
+  // the ceiling however narrow the range is.
+  return Math.min(from + 4, upTo - 1);
 };
 
 /**

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/quantity-discount-tiers.tsx
@@ -37,8 +37,12 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
 
   const enabled = tiers.fields.length > 0;
 
-  const minQuantity = item?.minQuantity ?? 1;
-  const maxQuantity = item?.maxQuantity;
+  // Normalized, not trusted. A number input under react-hook-form holds whatever was typed —
+  // the inferred type says number because zod coerces at the resolver, which runs later and
+  // returns a copy. Read raw, "3" + 4 is "34" and a boundary lands three hundred quantities
+  // above where the author meant.
+  const minQuantity = count(item?.minQuantity) ?? 1;
+  const maxQuantity = count(item?.maxQuantity);
 
   // An item whose whole range is one quantity cannot hold two bands, and two is the fewest that
   // means anything. Offered anyway, the control opened straight into a configuration the schema
@@ -48,10 +52,12 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
 
   // The last band splits only while it has room for two quantities. Left enabled past that, the
   // button produced a band starting above where it ends.
-  const lastBand = tierValues?.[tiers.fields.length - 1];
+  const lastBand = band(tierValues?.[tiers.fields.length - 1]);
   const canAddBand =
     lastBand === undefined ||
     lastBand.maximumQuantity === undefined ||
+    // Compared as numbers: as the strings they arrive as, "9" is greater than "10" and the
+    // control closes on a band with plenty of room left in it.
     lastBand.maximumQuantity > lastBand.minimumQuantity;
 
   // Only shown when exactly one price is written against this item: with two, "the" effective
@@ -86,7 +92,7 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
       return;
     }
 
-    const authored = (tierValues ?? []).some((tier) => (tier?.discountPercent ?? 0) > 0);
+    const authored = (tierValues ?? []).some((tier) => (count(tier?.discountPercent) ?? 0) > 0);
 
     // Only asked when there is something to lose. A confirm on every toggle trains people to
     // dismiss it, which is how the one that mattered gets dismissed too.
@@ -219,7 +225,7 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
             disabled={!canAddBand}
             onClick={() => {
               const lastIndex = tiers.fields.length - 1;
-              const last = tierValues?.[lastIndex];
+              const last = band(tierValues?.[lastIndex]);
               const start = last?.minimumQuantity ?? minQuantity;
 
               // The band being split is the last one, and when the item is unbounded it has no
@@ -231,7 +237,7 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
               tiers.update(lastIndex, {
                 minimumQuantity: start,
                 maximumQuantity: boundary,
-                discountPercent: last?.discountPercent ?? 0,
+                discountPercent: count(last?.discountPercent) ?? 0,
               });
               tiers.append({
                 minimumQuantity: boundary + 1,
@@ -239,7 +245,7 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
                 // item, and open on an unbounded one, which is the only shape the schema accepts
                 // for a final band there.
                 maximumQuantity: last?.maximumQuantity ?? maxQuantity,
-                discountPercent: last?.discountPercent ?? 0,
+                discountPercent: count(last?.discountPercent) ?? 0,
               });
             }}
           >
@@ -263,6 +269,37 @@ export const QuantityDiscountTiers = ({ itemIndex }: { itemIndex: number }) => {
     </div>
   );
 };
+
+/**
+ * A watched numeric field as a number, or nothing at all.
+ *
+ * An emptied optional input holds <code>""</code> rather than <code>undefined</code>, and an
+ * unbounded item read that way looked like an item with no room: <code>"" - 3 + 1</code> is
+ * negative, so the control disabled itself on a plan that could band perfectly well.
+ */
+const count = (value: unknown): number | undefined => {
+  if (value === "" || value === null || value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/** One band with its bounds normalized, for the arithmetic that decides the next one. */
+const band = (
+  tier: { minimumQuantity?: unknown; maximumQuantity?: unknown; discountPercent?: unknown } | undefined,
+):
+  | { minimumQuantity: number; maximumQuantity: number | undefined; discountPercent: unknown }
+  | undefined =>
+  tier === undefined
+    ? undefined
+    : {
+        minimumQuantity: count(tier.minimumQuantity) ?? 1,
+        maximumQuantity: count(tier.maximumQuantity),
+        discountPercent: tier.discountPercent,
+      };
 
 /**
  * Where to close the first of two bands covering everything from <code>from</code> upwards.

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -31,6 +31,7 @@ import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscriptio
 import { CardListItem, CardListShell } from "./card-list-shell";
 import { MeterRateTableFields } from "./meter-rate-table-fields";
 import { PlanPriceFields } from "./plan-price-fields";
+import { QuantityDiscountTiers } from "./quantity-discount-tiers";
 import { ThresholdChipInput } from "./threshold-chip-input";
 
 export const StepPricingModel = ({
@@ -74,6 +75,9 @@ export const StepPricingModel = ({
               unitLabel: "",
               minQuantity: 1,
               defaultQuantity: 1,
+              // No bands until asked for: a plan that sells at one price per unit is the common
+              // case, and an empty list is what tells the API to store none.
+              quantityDiscountTiers: [],
             })
           }
         >
@@ -133,6 +137,7 @@ export const StepPricingModel = ({
                   )}
                 />
               </div>
+              <QuantityDiscountTiers itemIndex={index} />
             </CardListItem>
           ))}
         </CardListShell>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -52,6 +52,10 @@ export const StepPricingModel = ({
   // Watched, not read from useFieldArray's snapshot, which only refreshes when the list
   // itself changes — see step-usage-limits for the same trap.
   const meterValues = useWatch({ control, name: "meters" });
+  const quantityItemValues = useWatch({ control, name: "quantityItems" });
+  const hasBands = (quantityItemValues ?? []).some(
+    (item) => (item?.quantityDiscountTiers?.length ?? 0) > 0,
+  );
 
   return (
     <div className="space-y-6">
@@ -141,6 +145,44 @@ export const StepPricingModel = ({
             </CardListItem>
           ))}
         </CardListShell>
+
+        {/* A plan-level decision, shown once the bands it governs exist. Hidden while no item has
+            bands, because with none there is nothing for a promotion to combine with — but the
+            value is still submitted, since a server that receives no policy resets the plan's to
+            BestDiscount. */}
+        {hasBands ? (
+          <FormField
+            control={control}
+            name="quantityDiscountCombinationPolicy"
+            render={({ field }) => (
+              <FormItem className="mt-4">
+                <FormLabel className="text-xs">
+                  When a subscriber also has a discount code
+                </FormLabel>
+                <Select
+                  value={String(field.value ?? 0)}
+                  onValueChange={(value) => field.onChange(Number(value))}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="0">Apply whichever is larger</SelectItem>
+                    <SelectItem value="1">Ignore the code, band only</SelectItem>
+                    <SelectItem value="2">Apply both, compounding</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Compounding gives away more than either discount alone, so choose it
+                  deliberately. A code that loses to a band is not spent.
+                </p>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        ) : null}
       </OptionalSection>
 
       <OptionalSection

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
@@ -194,3 +194,39 @@ describe("PlanSummaryCard", () => {
     expect(screen.queryByText(/During the/)).not.toBeInTheDocument();
   });
 });
+
+describe("volume bands", () => {
+  const banded = {
+    itemKey: "user",
+    unitLabel: "user",
+    defaultQuantity: 1,
+    maxQuantity: null,
+    quantityDiscountTiers: [
+      { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+      { minimumQuantity: 5, maximumQuantity: 9, discountBasisPoints: 500 },
+      { minimumQuantity: 10, maximumQuantity: null, discountBasisPoints: 2000 },
+    ],
+  };
+
+  it("reads out every band a buyer would be charged under", () => {
+    // A band list authored through the API used to be invisible on every screen describing the
+    // plan, so nobody reviewing a plan could see what it actually charged at ten users.
+    render(<PlanSummaryCard plan={plan({ quantityItems: [banded] })} />);
+
+    expect(screen.getByText("1–4 users — no discount")).toBeInTheDocument();
+    expect(screen.getByText("5–9 users — 5% off")).toBeInTheDocument();
+    expect(screen.getByText("10+ users — 20% off")).toBeInTheDocument();
+  });
+
+  it("says nothing about bands on an item that has none", () => {
+    render(
+      <PlanSummaryCard
+        plan={plan({
+          quantityItems: [{ itemKey: "user", unitLabel: "user", defaultQuantity: 1, maxQuantity: null }],
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/off$/)).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -8,6 +8,7 @@ import {
   formatPrice,
   formatTrialAllowance,
 } from "../utilities/subscription-format";
+import { describeQuantityBand } from "../utilities/quantity-discount-format";
 
 export interface PlanSummaryData {
   displayName: string;
@@ -20,6 +21,12 @@ export interface PlanSummaryData {
     unitLabel: string;
     defaultQuantity: number;
     maxQuantity: number | null;
+    /** Volume bands, when the item has any. Percentages are what an author authored. */
+    quantityDiscountTiers?: {
+      minimumQuantity: number;
+      maximumQuantity: number | null;
+      discountBasisPoints: number;
+    }[];
   }[];
   meters: {
     meterKey: string;
@@ -151,14 +158,26 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
             <Layers className="mt-0.5 h-4 w-4 shrink-0 text-blocks-primary-600" />
             <div className="space-y-0.5">
               {plan.quantityItems.map((item, index) => (
-                <p key={index}>
-                  {item.defaultQuantity.toLocaleString()} {item.unitLabel}
-                  {item.defaultQuantity === 1 ? "" : "s"} included by default
-                  {/* The ceiling is part of what the plan sells — a buyer choosing between
-                      tiers needs to see it, and it is the one quantity rule that refuses a
-                      subscription outright rather than just costing more. */}
-                  {item.maxQuantity === null ? "" : `, up to ${item.maxQuantity.toLocaleString()}`}
-                </p>
+                <div key={index} className="space-y-0.5">
+                  <p>
+                    {item.defaultQuantity.toLocaleString()} {item.unitLabel}
+                    {item.defaultQuantity === 1 ? "" : "s"} included by default
+                    {/* The ceiling is part of what the plan sells — a buyer choosing between
+                        tiers needs to see it, and it is the one quantity rule that refuses a
+                        subscription outright rather than just costing more. */}
+                    {item.maxQuantity === null ? "" : `, up to ${item.maxQuantity.toLocaleString()}`}
+                  </p>
+                  {/* Shown here because a band list is a pricing term, and one authored by hand
+                      through the API used to be invisible on every screen that describes the
+                      plan. */}
+                  {item.quantityDiscountTiers?.length ? (
+                    <ul className="text-muted-foreground">
+                      {item.quantityDiscountTiers.map((tier, tierIndex) => (
+                        <li key={tierIndex}>{describeQuantityBand(tier, item.unitLabel)}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
               ))}
             </div>
           </div>

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -40,12 +40,29 @@ export type MeterAggregationName = keyof typeof METER_AGGREGATION;
 export type MeterResetPolicyName = keyof typeof METER_RESET_POLICY;
 export type EntitlementLimitKindName = keyof typeof ENTITLEMENT_LIMIT_KIND;
 
+/**
+ * A volume band: how much is taken off when the quantity held falls inside it.
+ *
+ * Volume pricing, not graduated pricing. The band is chosen by the whole quantity and its
+ * discount applies to the whole charge — 10 users in a 10% band is 10 users at 10% off, not
+ * four at full price and six discounted.
+ */
+export interface QuantityDiscountTier {
+  minimumQuantity: number;
+  /** Null on the last band of an unbounded item: everything above the minimum falls in it. */
+  maximumQuantity: number | null;
+  /** 500 is 5%. Basis points on the wire; the builder edits percentages. */
+  discountBasisPoints: number;
+}
+
 export interface PlanQuantityItem {
   itemKey: string;
   unitLabel: string;
   minQuantity: number;
   maxQuantity: number | null;
   defaultQuantity: number;
+  /** Optional for the same reason trial grants are: plans stored before this lack it. */
+  quantityDiscountTiers?: QuantityDiscountTier[];
 }
 
 export interface MeterTier {
@@ -140,6 +157,14 @@ export interface CreatePlanQuantityItemRequest {
   minQuantity: number;
   maxQuantity?: number;
   defaultQuantity: number;
+  /** Omitted rather than sent empty, so a plan with no bands stays a plan with no bands. */
+  quantityDiscountTiers?: CreateQuantityDiscountTierRequest[];
+}
+
+export interface CreateQuantityDiscountTierRequest {
+  minimumQuantity: number;
+  maximumQuantity?: number;
+  discountBasisPoints: number;
 }
 
 export interface CreatePlanMeterRequest {

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -47,6 +47,15 @@ export type EntitlementLimitKindName = keyof typeof ENTITLEMENT_LIMIT_KIND;
  * discount applies to the whole charge — 10 users in a 10% band is 10 users at 10% off, not
  * four at full price and six discounted.
  */
+/**
+ * What happens when a subscriber holds both a volume band and a promotional code.
+ *
+ * A commercial choice, not an arithmetic one, which is why it is authored rather than inferred:
+ * <code>Stack</code> compounds, and a plan that meant to compound and was quietly reset to
+ * <code>BestDiscount</code> gives away a different amount of money every month.
+ */
+export type QuantityDiscountCombinationPolicyName = "BestDiscount" | "QuantityOnly" | "Stack";
+
 export interface QuantityDiscountTier {
   minimumQuantity: number;
   /** Null on the last band of an unbounded item: everything above the minimum falls in it. */
@@ -128,6 +137,11 @@ export interface SubscriptionPlan {
   familyRank?: number | null;
   usageInterval?: BillingIntervalName;
   usageIntervalCount?: number;
+  /**
+   * How a volume band and a promotional code combine. A name on the wire, like every other enum
+   * in a plan response, and absent on plans stored before bands existed.
+   */
+  quantityDiscountCombinationPolicy?: QuantityDiscountCombinationPolicyName;
   featuresJson: string | null;
   organizationId: string | null;
   trialDays: number | null;
@@ -205,6 +219,8 @@ export interface CreateSubscriptionPlanRequest {
   organizationId?: string;
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
+  /** Sent on every write: omitted, the server would reset it to BestDiscount. */
+  quantityDiscountCombinationPolicy: number;
   usageInterval: number;
   usageIntervalCount: number;
   familyCode?: string;
@@ -227,6 +243,8 @@ export interface UpdateSubscriptionPlanRequest {
   organizationId?: string;
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
+  /** Sent on every write: omitted, the server would reset it to BestDiscount. */
+  quantityDiscountCombinationPolicy: number;
   usageInterval: number;
   usageIntervalCount: number;
   familyCode?: string;

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -9,6 +9,7 @@ import { Card, CardTitle } from "@/components/ui-kits/card/card";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { toast } from "@/hooks/use-toast";
 import { ORGANIZATION_PAGE_SIZE } from "../constants/subscription.constants";
+import { describeQuantityBand } from "../utilities/quantity-discount-format";
 import { PlanSummaryCard, type PlanSummaryData } from "../components/plan-summary-card";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
 import { useArchiveSubscriptionPrice } from "../hooks/use-archive-subscription-price";
@@ -113,6 +114,7 @@ export const SubscriptionPlanDetailPage = () => {
     trialDays: plan.trialDays,
     trialRequiresPaymentMethod: plan.trialRequiresPaymentMethod,
     quantityItems: plan.quantityItems.map((item) => ({
+      quantityDiscountTiers: item.quantityDiscountTiers,
       itemKey: item.itemKey,
       unitLabel: item.unitLabel,
       defaultQuantity: item.defaultQuantity,
@@ -194,6 +196,16 @@ export const SubscriptionPlanDetailPage = () => {
                       {item.defaultQuantity === 1 ? "" : "s"} by default
                       {item.maxQuantity !== null && ` (max ${item.maxQuantity.toLocaleString()})`}
                     </p>
+                    {/* An administrator checking the live catalogue before editing it needs to see
+                        the bands here: they decide what every subscriber is charged, and were
+                        previously visible only by reading the API response. */}
+                    {item.quantityDiscountTiers?.length ? (
+                      <ul className="mt-2 space-y-0.5 text-sm text-muted-foreground">
+                        {item.quantityDiscountTiers.map((tier, index) => (
+                          <li key={index}>{describeQuantityBand(tier, item.unitLabel)}</li>
+                        ))}
+                      </ul>
+                    ) : null}
                   </Card>
                 ))}
               </div>

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
@@ -336,3 +336,173 @@ describe("createSubscriptionPlanSchema", () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe("quantity discount bands", () => {
+  const withTiers = (
+    tiers: { minimumQuantity: number; maximumQuantity?: number; discountPercent: number }[],
+    item: { minQuantity?: number; maxQuantity?: number } = {},
+  ) => ({
+    ...validPlan,
+    quantityItems: [
+      {
+        itemKey: "user",
+        unitLabel: "user",
+        minQuantity: item.minQuantity ?? 1,
+        maxQuantity: item.maxQuantity,
+        defaultQuantity: 1,
+        quantityDiscountTiers: tiers,
+      },
+    ],
+    prices: [{ ...price, quantityItemKey: "user" }],
+  });
+
+  const contiguous = [
+    { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+    { minimumQuantity: 5, maximumQuantity: 9, discountPercent: 5 },
+    { minimumQuantity: 10, discountPercent: 10 },
+  ];
+
+  it("accepts a quantity item with no bands at all", () => {
+    const result = createSubscriptionPlanSchema.safeParse(withTiers([]));
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts contiguous bands ending open on an unbounded item", () => {
+    const result = createSubscriptionPlanSchema.safeParse(withTiers(contiguous));
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a single band, which the unit price already expresses", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([{ minimumQuantity: 1, discountPercent: 10 }]),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a first band that does not start where the item does", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([
+        { minimumQuantity: 2, maximumQuantity: 4, discountPercent: 0 },
+        { minimumQuantity: 5, discountPercent: 5 },
+      ]),
+    );
+
+    expect(issuePaths(result)).toContainEqual([
+      "quantityItems",
+      0,
+      "quantityDiscountTiers",
+      0,
+      "minimumQuantity",
+    ]);
+  });
+
+  it("rejects a gap between bands", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([
+        { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+        { minimumQuantity: 7, discountPercent: 5 },
+      ]),
+    );
+
+    // Named on the band that starts in the wrong place, because that is the number an author
+    // fixes — "quantities 5 and 6 are priced by nothing" is not actionable on any other row.
+    expect(issuePaths(result)).toContainEqual([
+      "quantityItems",
+      0,
+      "quantityDiscountTiers",
+      1,
+      "minimumQuantity",
+    ]);
+  });
+
+  it("rejects overlapping bands", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([
+        { minimumQuantity: 1, maximumQuantity: 5, discountPercent: 0 },
+        { minimumQuantity: 5, discountPercent: 5 },
+      ]),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a band left open before the last one", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([
+        { minimumQuantity: 1, discountPercent: 0 },
+        { minimumQuantity: 5, discountPercent: 5 },
+      ]),
+    );
+
+    expect(issuePaths(result)).toContainEqual([
+      "quantityItems",
+      0,
+      "quantityDiscountTiers",
+      0,
+      "maximumQuantity",
+    ]);
+  });
+
+  it("requires the final band to reach a finite item maximum", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers(
+        [
+          { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+          { minimumQuantity: 5, maximumQuantity: 9, discountPercent: 5 },
+        ],
+        { maxQuantity: 30 },
+      ),
+    );
+
+    expect(issuePaths(result)).toContainEqual([
+      "quantityItems",
+      0,
+      "quantityDiscountTiers",
+      1,
+      "maximumQuantity",
+    ]);
+  });
+
+  it("requires the final band to stay open when the item has no maximum", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([
+        { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+        { minimumQuantity: 5, maximumQuantity: 9, discountPercent: 5 },
+      ]),
+    );
+
+    // Otherwise every quantity above 9 is sold at a price the plan never states.
+    expect(issuePaths(result)).toContainEqual([
+      "quantityItems",
+      0,
+      "quantityDiscountTiers",
+      1,
+      "maximumQuantity",
+    ]);
+  });
+
+  it("rejects a discount above 100 per cent", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([
+        { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+        { minimumQuantity: 5, discountPercent: 140 },
+      ]),
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a band ending below where it starts", () => {
+    const result = createSubscriptionPlanSchema.safeParse(
+      withTiers([
+        { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+        { minimumQuantity: 5, maximumQuantity: 2, discountPercent: 5 },
+      ]),
+    );
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -83,6 +83,22 @@ const meterSchema = z.object({
   rateTables: z.array(meterRateTableSchema),
 });
 
+/**
+ * One volume band, as the builder edits it.
+ *
+ * A percentage rather than the basis points the API carries: nobody authoring a price list thinks
+ * in ten-thousandths, and 5 typed where 500 was meant is a 0.05% discount that looks plausible in
+ * a table and is wrong by two orders of magnitude.
+ */
+const quantityDiscountTierSchema = z.object({
+  minimumQuantity: z.coerce.number().int().positive(),
+  maximumQuantity: z.coerce.number().int().positive().optional(),
+  discountPercent: z.coerce
+    .number()
+    .min(0, "A discount cannot be negative.")
+    .max(100, "A discount cannot exceed 100%."),
+});
+
 const quantityItemSchema = z
   .object({
     itemKey: key("item key"),
@@ -90,11 +106,103 @@ const quantityItemSchema = z
     minQuantity: z.coerce.number().int().min(0),
     maxQuantity: z.coerce.number().int().positive().optional(),
     defaultQuantity: z.coerce.number().int().min(0),
+    quantityDiscountTiers: z.array(quantityDiscountTierSchema).default([]),
   })
-  .refine((item) => item.maxQuantity === undefined || item.maxQuantity >= item.minQuantity, {
-    message: "The maximum cannot be below the minimum.",
-    path: ["maxQuantity"],
+  .superRefine((item, context) => {
+    if (item.maxQuantity !== undefined && item.maxQuantity < item.minQuantity) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["maxQuantity"],
+        message: "The maximum cannot be below the minimum.",
+      });
+    }
+
+    checkQuantityDiscountTiers(item, context);
   });
+
+/**
+ * The band rules, checked here rather than left to the server.
+ *
+ * The server refuses a gap, an overlap or a second open end with one error code for the whole
+ * plan, which tells an author that something is wrong and nothing about where. These are the same
+ * rules said per row, at the row that breaks them.
+ */
+const checkQuantityDiscountTiers = (
+  item: {
+    minQuantity: number;
+    maxQuantity?: number;
+    quantityDiscountTiers: { minimumQuantity: number; maximumQuantity?: number }[];
+  },
+  context: z.RefinementCtx,
+) => {
+  const tiers = item.quantityDiscountTiers;
+
+  if (tiers.length === 0) {
+    return;
+  }
+
+  const at = (index: number, field: string, message: string) =>
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["quantityDiscountTiers", index, field],
+      message,
+    });
+
+  // One band is a single discount on everything, which the unit price already expresses.
+  if (tiers.length < 2) {
+    at(0, "maximumQuantity", "Add a second band, or turn volume discounts off.");
+  }
+
+  if (tiers[0].minimumQuantity !== item.minQuantity) {
+    at(0, "minimumQuantity", `The first band must start at ${item.minQuantity}.`);
+  }
+
+  tiers.forEach((tier, index) => {
+    const isLast = index === tiers.length - 1;
+
+    if (tier.maximumQuantity !== undefined && tier.maximumQuantity < tier.minimumQuantity) {
+      at(index, "maximumQuantity", "The band cannot end below where it starts.");
+
+      return;
+    }
+
+    if (!isLast && tier.maximumQuantity === undefined) {
+      at(index, "maximumQuantity", "Only the final band can be left open.");
+
+      return;
+    }
+
+    // Contiguity in both directions at once: the next band starting anywhere but one past this
+    // one is either a gap nothing prices or an overlap two bands claim.
+    const next = tiers[index + 1];
+
+    if (next && tier.maximumQuantity !== undefined) {
+      const expected = tier.maximumQuantity + 1;
+
+      if (next.minimumQuantity !== expected) {
+        at(index + 1, "minimumQuantity", `The next band must begin at ${expected}.`);
+      }
+    }
+
+    if (!isLast) {
+      return;
+    }
+
+    if (item.maxQuantity === undefined && tier.maximumQuantity !== undefined) {
+      at(
+        index,
+        "maximumQuantity",
+        "This item has no maximum, so the final band must be left open.",
+      );
+
+      return;
+    }
+
+    if (item.maxQuantity !== undefined && tier.maximumQuantity !== item.maxQuantity) {
+      at(index, "maximumQuantity", `The final band must cover quantities up to ${item.maxQuantity}.`);
+    }
+  });
+};
 
 const entitlementSchema = z
   .object({

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -261,6 +261,10 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
       organizationId: z.string().min(1, "Choose an organization."),
       trialDays: z.coerce.number().int().min(1).max(365).optional(),
       trialRequiresPaymentMethod: z.boolean(),
+      // Always in the form, whether or not any item has bands: a plan edited while the field
+      // was absent came back from the server reset to BestDiscount, which changes what every
+      // subscriber on it is charged.
+      quantityDiscountCombinationPolicy: z.coerce.number().int().min(0).max(2).default(0),
       usageInterval: z.coerce.number().int().min(0).max(3),
       usageIntervalCount: z.coerce.number().int().min(1).max(100),
       familyCode: z.string().trim().max(SUBSCRIPTION_KEY_MAX_LENGTH).optional().or(z.literal("")),
@@ -400,6 +404,7 @@ export const defaultSubscriptionPlanFormValues: CreateSubscriptionPlanFormValues
   organizationId: TENANT_WIDE_ORGANIZATION,
   trialDays: undefined,
   trialRequiresPaymentMethod: true,
+  quantityDiscountCombinationPolicy: 0,
   usageInterval: 2,
   usageIntervalCount: 1,
   familyCode: "",

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -163,3 +163,86 @@ describe("toUpdatePlanRequest", () => {
     expect(request.trialGrants).toEqual([{ meterKey: "ses-signatures", includedQuantity: 5 }]);
   });
 });
+
+describe("quantity discount bands", () => {
+  const stored = (
+    tiers?: { minimumQuantity: number; maximumQuantity: number | null; discountBasisPoints: number }[],
+  ) =>
+    storedPlan({
+      quantityItems: [
+        {
+          itemKey: "user",
+          unitLabel: "user",
+          minQuantity: 1,
+          maxQuantity: null,
+          defaultQuantity: 1,
+          ...(tiers ? { quantityDiscountTiers: tiers } : {}),
+        },
+      ],
+    });
+
+  it("reopens basis points as the percentages an author typed", () => {
+    const values = planToFormValues(
+      stored([
+        { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+        { minimumQuantity: 5, maximumQuantity: 9, discountBasisPoints: 500 },
+        { minimumQuantity: 10, maximumQuantity: null, discountBasisPoints: 2000 },
+      ]),
+    );
+
+    expect(values.quantityItems[0].quantityDiscountTiers).toEqual([
+      { minimumQuantity: 1, maximumQuantity: 4, discountPercent: 0 },
+      { minimumQuantity: 5, maximumQuantity: 9, discountPercent: 5 },
+      { minimumQuantity: 10, maximumQuantity: undefined, discountPercent: 20 },
+    ]);
+  });
+
+  it("reopens a plan stored before bands existed with the control off", () => {
+    expect(planToFormValues(stored()).quantityItems[0].quantityDiscountTiers).toEqual([]);
+  });
+
+  it("sends percentages back as basis points", () => {
+    const request = toUpdatePlanRequest(
+      planToFormValues(
+        stored([
+          { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+          { minimumQuantity: 5, maximumQuantity: 9, discountBasisPoints: 500 },
+          { minimumQuantity: 10, maximumQuantity: null, discountBasisPoints: 1250 },
+        ]),
+      ),
+      "org-1",
+    );
+
+    // The round trip is the half that makes editing work: stored, reopened, submitted again, the
+    // numbers have to be the ones that were authored. Without it the server keeps the bands and
+    // the builder reopens as though they were never there.
+    expect(request.quantityItems[0].quantityDiscountTiers).toEqual([
+      { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+      { minimumQuantity: 5, maximumQuantity: 9, discountBasisPoints: 500 },
+      { minimumQuantity: 10, maximumQuantity: undefined, discountBasisPoints: 1250 },
+    ]);
+  });
+
+  it("carries an edited percentage through as basis points", () => {
+    const values = planToFormValues(
+      stored([
+        { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+        { minimumQuantity: 5, maximumQuantity: null, discountBasisPoints: 500 },
+      ]),
+    );
+
+    values.quantityItems[0].quantityDiscountTiers[1].discountPercent = 6;
+
+    const request = toUpdatePlanRequest(values, "org-1");
+
+    expect(request.quantityItems[0].quantityDiscountTiers?.[1].discountBasisPoints).toBe(600);
+  });
+
+  it("omits the field entirely when no bands are authored", () => {
+    const request = toUpdatePlanRequest(planToFormValues(stored()), "org-1");
+
+    // Not an empty array: absent and empty mean the same thing to the API, and sending one makes
+    // a plan that never had bands look like one whose bands were removed.
+    expect(request.quantityItems[0].quantityDiscountTiers).toBeUndefined();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -246,3 +246,38 @@ describe("quantity discount bands", () => {
     expect(request.quantityItems[0].quantityDiscountTiers).toBeUndefined();
   });
 });
+
+describe("quantity discount combination policy", () => {
+  it("reopens Stack as Stack and submits it unchanged", () => {
+    // The bug this guards: the field was absent from the client entirely, so every edit submitted
+    // nothing and the server reset the plan to BestDiscount. A plan authored to compound quietly
+    // stopped compounding the first time anyone opened it in the builder.
+    const values = planToFormValues(
+      storedPlan({ quantityDiscountCombinationPolicy: "Stack" }),
+    );
+
+    expect(values.quantityDiscountCombinationPolicy).toBe(2);
+    expect(toUpdatePlanRequest(values, "org-1").quantityDiscountCombinationPolicy).toBe(2);
+  });
+
+  it("reopens QuantityOnly as QuantityOnly", () => {
+    const values = planToFormValues(
+      storedPlan({ quantityDiscountCombinationPolicy: "QuantityOnly" }),
+    );
+
+    expect(values.quantityDiscountCombinationPolicy).toBe(1);
+    expect(toUpdatePlanRequest(values, "org-1").quantityDiscountCombinationPolicy).toBe(1);
+  });
+
+  it("treats a plan stored before the policy existed as the safe default", () => {
+    const values = planToFormValues(storedPlan());
+
+    expect(values.quantityDiscountCombinationPolicy).toBe(0);
+  });
+
+  it("always sends a policy, so the server never defaults one", () => {
+    const request = toUpdatePlanRequest(planToFormValues(storedPlan()), "org-1");
+
+    expect(request.quantityDiscountCombinationPolicy).toBeDefined();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -31,6 +31,18 @@ const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
     minQuantity: item.minQuantity,
     maxQuantity: item.maxQuantity,
     defaultQuantity: item.defaultQuantity,
+    // Omitted rather than sent empty: an empty array and an absent field mean the same thing to
+    // the API, and sending one keeps a plan with no bands looking like a plan whose bands were
+    // deleted.
+    quantityDiscountTiers: item.quantityDiscountTiers?.length
+      ? item.quantityDiscountTiers.map((tier) => ({
+          minimumQuantity: tier.minimumQuantity,
+          maximumQuantity: tier.maximumQuantity,
+          // Percent in the form, basis points on the wire. Rounded because 5.005 is not a
+          // discount anyone authored, and truncating it would quietly favour the merchant.
+          discountBasisPoints: Math.round(tier.discountPercent * 100),
+        }))
+      : undefined,
   })),
   meters: values.meters.map((meter) => ({
     meterKey: meter.meterKey.trim(),
@@ -120,6 +132,13 @@ export const planToFormValues = (plan: SubscriptionPlan): CreateSubscriptionPlan
     minQuantity: item.minQuantity,
     maxQuantity: item.maxQuantity ?? undefined,
     defaultQuantity: item.defaultQuantity,
+    // Plans stored before bands existed have no field at all, and reopen with the control off
+    // rather than with a row nobody authored.
+    quantityDiscountTiers: (item.quantityDiscountTiers ?? []).map((tier) => ({
+      minimumQuantity: tier.minimumQuantity,
+      maximumQuantity: tier.maximumQuantity ?? undefined,
+      discountPercent: tier.discountBasisPoints / 100,
+    })),
   })),
   meters: plan.meters.map((meter) => ({
     meterKey: meter.meterKey,

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -23,6 +23,7 @@ const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
   trialRequiresPaymentMethod: values.trialRequiresPaymentMethod,
   usageInterval: values.usageInterval,
   usageIntervalCount: values.usageIntervalCount,
+  quantityDiscountCombinationPolicy: values.quantityDiscountCombinationPolicy,
   familyCode: values.familyCode?.trim() || undefined,
   familyRank: values.familyRank,
   quantityItems: values.quantityItems.map((item) => ({
@@ -100,6 +101,9 @@ const aggregationValue = (name: string): number =>
 const resetPolicyValue = (name?: string): number =>
   METER_RESET_POLICY[name as keyof typeof METER_RESET_POLICY] ?? METER_RESET_POLICY.Periodic;
 
+const combinationPolicyValue = (name?: string): number =>
+  name === "Stack" ? 2 : name === "QuantityOnly" ? 1 : 0;
+
 const limitKindValue = (name: string): number =>
   ENTITLEMENT_LIMIT_KIND[name as keyof typeof ENTITLEMENT_LIMIT_KIND] ??
   ENTITLEMENT_LIMIT_KIND.Boolean;
@@ -124,6 +128,11 @@ export const planToFormValues = (plan: SubscriptionPlan): CreateSubscriptionPlan
     ? (BILLING_INTERVAL[plan.usageInterval] ?? BILLING_INTERVAL.Month)
     : BILLING_INTERVAL.Month,
   usageIntervalCount: plan.usageIntervalCount ?? 1,
+  // Read back rather than defaulted. Without this an edit of a Stack plan submitted BestDiscount
+  // and silently changed its pricing — the same shape of bug as dropping the bands themselves.
+  quantityDiscountCombinationPolicy: combinationPolicyValue(
+    plan.quantityDiscountCombinationPolicy,
+  ),
   familyCode: plan.familyCode ?? "",
   familyRank: plan.familyRank ?? undefined,
   quantityItems: plan.quantityItems.map((item) => ({

--- a/client/app/cross-modules/utilities/subscription/utilities/quantity-discount-format.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/quantity-discount-format.ts
@@ -1,0 +1,39 @@
+/**
+ * How a volume band reads to a person.
+ *
+ * Shared rather than written at each surface: the builder's review step, the plan detail page and
+ * the band editor all describe the same list, and three spellings of "30+ users, 20% off" is how a
+ * catalogue comes to look like it says different things in different places.
+ */
+export const formatDiscountPercent = (discountBasisPoints: number): string => {
+  if (discountBasisPoints <= 0) {
+    return "no discount";
+  }
+
+  // Basis points are integers, so at most two decimals can survive, and trailing zeros read as
+  // false precision on a price list.
+  const percent = discountBasisPoints / 100;
+
+  return `${Number(percent.toFixed(2))}% off`;
+};
+
+export const formatQuantityBand = (
+  tier: { minimumQuantity: number; maximumQuantity?: number | null },
+  unitLabel: string,
+): string => {
+  const unit = unitLabel || "unit";
+  const range =
+    tier.maximumQuantity === null || tier.maximumQuantity === undefined
+      ? `${tier.minimumQuantity.toLocaleString()}+`
+      : tier.minimumQuantity === tier.maximumQuantity
+        ? tier.minimumQuantity.toLocaleString()
+        : `${tier.minimumQuantity.toLocaleString()}\u2013${tier.maximumQuantity.toLocaleString()}`;
+
+  return `${range} ${unit}${tier.maximumQuantity === 1 ? "" : "s"}`;
+};
+
+export const describeQuantityBand = (
+  tier: { minimumQuantity: number; maximumQuantity?: number | null; discountBasisPoints: number },
+  unitLabel: string,
+): string =>
+  `${formatQuantityBand(tier, unitLabel)} \u2014 ${formatDiscountPercent(tier.discountBasisPoints)}`;

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -637,6 +637,33 @@
         </table>
       </div>
 
+      <div class="callout">
+        <p class="callout-title">Authoring bands, and what they are not</p>
+        <p class="prose">
+          Bands belong to a quantity item, not to the plan. One <code>user</code> item with five
+          bands covers every seat count — a plan per band would be five plans a subscriber has to
+          be moved between, and moving between them is a plan change with its own proration.
+          Changing quantity inside one plan simply selects the band the new quantity falls in.
+        </p>
+        <p class="prose">
+          The band is chosen by the <strong>total</strong> quantity, and its discount applies to the
+          <strong>whole</strong> charge. Ten users in a 10% band is ten users at 10% off, not four at
+          full price and six discounted. This is volume pricing; graduated pricing, where each band
+          prices only the units inside it, is not what this does.
+        </p>
+        <p class="prose">
+          Volume bands and discount codes are separate mechanisms. A band comes from the quantity
+          held; a code is redeemed by the subscriber. When both apply, the plan's
+          <code>quantityDiscountCombinationPolicy</code> decides which wins or whether they stack —
+          see <a href="#quantities">Buying more, or fewer, units</a>.
+        </p>
+        <p class="prose">
+          The plan builder writes all of this: enable <em>Apply volume discounts</em> on a quantity
+          item and edit the bands as a table of from, to and percent. Percentages there are basis
+          points here — 5% is <code>500</code>.
+        </p>
+      </div>
+
       <h3 id="meter">Meter</h3>
       <p>The counter. One per thing you measure.</p>
       <div class="table-wrap">

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -660,7 +660,9 @@
         <p class="prose">
           The plan builder writes all of this: enable <em>Apply volume discounts</em> on a quantity
           item and edit the bands as a table of from, to and percent. Percentages there are basis
-          points here — 5% is <code>500</code>.
+          points here — 5% is <code>500</code>. The combination policy is authored alongside them,
+          and is sent on every write: a plan updated without it is reset to
+          <code>BestDiscount</code>, which silently changes what its subscribers are charged.
         </p>
       </div>
 


### PR DESCRIPTION
Volume bands landed server-side in #263 with no way to author them. The builder had no control, the form schema had no field, and the reverse mapping dropped them — so a tiered plan could only be configured by calling the plan API by hand, and a plan authored that way **reopened in the builder as though it had no bands at all**. Saving from that screen would have removed them.

## What this adds

A quantity item now carries its bands through every layer that touches a plan.

| Layer | Change |
| --- | --- |
| API model | `QuantityDiscountTier`, on `PlanQuantityItem` and the create/update request |
| Form schema | `quantityDiscountTiers` per quantity item, edited as percentages |
| Mapping | percent → basis points on submit, basis points → percent on reopen |
| Builder | from/to/discount table behind one checkbox per quantity item |
| Review step | every band, in words |
| Plan detail | the same, so the live catalogue can be checked before editing |

**Editing works because the mapping goes both ways.** That is the half whose absence made the server-side feature unusable: the API stored bands, the builder reopened without them.

## Authoring behaviour

- Enabling seeds a **contiguous pair** — a single band is a flat discount the unit price already expresses, and the schema refuses it.
- Adding a band splits the open one and derives the new boundary from where that band starts, keeping the list contiguous. The rate-table editor learned the same lesson from a constant that put two bands on one boundary the second time it was clicked.
- Disabling asks for confirmation **only** when a non-zero discount would be lost. A confirm on every toggle trains people to dismiss it.
- The final band must be left open on an unbounded item and must reach the ceiling on a bounded one — otherwise a quantity above the last band is sold at a price the plan never states.

## Validation

The band rules are checked in the schema and reported **on the row that breaks them**. The server refuses a gap, an overlap or a second open end with one error code for the whole plan, which tells an author that something is wrong and nothing about where:

- `The next band must begin at 6.`
- `The final band must cover quantities up to 30.`
- `Only the final band can be left open.`
- `Add a second band, or turn volume discounts off.`

## Volume, not graduated

Said on screen and in the guide: the band is chosen by the **total** quantity and its discount applies to the **whole** charge. Ten users in a 10% band is ten users at 10% off, not four at full price and six discounted. An author who reads it the other way prices their catalogue wrong and finds out from an invoice.

Where exactly one price is written against the item, each row also shows what a unit costs inside that band. Presentation only, and omitted when two prices target the item, because "the" effective price is then a fiction.

## Verification

- `npm run type-check` — clean
- `npx eslint app/cross-modules/utilities/subscription/**` — 0 problems
- `npm test` — **1946 passing**, including 39 new tests across the editor, schema, mapping and summary card

Five test *files* fail to load with `TypeError: ... Received 'file:///assets/github-icon.svg'` (create-project, devops, repository-selection). Pre-existing and unrelated: I confirmed they fail identically with this branch's changes stashed.

## Not covered

Nothing here has been exercised against a live plan end to end — authored through the UI, stored, reopened, edited, and a subscription moved from 4 to 5 users to see the 5% band apply. That is the acceptance run, and it needs a dev environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)