### PR TITLE
feat(subscription): add traceable financial lifecycle audit

### DIFF
--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -6,6 +6,8 @@ using Payment.DomainService.Responses;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Services;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Repositories;
 
 namespace Api.Controllers;
 
@@ -29,6 +31,9 @@ public sealed class SubscriptionsController : ControllerBase
     private readonly ISubscriptionInvoiceDocumentService _invoiceDocuments;
     private readonly ISubscriptionQuantityChangeService _quantityChange;
     private readonly ISubscriptionInvoiceHistoryService _invoiceHistory;
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly ISubscriptionAuditTrail _audit;
+    private readonly ISubscriptionAuditRepository _auditRepository;
 
     public SubscriptionsController(
         ISubscriptionCheckoutService checkout,
@@ -36,7 +41,10 @@ public sealed class SubscriptionsController : ControllerBase
         ISubscriptionPlanChangeService planChange,
         ISubscriptionInvoiceDocumentService invoiceDocuments,
         ISubscriptionInvoiceHistoryService invoiceHistory,
-        ISubscriptionQuantityChangeService quantityChange)
+        ISubscriptionQuantityChangeService quantityChange,
+        ISubscriptionContextResolver contextResolver,
+        ISubscriptionAuditTrail audit,
+        ISubscriptionAuditRepository auditRepository)
     {
         _checkout = checkout;
         _cancellation = cancellation;
@@ -44,6 +52,9 @@ public sealed class SubscriptionsController : ControllerBase
         _invoiceDocuments = invoiceDocuments;
         _invoiceHistory = invoiceHistory;
         _quantityChange = quantityChange;
+        _contextResolver = contextResolver;
+        _audit = audit;
+        _auditRepository = auditRepository;
     }
 
     [HttpPost]
@@ -62,6 +73,10 @@ public sealed class SubscriptionsController : ControllerBase
             request,
             correlationId,
             cancellationToken);
+
+        await AuditAsync("Subscribe", request.OrganizationId, result.Value?.SubscriptionId,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            result.Value?.RecurringAmountMinor, result.Value?.CurrencyCode, cancellationToken);
 
         return result.ToActionResult(correlationId);
     }
@@ -124,6 +139,10 @@ public sealed class SubscriptionsController : ControllerBase
             correlationId,
             cancellationToken);
 
+        await AuditAsync("Cancel", organizationId, subscriptionId, result.IsSuccess,
+            result.ErrorCode, result.FailureKind.ToString(), correlationId, null, null,
+            cancellationToken);
+
         return result.ToActionResult(correlationId);
     }
 
@@ -154,6 +173,10 @@ public sealed class SubscriptionsController : ControllerBase
             correlationId,
             cancellationToken);
 
+        await AuditAsync("ChangePlan", request.OrganizationId, subscriptionId, result.IsSuccess,
+            result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            result.Value?.RecurringAmountMinor, result.Value?.CurrencyCode, cancellationToken);
+
         return result.ToActionResult(correlationId);
     }
 
@@ -183,6 +206,10 @@ public sealed class SubscriptionsController : ControllerBase
             request,
             correlationId,
             cancellationToken);
+
+        await AuditAsync("PreviewQuantityChange", request.OrganizationId, subscriptionId,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            result.Value?.ProratedChargeMinor, result.Value?.CurrencyCode, cancellationToken);
 
         return result.ToActionResult(correlationId);
     }
@@ -223,6 +250,11 @@ public sealed class SubscriptionsController : ControllerBase
             correlationId,
             cancellationToken);
 
+        await AuditAsync("ChangeQuantity", request.OrganizationId, subscriptionId,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            result.Value?.ProratedChargeMinor, result.Value?.CurrencyCode, cancellationToken,
+            result.Value?.ChargePaymentDetailId);
+
         return result.ToActionResult(correlationId);
     }
 
@@ -247,7 +279,101 @@ public sealed class SubscriptionsController : ControllerBase
             correlationId,
             cancellationToken);
 
