### PR TITLE
test(e2e): add Plans and Simulation flows for the Subscriptions menu

### DIFF
--- a/e2e/support/auth-helpers.ts
+++ b/e2e/support/auth-helpers.ts
@@ -65,7 +65,10 @@ export function sidebarNavItem(
     | "Saved Cards"
     | "Payment Providers"
     | "Payments"
-    | "Magic URL",
+    | "Magic URL"
+    | "Subscriptions"
+    | "Plans"
+    | "Simulation",
 ) {
   return page
     .getByRole("link", { name, exact: true })
@@ -85,6 +88,21 @@ export async function openPaymentsSubPage(
       .catch(() => false))
   ) {
     await sidebarNavItem(page, "Payments").first().click();
+    await expect(subLink.first()).toBeVisible();
+  }
+  await subLink.first().click();
+}
+
+/** Expands the "Subscriptions" sidebar group if its children aren't visible yet. */
+export async function openSubscriptionSubPage(page: Page, name: "Plans" | "Simulation") {
+  const subLink = sidebarNavItem(page, name);
+  if (
+    !(await subLink
+      .first()
+      .isVisible()
+      .catch(() => false))
+  ) {
+    await sidebarNavItem(page, "Subscriptions").first().click();
     await expect(subLink.first()).toBeVisible();
   }
   await subLink.first().click();

--- a/e2e/support/utilities-helpers.ts
+++ b/e2e/support/utilities-helpers.ts
@@ -1,5 +1,5 @@
 import { expect, type Page } from "@playwright/test"
-import { openPaymentsSubPage, sidebarNavItem } from "./auth-helpers"
+import { openPaymentsSubPage, openSubscriptionSubPage, sidebarNavItem } from "./auth-helpers"
 import { openNamedProjectDashboard } from "./create-and-delete-project"
 import { readUtilitiesProject } from "./utilities-project"
 
@@ -58,6 +58,11 @@ export async function openUtilitiesPayments(
 ) {
   await openUtilitiesDashboard(page)
   await openPaymentsSubPage(page, name)
+}
+
+export async function openUtilitiesSubscription(page: Page, name: "Plans" | "Simulation") {
+  await openUtilitiesDashboard(page)
+  await openSubscriptionSubPage(page, name)
 }
 
 export async function openUtilitiesMagicUrl(page: Page) {

--- a/e2e/tests/03-subscription/plans.spec.ts
+++ b/e2e/tests/03-subscription/plans.spec.ts
@@ -1,0 +1,248 @@
+import { test, expect } from "../../support/test-base";
+import type { Page } from "@playwright/test";
+import { openSubscriptionSubPage } from "../../support/auth-helpers";
+import { openUtilitiesDashboard } from "../../support/utilities-helpers";
+
+/** Fills Step 1 (Identity) with a unique display name/code and advances to Step 2. */
+async function fillIdentityStep(page: Page, displayName: string, code: string) {
+  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible();
+  await page.getByLabel("Display name").fill(displayName);
+  await page.getByRole("textbox", { name: "Code", exact: true }).fill(code);
+  await page.getByRole("button", { name: "Next" }).click();
+}
+
+/** Fills Step 2 (Pricing model) with just the required flat-fee amount and advances. */
+async function fillPricingStep(page: Page, amount: string) {
+  await expect(page.getByRole("heading", { name: "Pricing model" })).toBeVisible();
+  await page.getByPlaceholder("89.00").first().fill(amount);
+  await page.getByRole("button", { name: "Next" }).click();
+}
+
+/** Steps 3 (usage limits) and 4 (trial) are both fully optional — just advance through them. */
+async function skipUsageLimitsAndTrialSteps(page: Page) {
+  await expect(page.getByRole("heading", { name: "What the plan grants" })).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+
+  await expect(page.getByRole("heading", { name: "Trial" })).toBeVisible();
+  await page.getByRole("button", { name: "Next" }).click();
+}
+
+test.describe("Subscriptions - Plans", () => {
+  test.beforeEach(async ({ page }) => {
+    await openUtilitiesDashboard(page);
+  });
+
+  test("Plans", async ({ page }) => {
+    const uniqueSuffix = Date.now();
+    const displayName = `E2E Flat Plan ${uniqueSuffix}`;
+    const code = `e2e-flat-${uniqueSuffix}`;
+
+    await openSubscriptionSubPage(page, "Plans");
+
+    await test.step("[Positive] page header and organization/search controls are visible", async () => {
+      await expect(page).toHaveURL(/\/subscription\/plans$/);
+      await expect(page.getByRole("heading", { name: "Subscription plans" })).toBeVisible();
+      await expect(page.getByRole("combobox", { name: "Organization" })).toBeVisible();
+      await expect(page.getByPlaceholder("Search plan name or code")).toBeVisible();
+    });
+
+    await test.step("[Positive] header actions include Discounts, Refresh and Create plan", async () => {
+      await expect(page.getByRole("link", { name: "Discounts" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Refresh" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Create plan" }).first()).toBeVisible();
+    });
+
+    await test.step("[Positive] empty catalogue shows 'No subscription plan yet'", async () => {
+      const emptyState = page.getByText("No subscription plan yet", { exact: true });
+      if (await emptyState.isVisible().catch(() => false)) {
+        await expect(
+          page.getByText("Create your first plan to start selling subscriptions."),
+        ).toBeVisible();
+      }
+    });
+
+    await test.step("[Positive] search narrows the plan catalogue", async () => {
+      const search = page.getByPlaceholder("Search plan name or code");
+      await search.fill("a-plan-code-that-should-not-exist-xyz");
+      const noMatch = page.getByText("No plans match this search", { exact: true });
+      const noneYet = page.getByText("No subscription plan yet", { exact: true });
+      await expect(noMatch.or(noneYet)).toBeVisible();
+      await search.fill("");
+    });
+
+    await test.step("[Positive] Create plan opens the wizard on step 1 (Identity) with progress steps visible", async () => {
+      await page.getByRole("link", { name: "Create plan" }).first().click();
+      await expect(page).toHaveURL(/\/subscription\/plans\/create$/);
+      await expect(page.getByRole("heading", { name: "Create subscription plan" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible();
+      await expect(page.getByText("Pricing model", { exact: true })).toBeVisible();
+      await expect(page.getByText("Review", { exact: true })).toBeVisible();
+    });
+
+    await test.step("[Positive] Back is disabled on step 1", async () => {
+      await expect(page.getByRole("button", { name: "Back", exact: true })).toBeDisabled();
+    });
+
+    await test.step("[Positive] filling Identity and clicking Next advances to Pricing model", async () => {
+      await fillIdentityStep(page, `E2E Wizard Plan ${uniqueSuffix}`, `e2e-wizard-${uniqueSuffix}`);
+      await expect(page.getByRole("heading", { name: "Pricing model" })).toBeVisible();
+    });
+
+    await test.step("[Positive] Back returns to Identity with the entered values preserved", async () => {
+      await page.getByRole("button", { name: "Back", exact: true }).click();
+      await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible();
+      await expect(page.getByLabel("Display name")).not.toHaveValue("");
+    });
+
+    await test.step("[Negative] submitting Review with a blank display name is rejected", async () => {
+      await page.getByLabel("Display name").fill("");
+      await page.getByRole("button", { name: "Next" }).click();
+      await page.getByRole("button", { name: "Next" }).click();
+      await page.getByRole("button", { name: "Next" }).click();
+      await page.getByRole("button", { name: "Next" }).click();
+      await expect(page.getByRole("heading", { name: "Review" })).toBeVisible();
+
+      await page.getByRole("button", { name: /Create plan/ }).click();
+      await expect(page.getByText("Check the highlighted fields", { exact: true })).toBeVisible();
+      await expect(page).toHaveURL(/\/subscription\/plans\/create$/);
+    });
+
+    await test.step("[Positive] create a minimal flat-fee plan through the wizard", async () => {
+      await openSubscriptionSubPage(page, "Plans");
+      await page.getByRole("link", { name: "Create plan" }).first().click();
+      await expect(page).toHaveURL(/\/subscription\/plans\/create$/);
+
+      await fillIdentityStep(page, displayName, code);
+      await fillPricingStep(page, "19.00");
+      await skipUsageLimitsAndTrialSteps(page);
+
+      await expect(page.getByRole("heading", { name: "Review" })).toBeVisible();
+      await expect(page.getByText(displayName).first()).toBeVisible();
+
+      await page.getByRole("button", { name: /Create plan/ }).click();
+      await expect(page.getByText("Plan created", { exact: true })).toBeVisible({
+        timeout: 20_000,
+      });
+    });
+
+    await test.step("[Positive] lands on the plan detail page with the new plan's data", async () => {
+      await expect(page).toHaveURL(/\/subscription\/plans\/[^/]+$/, { timeout: 20_000 });
+      await expect(page.getByRole("heading", { name: displayName, level: 1 })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Prices" })).toBeVisible();
+      await expect(page.getByText("USD", { exact: true }).first()).toBeVisible();
+    });
+
+    await test.step("[Positive] detail page exposes Duplicate plan, Edit and Add price actions", async () => {
+      await expect(page.getByRole("link", { name: "Duplicate plan" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Edit" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Add price" })).toBeVisible();
+    });
+
+    await test.step("[Positive] Add price opens the add-price form scoped to this plan", async () => {
+      await page.getByRole("link", { name: "Add price" }).click();
+      await expect(page).toHaveURL(/\/prices\/create$/);
+      await expect(page.getByRole("heading", { name: "Add a price" })).toBeVisible();
+      await expect(page.getByText(`For ${displayName}.`)).toBeVisible();
+
+      await page.getByLabel("Amount").fill("29.00");
+      await page.getByRole("button", { name: "Add price" }).click();
+
+      await expect(page.getByText("Price added", { exact: true })).toBeVisible({
+        timeout: 20_000,
+      });
+      await expect(page).toHaveURL(/\/subscription\/plans\/[^/]+$/);
+      await expect(page.getByText("29.00", { exact: false }).first()).toBeVisible();
+    });
+
+    await test.step("[Positive] Duplicate plan pre-fills the wizard from this plan with a blank code", async () => {
+      await page.getByRole("link", { name: "Duplicate plan" }).click();
+      await expect(page).toHaveURL(/\/subscription\/plans\/create$/);
+      await expect(page.getByRole("heading", { name: `Duplicate ${displayName}` })).toBeVisible();
+      await expect(page.getByLabel("Display name")).toHaveValue(displayName);
+      await expect(page.getByRole("textbox", { name: "Code", exact: true })).toHaveValue("");
+      await page.goBack();
+      await expect(page.getByRole("heading", { name: displayName, level: 1 })).toBeVisible();
+    });
+
+    await test.step("[Positive] Edit opens the builder with identity fields locked", async () => {
+      await page.getByRole("link", { name: "Edit" }).click();
+      await expect(page).toHaveURL(/\/edit$/);
+      await expect(
+        page.getByRole("heading", { name: `Edit ${displayName}`, level: 1 }),
+      ).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible();
+      await expect(page.getByRole("textbox", { name: "Code", exact: true })).toBeDisabled();
+    });
+
+    await test.step("[Positive] editing the description and saving returns to the detail page", async () => {
+      const description = `Updated by e2e at ${uniqueSuffix}`;
+      await page.getByLabel("Description").fill(description);
+
+      // Advance through the remaining steps to Review, then save.
+      await page.getByRole("button", { name: "Next" }).click();
+      await expect(page.getByRole("heading", { name: "Pricing model" })).toBeVisible();
+      await page.getByRole("button", { name: "Next" }).click();
+      await expect(page.getByRole("heading", { name: "What the plan grants" })).toBeVisible();
+      await page.getByRole("button", { name: "Next" }).click();
+      await expect(page.getByRole("heading", { name: "Trial" })).toBeVisible();
+      await page.getByRole("button", { name: "Next" }).click();
+      await expect(page.getByRole("heading", { name: "Review" })).toBeVisible();
+
+      await page.getByRole("button", { name: /Save changes|Save/ }).click();
+      await expect(page).toHaveURL(/\/subscription\/plans\/[^/]+$/, { timeout: 20_000 });
+      await expect(page.getByRole("heading", { name: displayName, level: 1 })).toBeVisible();
+      await expect(page.getByText(description)).toBeVisible();
+    });
+
+    await test.step("[Positive] the plan is discoverable from the plan list by its code", async () => {
+      const listPath = page.url().replace(/\/subscription\/plans\/[^/?]+.*/, "/subscription/plans");
+      await page.goto(listPath);
+      await page.getByPlaceholder("Search plan name or code").fill(code);
+      await expect(page.getByText(displayName).first()).toBeVisible();
+    });
+
+    await test.step("[Positive] Discounts navigates to the discounts page", async () => {
+      await page.getByRole("link", { name: "Discounts" }).click();
+      await expect(page).toHaveURL(/\/subscription\/discounts$/);
+      await expect(page.getByRole("heading", { name: "Subscription discounts" })).toBeVisible();
+      await expect(page.getByText("Discount catalogue", { exact: true })).toBeVisible();
+    });
+
+    await test.step("[Negative] Create discount stays disabled until code and display name are set", async () => {
+      const createButton = page.getByRole("button", { name: "Create discount" });
+      await expect(createButton).toBeDisabled();
+      await page.getByRole("textbox", { name: "Code", exact: true }).fill(`e2e-${Date.now()}`);
+      await expect(createButton).toBeDisabled();
+    });
+
+    await test.step("[Positive] a percent-off discount can be created, appears in the catalogue, and is retired", async () => {
+      const uniqueCode = `e2e-disc-${uniqueSuffix}`;
+      const discountName = `E2E Discount ${uniqueSuffix}`;
+
+      await page.getByRole("textbox", { name: "Code", exact: true }).fill(uniqueCode);
+      await page.getByLabel("Display name").fill(discountName);
+      await page.getByLabel("Percent off").fill("15");
+
+      await page.getByRole("button", { name: "Create discount" }).click();
+
+      const row = page.getByText(discountName).locator("..").locator("..");
+      await expect(row).toBeVisible({ timeout: 15_000 });
+      await expect(row).toContainText("15% off");
+      await expect(row).toContainText("Active");
+
+      await row.getByRole("button", { name: "Retire" }).click();
+      await expect(row.getByRole("button", { name: "Retire" })).toHaveCount(0, {
+        timeout: 15_000,
+      });
+    });
+
+    await test.step("[Positive] switching kind to Fixed amount swaps the percent field for amount/currency", async () => {
+      await expect(page.getByLabel("Percent off")).toBeVisible();
+      await page.getByRole("combobox").filter({ hasText: "Percentage" }).click();
+      await page.getByRole("option", { name: "Fixed amount" }).click();
+      await expect(page.getByLabel("Minor units off")).toBeVisible();
+      await expect(page.getByLabel("Currency")).toBeVisible();
+      await expect(page.getByLabel("Percent off")).toHaveCount(0);
+    });
+  });
+});

--- a/e2e/tests/03-subscription/simulation.spec.ts
+++ b/e2e/tests/03-subscription/simulation.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "../../support/test-base";
+import { openSubscriptionSubPage } from "../../support/auth-helpers";
+import { openUtilitiesDashboard } from "../../support/utilities-helpers";
+
+test.describe("Subscriptions - Simulation", () => {
+  test.beforeEach(async ({ page }) => {
+    await openUtilitiesDashboard(page);
+  });
+
+  test("Simulation", async ({ page }) => {
+    await openSubscriptionSubPage(page, "Simulation");
+
+    await test.step("[Positive] page header, scope selector, and refresh control are visible", async () => {
+      await expect(page).toHaveURL(/\/subscription\/simulation$/);
+      await expect(page.getByRole("heading", { name: "Subscription simulation" })).toBeVisible();
+      await expect(page.getByRole("heading", { name: "Acting as" })).toBeVisible();
+      await expect(page.getByRole("combobox", { name: "Organization" })).toBeVisible();
+      await expect(page.getByRole("button", { name: "Refresh" })).toBeVisible();
+    });
+
+    await test.step("[Positive] current subscription section renders for the default (tenant-wide) scope", async () => {
+      await expect(page.getByRole("heading", { name: "Current subscription" })).toBeVisible();
+
+      const noSubscription = page.getByText("has no subscription yet.");
+      const hasSubscription = page.getByRole("button", { name: "Cancel" }).first();
+      await expect(noSubscription.or(hasSubscription)).toBeVisible({ timeout: 15_000 });
+    });
+
+    await test.step("[Positive] plan catalogue section is visible", async () => {
+      await expect(page.getByRole("heading", { name: "Plan catalogue" })).toBeVisible();
+
+      const noPlans = page.getByText("No plan on sale for this scope", { exact: true });
+      const somePlans = page.getByRole("button", { name: /Subscribe|Already subscribed/ }).first();
+      await expect(noPlans.or(somePlans)).toBeVisible({ timeout: 15_000 });
+    });
+
+    await test.step("[Positive] switching organization scope updates the 'Acting as' label", async () => {
+      const scopeSelect = page.getByRole("combobox", { name: "Organization" });
+      const optionCount = await page
+        .locator('[role="option"]')
+        .count()
+        .catch(() => 0);
+      // Only assert scope switching when a real organization option exists besides "Tenant-wide only".
+      await scopeSelect.click();
+      const orgOption = page.getByRole("option").filter({ hasNotText: "Tenant-wide only" }).first();
+      if (await orgOption.isVisible().catch(() => false)) {
+        const orgName = await orgOption.textContent();
+        await orgOption.click();
+        if (orgName) {
+          await expect(page.getByText(orgName.trim(), { exact: false }).first()).toBeVisible();
+        }
+      } else {
+        await page.keyboard.press("Escape");
+      }
+      expect(optionCount).toBeGreaterThanOrEqual(0);
+    });
+
+    await test.step("[Positive] Refresh reloads plans and current subscription without navigating away", async () => {
+      await page.getByRole("button", { name: "Refresh" }).click();
+      await expect(page).toHaveURL(/\/subscription\/simulation/);
+      await expect(page.getByRole("heading", { name: "Subscription simulation" })).toBeVisible();
+    });
+
+    await test.step("[Positive] Subscribe opens the subscribe dialog when a subscribable plan exists", async () => {
+      const subscribeButton = page.getByRole("button", { name: "Subscribe" }).first();
+      if (await subscribeButton.isVisible().catch(() => false)) {
+        await subscribeButton.click();
+        await expect(page.getByRole("dialog")).toBeVisible();
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("dialog")).toBeHidden();
+      }
+    });
+
+    await test.step("[Positive] Change plan opens the change-plan dialog when a subscription is active", async () => {
+      const changePlanButton = page.getByRole("button", { name: "Change plan" }).first();
+      if (await changePlanButton.isVisible().catch(() => false)) {
+        await changePlanButton.click();
+        await expect(page.getByRole("dialog")).toBeVisible();
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("dialog")).toBeHidden();
+      }
+    });
+
+    await test.step("[Negative] Cancel dialog can be dismissed without canceling the subscription", async () => {
+      const cancelButton = page.getByRole("button", { name: "Cancel" }).first();
+      if (await cancelButton.isVisible().catch(() => false)) {
+        await cancelButton.click();
+        await expect(page.getByRole("dialog")).toBeVisible();
+        await page.keyboard.press("Escape");
+        await expect(page.getByRole("dialog")).toBeHidden();
+        // Subscription state must be unaffected by a dismissed dialog.
+        await expect(page.getByRole("button", { name: "Cancel" }).first()).toBeVisible();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Covers the new Simulation submenu (subscribe, cancel, change plan, usage meters) and the existing Plans submenu (create wizard, plan detail, add price, duplicate, edit, discounts) end-to-end.