### PR TITLE
fix(subscription): scope cancel and change-plan calls to the selected organization

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/cancel-subscription-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/cancel-subscription-dialog.tsx
@@ -18,10 +18,12 @@ import type { SimulatedSubscription } from "../models/subscription-simulation.mo
 
 export const CancelSubscriptionDialog = ({
   subscription,
+  organizationId,
   open,
   onOpenChange,
 }: {
   subscription: SimulatedSubscription;
+  organizationId: string | undefined;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
@@ -39,6 +41,7 @@ export const CancelSubscriptionDialog = ({
         subscriptionId: subscription.subscriptionId,
         immediately,
         reason: reason.trim() || undefined,
+        organizationId,
       });
 
       toast({

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -33,12 +33,14 @@ export const ChangePlanDialog = ({
   subscription,
   currentPlan,
   plans,
+  organizationId,
   open,
   onOpenChange,
 }: {
   subscription: SimulatedSubscription;
   currentPlan: SubscriptionPlan | undefined;
   plans: SubscriptionPlan[];
+  organizationId: string | undefined;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
@@ -113,6 +115,7 @@ export const ChangePlanDialog = ({
       await mutateAsync({
         subscriptionId: subscription.subscriptionId,
         request: { priceId, quantities: parsedQuantities },
+        organizationId,
       });
 
       toast({

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-change-subscription-plan.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-change-subscription-plan.ts
@@ -9,10 +9,12 @@ export const useChangeSubscriptionPlan = () => {
     mutationFn: ({
       subscriptionId,
       request,
+      organizationId,
     }: {
       subscriptionId: string;
       request: ChangeSubscriptionPlanRequest;
-    }) => subscriptionSimulationService.changePlan(subscriptionId, request),
+      organizationId?: string;
+    }) => subscriptionSimulationService.changePlan(subscriptionId, request, organizationId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] });
       queryClient.invalidateQueries({ queryKey: ["subscription-simulation-entitlements"] });

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -59,6 +59,8 @@ export interface CancelSubscriptionRequest {
   /** Default false — keeps granting until the paid period ends. True stops right away. */
   immediately: boolean;
   reason?: string;
+  /** Honoured only for this portal acting as the platform console; see SubscribeToPlanRequest. */
+  organizationId?: string;
 }
 
 /**

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -246,6 +246,7 @@ export const SubscriptionSimulationPage = () => {
       {isCanceling && currentSubscription && (
         <CancelSubscriptionDialog
           subscription={currentSubscription}
+          organizationId={organizationScope}
           open={isCanceling}
           onOpenChange={setIsCanceling}
         />
@@ -256,6 +257,7 @@ export const SubscriptionSimulationPage = () => {
           subscription={currentSubscription}
           currentPlan={currentPlan}
           plans={plans ?? []}
+          organizationId={organizationScope}
           open={isChangingPlan}
           onOpenChange={setIsChangingPlan}
         />

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -71,6 +71,12 @@ class SubscriptionSimulationService {
     if (request.reason) {
       query.set("reason", request.reason);
     }
+    // Without this, the console falls back to its own organization's context, which does not
+    // own the subscription being acted on — the lookup then 404s as "not found" rather than
+    // "not yours" (see the docs' "A 404 may mean not yours").
+    if (request.organizationId) {
+      query.set("organizationId", request.organizationId);
+    }
 
     const response = await serviceInstances.utitlitiesService.delete<
       SimulationApiResponse<SimulatedSubscription>
@@ -90,10 +96,17 @@ class SubscriptionSimulationService {
   async changePlan(
     subscriptionId: string,
     request: ChangeSubscriptionPlanRequest,
+    organizationId?: string,
   ): Promise<SimulatedSubscription> {
+    // Same reason as cancel(): resolving against the console's own organization rather than the
+    // one the subscription actually belongs to reads back as "subscription not found".
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+
     const response = await serviceInstances.utitlitiesService.put<
       SimulationApiResponse<SimulatedSubscription>
-    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan`, request);
+    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan${query}`, request);
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "The plan could not be changed.");


### PR DESCRIPTION
## Summary
- Follow-up to #265 (already merged), which shipped the Subscription simulation module. A bug was found post-merge: canceling or changing the plan of a subscription belonging to a non-default organization returned `404 subscription_not_found` even though the subscription was clearly shown as Active on screen.
- Root cause: `GET /api/subscriptions/current` correctly honors the `organizationId` query param (so the UI shows the right organization's subscription), but the `DELETE /api/subscriptions/{id}` and `PUT /api/subscriptions/{id}/plan` calls never sent `organizationId` at all. They resolved against the console's own default organization instead of the one being simulated, and the API reports a resource belonging to another organization as "not found" rather than "forbidden" — so the mismatch surfaced as a confusing 404 instead of an obvious scoping error.
- Fix: `cancel()` and `changePlan()` now accept `organizationId` and send it as a query param, matching the convention already used by the other console-scoped calls (`GET /api/subscriptions/current`, `GET /api/entitlements`). Threaded through `CancelSubscriptionDialog` → `useCancelSubscription` and `ChangePlanDialog` → `useChangeSubscriptionPlan`, sourced from the page's selected organization scope.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` (scoped to the changed module) passes clean
- [ ] Manual verification against a live backend: cancel and change-plan for a subscription owned by a non-default organization, confirm no more 404 (not run in this environment — no backend credentials available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)