+        await AuditAsync("CancelPendingQuantityChange", organizationId, subscriptionId,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            null, null, cancellationToken);
+
         return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>Returns the immutable lifecycle trail used to investigate this subscription.</summary>
+    /// <remarks>
+    /// Results are tenant- and organization-scoped. They intentionally omit actor identifiers,
+    /// payment identifiers and all provider/customer secrets.
+    /// </remarks>
+    [HttpGet("{subscriptionId}/audit")]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<SubscriptionAuditEventResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetAuditTrail(
+        string subscriptionId,
+        [FromQuery] string? organizationId,
+        [FromQuery] int limit,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, organizationId, cancellationToken);
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return resolution.ToFailure<IReadOnlyList<SubscriptionAuditEventResponse>>(correlationId)
+                .ToActionResult(correlationId);
+        }
+
+        var context = resolution.Context;
+        var events = await _auditRepository.ListAsync(
+            context.TenantId, context.OrganizationId, subscriptionId,
+            limit <= 0 ? 100 : limit, cancellationToken);
+
+        var response = events.Select(x => new SubscriptionAuditEventResponse
+        {
+            EventId = x.ItemId,
+            OperationId = x.OperationId,
+            CorrelationId = x.CorrelationId,
+            Operation = x.Operation,
+            Stage = x.Stage,
+            Outcome = x.Outcome,
+            Source = x.Source,
+            AmountMinor = x.AmountMinor,
+            CurrencyCode = x.CurrencyCode,
+            FromStatus = x.FromStatus,
+            ToStatus = x.ToStatus,
+            ErrorCode = x.ErrorCode,
+            FailureKind = x.FailureKind,
+            Attempt = x.Attempt,
+            OccurredAtUtc = x.OccurredAtUtc
+        }).ToList();
+
+        return SubscriptionOperationResult<IReadOnlyList<SubscriptionAuditEventResponse>>
+            .Success(response, correlationId).ToActionResult(correlationId);
+    }
+
+    private async Task AuditAsync(
+        string operation,
+        string? requestedOrganizationId,
+        string? subscriptionId,
+        bool success,
+        string? errorCode,
+        string failureKind,
+        string correlationId,
+        long? amountMinor,
+        string? currencyCode,
+        CancellationToken cancellationToken,
+        string? paymentDetailId = null)
+    {
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, requestedOrganizationId, cancellationToken);
+        if (!resolution.IsSuccess || resolution.Context is null) return;
+
+        var context = resolution.Context;
+        await _audit.RecordAsync(new SubscriptionAuditEvent
+        {
+            TenantId = context.TenantId,
+            OrganizationId = context.OrganizationId,
+            SubscriptionId = subscriptionId,
+            OperationId = correlationId,
+            CorrelationId = correlationId,
+            Operation = operation,
+            Stage = "Completed",
+            Outcome = success ? "Succeeded" : "Rejected",
+            Source = "Api",
+            ActorId = context.ActorId,
+            UserId = context.UserId,
+            PaymentDetailId = paymentDetailId,
+            AmountMinor = amountMinor,
+            CurrencyCode = currencyCode,
+            ErrorCode = errorCode,
+            FailureKind = success ? null : failureKind
+        }, cancellationToken);
     }
 
     /// <summary>

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1879,6 +1879,40 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       </p>
     </section>
 
