### PR TITLE
feat(subscription): change purchased quantity from the subscriber portal

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
@@ -1,0 +1,349 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import type {
+  QuantityChangeQuote,
+  SimulatedSubscription,
+} from "../models/subscription-simulation.model";
+
+const toast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({ toast: (...args: unknown[]) => toast(...args) }));
+
+const previewQuantityChange = vi.fn();
+const changeQuantity = vi.fn();
+
+vi.mock("../services/subscription-simulation.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../services/subscription-simulation.service")
+  >("../services/subscription-simulation.service");
+
+  return {
+    ...actual,
+    subscriptionSimulationService: {
+      previewQuantityChange: (...args: unknown[]) => previewQuantityChange(...args),
+      changeQuantity: (...args: unknown[]) => changeQuantity(...args),
+    },
+  };
+});
+
+import { ChangeQuantityDialog } from "./change-quantity-dialog";
+import { SubscriptionOperationError } from "../services/subscription-simulation.service";
+
+const subscription: SimulatedSubscription = {
+  subscriptionId: "sub-1",
+  status: "Active",
+  planCode: "team",
+  planName: "Team",
+  currencyCode: "CHF",
+  unitAmountMinor: 14_500,
+  interval: "Month",
+  intervalCount: 1,
+  displayPriceNote: null,
+  quantities: [{ itemKey: "user", quantity: 4, unitLabel: "user" }],
+  currentPeriodStartUtc: "2026-08-01T00:00:00Z",
+  currentPeriodEndUtc: "2026-09-01T00:00:00Z",
+  nextPaymentAtUtc: "2026-09-01T00:00:00Z",
+  trialEndsAtUtc: null,
+  cancelAtPeriodEnd: false,
+  canceledAtUtc: null,
+  pendingQuantityChange: null,
+  currentTier: { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+  recurringAmountMinor: 58_000,
+  checkoutUrl: null,
+  version: 7,
+};
+
+const plan = {
+  planId: "plan-1",
+  quantityItems: [
+    { itemKey: "user", unitLabel: "user", minQuantity: 1, maxQuantity: null, defaultQuantity: 1 },
+  ],
+} as unknown as SubscriptionPlan;
+
+const increaseQuote: QuantityChangeQuote = {
+  subscriptionId: "sub-1",
+  version: 7,
+  preview: true,
+  timing: "Immediate",
+  effectiveAtUtc: "2026-08-16T12:00:00Z",
+  quantities: [{ itemKey: "user", quantity: 5, unitLabel: "user" }],
+  currentTier: { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+  targetTier: { minimumQuantity: 5, maximumQuantity: 9, discountBasisPoints: 500 },
+  proratedChargeMinor: 5_437,
+  nextRenewalAmountMinor: 68_875,
+  currencyCode: "CHF",
+  chargePaymentDetailId: null,
+  pendingQuantityChange: null,
+};
+
+const decreaseQuote: QuantityChangeQuote = {
+  ...increaseQuote,
+  timing: "NextPeriod",
+  effectiveAtUtc: "2026-09-01T00:00:00Z",
+  quantities: [{ itemKey: "user", quantity: 3, unitLabel: "user" }],
+  targetTier: { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
+  proratedChargeMinor: 0,
+  nextRenewalAmountMinor: 43_500,
+  pendingQuantityChange: {
+    quantities: [{ itemKey: "user", quantity: 3, unitLabel: "user" }],
+    requestedAtUtc: "2026-08-16T12:00:00Z",
+    effectiveAtUtc: "2026-09-01T00:00:00Z",
+  },
+};
+
+const onRefresh = vi.fn();
+
+const renderDialog = (current: SimulatedSubscription = subscription) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <ChangeQuantityDialog
+        subscription={current}
+        currentPlan={plan}
+        open
+        onOpenChange={() => {}}
+        onRefresh={onRefresh}
+      />
+    </QueryClientProvider>,
+  );
+};
+
+const setQuantity = (value: string) =>
+  fireEvent.change(screen.getByLabelText(/users/), { target: { value } });
+
+const click = (name: RegExp) => fireEvent.click(screen.getByRole("button", { name }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ChangeQuantityDialog", () => {
+  it("previews the target band and its prorated charge before anything is confirmed", async () => {
+    previewQuantityChange.mockResolvedValue(increaseQuote);
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText("5–9 · 5% off")).toBeInTheDocument();
+    });
+
+    // CHF 54.37 now, CHF 137.75 per user at the new band, CHF 688.75 next renewal.
+    expect(screen.getByText(/54\.37/)).toBeInTheDocument();
+    expect(screen.getByText(/137\.75 each/)).toBeInTheDocument();
+    expect(screen.getByText(/688\.75/)).toBeInTheDocument();
+
+    // The preview writes nothing.
+    expect(changeQuantity).not.toHaveBeenCalled();
+  });
+
+  it("sends the quantity and the version it was quoted against, never a band", async () => {
+    previewQuantityChange.mockResolvedValue(increaseQuote);
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => expect(previewQuantityChange).toHaveBeenCalled());
+
+    expect(previewQuantityChange).toHaveBeenCalledWith("sub-1", {
+      version: 7,
+      quantities: [{ itemKey: "user", quantity: 5 }],
+    });
+  });
+
+  it("cannot confirm before a preview", () => {
+    renderDialog();
+    setQuantity("5");
+
+    expect(screen.getByRole("button", { name: /Confirm and pay/ })).toBeDisabled();
+  });
+
+  it("discards the quote when the quantity is edited again", async () => {
+    previewQuantityChange.mockResolvedValue(increaseQuote);
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Confirm and pay/ })).not.toBeDisabled(),
+    );
+
+    // Confirming figures the subscriber can no longer see is confirming numbers they never saw.
+    setQuantity("9");
+
+    expect(screen.getByRole("button", { name: /Confirm and pay/ })).toBeDisabled();
+  });
+
+  it("applies a confirmed increase and reports it", async () => {
+    previewQuantityChange.mockResolvedValue(increaseQuote);
+    changeQuantity.mockResolvedValue({ ...increaseQuote, preview: false, version: 9 });
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Confirm and pay/ })).not.toBeDisabled(),
+    );
+
+    click(/Confirm and pay/);
+
+    await waitFor(() => expect(changeQuantity).toHaveBeenCalled());
+
+    expect(changeQuantity).toHaveBeenCalledWith("sub-1", {
+      version: 7,
+      quantities: [{ itemKey: "user", quantity: 5 }],
+    });
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success", title: "Quantity updated" }),
+    );
+  });
+
+  it("says a decrease waits for the paid period and names the date", async () => {
+    previewQuantityChange.mockResolvedValue(decreaseQuote);
+
+    renderDialog();
+    setQuantity("3");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText("Scheduled for the period end")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Nothing is refunded/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Schedule change/ })).toBeInTheDocument();
+    // Never "charged now" on a reduction.
+    expect(screen.getByText("Nothing")).toBeInTheDocument();
+  });
+
+  it("shows a scheduled reduction that is already booked", () => {
+    renderDialog({
+      ...subscription,
+      pendingQuantityChange: decreaseQuote.pendingQuantityChange,
+    });
+
+    expect(screen.getByText(/is already scheduled for/)).toBeInTheDocument();
+  });
+
+  it("reloads and asks for a fresh preview after a stale version", async () => {
+    previewQuantityChange.mockResolvedValue(increaseQuote);
+    changeQuantity.mockRejectedValue(
+      new SubscriptionOperationError("Conflict.", "subscription_version_conflict", 409),
+    );
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Confirm and pay/ })).not.toBeDisabled(),
+    );
+
+    click(/Confirm and pay/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/preview the new quantity again/)).toBeInTheDocument();
+    });
+
+    // Re-read, and the stale quote withdrawn so it cannot be sent a second time.
+    expect(onRefresh).toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /Confirm and pay/ })).toBeDisabled();
+  });
+
+  it("keeps the quantity as it was when the card is declined", async () => {
+    previewQuantityChange.mockResolvedValue(increaseQuote);
+    changeQuantity.mockRejectedValue(
+      new SubscriptionOperationError("Declined.", "subscription_quantity_charge_failed", 422),
+    );
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Confirm and pay/ })).not.toBeDisabled(),
+    );
+
+    click(/Confirm and pay/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Nothing changed/)).toBeInTheDocument();
+    });
+
+    // A decline is not an application: the dialog stays open and reports it, and nothing claims
+    // the larger quantity is in force.
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "success" }),
+    );
+  });
+
+  it("tells a subscriber not to retry a charge nobody can answer for", async () => {
+    previewQuantityChange.mockResolvedValue(increaseQuote);
+    changeQuantity.mockRejectedValue(
+      new SubscriptionOperationError(
+        "Unresolved.",
+        "subscription_quantity_charge_unresolved",
+        504,
+      ),
+    );
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Confirm and pay/ })).not.toBeDisabled(),
+    );
+
+    click(/Confirm and pay/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Do not try again/)).toBeInTheDocument();
+    });
+
+    // The money may already have moved, so this is the one failure that must not invite a retry.
+    expect(screen.getByRole("button", { name: /Confirm and pay/ })).toBeDisabled();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("explains a settlement that is still in flight", async () => {
+    previewQuantityChange.mockRejectedValue(
+      new SubscriptionOperationError(
+        "In flight.",
+        "subscription_quantity_change_in_flight",
+        409,
+      ),
+    );
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/still being settled/)).toBeInTheDocument();
+    });
+  });
+
+  it("refuses a quantity outside the plan before calling the server", () => {
+    renderDialog();
+    setQuantity("0");
+    click(/^Preview$/);
+
+    expect(screen.getByText(/at least 1 user/)).toBeInTheDocument();
+    expect(previewQuantityChange).not.toHaveBeenCalled();
+  });
+
+  it("refuses a quantity that is already in force", () => {
+    renderDialog();
+    setQuantity("4");
+    click(/^Preview$/);
+
+    expect(screen.getByText(/already the quantity in force/)).toBeInTheDocument();
+    expect(previewQuantityChange).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
@@ -294,6 +294,32 @@ describe("ChangeQuantityDialog", () => {
     expect(screen.queryByText("Effective unit price")).not.toBeInTheDocument();
   });
 
+  it("explains a flat-fee promotion without inventing a unit price or a band", async () => {
+    // The discount is real and worth saying; the unit price and the band are not, and the note
+    // used to describe both on a card that showed neither.
+    previewQuantityChange.mockResolvedValue({
+      ...increaseQuote,
+      effectiveUnitAmountMinor: null,
+      targetTier: null,
+      promotionApplied: true,
+    });
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Includes the promotional discount on this subscription."),
+      ).toBeInTheDocument();
+    });
+
+    // The row that says there is no band is fine — it is true, and it is not the note under test.
+    expect(screen.queryByText(/unit price is below/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/each/)).not.toBeInTheDocument();
+    expect(screen.getByText("No band — one price at every quantity")).toBeInTheDocument();
+  });
+
   it("says a decrease waits for the paid period and names the date", async () => {
     previewQuantityChange.mockResolvedValue(decreaseQuote);
 

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
@@ -72,6 +72,8 @@ const increaseQuote: QuantityChangeQuote = {
   targetTier: { minimumQuantity: 5, maximumQuantity: 9, discountBasisPoints: 500 },
   proratedChargeMinor: 5_437,
   nextRenewalAmountMinor: 68_875,
+  effectiveUnitAmountMinor: 13_775,
+  promotionApplied: false,
   currencyCode: "CHF",
   chargePaymentDetailId: null,
   pendingQuantityChange: null,
@@ -85,6 +87,8 @@ const decreaseQuote: QuantityChangeQuote = {
   targetTier: { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
   proratedChargeMinor: 0,
   nextRenewalAmountMinor: 43_500,
+  effectiveUnitAmountMinor: 14_500,
+  promotionApplied: false,
   pendingQuantityChange: {
     quantities: [{ itemKey: "user", quantity: 3, unitLabel: "user" }],
     requestedAtUtc: "2026-08-16T12:00:00Z",
@@ -102,6 +106,7 @@ const renderDialog = (current: SimulatedSubscription = subscription) => {
       <ChangeQuantityDialog
         subscription={current}
         currentPlan={plan}
+        organizationId="org-acting-as"
         open
         onOpenChange={() => {}}
         onRefresh={onRefresh}
@@ -152,6 +157,7 @@ describe("ChangeQuantityDialog", () => {
     expect(previewQuantityChange).toHaveBeenCalledWith("sub-1", {
       version: 7,
       quantities: [{ itemKey: "user", quantity: 5 }],
+      organizationId: "org-acting-as",
     });
   });
 
@@ -198,10 +204,50 @@ describe("ChangeQuantityDialog", () => {
     expect(changeQuantity).toHaveBeenCalledWith("sub-1", {
       version: 7,
       quantities: [{ itemKey: "user", quantity: 5 }],
+      organizationId: "org-acting-as",
     });
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ variant: "success", title: "Quantity updated" }),
     );
+  });
+
+  it("shows the unit price the server stated rather than one derived here", async () => {
+    // A promotion, the plan's combination policy and the server's own rounding all move this, so a
+    // percentage applied to the list price in the browser can disagree with the charge being
+    // confirmed — on the one screen where that matters most.
+    previewQuantityChange.mockResolvedValue({
+      ...increaseQuote,
+      // Deliberately not 145 less 5%: a client recomputing from the band would print 137.75.
+      effectiveUnitAmountMinor: 11_020,
+      promotionApplied: true,
+    });
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/110\.20 each/)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/137\.75/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Includes the discount on this subscription/)).toBeInTheDocument();
+  });
+
+  it("states a unit price even where the quantity selects no band", async () => {
+    previewQuantityChange.mockResolvedValue({
+      ...increaseQuote,
+      targetTier: null,
+      effectiveUnitAmountMinor: 14_500,
+    });
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/145\.00 each/)).toBeInTheDocument();
+    });
   });
 
   it("says a decrease waits for the paid period and names the date", async () => {

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
@@ -73,6 +73,7 @@ const increaseQuote: QuantityChangeQuote = {
   proratedChargeMinor: 5_437,
   nextRenewalAmountMinor: 68_875,
   effectiveUnitAmountMinor: 13_775,
+  taxAmountMinor: 0,
   promotionApplied: false,
   currencyCode: "CHF",
   chargePaymentDetailId: null,
@@ -88,6 +89,7 @@ const decreaseQuote: QuantityChangeQuote = {
   proratedChargeMinor: 0,
   nextRenewalAmountMinor: 43_500,
   effectiveUnitAmountMinor: 14_500,
+  taxAmountMinor: 0,
   promotionApplied: false,
   pendingQuantityChange: {
     quantities: [{ itemKey: "user", quantity: 3, unitLabel: "user" }],
@@ -138,7 +140,7 @@ describe("ChangeQuantityDialog", () => {
 
     // CHF 54.37 now, CHF 137.75 per user at the new band, CHF 688.75 next renewal.
     expect(screen.getByText(/54\.37/)).toBeInTheDocument();
-    expect(screen.getByText(/137\.75 each/)).toBeInTheDocument();
+    expect(screen.getByText(/137\.75 each, before tax/)).toBeInTheDocument();
     expect(screen.getByText(/688\.75/)).toBeInTheDocument();
 
     // The preview writes nothing.
@@ -248,6 +250,48 @@ describe("ChangeQuantityDialog", () => {
     await waitFor(() => {
       expect(screen.getByText(/145\.00 each/)).toBeInTheDocument();
     });
+  });
+
+  it("states tax beside the total rather than inside the unit price", async () => {
+    // Folded in, a 5% band on a taxed price showed a unit costing more than the list price on a
+    // card that also said 5% off.
+    previewQuantityChange.mockResolvedValue({
+      ...increaseQuote,
+      taxAmountMinor: 5_510,
+      nextRenewalAmountMinor: 74_385,
+    });
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText("Next renewal, incl. tax")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/137\.75 each, before tax/)).toBeInTheDocument();
+    expect(screen.getByText("of which tax")).toBeInTheDocument();
+    expect(screen.getByText(/55\.10/)).toBeInTheDocument();
+  });
+
+  it("says nothing about a unit price on a flat fee", async () => {
+    // A plan that tracks a quantity item for free has no per-unit price, and printing the whole
+    // plan fee as the cost of "each" would be worse than printing nothing.
+    previewQuantityChange.mockResolvedValue({
+      ...increaseQuote,
+      effectiveUnitAmountMinor: null,
+    });
+
+    renderDialog();
+    setQuantity("5");
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText("Next renewal")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/each/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Effective unit price")).not.toBeInTheDocument();
   });
 
   it("says a decrease waits for the paid period and names the date", async () => {

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
@@ -1,0 +1,390 @@
+import { AlertTriangle, CalendarClock, Loader2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui-kits/badge/badge";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import { toast } from "@/hooks/use-toast";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { formatMoney } from "../../subscription/utilities/subscription-format";
+import { useChangeQuantity, usePreviewQuantityChange } from "../hooks/use-quantity-change";
+import type {
+  QuantityChangeQuote,
+  QuantityDiscountTier,
+  SimulatedSubscription,
+} from "../models/subscription-simulation.model";
+import { SubscriptionOperationError } from "../services/subscription-simulation.service";
+
+/**
+ * Changing how many units a subscription has bought, without changing what it is on.
+ *
+ * Quantity in, band out: the subscriber names a quantity and the server decides which volume band
+ * that falls in. Letting a client name the band would be letting it name a price the plan may not
+ * agree to.
+ *
+ * Nothing is charged from this screen without a preview first, and editing a quantity discards the
+ * quote it produced — a confirmation that can be sent after its figures stopped applying is a
+ * confirmation of numbers the subscriber never saw.
+ */
+export const ChangeQuantityDialog = ({
+  subscription,
+  currentPlan,
+  open,
+  onOpenChange,
+  onRefresh,
+}: {
+  subscription: SimulatedSubscription;
+  currentPlan: SubscriptionPlan | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRefresh: () => void;
+}) => {
+  const preview = usePreviewQuantityChange();
+  const apply = useChangeQuantity();
+
+  // Seeded once, from the subscription as it read when this opened. The dialog is mounted per
+  // opening, so there is nothing to re-synchronize later — and a quote can never outlive the
+  // quantities it was calculated from.
+  const [targets, setTargets] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      subscription.quantities.map((held) => [held.itemKey, String(held.quantity)]),
+    ),
+  );
+  const [quote, setQuote] = useState<QuantityChangeQuote | null>(null);
+  const [failure, setFailure] = useState<{ code: string; message: string } | null>(null);
+
+  const items = useMemo(
+    () =>
+      subscription.quantities.map((held) => {
+        const defined = currentPlan?.quantityItems.find(
+          (candidate) => candidate.itemKey === held.itemKey,
+        );
+
+        return {
+          itemKey: held.itemKey,
+          unitLabel: held.unitLabel ?? defined?.unitLabel ?? held.itemKey,
+          held: held.quantity,
+          minQuantity: defined?.minQuantity ?? 1,
+          maxQuantity: defined?.maxQuantity ?? null,
+        };
+      }),
+    [subscription.quantities, currentPlan],
+  );
+
+  const busy = preview.isPending || apply.isPending;
+
+  const edit = (itemKey: string, value: string) => {
+    setTargets((current) => ({ ...current, [itemKey]: value }));
+    // The quote described the quantities as they were a keystroke ago.
+    setQuote(null);
+    setFailure(null);
+  };
+
+  const requested = () => {
+    const quantities: { itemKey: string; quantity: number }[] = [];
+
+    for (const item of items) {
+      const raw = targets[item.itemKey] ?? "";
+      const quantity = Number(raw);
+
+      if (!raw.trim() || !Number.isInteger(quantity)) {
+        return { error: `Enter a whole number of ${item.unitLabel}s.` } as const;
+      }
+
+      if (quantity < item.minQuantity) {
+        return {
+          error: `This plan needs at least ${item.minQuantity} ${item.unitLabel}${
+            item.minQuantity === 1 ? "" : "s"
+          }.`,
+        } as const;
+      }
+
+      if (item.maxQuantity !== null && quantity > item.maxQuantity) {
+        return {
+          error: `This plan allows at most ${item.maxQuantity} ${item.unitLabel}${
+            item.maxQuantity === 1 ? "" : "s"
+          }.`,
+        } as const;
+      }
+
+      quantities.push({ itemKey: item.itemKey, quantity });
+    }
+
+    if (quantities.every((entry) => entry.quantity === items.find((item) => item.itemKey === entry.itemKey)?.held)) {
+      return { error: "That is already the quantity in force." } as const;
+    }
+
+    return { quantities } as const;
+  };
+
+  const run = async (mode: "preview" | "apply") => {
+    const parsed = requested();
+
+    if ("error" in parsed) {
+      setFailure({ code: "local_validation", message: parsed.error });
+
+      return;
+    }
+
+    setFailure(null);
+
+    const request = { version: subscription.version, quantities: parsed.quantities };
+
+    try {
+      if (mode === "preview") {
+        setQuote(
+          await preview.mutateAsync({
+            subscriptionId: subscription.subscriptionId,
+            request,
+          }),
+        );
+
+        return;
+      }
+
+      const applied = await apply.mutateAsync({
+        subscriptionId: subscription.subscriptionId,
+        request,
+      });
+
+      toast({
+        variant: "success",
+        title: applied.timing === "Immediate" ? "Quantity updated" : "Change scheduled",
+        description:
+          applied.timing === "Immediate"
+            ? describeQuantities(applied)
+            : `${describeQuantities(applied)} from ${formatDate(applied.effectiveAtUtc)}.`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      const code = error instanceof SubscriptionOperationError ? error.code : "unknown";
+
+      setFailure({ code, message: explain(code, error) });
+      setQuote(null);
+
+      // A stale version cannot be retried against what this dialog holds, so the subscription is
+      // re-read and the subscriber previews again from the quantities that actually apply.
+      if (code === "subscription_version_conflict" || code === "subscription_quantity_change_in_flight") {
+        onRefresh();
+      }
+    }
+  };
+
+  const decrease = quote?.timing === "NextPeriod";
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!busy) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Change quantity</DialogTitle>
+          <DialogDescription>
+            An increase is charged for the rest of the paid period and applies at once. A decrease
+            keeps the units until the period ends, then bills the smaller quantity.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-md border p-3 text-sm">
+            <p className="font-medium">In force now</p>
+            <p className="text-muted-foreground">
+              {subscription.quantities
+                .map((held) => `${held.quantity} ${held.unitLabel ?? held.itemKey}`)
+                .join(", ") || "—"}
+              {subscription.currentTier ? ` · ${describeTier(subscription.currentTier)}` : ""}
+            </p>
+            <p className="text-muted-foreground">
+              {formatMoney(subscription.recurringAmountMinor, subscription.currencyCode)} per period
+            </p>
+          </div>
+
+          {subscription.pendingQuantityChange ? (
+            <div className="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 p-3 text-sm">
+              <CalendarClock className="mt-0.5 h-4 w-4 shrink-0 text-warning-800" />
+              <p className="text-warning-900">
+                A reduction to{" "}
+                {subscription.pendingQuantityChange.quantities
+                  .map((entry) => `${entry.quantity} ${entry.unitLabel ?? entry.itemKey}`)
+                  .join(", ")}{" "}
+                is already scheduled for {formatDate(subscription.pendingQuantityChange.effectiveAtUtc)}.
+                Confirming again replaces it.
+              </p>
+            </div>
+          ) : null}
+
+          {items.map((item) => (
+            <div key={item.itemKey} className="space-y-1.5">
+              <Label htmlFor={`quantity-${item.itemKey}`}>
+                {item.unitLabel}s
+                <span className="ml-2 text-xs text-muted-foreground">
+                  {item.minQuantity}
+                  {item.maxQuantity === null ? " or more" : `–${item.maxQuantity}`}
+                </span>
+              </Label>
+              <Input
+                id={`quantity-${item.itemKey}`}
+                type="number"
+                min={item.minQuantity}
+                max={item.maxQuantity ?? undefined}
+                value={targets[item.itemKey] ?? ""}
+                onChange={(event) => edit(item.itemKey, event.target.value)}
+              />
+            </div>
+          ))}
+
+          {quote ? (
+            <div className="space-y-2 rounded-md border p-3 text-sm">
+              <div className="flex items-center justify-between">
+                <p className="font-medium">
+                  {decrease ? "Scheduled for the period end" : "Applies immediately"}
+                </p>
+                <Badge variant={decrease ? "secondary" : "default"}>
+                  {decrease ? formatDate(quote.effectiveAtUtc) : "Now"}
+                </Badge>
+              </div>
+
+              <Row label="New quantity" value={describeQuantities(quote)} />
+              <Row
+                label="Volume band"
+                value={
+                  quote.targetTier
+                    ? describeTier(quote.targetTier)
+                    : "No band — one price at every quantity"
+                }
+              />
+              {quote.targetTier ? (
+                <Row
+                  label="Effective unit price"
+                  value={`${formatMoney(
+                    discounted(subscription.unitAmountMinor, quote.targetTier),
+                    quote.currencyCode,
+                  )} each`}
+                />
+              ) : null}
+              <Row
+                label={decrease ? "Charged now" : "Prorated charge"}
+                value={
+                  quote.proratedChargeMinor > 0
+                    ? formatMoney(quote.proratedChargeMinor, quote.currencyCode)
+                    : "Nothing"
+                }
+              />
+              <Row
+                label="Next renewal"
+                value={formatMoney(quote.nextRenewalAmountMinor, quote.currencyCode)}
+              />
+
+              {decrease ? (
+                <p className="text-xs text-muted-foreground">
+                  Nothing is refunded: the units stay available until{" "}
+                  {formatDate(quote.effectiveAtUtc)}, and the renewal then bills the smaller
+                  quantity at its band.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+
+          {failure ? (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+              <p className="text-destructive">{failure.message}</p>
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
+            Close
+          </Button>
+          <Button variant="outline" onClick={() => run("preview")} disabled={busy}>
+            {preview.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Preview
+          </Button>
+          {/* Nothing is charged without a quote on screen, and the quote is discarded the moment a
+              quantity changes — so this button can only ever send the figures just shown. */}
+          <Button onClick={() => run("apply")} disabled={busy || quote === null}>
+            {apply.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {decrease ? "Schedule change" : "Confirm and pay"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-baseline justify-between gap-4">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="text-right font-medium">{value}</span>
+  </div>
+);
+
+const formatDate = (isoDate: string) => new Date(isoDate).toLocaleString();
+
+const describeQuantities = (quote: QuantityChangeQuote) =>
+  quote.quantities
+    .map((entry) => `${entry.quantity} ${entry.unitLabel ?? entry.itemKey}`)
+    .join(", ");
+
+const describeTier = (tier: QuantityDiscountTier) => {
+  const range =
+    tier.maximumQuantity === null
+      ? `${tier.minimumQuantity}+`
+      : `${tier.minimumQuantity}–${tier.maximumQuantity}`;
+
+  return tier.discountBasisPoints > 0
+    ? `${range} · ${Number((tier.discountBasisPoints / 100).toFixed(2))}% off`
+    : `${range} · no discount`;
+};
+
+const discounted = (unitAmountMinor: number, tier: QuantityDiscountTier) =>
+  Math.round(unitAmountMinor * (1 - tier.discountBasisPoints / 10_000));
+
+/**
+ * What a subscriber should do about each outcome.
+ *
+ * The distinction that matters is between a refusal and an unanswered charge. A decline changed
+ * nothing and can be retried; a charge whose outcome nobody knows must not be retried at all,
+ * because the reservation behind it is still holding and the money may already have moved.
+ */
+const explain = (code: string, error: unknown): string => {
+  switch (code) {
+    case "subscription_version_conflict":
+      return "This subscription changed while you were deciding. It has been reloaded — preview the new quantity again.";
+    case "subscription_quantity_change_in_flight":
+      return "An earlier change is still being settled with the payment provider. Try again in a few minutes.";
+    case "subscription_quantity_charge_failed":
+      return "The saved card declined the charge. Nothing changed: the quantity is exactly as it was.";
+    case "subscription_quantity_charge_unresolved":
+      return "The payment provider did not answer, so whether the charge went through is not yet known. Do not try again — reload in a few minutes and the outcome will be settled by then.";
+    case "subscription_payment_method_missing":
+      return "An increase has to be charged, and there is no saved card to charge. Add a payment method first.";
+    case "subscription_quantity_change_not_allowed":
+      return "This subscription cannot change quantity in its current state.";
+    case "subscription_quantity_item_unknown":
+      return "This plan does not sell that item.";
+    case "subscription_quantity_unchanged":
+      return "That is already the quantity in force.";
+    case "subscription_quantity_invalid":
+      return "That quantity is outside what this plan allows.";
+    case "local_validation":
+      return error instanceof Error ? error.message : "Check the quantity and try again.";
+    default:
+      return error instanceof Error ? error.message : "The quantity could not be changed.";
+  }
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
@@ -278,14 +278,18 @@ export const ChangeQuantityDialog = ({
               />
               {/* The server's figure, not one derived here: the band alone does not determine it,
                   and a number that disagrees with the charge beside it is worst of all on the
-                  screen where somebody confirms a payment. */}
-              <Row
-                label="Effective unit price"
-                value={`${formatMoney(
-                  quote.effectiveUnitAmountMinor,
-                  quote.currencyCode,
-                )} each`}
-              />
+                  screen where somebody confirms a payment. Absent on a flat fee, where nothing is
+                  sold by the unit — printing the plan's whole price as the cost of "each" of a
+                  freely tracked item would be worse than printing nothing. */}
+              {quote.effectiveUnitAmountMinor !== null ? (
+                <Row
+                  label="Effective unit price"
+                  value={`${formatMoney(
+                    quote.effectiveUnitAmountMinor,
+                    quote.currencyCode,
+                  )} each, before tax`}
+                />
+              ) : null}
               {quote.promotionApplied ? (
                 <p className="text-xs text-muted-foreground">
                   Includes the discount on this subscription, so the unit price is below the
@@ -301,9 +305,18 @@ export const ChangeQuantityDialog = ({
                 }
               />
               <Row
-                label="Next renewal"
+                label={quote.taxAmountMinor > 0 ? "Next renewal, incl. tax" : "Next renewal"}
                 value={formatMoney(quote.nextRenewalAmountMinor, quote.currencyCode)}
               />
+              {/* Named rather than folded into the unit price: tax is a proportion of the whole
+                  charge, and a unit price carrying it read higher than the list price on a card
+                  that also said the band took 5% off. */}
+              {quote.taxAmountMinor > 0 ? (
+                <Row
+                  label="of which tax"
+                  value={formatMoney(quote.taxAmountMinor, quote.currencyCode)}
+                />
+              ) : null}
 
               {decrease ? (
                 <p className="text-xs text-muted-foreground">

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
@@ -37,12 +37,15 @@ import { SubscriptionOperationError } from "../services/subscription-simulation.
 export const ChangeQuantityDialog = ({
   subscription,
   currentPlan,
+  organizationId,
   open,
   onOpenChange,
   onRefresh,
 }: {
   subscription: SimulatedSubscription;
   currentPlan: SubscriptionPlan | undefined;
+  /** The organization being acted on, when the console is acting on one. */
+  organizationId?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onRefresh: () => void;
@@ -136,7 +139,13 @@ export const ChangeQuantityDialog = ({
 
     setFailure(null);
 
-    const request = { version: subscription.version, quantities: parsed.quantities };
+    // The same body for the preview and the apply, scope included: a quote resolved against one
+    // organization and applied against another is not the same operation.
+    const request = {
+      version: subscription.version,
+      quantities: parsed.quantities,
+      organizationId,
+    };
 
     try {
       if (mode === "preview") {
@@ -267,14 +276,21 @@ export const ChangeQuantityDialog = ({
                     : "No band — one price at every quantity"
                 }
               />
-              {quote.targetTier ? (
-                <Row
-                  label="Effective unit price"
-                  value={`${formatMoney(
-                    discounted(subscription.unitAmountMinor, quote.targetTier),
-                    quote.currencyCode,
-                  )} each`}
-                />
+              {/* The server's figure, not one derived here: the band alone does not determine it,
+                  and a number that disagrees with the charge beside it is worst of all on the
+                  screen where somebody confirms a payment. */}
+              <Row
+                label="Effective unit price"
+                value={`${formatMoney(
+                  quote.effectiveUnitAmountMinor,
+                  quote.currencyCode,
+                )} each`}
+              />
+              {quote.promotionApplied ? (
+                <p className="text-xs text-muted-foreground">
+                  Includes the discount on this subscription, so the unit price is below the
+                  band&apos;s own reduction.
+                </p>
               ) : null}
               <Row
                 label={decrease ? "Charged now" : "Prorated charge"}
@@ -351,9 +367,6 @@ const describeTier = (tier: QuantityDiscountTier) => {
     ? `${range} · ${Number((tier.discountBasisPoints / 100).toFixed(2))}% off`
     : `${range} · no discount`;
 };
-
-const discounted = (unitAmountMinor: number, tier: QuantityDiscountTier) =>
-  Math.round(unitAmountMinor * (1 - tier.discountBasisPoints / 10_000));
 
 /**
  * What a subscriber should do about each outcome.

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
@@ -290,10 +290,15 @@ export const ChangeQuantityDialog = ({
                   )} each, before tax`}
                 />
               ) : null}
+              {/* Worded to what is actually on screen. A flat fee has neither a unit price nor a
+                  band, so explaining that "the unit price is below the band's own reduction" there
+                  described two things the card never showed — while still being worth saying that a
+                  discount is in these figures at all. */}
               {quote.promotionApplied ? (
                 <p className="text-xs text-muted-foreground">
-                  Includes the discount on this subscription, so the unit price is below the
-                  band&apos;s own reduction.
+                  {quote.effectiveUnitAmountMinor !== null
+                    ? "Includes the discount on this subscription, so the unit price is below the band’s own reduction."
+                    : "Includes the promotional discount on this subscription."}
                 </p>
               ) : null}
               <Row

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
@@ -3,11 +3,25 @@ import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import { formatPrice } from "../../subscription/utilities/subscription-format";
-import type { SimulatedSubscription } from "../models/subscription-simulation.model";
+import type {
+  QuantityDiscountTier,
+  SimulatedSubscription,
+} from "../models/subscription-simulation.model";
 import { SubscriptionStatusBadge } from "./subscription-status-badge";
 
 const formatDate = (isoDate: string | null) =>
   isoDate ? new Date(isoDate).toLocaleString() : "—";
+
+const describeTier = (tier: QuantityDiscountTier) => {
+  const range =
+    tier.maximumQuantity === null
+      ? `${tier.minimumQuantity}+`
+      : `${tier.minimumQuantity}\u2013${tier.maximumQuantity}`;
+
+  return tier.discountBasisPoints > 0
+    ? `${range} band \u00b7 ${Number((tier.discountBasisPoints / 100).toFixed(2))}% off`
+    : `${range} band \u00b7 no discount`;
+};
 
 const CANCELABLE_STATUSES = new Set(["Incomplete", "Trialing", "Active", "PastDue"]);
 // Incomplete has not paid yet, so it is not eligible to change plan — the doc has you continue
@@ -23,6 +37,9 @@ export const CurrentSubscriptionCard = ({
   onRetry,
   onCancel,
   onChangePlan,
+  onChangeQuantity,
+  onCancelPendingQuantityChange,
+  isCancelingPendingQuantityChange,
 }: {
   subscription: SimulatedSubscription | null | undefined;
   isLoading: boolean;
@@ -32,6 +49,9 @@ export const CurrentSubscriptionCard = ({
   onRetry: () => void;
   onCancel: () => void;
   onChangePlan: () => void;
+  onChangeQuantity: () => void;
+  onCancelPendingQuantityChange: () => void;
+  isCancelingPendingQuantityChange: boolean;
 }) => {
   if (isLoading) {
     return <Skeleton className="h-28 w-full rounded-xl" />;
@@ -95,6 +115,11 @@ export const CurrentSubscriptionCard = ({
               </a>
             </Button>
           )}
+          {CHANGEABLE_STATUSES.has(subscription.status) && subscription.quantities.length > 0 && (
+            <Button size="sm" variant="outline" onClick={onChangeQuantity}>
+              Change quantity
+            </Button>
+          )}
           {CHANGEABLE_STATUSES.has(subscription.status) && (
             <Button size="sm" variant="outline" onClick={onChangePlan}>
               Change plan
@@ -126,7 +151,36 @@ export const CurrentSubscriptionCard = ({
               .join(", ")}
           </span>
         )}
+        {/* The band decides what every one of those units costs, so it belongs next to them
+            rather than only inside the change dialog. */}
+        {subscription.currentTier && (
+          <span>{describeTier(subscription.currentTier)}</span>
+        )}
       </div>
+
+      {/* A reduction already booked. Shown on the subscription itself, not only in the response to
+          the request that made it: without this a reload shows the larger quantity with nothing to
+          say a smaller one is coming, and no way to call it off. */}
+      {subscription.pendingQuantityChange && (
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-300 bg-warning-50 p-2.5 text-xs">
+          <span className="flex items-center gap-1.5 text-warning-900">
+            <CalendarClock className="h-3.5 w-3.5 shrink-0" />
+            Reducing to{" "}
+            {subscription.pendingQuantityChange.quantities
+              .map((entry) => `${entry.quantity} ${entry.unitLabel ?? entry.itemKey}`)
+              .join(", ")}{" "}
+            on {formatDate(subscription.pendingQuantityChange.effectiveAtUtc)}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onCancelPendingQuantityChange}
+            disabled={isCancelingPendingQuantityChange}
+          >
+            Keep current quantity
+          </Button>
+        </div>
+      )}
     </Card>
   );
 };

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-quantity-change.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-quantity-change.ts
@@ -46,8 +46,14 @@ export const useCancelPendingQuantityChange = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (subscriptionId: string) =>
-      subscriptionSimulationService.cancelPendingQuantityChange(subscriptionId),
+    mutationFn: ({
+      subscriptionId,
+      organizationId,
+    }: {
+      subscriptionId: string;
+      organizationId?: string;
+    }) =>
+      subscriptionSimulationService.cancelPendingQuantityChange(subscriptionId, organizationId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] });
       queryClient.invalidateQueries({ queryKey: ["subscription-simulation-entitlements"] });

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-quantity-change.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-quantity-change.ts
@@ -1,0 +1,56 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { ChangeQuantityRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/**
+ * What a quantity change would cost. Writes nothing, so it invalidates nothing.
+ */
+export const usePreviewQuantityChange = () =>
+  useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: ChangeQuantityRequest;
+    }) => subscriptionSimulationService.previewQuantityChange(subscriptionId, request),
+  });
+
+/**
+ * Applies the change.
+ *
+ * The subscription is re-read on success rather than patched from the response: an increase moves
+ * the version twice — once to reserve the units, once to grant them — and entitlement is derived
+ * from the quantity, so both have to come from the server rather than be inferred here.
+ */
+export const useChangeQuantity = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: ChangeQuantityRequest;
+    }) => subscriptionSimulationService.changeQuantity(subscriptionId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] });
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-entitlements"] });
+    },
+  });
+};
+
+/** Withdraws a scheduled decrease. */
+export const useCancelPendingQuantityChange = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (subscriptionId: string) =>
+      subscriptionSimulationService.cancelPendingQuantityChange(subscriptionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] });
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-entitlements"] });
+    },
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -103,13 +103,16 @@ export interface QuantityChangeQuote {
   proratedChargeMinor: number;
   nextRenewalAmountMinor: number;
   /**
-   * What one unit costs at the target quantity, stated by the server.
+   * What one unit costs at the target quantity, before tax, as stated by the server. Null when the
+   * price is a flat fee and there is no such thing as a unit price.
    *
    * Never recomputed here. The band alone does not determine it — a promotion on the subscription,
    * the plan's combination policy and the server's rounding all move it — so a percentage applied
    * to the list price in the browser can disagree with the charge being confirmed.
    */
-  effectiveUnitAmountMinor: number;
+  effectiveUnitAmountMinor: number | null;
+  /** The tax inside `nextRenewalAmountMinor`, which is the tax-inclusive total. */
+  taxAmountMinor: number;
   /** Whether a promotional discount is part of these figures. */
   promotionApplied: boolean;
   currencyCode: string;

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -75,6 +75,13 @@ export interface SimulatedSubscription {
 export interface ChangeQuantityRequest {
   version: number;
   quantities: { itemKey: string; quantity: number }[];
+  /**
+   * Which organization the subscription belongs to. Carried for the same reason subscribing
+   * carries it: this portal calls the API as the console acting on a chosen organization's behalf,
+   * and without it every quantity call resolves against the caller's own organization and answers
+   * "subscription not found". Ignored for an ordinary integrator's token, whose scope is its own.
+   */
+  organizationId?: string;
 }
 
 /**
@@ -95,6 +102,16 @@ export interface QuantityChangeQuote {
   /** Owed now for the rest of the period. Zero for a decrease, which is never refunded. */
   proratedChargeMinor: number;
   nextRenewalAmountMinor: number;
+  /**
+   * What one unit costs at the target quantity, stated by the server.
+   *
+   * Never recomputed here. The band alone does not determine it — a promotion on the subscription,
+   * the plan's combination policy and the server's rounding all move it — so a percentage applied
+   * to the list price in the browser can disagree with the charge being confirmed.
+   */
+  effectiveUnitAmountMinor: number;
+  /** Whether a promotional discount is part of these figures. */
+  promotionApplied: boolean;
   currencyCode: string;
   chargePaymentDetailId: string | null;
   pendingQuantityChange: PendingQuantityChange | null;

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -12,6 +12,27 @@ export type SubscriptionStatus =
 export interface SubscriptionQuantity {
   itemKey: string;
   quantity: number;
+  /** Present on reads, absent on writes: the server owns the label. */
+  unitLabel?: string;
+}
+
+/**
+ * The volume band a quantity falls in.
+ *
+ * Read, never chosen. A client that sent a band would be naming a price the plan may not agree
+ * to; the quantity is the input and the band is the consequence.
+ */
+export interface QuantityDiscountTier {
+  minimumQuantity: number;
+  maximumQuantity: number | null;
+  discountBasisPoints: number;
+}
+
+/** A reduction already booked for the end of the paid period. */
+export interface PendingQuantityChange {
+  quantities: SubscriptionQuantity[];
+  requestedAtUtc: string;
+  effectiveAtUtc: string;
 }
 
 export interface SimulatedSubscription {
@@ -31,9 +52,52 @@ export interface SimulatedSubscription {
   trialEndsAtUtc: string | null;
   cancelAtPeriodEnd: boolean;
   canceledAtUtc: string | null;
+  /**
+   * A decrease waiting for the paid period to end, if one is scheduled. The quantities above are
+   * still what the subscriber holds and pays for until then.
+   */
+  pendingQuantityChange: PendingQuantityChange | null;
+  /** The band the quantity in force selects, if the plan defines any. */
+  currentTier: QuantityDiscountTier | null;
+  /** What the next renewal costs at the quantity, band and discount in force. */
+  recurringAmountMinor: number;
   /** Only present while payment is outstanding; null once activated. */
   checkoutUrl: string | null;
   version: number;
+}
+
+/**
+ * A requested quantity, and the version it was quoted against.
+ *
+ * The version is required: without it a stale tab can overwrite a seat count somebody else moved
+ * a minute ago. A request naming one item leaves the others alone.
+ */
+export interface ChangeQuantityRequest {
+  version: number;
+  quantities: { itemKey: string; quantity: number }[];
+}
+
+/**
+ * What a quantity change costs and when it takes effect — the same shape whether it was previewed
+ * or applied, so a confirmation screen and its outcome are rendered from one set of fields.
+ */
+export interface QuantityChangeQuote {
+  subscriptionId: string;
+  /** The version after the change. Unchanged on a preview. */
+  version: number;
+  preview: boolean;
+  /** <code>Immediate</code> for an increase, <code>NextPeriod</code> for a decrease. */
+  timing: "Immediate" | "NextPeriod";
+  effectiveAtUtc: string;
+  quantities: SubscriptionQuantity[];
+  currentTier: QuantityDiscountTier | null;
+  targetTier: QuantityDiscountTier | null;
+  /** Owed now for the rest of the period. Zero for a decrease, which is never refunded. */
+  proratedChargeMinor: number;
+  nextRenewalAmountMinor: number;
+  currencyCode: string;
+  chargePaymentDetailId: string | null;
+  pendingQuantityChange: PendingQuantityChange | null;
 }
 
 export interface SubscribeToPlanRequest {

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -24,6 +24,8 @@ import { useSubscriptionPlans } from "../../subscription/hooks/use-subscription-
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
 import { CancelSubscriptionDialog } from "../components/cancel-subscription-dialog";
 import { ChangePlanDialog } from "../components/change-plan-dialog";
+import { ChangeQuantityDialog } from "../components/change-quantity-dialog";
+import { useCancelPendingQuantityChange } from "../hooks/use-quantity-change";
 import { CurrentSubscriptionCard } from "../components/current-subscription-card";
 import { SimulatedPlanCard } from "../components/simulated-plan-card";
 import { SubscribeDialog } from "../components/subscribe-dialog";
@@ -41,6 +43,7 @@ export const SubscriptionSimulationPage = () => {
   const [subscribingTo, setSubscribingTo] = useState<SubscriptionPlan | null>(null);
   const [isCanceling, setIsCanceling] = useState(false);
   const [isChangingPlan, setIsChangingPlan] = useState(false);
+  const [isChangingQuantity, setIsChangingQuantity] = useState(false);
 
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData } = useGetOrganizations({
@@ -89,6 +92,35 @@ export const SubscriptionSimulationPage = () => {
   const refresh = () => {
     refetchPlans();
     refetchCurrent();
+  };
+
+  const cancelPendingQuantity = useCancelPendingQuantityChange();
+
+  /**
+   * Withdraws a scheduled reduction. Reported as a toast rather than inline, because the control
+   * that raised it disappears the moment the subscription is re-read without a pending change.
+   */
+  const withdrawScheduledQuantityChange = async () => {
+    if (!currentSubscription) {
+      return;
+    }
+
+    try {
+      await cancelPendingQuantity.mutateAsync(currentSubscription.subscriptionId);
+
+      toast({
+        variant: "success",
+        title: "Scheduled reduction withdrawn",
+        description: "The current quantity stays in force.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "The reduction could not be withdrawn",
+        description:
+          error instanceof Error ? error.message : "Reload and try again.",
+      });
+    }
   };
 
   return (
@@ -153,6 +185,9 @@ export const SubscriptionSimulationPage = () => {
             onRetry={() => refetchCurrent()}
             onCancel={() => setIsCanceling(true)}
             onChangePlan={() => setIsChangingPlan(true)}
+            onChangeQuantity={() => setIsChangingQuantity(true)}
+            onCancelPendingQuantityChange={withdrawScheduledQuantityChange}
+            isCancelingPendingQuantityChange={cancelPendingQuantity.isPending}
           />
         </div>
       </Card>
@@ -248,6 +283,16 @@ export const SubscriptionSimulationPage = () => {
           subscription={currentSubscription}
           open={isCanceling}
           onOpenChange={setIsCanceling}
+        />
+      )}
+
+      {isChangingQuantity && currentSubscription && (
+        <ChangeQuantityDialog
+          subscription={currentSubscription}
+          currentPlan={currentPlan}
+          open={isChangingQuantity}
+          onOpenChange={setIsChangingQuantity}
+          onRefresh={() => refetchCurrent()}
         />
       )}
 

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -106,7 +106,10 @@ export const SubscriptionSimulationPage = () => {
     }
 
     try {
-      await cancelPendingQuantity.mutateAsync(currentSubscription.subscriptionId);
+      await cancelPendingQuantity.mutateAsync({
+        subscriptionId: currentSubscription.subscriptionId,
+        organizationId: organizationScope,
+      });
 
       toast({
         variant: "success",
@@ -290,6 +293,7 @@ export const SubscriptionSimulationPage = () => {
         <ChangeQuantityDialog
           subscription={currentSubscription}
           currentPlan={currentPlan}
+          organizationId={organizationScope}
           open={isChangingQuantity}
           onOpenChange={setIsChangingQuantity}
           onRefresh={() => refetchCurrent()}

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -198,9 +198,24 @@ class SubscriptionSimulationService {
     return this.quantityCall("put", this.quantityPath(subscriptionId), request);
   }
 
-  /** Withdraws a scheduled decrease, leaving the current quantity in place. */
-  async cancelPendingQuantityChange(subscriptionId: string): Promise<QuantityChangeQuote> {
-    return this.quantityCall("delete", `${this.quantityPath(subscriptionId)}/pending`);
+  /**
+   * Withdraws a scheduled decrease, leaving the current quantity in place.
+   *
+   * Scope travels in the query here rather than a body, because that is what this endpoint reads —
+   * a DELETE with no body to put it in.
+   */
+  async cancelPendingQuantityChange(
+    subscriptionId: string,
+    organizationId?: string,
+  ): Promise<QuantityChangeQuote> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+
+    return this.quantityCall(
+      "delete",
+      `${this.quantityPath(subscriptionId)}/pending${query}`,
+    );
   }
 
   private quantityPath(subscriptionId: string): string {

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -8,7 +8,9 @@ import {
 } from "../constants/subscription-simulation.constants";
 import type {
   CancelSubscriptionRequest,
+  ChangeQuantityRequest,
   ChangeSubscriptionPlanRequest,
+  QuantityChangeQuote,
   EntitlementDecision,
   EntitlementsSnapshot,
   RecordUsageRequest,
@@ -27,6 +29,25 @@ interface SimulationApiResponse<T> {
   success: boolean;
   data: T | null;
   error: SimulationApiError | null;
+}
+
+/**
+ * A failed call, with the server's own error code kept.
+ *
+ * Thrown rather than a bare Error for the quantity paths, where four outcomes have to be told
+ * apart and only the code distinguishes them: a declined card, a charge whose outcome is unknown,
+ * a stale version, and another settlement already in flight. Reduced to a message, "the change
+ * could not be applied" is the same sentence for a retry that is safe and one that is not.
+ */
+export class SubscriptionOperationError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "SubscriptionOperationError";
+  }
 }
 
 class SubscriptionSimulationService {
@@ -156,6 +177,80 @@ class SubscriptionSimulationService {
     return response.data;
   }
 
+  /**
+   * What a quantity change would cost, writing nothing.
+   *
+   * A separate endpoint rather than a flag on the update: the preview and the apply share a request
+   * body, so what a subscriber is quoted is what the confirm then sends.
+   */
+  async previewQuantityChange(
+    subscriptionId: string,
+    request: ChangeQuantityRequest,
+  ): Promise<QuantityChangeQuote> {
+    return this.quantityCall("post", `${this.quantityPath(subscriptionId)}/preview`, request);
+  }
+
+  /** Applies the change the preview quoted. An increase is charged before the units move. */
+  async changeQuantity(
+    subscriptionId: string,
+    request: ChangeQuantityRequest,
+  ): Promise<QuantityChangeQuote> {
+    return this.quantityCall("put", this.quantityPath(subscriptionId), request);
+  }
+
+  /** Withdraws a scheduled decrease, leaving the current quantity in place. */
+  async cancelPendingQuantityChange(subscriptionId: string): Promise<QuantityChangeQuote> {
+    return this.quantityCall("delete", `${this.quantityPath(subscriptionId)}/pending`);
+  }
+
+  private quantityPath(subscriptionId: string): string {
+    return `${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/quantities`;
+  }
+
+  private async quantityCall(
+    method: "post" | "put" | "delete",
+    path: string,
+    request?: ChangeQuantityRequest,
+  ): Promise<QuantityChangeQuote> {
+    try {
+      const client = serviceInstances.utitlitiesService;
+      const response =
+        method === "delete"
+          ? await client.delete<SimulationApiResponse<QuantityChangeQuote>>(path)
+          : method === "put"
+            ? await client.put<SimulationApiResponse<QuantityChangeQuote>>(path, request)
+            : await client.post<SimulationApiResponse<QuantityChangeQuote>>(path, request);
+
+      if (!response.success || !response.data) {
+        throw new SubscriptionOperationError(
+          response.error?.message || "The quantity could not be changed.",
+          response.error?.code ?? "unknown",
+        );
+      }
+
+      return response.data;
+    } catch (error) {
+      if (error instanceof SubscriptionOperationError) {
+        throw error;
+      }
+
+      // A 409 or 422 arrives as an HttpError, and where the envelope's error lands on it varies
+      // with the transport — HttpError carries `errors`, not the response body. Searched for
+      // rather than read from a fixed path, the same way the payment module recognizes its own
+      // provider-unavailable code, because guessing one path and being wrong turns every named
+      // outcome into "unknown" and every retry into a guess.
+      if (error instanceof HttpError) {
+        throw new SubscriptionOperationError(
+          messageFrom(error),
+          quantityErrorCode(error),
+          error.status,
+        );
+      }
+
+      throw error;
+    }
+  }
+
   /** The authoritative gate — the figures returned include this call. */
   async recordUsage(request: RecordUsageRequest): Promise<RecordUsageResult> {
     const response = await serviceInstances.utitlitiesService.post<
@@ -169,5 +264,66 @@ class SubscriptionSimulationService {
     return response.data;
   }
 }
+
+/**
+ * The outcomes a caller has to tell apart, and nothing else.
+ *
+ * Listed rather than parsed out of a path on the error object: the envelope arrives in different
+ * shapes for a 409 and a 422, and a code read from the wrong place is silently "unknown" — which
+ * is the one answer that makes a charge-unresolved look like a decline.
+ */
+const QUANTITY_ERROR_CODES = [
+  "subscription_quantity_charge_unresolved",
+  "subscription_quantity_charge_failed",
+  "subscription_quantity_change_in_flight",
+  "subscription_version_conflict",
+  "subscription_payment_method_missing",
+  "subscription_quantity_change_not_allowed",
+  "subscription_quantity_item_unknown",
+  "subscription_quantity_unchanged",
+  "subscription_quantity_invalid",
+  "subscription_pending_quantity_change_not_found",
+] as const;
+
+const serialize = (error: unknown): string => {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error, [
+      "message",
+      "code",
+      "error",
+      "errors",
+      "data",
+      "detail",
+      "title",
+    ] as never);
+  } catch {
+    return String(error);
+  }
+};
+
+const quantityErrorCode = (error: unknown): string => {
+  const haystack = `${serialize(error)} ${error instanceof Error ? error.message : ""}`;
+
+  return QUANTITY_ERROR_CODES.find((code) => haystack.includes(code)) ?? "unknown";
+};
+
+const messageFrom = (error: unknown): string => {
+  if (error instanceof HttpError) {
+    const values = Object.values(error.errors ?? {}).flat();
+    const first = values.find((value) => typeof value === "string" && value.trim().length > 0);
+
+    if (first) {
+      return first;
+    }
+  }
+
+  return error instanceof Error && error.message
+    ? error.message
+    : "The quantity could not be changed.";
+};
 
 export const subscriptionSimulationService = new SubscriptionSimulationService();

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1137,6 +1137,7 @@ Content-Type: application/json
   "proratedChargeMinor": 5437,
   "nextRenewalAmountMinor": 68875,
   "effectiveUnitAmountMinor": 13775,
+  "taxAmountMinor": 0,
   "promotionApplied": false,
   "currencyCode": "CHF",
   "chargePaymentDetailId": "3f852b0b-…",
@@ -1146,7 +1147,12 @@ Content-Type: application/json
             Take <code>effectiveUnitAmountMinor</code> from the response rather than multiplying
             <code>unitAmountMinor</code> by the band's percentage. The subscription's own discount,
             the plan's combination policy and this module's rounding all move it, so a figure
-            derived in a client can disagree with the charge it is about to confirm.
+            derived in a client can disagree with the charge it is about to confirm. It is stated
+            <strong>before tax</strong> and is <code>null</code> for a flat-fee price, where nothing
+            is sold by the unit — label it "each" only when it is present.
+            <code>nextRenewalAmountMinor</code> is the tax-inclusive total and
+            <code>taxAmountMinor</code> is the tax inside it; adding tax to a per-unit figure
+            instead produces a unit price above the list price on a plan that is discounting.
             <code>promotionApplied</code> says whether a promotional discount is part of these
             numbers. Both the preview and the update accept <code>organizationId</code>, honoured
             only for a console caller acting on another organization&apos;s behalf — and the

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1136,10 +1136,22 @@ Content-Type: application/json
   "targetTier": { "minimumQuantity": 5, "maximumQuantity": 9, "discountBasisPoints": 500 },
   "proratedChargeMinor": 5437,
   "nextRenewalAmountMinor": 68875,
+  "effectiveUnitAmountMinor": 13775,
+  "promotionApplied": false,
   "currencyCode": "CHF",
   "chargePaymentDetailId": "3f852b0b-…",
   "pendingQuantityChange": null
 }</code></pre>
+          <p class="prose">
+            Take <code>effectiveUnitAmountMinor</code> from the response rather than multiplying
+            <code>unitAmountMinor</code> by the band's percentage. The subscription's own discount,
+            the plan's combination policy and this module's rounding all move it, so a figure
+            derived in a client can disagree with the charge it is about to confirm.
+            <code>promotionApplied</code> says whether a promotional discount is part of these
+            numbers. Both the preview and the update accept <code>organizationId</code>, honoured
+            only for a console caller acting on another organization&apos;s behalf — and the
+            withdrawal takes the same value as a query parameter.
+          </p>
           <h4>Returns</h4>
           <p>
             <code>200</code> · <code>400</code> invalid quantity, unchanged quantity, or an item

--- a/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
+++ b/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
@@ -45,21 +45,30 @@ public sealed class QuantityChangeResponse
     public long NextRenewalAmountMinor { get; init; }
 
     /// <summary>
-    /// What one unit costs at the new quantity, after everything that reduces the charge.
+    /// What one unit costs at the new quantity, after every reduction and <em>before</em> tax.
+    /// Null when the price is a flat fee.
     /// </summary>
     /// <remarks>
-    /// Stated here because it cannot be derived from the unit amount and the band alone. The
+    /// Stated here because it cannot be derived from the unit amount and the band alone: the
     /// promotion on the subscription, the plan's combination policy and this module's rounding all
     /// move it, and a client that multiplies a percentage against the list price shows a figure
-    /// that disagrees with what it is about to charge — immediately before asking someone to
-    /// confirm a payment.
+    /// that disagrees with what it is about to charge.
     /// <para>
-    /// Derived from <see cref="NextRenewalAmountMinor"/>, so the two cannot disagree: it is that
-    /// figure divided by the units it charges for. A flat-fee price has no units to divide by and
-    /// reports the price's own amount.
+    /// Before tax, deliberately. Tax is a proportion of the whole charge rather than a property of
+    /// a unit, and folding it in produced a "per unit" figure <em>above</em> the list price on a
+    /// screen that also said "5% off" — arithmetic nobody could follow.
+    /// <see cref="TaxAmountMinor"/> carries it instead.
+    /// </para>
+    /// <para>
+    /// Null rather than the plan's fee where the price has no quantity item. A flat fee is not sold
+    /// by the unit, and a plan that merely tracks a free quantity item would otherwise report its
+    /// whole fee as the price of each one.
     /// </para>
     /// </remarks>
-    public long EffectiveUnitAmountMinor { get; init; }
+    public long? EffectiveUnitAmountMinor { get; init; }
+
+    /// <summary>The tax inside <see cref="NextRenewalAmountMinor"/>, which is tax-inclusive.</summary>
+    public long TaxAmountMinor { get; init; }
 
     /// <summary>
     /// Whether a promotional discount is part of the figures above, so a client can say why the

--- a/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
+++ b/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
@@ -44,6 +44,29 @@ public sealed class QuantityChangeResponse
     /// <summary>What the next renewal will charge at the new quantity and band.</summary>
     public long NextRenewalAmountMinor { get; init; }
 
+    /// <summary>
+    /// What one unit costs at the new quantity, after everything that reduces the charge.
+    /// </summary>
+    /// <remarks>
+    /// Stated here because it cannot be derived from the unit amount and the band alone. The
+    /// promotion on the subscription, the plan's combination policy and this module's rounding all
+    /// move it, and a client that multiplies a percentage against the list price shows a figure
+    /// that disagrees with what it is about to charge — immediately before asking someone to
+    /// confirm a payment.
+    /// <para>
+    /// Derived from <see cref="NextRenewalAmountMinor"/>, so the two cannot disagree: it is that
+    /// figure divided by the units it charges for. A flat-fee price has no units to divide by and
+    /// reports the price's own amount.
+    /// </para>
+    /// </remarks>
+    public long EffectiveUnitAmountMinor { get; init; }
+
+    /// <summary>
+    /// Whether a promotional discount is part of the figures above, so a client can say why the
+    /// unit price is below the band's own arithmetic rather than leaving it unexplained.
+    /// </summary>
+    public bool PromotionApplied { get; init; }
+
     public string CurrencyCode { get; init; } = string.Empty;
 
     /// <summary>The payment taken for an applied increase. Null on a preview or a decrease.</summary>

--- a/server/Subscription.DomainService/Services/QuantityDiscountCalculator.cs
+++ b/server/Subscription.DomainService/Services/QuantityDiscountCalculator.cs
@@ -95,6 +95,31 @@ public static class QuantityDiscountCalculator
 
         return Resolve(tiers, unitAmount, held.Sum(item => item.Quantity));
     }
+
+    /// <summary>
+    /// The units this price actually charges for — those matching its quantity item.
+    /// </summary>
+    /// <remarks>
+    /// Zero for a flat fee, which has no quantity to charge by. Shared with the change service so
+    /// "which units carry money" is answered once: two answers to that question is how a free item
+    /// comes to outvote a priced one.
+    /// </remarks>
+    public static long PricedUnits(
+        PriceSnapshot price,
+        IReadOnlyList<SubscriptionQuantityItem> quantityItems)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+        ArgumentNullException.ThrowIfNull(quantityItems);
+
+        return string.IsNullOrWhiteSpace(price.QuantityItemKey)
+            ? 0
+            : quantityItems
+                .Where(item => string.Equals(
+                    item.ItemKey,
+                    price.QuantityItemKey,
+                    StringComparison.Ordinal))
+                .Sum(item => item.Quantity);
+    }
 }
 
 /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -261,8 +261,8 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
         // already paid for. A change that moves only free items reaches IncreaseAsync, prices at
         // zero and applies at once, which is what an increase costing nothing should do.
         var direction =
-            PricedUnits(target, subscription.Price)
-                .CompareTo(PricedUnits(effective, subscription.Price));
+            QuantityDiscountCalculator.PricedUnits(subscription.Price, target)
+                .CompareTo(QuantityDiscountCalculator.PricedUnits(subscription.Price, effective));
 
         return direction < 0
             ? await DecreaseAsync(
@@ -685,18 +685,6 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
     /// The units the recurring amount is actually calculated from — those matching the price's
     /// quantity item. Zero for a flat-fee price, where no quantity moves any money at all.
     /// </summary>
-    private static long PricedUnits(
-        IReadOnlyList<SubscriptionQuantityItem> items,
-        PriceSnapshot price) =>
-        string.IsNullOrWhiteSpace(price.QuantityItemKey)
-            ? 0
-            : items
-                .Where(item => string.Equals(
-                    item.ItemKey,
-                    price.QuantityItemKey,
-                    StringComparison.Ordinal))
-                .Sum(item => item.Quantity);
-
     private QuantityChangeResponse Describe(
         SubscriptionDetail subscription,
         List<SubscriptionQuantityItem> target,
@@ -738,9 +726,33 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
             TargetTier = QuantityResponseMapper.Tier(next.Tier),
             ProratedChargeMinor = proratedChargeMinor,
             NextRenewalAmountMinor = renewal.AmountMinor,
+            EffectiveUnitAmountMinor = EffectiveUnitAmount(subscription, target, renewal),
+            PromotionApplied = renewal.DiscountApplied,
             ChargePaymentDetailId = paymentDetailId,
             PendingQuantityChange = QuantityResponseMapper.Pending(pending)
         };
+    }
+
+    /// <summary>
+    /// What one unit costs at the target quantity, taken from the charge rather than recomputed.
+    /// </summary>
+    /// <remarks>
+    /// The period amount already carries the band, the promotion, the combination policy and this
+    /// module's rounding. Dividing it is the only way to state a unit price that cannot disagree
+    /// with the total beside it — and disagreeing with the total, on a confirmation screen, is
+    /// worse than showing no unit price at all.
+    /// </remarks>
+    private static long EffectiveUnitAmount(
+        SubscriptionDetail subscription,
+        List<SubscriptionQuantityItem> target,
+        PeriodCharge renewal)
+    {
+        var units = QuantityDiscountCalculator.PricedUnits(subscription.Price, target);
+
+        return units > 0
+            ? (long)Math.Round((decimal)renewal.AmountMinor / units, MidpointRounding.AwayFromZero)
+            // A flat fee is not sold by the unit, so the price's own amount is the honest answer.
+            : subscription.Price.UnitAmountMinor;
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -708,10 +708,9 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
 
         // What the next renewal charges, priced through the same path the renewal itself uses so
         // the figure shown cannot drift from the figure taken.
+        var now = _time.GetUtcNow().UtcDateTime;
         var atTarget = CloneAtQuantities(subscription, target);
-        var renewal = SubscriptionAmountCalculator.PeriodAmountMinor(
-            atTarget,
-            _time.GetUtcNow().UtcDateTime);
+        var renewal = SubscriptionAmountCalculator.PeriodAmountMinor(atTarget, now);
 
         return new QuantityChangeResponse
         {
@@ -726,7 +725,8 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
             TargetTier = QuantityResponseMapper.Tier(next.Tier),
             ProratedChargeMinor = proratedChargeMinor,
             NextRenewalAmountMinor = renewal.AmountMinor,
-            EffectiveUnitAmountMinor = EffectiveUnitAmount(subscription, target, renewal),
+            EffectiveUnitAmountMinor = EffectiveUnitAmount(atTarget, now),
+            TaxAmountMinor = renewal.TaxAmountMinor,
             PromotionApplied = renewal.DiscountApplied,
             ChargePaymentDetailId = paymentDetailId,
             PendingQuantityChange = QuantityResponseMapper.Pending(pending)
@@ -734,25 +734,39 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
     }
 
     /// <summary>
-    /// What one unit costs at the target quantity, taken from the charge rather than recomputed.
+    /// What one unit costs at the target quantity, before tax, or nothing where units do not price
+    /// the subscription at all.
     /// </summary>
     /// <remarks>
-    /// The period amount already carries the band, the promotion, the combination policy and this
-    /// module's rounding. Dividing it is the only way to state a unit price that cannot disagree
-    /// with the total beside it — and disagreeing with the total, on a confirmation screen, is
-    /// worse than showing no unit price at all.
+    /// Taken from the same calculation the charge comes from, one step earlier: after the band, the
+    /// promotion and the combination policy, but before tax is added to the whole. Divided out of
+    /// the tax-inclusive total instead, a 5% band on a taxed price reported a unit costing
+    /// <em>more</em> than the undiscounted list price.
+    /// <para>
+    /// Null for a flat fee, so a caller cannot print the plan's whole price as the cost of each of
+    /// something it tracks for free.
+    /// </para>
     /// </remarks>
-    private static long EffectiveUnitAmount(
-        SubscriptionDetail subscription,
-        List<SubscriptionQuantityItem> target,
-        PeriodCharge renewal)
+    private static long? EffectiveUnitAmount(SubscriptionDetail atTarget, DateTime nowUtc)
     {
-        var units = QuantityDiscountCalculator.PricedUnits(subscription.Price, target);
+        var units = QuantityDiscountCalculator.PricedUnits(atTarget.Price, atTarget.QuantityItems);
 
-        return units > 0
-            ? (long)Math.Round((decimal)renewal.AmountMinor / units, MidpointRounding.AwayFromZero)
-            // A flat fee is not sold by the unit, so the price's own amount is the honest answer.
-            : subscription.Price.UnitAmountMinor;
+        if (units <= 0)
+        {
+            return null;
+        }
+
+        // The pre-tax figure behind the same renewal amount, so the two agree to the currency's
+        // last unit once tax is added back.
+        var beforeTax = SubscriptionAmountCalculator.DiscountedAmountMinor(
+            atTarget.Plan,
+            atTarget.Discount,
+            atTarget.Price,
+            atTarget.QuantityItems,
+            atTarget.DiscountPeriodsApplied,
+            nowUtc);
+
+        return (long)Math.Round((decimal)beforeTax.AmountMinor / units, MidpointRounding.AwayFromZero);
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
@@ -193,14 +193,38 @@ public sealed class SubscriptionQuantityChangeServiceTests
     }
 
     [Fact]
-    public async Task A_flat_fee_price_reports_its_own_amount_as_the_unit_price()
+    public async Task A_flat_fee_price_states_no_unit_price_at_all()
     {
-        // Nothing to divide by: a flat fee is not sold by the unit, and zero would be a lie.
+        // Nothing is sold by the unit here. Reporting the plan's whole fee would have a client
+        // print it as the cost of each of something the plan merely tracks for free.
         _subscription.Price.QuantityItemKey = string.Empty;
 
         var result = await Service().PreviewAsync("sub-1", Request(5), "corr-1", default);
 
-        result.Value!.EffectiveUnitAmountMinor.Should().Be(UnitAmount);
+        result.Value!.EffectiveUnitAmountMinor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task The_unit_price_is_stated_before_tax_and_the_tax_beside_it()
+    {
+        // Divided out of the tax-inclusive total, a 5% band on an 8% taxed price reported CHF
+        // 148.77 a unit — more than the undiscounted CHF 145 list price, on a card that also said
+        // the band took 5% off.
+        _subscription.Price.TaxRateBasisPoints = 800;
+
+        var result = await Service().PreviewAsync("sub-1", Request(5), "corr-1", default);
+
+        result.Value!.EffectiveUnitAmountMinor.Should().Be(13_775);
+        result.Value.TaxAmountMinor.Should().Be(5_510);
+        result.Value.NextRenewalAmountMinor.Should().Be(74_385, "the total is tax-inclusive");
+    }
+
+    [Fact]
+    public async Task An_untaxed_price_states_no_tax()
+    {
+        var result = await Service().PreviewAsync("sub-1", Request(5), "corr-1", default);
+
+        result.Value!.TaxAmountMinor.Should().Be(0);
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
@@ -160,6 +160,50 @@ public sealed class SubscriptionQuantityChangeServiceTests
     }
 
     [Fact]
+    public async Task The_quote_states_the_unit_price_rather_than_leaving_it_to_be_derived()
+    {
+        var result = await Service().PreviewAsync("sub-1", Request(5), "corr-1", default);
+
+        // CHF 688.75 for five users, so CHF 137.75 each. Taken from the period total rather than
+        // recomputed, so the two figures on a confirmation screen cannot disagree.
+        result.Value!.NextRenewalAmountMinor.Should().Be(68_875);
+        result.Value.EffectiveUnitAmountMinor.Should().Be(13_775);
+        result.Value.PromotionApplied.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task The_unit_price_reflects_a_promotion_the_band_arithmetic_knows_nothing_about()
+    {
+        // The reason a client must not compute this. A percentage applied to the list price gives
+        // CHF 137.75 a unit; the plan's BestDiscount policy takes the larger reduction instead, so
+        // the real figure is CHF 116.00 — and a screen showing 137.75 would be quoting a number
+        // nobody is about to be charged.
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "LAUNCH20",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_000
+        };
+
+        var result = await Service().PreviewAsync("sub-1", Request(5), "corr-1", default);
+
+        result.Value!.NextRenewalAmountMinor.Should().Be(58_000);
+        result.Value.EffectiveUnitAmountMinor.Should().Be(11_600);
+        result.Value.PromotionApplied.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_flat_fee_price_reports_its_own_amount_as_the_unit_price()
+    {
+        // Nothing to divide by: a flat fee is not sold by the unit, and zero would be a lie.
+        _subscription.Price.QuantityItemKey = string.Empty;
+
+        var result = await Service().PreviewAsync("sub-1", Request(5), "corr-1", default);
+
+        result.Value!.EffectiveUnitAmountMinor.Should().Be(UnitAmount);
+    }
+
+    [Fact]
     public async Task An_increase_is_reserved_then_charged_then_granted()
     {
         await Service().ChangeAsync("sub-1", Request(5), "corr-1", default);


### PR DESCRIPTION
Closes #267.

The quantity endpoints have been callable since the volume-band work landed, but only by hand. The subscriber portal could start a subscription, change its plan and cancel it — and had nothing for moving the number of units it had bought.

## Endpoint note

The ticket names `PUT /api/subscriptions/{id}/quantity` with `preview=true`. That route does not exist; there are three:

| Ticket | Actual |
| --- | --- |
| `PUT .../quantity?preview=true` | `POST .../quantities/preview` |
| `PUT .../quantity` | `PUT .../quantities` |
| — | `DELETE .../quantities/pending` |

Built against the real API. The separate preview endpoint serves the ticket's intent better anyway: it shares a request body with the apply, so what a subscriber is quoted is exactly what confirm sends.

## What it does

**Quantity in, band out.** The subscriber names a quantity; the server decides the band. A client that named a band would be naming a price the plan may not agree to.

- The dialog opens on the quantities in force, the band they select, and what the period currently costs.
- **Preview** quotes the target band, its discount, the effective unit price, what is owed now, the next renewal amount, and whether the change is immediate or scheduled.
- **Confirm is disabled until a preview exists, and editing a quantity discards the quote.** A confirmation that outlives its figures is a confirmation of numbers nobody saw.
- A decrease is labelled as scheduled, dated, and says plainly that nothing is refunded and the units stay until the period ends.
- The subscription card shows the band in force, any booked reduction with its effective date, and offers to withdraw it. Without that last part a reload showed the larger quantity with nothing to say a smaller one was coming.

## Failures are told apart, because they are not alike

`SubscriptionOperationError` keeps the server's error code. It is recognised from a known list rather than read from a fixed path, because `HttpError` exposes `errors` rather than the response body — a code read from the wrong place silently becomes `unknown`.

That matters most for one pair:

| Outcome | What the subscriber is told |
| --- | --- |
| `subscription_quantity_charge_failed` | The card declined. **Nothing changed** — retry is safe. |
| `subscription_quantity_charge_unresolved` | The provider never answered. **Do not try again** — reload in a few minutes. Confirm stays disabled. |

The second is the one that must never read as a decline: the settlement reservation is still holding and the money may already have moved. A stale version and a settlement already in flight both re-read the subscription and ask for a fresh preview.

## Verification

- `npm run type-check` — clean
- `npx eslint app/cross-modules/utilities/subscription-simulation/**` — clean
- **13 new dialog tests**: preview figures, request shape (quantity and version, never a band), confirm gated on a preview, quote discarded on edit, applied increase, scheduled decrease, already-booked reduction, stale-version retry, decline, unresolved charge, settlement in flight, and two local validation refusals

The full client suite was still running when this was opened; I will report its result. Its only known failures on `dev` are five test files that fail to load on an SVG asset error, unrelated to this module.

## Not covered

No end-to-end run against live Stripe: 4 → 5 users previewing and charging the 5–9 band, a decrease landing at the period boundary, and a forced timeout to see the unresolved path. That is acceptance items 1–4 against a real provider, and it needs the dev environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)