### PR TITLE
fix(subscription): send target planCode and body-bound organizationId on plan change

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -114,8 +114,12 @@ export const ChangePlanDialog = ({
     try {
       await mutateAsync({
         subscriptionId: subscription.subscriptionId,
-        request: { priceId, quantities: parsedQuantities },
-        organizationId,
+        request: {
+          planCode: targetPlan.code,
+          priceId,
+          quantities: parsedQuantities,
+          organizationId,
+        },
       });
 
       toast({

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-change-subscription-plan.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-change-subscription-plan.ts
@@ -9,12 +9,10 @@ export const useChangeSubscriptionPlan = () => {
     mutationFn: ({
       subscriptionId,
       request,
-      organizationId,
     }: {
       subscriptionId: string;
       request: ChangeSubscriptionPlanRequest;
-      organizationId?: string;
-    }) => subscriptionSimulationService.changePlan(subscriptionId, request, organizationId),
+    }) => subscriptionSimulationService.changePlan(subscriptionId, request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] });
       queryClient.invalidateQueries({ queryKey: ["subscription-simulation-entitlements"] });

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -64,13 +64,16 @@ export interface CancelSubscriptionRequest {
 }
 
 /**
- * A client never sends a target planCode. It sends the target price; the server follows
- * `priceId → Price.PlanId → Plan` on its own, applies the new snapshots atomically, and handles
- * proration.
+ * The server looks the target plan up by `planCode`, then requires `priceId` to belong to that
+ * plan (mismatch is `subscription_price_not_found`) — despite what the integration guide says,
+ * naming only the price is not enough; the plan the price sits on must be named too.
  */
 export interface ChangeSubscriptionPlanRequest {
+  planCode: string;
   priceId: string;
   quantities: SubscriptionQuantity[];
+  /** Honoured only for this portal acting as the platform console; see SubscribeToPlanRequest. */
+  organizationId?: string;
 }
 
 export type PlanChangeLabel =

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -90,23 +90,17 @@ class SubscriptionSimulationService {
   }
 
   /**
-   * Moves an existing subscription to another price. The server resolves
-   * `priceId → Price.PlanId → Plan` itself — the client never names a target plan directly.
+   * Moves an existing subscription to another price. The whole request is body-bound
+   * (`[FromBody]` on the server), so — unlike the GET/DELETE endpoints — `organizationId` has to
+   * travel as a field on `request`, not as a query parameter.
    */
   async changePlan(
     subscriptionId: string,
     request: ChangeSubscriptionPlanRequest,
-    organizationId?: string,
   ): Promise<SimulatedSubscription> {
-    // Same reason as cancel(): resolving against the console's own organization rather than the
-    // one the subscription actually belongs to reads back as "subscription not found".
-    const query = organizationId
-      ? `?organizationId=${encodeURIComponent(organizationId)}`
-      : "";
-
     const response = await serviceInstances.utitlitiesService.put<
       SimulationApiResponse<SimulatedSubscription>
-    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan${query}`, request);
+    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan`, request);
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "The plan could not be changed.");


### PR DESCRIPTION
## Summary
- Follow-up to #268 (already merged before this commit landed on that branch).
- The Change plan dialog was failing every request with `400 subscription_plan_change_invalid` / `"'Plan Code' must not be empty."`.
- Root cause, found by reading the actual server code rather than the integration doc (which is stale here):
  - `ChangeSubscriptionPlanRequestValidator` requires `PlanCode` and `SubscriptionPlanChangeService.ResolveTargetAsync` looks the target plan up by it *before* checking the given `priceId` belongs to that plan — contrary to the doc's claim that naming a price alone is enough.
  - `SubscriptionsController.ChangePlan` binds its whole request with `[FromBody]`, so `organizationId` needs to be a field on the body, not a query parameter (unlike `Cancel`, which takes it via `[FromQuery]`).
- Fix: `ChangeSubscriptionPlanRequest` now includes `planCode` and `organizationId`; the dialog sends the selected target plan's `code`, and the service posts the whole thing as the request body with no query string.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` (scoped to the changed module) passes clean
- [ ] Manual verification against a live backend: change plan for a subscription owned by a non-default organization, confirm no more `subscription_plan_change_invalid` (not run in this environment — no backend credentials available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)