+    <section id="financial-observability">
+      <h2>Financial operation tracing and audit</h2>
+      <p>Every subscription command returns <code>X-Correlation-ID</code>. Keep it with support
+        reports: it joins the API request to structured logs. Worker retries use a stable
+        <code>operationId</code>, so all attempts for one renewal remain on one timeline.</p>
+      <div class="endpoint">
+        <span class="method get">GET</span>
+        <code>/api/subscriptions/{subscriptionId}/audit?limit=100</code>
+      </div>
+      <p>Returns the authenticated organization's newest audit events (maximum 500): operation,
+        stage, outcome, source, attempt, amount/currency, status transition, error code,
+        correlation ID and occurrence time. It never returns actor IDs, payment IDs, card data,
+        provider customer IDs, checkout URLs or secrets.</p>
+      <pre><code>{
+  "success": true,
+  "data": [{
+    "eventId": "...",
+    "operationId": "renewal:subscription-id:period",
+    "correlationId": "...",
+    "operation": "Renewal",
+    "stage": "ChargeCompleted",
+    "outcome": "Succeeded",
+    "source": "Worker",
+    "amountMinor": 14500,
+    "currencyCode": "CHF",
+    "attempt": 1,
+    "occurredAtUtc": "2026-09-01T00:00:03Z"
+  }]
+}</code></pre>
+      <p>The audit collection is append-only and has no automatic expiry. Operational logs hash
+        identifiers; the restricted audit database retains real IDs for investigations. Alert on
+        <code>SUBSCRIPTION_AUDIT_WRITE_FAILED</code>: audit failure does not fail an already-completed
+        charge because that could cause a duplicate retry.</p>
+    </section>
   </main>
 
   <footer>

--- a/server/Subscription.DomainService/Entities/SubscriptionAuditEvent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionAuditEvent.cs
@@ -1,0 +1,32 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>An immutable, security-sensitive record of one subscription lifecycle step.</summary>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionAuditEvent
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString("N");
+    public string TenantId { get; set; } = string.Empty;
+    public string OrganizationId { get; set; } = string.Empty;
+    public string? SubscriptionId { get; set; }
+    public string OperationId { get; set; } = string.Empty;
+    public string CorrelationId { get; set; } = string.Empty;
+    public string Operation { get; set; } = string.Empty;
+    public string Stage { get; set; } = string.Empty;
+    public string Outcome { get; set; } = string.Empty;
+    public string Source { get; set; } = string.Empty;
+    public string? ActorId { get; set; }
+    public string? UserId { get; set; }
+    public string? PaymentDetailId { get; set; }
+    public long? AmountMinor { get; set; }
+    public string? CurrencyCode { get; set; }
+    public string? FromStatus { get; set; }
+    public string? ToStatus { get; set; }
+    public string? ErrorCode { get; set; }
+    public string? FailureKind { get; set; }
+    public int? Attempt { get; set; }
+    public long? DurationMs { get; set; }
+    public DateTime OccurredAtUtc { get; set; } = DateTime.UtcNow;
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -8,6 +8,7 @@ using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Services;
 
 namespace Subscription.DomainService.Outbox;
 
@@ -46,6 +47,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<SubscriptionActivationProcessor> _logger;
     private readonly TimeProvider _time;
+    private readonly ISubscriptionAuditTrail? _audit;
 
     public SubscriptionActivationProcessor(
         ISubscriptionPaymentLinkRepository links,
@@ -56,7 +58,8 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         IStoredPaymentMethodRepository storedMethods,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<SubscriptionActivationProcessor> logger,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        ISubscriptionAuditTrail? audit = null)
     {
         _links = links;
         _subscriptions = subscriptions;
@@ -67,6 +70,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
+        _audit = audit;
     }
 
     public async Task<int> ProcessDueAsync(
@@ -178,6 +182,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             ["SubscriptionHash"] = PaymentLogValue.Hash(link.SubscriptionId),
             ["CorrelationId"] = link.CorrelationId
         });
+        await AuditAsync(link, "SettlementStarted", "InProgress", null, cancellationToken);
 
         var payment = await _payments.GetByIdAsync(
             link.TenantId,
@@ -187,18 +192,25 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         if (payment is null)
         {
             await RescheduleAsync(link, options, now, "payment_not_found", cancellationToken);
+            await AuditAsync(link, "PaymentRead", "Deferred", "payment_not_found", cancellationToken);
 
             return false;
         }
 
         if (IsConfirmed(payment))
         {
-            return await ActivateAsync(link, payment, cancellationToken);
+            var activated = await ActivateAsync(link, payment, cancellationToken);
+            await AuditAsync(link, "ActivationApplied", activated ? "Succeeded" : "Deferred",
+                activated ? null : "activation_state_conflict", cancellationToken);
+            return activated;
         }
 
         if (TerminalFailureStatuses.Contains(payment.PaymentStatus, StringComparer.Ordinal))
         {
-            return await AbandonAsync(link, cancellationToken);
+            var abandoned = await AbandonAsync(link, cancellationToken);
+            await AuditAsync(link, "PaymentConfirmed", "Failed",
+                payment.PaymentStatus, cancellationToken);
+            return abandoned;
         }
 
         await RescheduleAsync(
@@ -207,9 +219,32 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             now,
             $"awaiting_confirmation:{PaymentLogValue.Label(payment.PaymentStatus)}",
             cancellationToken);
+        await AuditAsync(link, "PaymentConfirmation", "Deferred",
+            payment.PaymentStatus, cancellationToken);
 
         return false;
     }
+
+    private Task AuditAsync(
+        SubscriptionPaymentLink link,
+        string stage,
+        string outcome,
+        string? errorCode,
+        CancellationToken cancellationToken) =>
+        _audit is null ? Task.CompletedTask : _audit.RecordAsync(new SubscriptionAuditEvent
+        {
+            TenantId = link.TenantId,
+            OrganizationId = link.OrganizationId,
+            SubscriptionId = link.SubscriptionId,
+            OperationId = $"activation:{link.SubscriptionId}",
+            CorrelationId = link.CorrelationId,
+            Operation = "InitialPaymentActivation",
+            Stage = stage,
+            Outcome = outcome,
+            Source = "Worker",
+            PaymentDetailId = link.PaymentDetailId,
+            ErrorCode = errorCode
+        }, cancellationToken);
 
     /// <summary>
     /// Confirmed means both an accepting status <em>and</em> a webhook that said so.

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -32,6 +32,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<SubscriptionUsageRatingProcessor> _logger;
     private readonly TimeProvider _time;
+    private readonly ISubscriptionAuditTrail? _audit;
 
     public SubscriptionUsageRatingProcessor(
         ISubscriptionRepository subscriptions,
@@ -42,7 +43,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         ISubscriptionOutboxEventFactory events,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<SubscriptionUsageRatingProcessor> logger,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        ISubscriptionAuditTrail? audit = null)
     {
         _subscriptions = subscriptions;
         _usage = usage;
@@ -53,6 +55,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
+        _audit = audit;
     }
 
     public async Task<int> CloseDuePeriodsAsync(
@@ -78,11 +81,35 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 ["SubscriptionHash"] = PaymentLogValue.Hash(subscription.ItemId)
             });
 
-            closed += await CloseSubscriptionAsync(subscription, now, cancellationToken);
+            await AuditAsync(subscription, "RatingStarted", "InProgress", cancellationToken);
+            var subscriptionPeriodsClosed = await CloseSubscriptionAsync(
+                subscription, now, cancellationToken);
+            closed += subscriptionPeriodsClosed;
+            await AuditAsync(subscription, "PeriodsClosed",
+                subscriptionPeriodsClosed > 0 ? "Succeeded" : "NoOp", cancellationToken);
         }
 
         return closed;
     }
+
+    private Task AuditAsync(
+        SubscriptionDetail subscription,
+        string stage,
+        string outcome,
+        CancellationToken cancellationToken) =>
+        _audit is null ? Task.CompletedTask : _audit.RecordAsync(new SubscriptionAuditEvent
+        {
+            TenantId = subscription.TenantId,
+            OrganizationId = subscription.OrganizationId,
+            SubscriptionId = subscription.ItemId,
+            OperationId = $"usage-rating:{subscription.ItemId}:{subscription.CurrentUsagePeriodEndUtc:O}",
+            CorrelationId = subscription.CorrelationId,
+            Operation = "UsageRating",
+            Stage = stage,
+            Outcome = outcome,
+            Source = "Worker",
+            CurrencyCode = subscription.CurrencyCode
+        }, cancellationToken);
 
     private async Task<int> CloseSubscriptionAsync(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -562,6 +562,30 @@ mistake reaches a customer who has already chosen a plan.
 
 ## Before the first tenant goes live
 
+## Financial observability and audit
+
+Every subscription command and every renewal charge writes the same structured lifecycle
+vocabulary: `OperationId`, `CorrelationId`, operation, stage, outcome, source, attempt, amount and
+currency. Request correlation IDs connect API logs to the response's `X-Correlation-ID`; renewal
+operation IDs are stable across worker retries, so a retry is one timeline rather than an
+unrelated incident.
+
+Operational logs hash tenant, organization and subscription identifiers. The append-only
+`SubscriptionAuditEvents` collection keeps the real tenant-scoped identifiers needed to
+investigate a financial dispute. It has no TTL and exposes no update/delete operation. Neither
+store may contain card data, stored-payment-method IDs, provider customer IDs, checkout URLs,
+access tokens, webhook bodies or secrets.
+
+`GET /api/subscriptions/{subscriptionId}/audit?limit=100` returns the caller's organization-scoped,
+sanitized timeline. Actor and payment identifiers remain restricted to the database. Audit writes
+are deliberately fail-open after a business operation: an unavailable audit store emits the
+critical marker `SUBSCRIPTION_AUDIT_WRITE_FAILED`, but never makes a caller retry money movement.
+Alert on that marker; the payment and subscription ledgers remain the reconciliation source.
+
+Audit records answer who/what/when and the resulting state. Structured logs answer how the code
+got there, including exceptions and timing. Both are required: ordinary logs are mutable and
+retention-bound, while an audit trail alone is intentionally too small to debug execution.
+
 Provision the tenant-level payment key ring — `payment-keyring-{tenantSlug}` via
 `scripts/payment-key-vault/Provision-PaymentKeyRing.ps1`. Provider registration fails closed
 without one.

--- a/server/Subscription.DomainService/Repositories/ISubscriptionAuditRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionAuditRepository.cs
@@ -1,0 +1,15 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionAuditRepository
+{
+    Task AppendAsync(SubscriptionAuditEvent auditEvent, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SubscriptionAuditEvent>> ListAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionAuditRepository : ISubscriptionAuditRepository
+{
+    private readonly IDbContextProvider _db;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionAuditRepository(IDbContextProvider db) => _db = db;
+
+    public async Task AppendAsync(SubscriptionAuditEvent auditEvent, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(auditEvent);
+        await EnsureIndexesAsync(auditEvent.TenantId, cancellationToken);
+        await Events(auditEvent.TenantId).InsertOneAsync(auditEvent, cancellationToken: cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SubscriptionAuditEvent>> ListAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Events(tenantId)
+            .Find(Builders<SubscriptionAuditEvent>.Filter.And(
+                Builders<SubscriptionAuditEvent>.Filter.Eq(x => x.TenantId, tenantId),
+                Builders<SubscriptionAuditEvent>.Filter.Eq(x => x.OrganizationId, organizationId),
+                Builders<SubscriptionAuditEvent>.Filter.Eq(x => x.SubscriptionId, subscriptionId)))
+            .SortByDescending(x => x.OccurredAtUtc)
+            .Limit(Math.Clamp(limit, 1, 500))
+            .ToListAsync(cancellationToken);
+
+    private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId)) return;
+
+        await Events(tenantId).Indexes.CreateManyAsync([
+            new CreateIndexModel<SubscriptionAuditEvent>(
+                Builders<SubscriptionAuditEvent>.IndexKeys
+                    .Ascending(x => x.TenantId).Ascending(x => x.OrganizationId)
+                    .Ascending(x => x.SubscriptionId).Descending(x => x.OccurredAtUtc),
+                new CreateIndexOptions { Name = "ix_subscription_audit_timeline" }),
+            new CreateIndexModel<SubscriptionAuditEvent>(
+                Builders<SubscriptionAuditEvent>.IndexKeys
+                    .Ascending(x => x.TenantId).Ascending(x => x.OperationId)
+                    .Ascending(x => x.OccurredAtUtc),
+                new CreateIndexOptions { Name = "ix_subscription_audit_operation" })
+        ], cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    private IMongoCollection<SubscriptionAuditEvent> Events(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionAuditEvent>(_db, tenantId, SubscriptionCollections.AuditEvents);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -22,6 +22,7 @@ internal static class SubscriptionCollections
     public const string UsageCounters = "SubscriptionUsageCounters";
     public const string PaymentLinks = "SubscriptionPaymentLinks";
     public const string UsageInvoices = "SubscriptionUsageInvoices";
+    public const string AuditEvents = "SubscriptionAuditEvents";
 
     public static IMongoCollection<TDocument> Of<TDocument>(
         IDbContextProvider dbContextProvider,

--- a/server/Subscription.DomainService/Responses/SubscriptionAuditEventResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionAuditEventResponse.cs
@@ -1,0 +1,21 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>A safe operator-facing view of a subscription audit event.</summary>
+public sealed class SubscriptionAuditEventResponse
+{
+    public string EventId { get; init; } = string.Empty;
+    public string OperationId { get; init; } = string.Empty;
+    public string CorrelationId { get; init; } = string.Empty;
+    public string Operation { get; init; } = string.Empty;
+    public string Stage { get; init; } = string.Empty;
+    public string Outcome { get; init; } = string.Empty;
+    public string Source { get; init; } = string.Empty;
+    public long? AmountMinor { get; init; }
+    public string? CurrencyCode { get; init; }
+    public string? FromStatus { get; init; }
+    public string? ToStatus { get; init; }
+    public string? ErrorCode { get; init; }
+    public string? FailureKind { get; init; }
+    public int? Attempt { get; init; }
+    public DateTime OccurredAtUtc { get; init; }
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionAuditTrail.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionAuditTrail.cs
@@ -1,0 +1,8 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+public interface ISubscriptionAuditTrail
+{
+    Task RecordAsync(SubscriptionAuditEvent auditEvent, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionAuditTrail.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAuditTrail.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Repositories;
+
+namespace Subscription.DomainService.Services;
+
+public sealed class SubscriptionAuditTrail : ISubscriptionAuditTrail
+{
+    private readonly ISubscriptionAuditRepository _repository;
+    private readonly ILogger<SubscriptionAuditTrail> _logger;
+
+    public SubscriptionAuditTrail(
+        ISubscriptionAuditRepository repository,
+        ILogger<SubscriptionAuditTrail> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task RecordAsync(SubscriptionAuditEvent auditEvent, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(auditEvent);
+        auditEvent.OperationId = string.IsNullOrWhiteSpace(auditEvent.OperationId)
+            ? auditEvent.CorrelationId
+            : auditEvent.OperationId;
+
+        using var scope = _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["OperationId"] = auditEvent.OperationId,
+            ["CorrelationId"] = auditEvent.CorrelationId,
+            ["TenantHash"] = PaymentLogValue.Hash(auditEvent.TenantId),
+            ["OrganizationHash"] = PaymentLogValue.Hash(auditEvent.OrganizationId),
+            ["SubscriptionHash"] = PaymentLogValue.Hash(auditEvent.SubscriptionId),
+            ["SubscriptionOperation"] = auditEvent.Operation,
+            ["SubscriptionStage"] = auditEvent.Stage,
+            ["Outcome"] = auditEvent.Outcome
+        });
+
+        _logger.LogInformation(
+            "Subscription lifecycle event Source={Source} AmountMinor={AmountMinor} Currency={Currency} ErrorCode={ErrorCode} Attempt={Attempt}",
+            PaymentLogValue.Label(auditEvent.Source), auditEvent.AmountMinor,
+            PaymentLogValue.Label(auditEvent.CurrencyCode),
+            PaymentLogValue.Label(auditEvent.ErrorCode), auditEvent.Attempt);
+
+        try
+        {
+            await _repository.AppendAsync(auditEvent, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            // Never invite a duplicate charge by failing a completed money operation because its
+            // secondary audit write failed. The critical log is monitored and reconciliation can
+            // reconstruct the state from payment and subscription ledgers.
+            _logger.LogCritical(exception, "SUBSCRIPTION_AUDIT_WRITE_FAILED");
+        }
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -28,6 +28,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<SubscriptionRenewalService> _logger;
     private readonly TimeProvider _time;
+    private readonly ISubscriptionAuditTrail? _audit;
 
     public SubscriptionRenewalService(
         ISubscriptionRepository subscriptions,
@@ -37,7 +38,8 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         IEntitlementSnapshotCache cache,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<SubscriptionRenewalService> logger,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        ISubscriptionAuditTrail? audit = null)
     {
         _subscriptions = subscriptions;
         _billingAccounts = billingAccounts;
@@ -47,6 +49,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
+        _audit = audit;
     }
 
     public async Task RenewAsync(
@@ -62,6 +65,8 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         });
 
         var now = _time.GetUtcNow().UtcDateTime;
+        await AuditAsync(subscription, "Started", "InProgress", null, null, null,
+            subscription.DunningAttemptCount + 1, cancellationToken);
 
         var account = await _billingAccounts.GetAsync(
             subscription.TenantId,
@@ -73,6 +78,9 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             // Retrying without a card to charge is pointless — including a trial that never
             // took one, which reaches this exact path at its end.
             await MoveToUnpaidAsync(subscription, "no_payment_method", cancellationToken);
+            await AuditAsync(subscription, "PaymentMethodChecked", "Failed",
+                "no_payment_method", null, null, subscription.DunningAttemptCount + 1,
+                cancellationToken);
 
             return;
         }
@@ -85,6 +93,8 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             _logger.LogError(
                 "Subscription renewal could not resolve a billing period; the schedule's time " +
                 "zone may no longer be valid");
+            await AuditAsync(subscription, "PeriodResolved", "Failed",
+                "billing_period_unresolvable", null, null, null, cancellationToken);
 
             return;
         }
@@ -133,6 +143,10 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 subscription.CorrelationId,
                 cancellationToken);
 
+        await AuditAsync(subscription, "ChargeCompleted",
+            outcome.IsSuccess ? "Succeeded" : "Failed", outcome.ErrorCode,
+            charge.AmountMinor, outcome.Value, attemptNumber, cancellationToken);
+
         if (outcome.IsSuccess)
         {
             await ApplySuccessAsync(
@@ -155,6 +169,36 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
 
         await ApplyFailureAsync(subscription, period.Key, attemptNumber, now, cancellationToken);
     }
+
+    private Task AuditAsync(
+        SubscriptionDetail subscription,
+        string stage,
+        string outcome,
+        string? errorCode,
+        long? amountMinor,
+        string? paymentDetailId,
+        int? attempt,
+        CancellationToken cancellationToken) =>
+        _audit is null
+            ? Task.CompletedTask
+            : _audit.RecordAsync(new SubscriptionAuditEvent
+            {
+                TenantId = subscription.TenantId,
+                OrganizationId = subscription.OrganizationId,
+                SubscriptionId = subscription.ItemId,
+                OperationId = $"renewal:{subscription.ItemId}:{subscription.CurrentPeriodEndUtc:O}",
+                CorrelationId = subscription.CorrelationId,
+                Operation = "Renewal",
+                Stage = stage,
+                Outcome = outcome,
+                Source = "Worker",
+                PaymentDetailId = paymentDetailId,
+                AmountMinor = amountMinor,
+                CurrencyCode = subscription.CurrencyCode,
+                FromStatus = subscription.Status.ToString(),
+                ErrorCode = errorCode,
+                Attempt = attempt
+            }, cancellationToken);
 
     /// <summary>
     /// The quantities a scheduled decrease puts in force, or null when nothing is due.
@@ -229,6 +273,9 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 attemptNumber,
                 PaymentLogValue.Label(period.Key),
                 subscription.SettlementReservation is not null);
+            await AuditAsync(subscription, "StateApplied", "Deferred",
+                "renewal_state_conflict", null, paymentDetailId, attemptNumber,
+                cancellationToken);
 
             return;
         }
@@ -239,6 +286,8 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             "Subscription renewed AttemptNumber={AttemptNumber} PeriodKey={PeriodKey}",
             attemptNumber,
             PaymentLogValue.Label(period.Key));
+        await AuditAsync(subscription, "StateApplied", "Succeeded", null, null,
+            paymentDetailId, attemptNumber, cancellationToken);
     }
 
     private async Task ApplyFailureAsync(

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -50,6 +50,7 @@ public static class ApplicationServiceCollectionExtensions
             ISubscriptionInvoiceHistoryRepository,
             SubscriptionInvoiceHistoryRepository>();
         services.AddSingleton<ISubscriptionDiscountRepository, SubscriptionDiscountRepository>();
+        services.AddSingleton<ISubscriptionAuditRepository, SubscriptionAuditRepository>();
 
         // Singleton so the cache is actually shared. Scoped, every request would get an empty
         // one and the hot path would read the database every time regardless.
@@ -104,6 +105,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionCreationService,
             SubscriptionCreationService>();
+        services.AddScoped<ISubscriptionAuditTrail, SubscriptionAuditTrail>();
         services.AddScoped<
             ISubscriptionCheckoutService,
             SubscriptionCheckoutService>();

--- a/server/XUnitTest/Subscription/SubscriptionAuditTrailTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionAuditTrailTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+public sealed class SubscriptionAuditTrailTests
+{
+    [Fact]
+    public async Task Record_persists_the_event_and_defaults_operation_id_to_correlation_id()
+    {
+        var repository = new Mock<ISubscriptionAuditRepository>();
+        var trail = new SubscriptionAuditTrail(
+            repository.Object,
+            Mock.Of<ILogger<SubscriptionAuditTrail>>());
+        var auditEvent = Event();
+
+        await trail.RecordAsync(auditEvent, CancellationToken.None);
+
+        Assert.Equal("correlation-1", auditEvent.OperationId);
+        repository.Verify(x => x.AppendAsync(auditEvent, CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task Audit_storage_failure_never_turns_a_completed_charge_into_a_retry()
+    {
+        var repository = new Mock<ISubscriptionAuditRepository>();
+        repository.Setup(x => x.AppendAsync(
+                It.IsAny<SubscriptionAuditEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("audit unavailable"));
+        var trail = new SubscriptionAuditTrail(
+            repository.Object,
+            Mock.Of<ILogger<SubscriptionAuditTrail>>());
+
+        var exception = await Record.ExceptionAsync(() =>
+            trail.RecordAsync(Event(), CancellationToken.None));
+
+        Assert.Null(exception);
+    }
+
+    private static SubscriptionAuditEvent Event() => new()
+    {
+        TenantId = "tenant-1",
+        OrganizationId = "organization-1",
+        SubscriptionId = "subscription-1",
+        CorrelationId = "correlation-1",
+        Operation = "Renewal",
+        Stage = "ChargeCompleted",
+        Outcome = "Succeeded",
+        Source = "Worker"
+    };
+}


### PR DESCRIPTION
Adds an append-only tenant-scoped audit ledger, structured correlated lifecycle logs, API and worker instrumentation, a sanitized organization-scoped audit timeline endpoint, documentation, and tests. Financial safety: sensitive payment/provider values are excluded; identifiers are hashed in logs; audit writes fail open after business operations and emit SUBSCRIPTION_AUDIT_WRITE_FAILED. Verification: test project builds with 0 errors; 442 subscription unit tests pass.