### PR TITLE
feat(subscription): add audit trail UI to the simulation module

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/audit-outcome-badge.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/audit-outcome-badge.tsx
@@ -1,0 +1,18 @@
+import { Badge, type BadgeProps } from "@/components/ui-kits/badge/badge";
+
+/**
+ * `outcome` is a free-form string owned by the server, not a closed enum the client validates —
+ * worker-raised events can introduce a new one without this needing to change. Anything not
+ * recognized falls back to a neutral badge rather than guessing.
+ */
+const OUTCOME_VARIANT: Record<string, BadgeProps["variant"]> = {
+  Succeeded: "success",
+  Rejected: "error",
+  Failed: "error",
+};
+
+export const AuditOutcomeBadge = ({ outcome }: { outcome: string }) => (
+  <Badge variant={OUTCOME_VARIANT[outcome] ?? "secondary"} className="font-normal">
+    {outcome}
+  </Badge>
+);

--- a/client/app/cross-modules/utilities/subscription-simulation/components/audit-trail-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/audit-trail-dialog.tsx
@@ -1,0 +1,201 @@
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { CopyToClipboardButton } from "@/components/copy-to-clipboard-button";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui-kits/table/table";
+import {
+  AUDIT_TRAIL_DEFAULT_LIMIT,
+  AUDIT_TRAIL_LIMIT_OPTIONS,
+} from "../constants/subscription-simulation.constants";
+import { useAuditTrail } from "../hooks/use-audit-trail";
+import { formatMoney } from "../../subscription/utilities/subscription-format";
+import { AuditOutcomeBadge } from "./audit-outcome-badge";
+
+const shortenId = (id: string) => (id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id);
+
+export const AuditTrailDialog = ({
+  subscriptionId,
+  planName,
+  organizationId,
+  open,
+  onOpenChange,
+}: {
+  subscriptionId: string;
+  planName: string;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const [limit, setLimit] = useState(AUDIT_TRAIL_DEFAULT_LIMIT);
+
+  const {
+    data: events,
+    error,
+    isError,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useAuditTrail(subscriptionId, organizationId, limit, open);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] w-[95vw] max-w-5xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Audit trail — {planName}</DialogTitle>
+          <DialogDescription>
+            Sends{" "}
+            <code>
+              GET /api/subscriptions/{subscriptionId}/audit
+            </code>
+            . The immutable lifecycle trail for this subscription, newest first — it never carries
+            who performed an action or a payment identifier, and it is scoped to this subscription
+            only, not a tenant-wide audit search.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center justify-between gap-2">
+          <Select
+            value={String(limit)}
+            onValueChange={(value) => setLimit(Number(value))}
+          >
+            <SelectTrigger className="w-40" aria-label="Number of events">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AUDIT_TRAIL_LIMIT_OPTIONS.map((option) => (
+                <SelectItem key={option} value={String(option)}>
+                  Last {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            <RefreshCw className={`mr-2 h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 5 }, (_, index) => (
+              <Skeleton key={index} className="h-10 w-full rounded-md" />
+            ))}
+          </div>
+        ) : isError ? (
+          <div className="flex flex-col items-start gap-2">
+            <div className="flex items-center gap-2 text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span className="font-medium">The audit trail could not be loaded</span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {error instanceof Error ? error.message : "Try again in a moment."}
+            </p>
+            <Button size="sm" variant="outline" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </div>
+        ) : !events?.length ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No audit events recorded for this subscription yet.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Time</TableHead>
+                <TableHead>Operation / stage</TableHead>
+                <TableHead>Outcome</TableHead>
+                <TableHead>Status transition</TableHead>
+                <TableHead>Amount</TableHead>
+                <TableHead>Source</TableHead>
+                <TableHead>Attempt</TableHead>
+                <TableHead>Error</TableHead>
+                <TableHead>IDs</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {events.map((event) => (
+                <TableRow key={event.eventId}>
+                  <TableCell className="whitespace-nowrap text-xs">
+                    {new Date(event.occurredAtUtc).toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    <div className="font-medium">{event.operation}</div>
+                    <div className="text-muted-foreground">{event.stage}</div>
+                  </TableCell>
+                  <TableCell>
+                    <AuditOutcomeBadge outcome={event.outcome} />
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-xs">
+                    {event.fromStatus && event.toStatus
+                      ? `${event.fromStatus} → ${event.toStatus}`
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-xs">
+                    {event.amountMinor != null && event.currencyCode
+                      ? formatMoney(event.amountMinor, event.currencyCode)
+                      : "—"}
+                  </TableCell>
+                  <TableCell className="text-xs">{event.source}</TableCell>
+                  <TableCell className="text-xs">{event.attempt ?? "—"}</TableCell>
+                  <TableCell className="text-xs">
+                    {event.errorCode ? (
+                      <div>
+                        <div className="font-medium text-destructive">{event.errorCode}</div>
+                        {event.failureKind && (
+                          <div className="text-muted-foreground">{event.failureKind}</div>
+                        )}
+                      </div>
+                    ) : (
+                      "—"
+                    )}
+                  </TableCell>
+                  <TableCell className="space-y-1 text-xs">
+                    <CopyToClipboardButton textToCopy={event.correlationId} isHoverable>
+                      <span title={event.correlationId}>
+                        corr {shortenId(event.correlationId)}
+                      </span>
+                    </CopyToClipboardButton>
+                    <CopyToClipboardButton textToCopy={event.operationId} isHoverable>
+                      <span title={event.operationId}>
+                        op {shortenId(event.operationId)}
+                      </span>
+                    </CopyToClipboardButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, CalendarClock, ExternalLink, Inbox } from "lucide-react";
+import { AlertCircle, CalendarClock, ExternalLink, History, Inbox } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
@@ -40,6 +40,7 @@ export const CurrentSubscriptionCard = ({
   onChangeQuantity,
   onCancelPendingQuantityChange,
   isCancelingPendingQuantityChange,
+  onViewAuditTrail,
 }: {
   subscription: SimulatedSubscription | null | undefined;
   isLoading: boolean;
@@ -52,6 +53,7 @@ export const CurrentSubscriptionCard = ({
   onChangeQuantity: () => void;
   onCancelPendingQuantityChange: () => void;
   isCancelingPendingQuantityChange: boolean;
+  onViewAuditTrail: () => void;
 }) => {
   if (isLoading) {
     return <Skeleton className="h-28 w-full rounded-xl" />;
@@ -106,7 +108,11 @@ export const CurrentSubscriptionCard = ({
           </p>
         </div>
 
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
+          <Button size="sm" variant="ghost" onClick={onViewAuditTrail}>
+            <History className="mr-2 h-3.5 w-3.5" />
+            Audit trail
+          </Button>
           {subscription.checkoutUrl && (
             <Button size="sm" asChild>
               <a href={subscription.checkoutUrl} target="_blank" rel="noreferrer">

--- a/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
@@ -3,6 +3,11 @@ export const SUBSCRIPTIONS_CURRENT_ENDPOINT = "/api/subscriptions/current";
 export const ENTITLEMENTS_ENDPOINT = "/api/entitlements";
 export const SUBSCRIPTION_USAGE_ENDPOINT = "/api/subscription-usage";
 
+export const AUDIT_TRAIL_DEFAULT_LIMIT = 100;
+/** The server clamps anything above this back down rather than rejecting it. */
+export const AUDIT_TRAIL_MAX_LIMIT = 500;
+export const AUDIT_TRAIL_LIMIT_OPTIONS = [50, 100, 250, 500] as const;
+
 /**
  * The browser's own IANA zone. Periods turn over on this clock, so simulating from wherever the
  * tester happens to sit is the closest stand-in for a real subscriber's timezone.

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-audit-trail.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-audit-trail.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { AUDIT_TRAIL_DEFAULT_LIMIT } from "../constants/subscription-simulation.constants";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/** `enabled` keeps this from fetching until the trail is actually opened. */
+export const useAuditTrail = (
+  subscriptionId: string | undefined,
+  organizationId: string | undefined,
+  limit: number = AUDIT_TRAIL_DEFAULT_LIMIT,
+  enabled = true,
+) =>
+  useQuery({
+    queryKey: ["subscription-simulation-audit-trail", subscriptionId, organizationId ?? null, limit],
+    queryFn: () =>
+      subscriptionSimulationService.getAuditTrail(subscriptionId!, organizationId, limit),
+    enabled: enabled && Boolean(subscriptionId),
+  });

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -204,6 +204,33 @@ export interface RecordUsageRequest {
   organizationId?: string;
 }
 
+/**
+ * One step of the immutable lifecycle trail kept for investigating a subscription.
+ *
+ * Deliberately thin: the server never returns an actor id or a payment id here, so this can be
+ * shown to whoever is looking at the simulation without exposing who did it or linking straight
+ * to a payment record. `operation`, `stage`, `outcome`, `source` and `failureKind` are free-form
+ * strings owned by the server (worker-raised events use different values than API-raised ones),
+ * not a closed set the client can validate against.
+ */
+export interface SubscriptionAuditEvent {
+  eventId: string;
+  operationId: string;
+  correlationId: string;
+  operation: string;
+  stage: string;
+  outcome: string;
+  source: string;
+  amountMinor: number | null;
+  currencyCode: string | null;
+  fromStatus: string | null;
+  toStatus: string | null;
+  errorCode: string | null;
+  failureKind: string | null;
+  attempt: number | null;
+  occurredAtUtc: string;
+}
+
 export interface RecordUsageResult {
   allowed: boolean;
   meterKey: string;

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -22,6 +22,7 @@ import {
 import { SubscriptionPlanPageHeader } from "../../subscription/components/subscription-plan-page-header";
 import { useSubscriptionPlans } from "../../subscription/hooks/use-subscription-plans";
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { AuditTrailDialog } from "../components/audit-trail-dialog";
 import { CancelSubscriptionDialog } from "../components/cancel-subscription-dialog";
 import { ChangePlanDialog } from "../components/change-plan-dialog";
 import { ChangeQuantityDialog } from "../components/change-quantity-dialog";
@@ -44,6 +45,7 @@ export const SubscriptionSimulationPage = () => {
   const [isCanceling, setIsCanceling] = useState(false);
   const [isChangingPlan, setIsChangingPlan] = useState(false);
   const [isChangingQuantity, setIsChangingQuantity] = useState(false);
+  const [isViewingAuditTrail, setIsViewingAuditTrail] = useState(false);
 
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData } = useGetOrganizations({
@@ -191,6 +193,7 @@ export const SubscriptionSimulationPage = () => {
             onChangeQuantity={() => setIsChangingQuantity(true)}
             onCancelPendingQuantityChange={withdrawScheduledQuantityChange}
             isCancelingPendingQuantityChange={cancelPendingQuantity.isPending}
+            onViewAuditTrail={() => setIsViewingAuditTrail(true)}
           />
         </div>
       </Card>
@@ -309,6 +312,16 @@ export const SubscriptionSimulationPage = () => {
           organizationId={organizationScope}
           open={isChangingPlan}
           onOpenChange={setIsChangingPlan}
+        />
+      )}
+
+      {isViewingAuditTrail && currentSubscription && (
+        <AuditTrailDialog
+          subscriptionId={currentSubscription.subscriptionId}
+          planName={currentSubscription.planName}
+          organizationId={organizationScope}
+          open={isViewingAuditTrail}
+          onOpenChange={setIsViewingAuditTrail}
         />
       )}
     </main>

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -1,6 +1,7 @@
 import { HttpError } from "@seliseblocks/genesis-os/lib";
 import { serviceInstances } from "@/lib/http-client";
 import {
+  AUDIT_TRAIL_DEFAULT_LIMIT,
   ENTITLEMENTS_ENDPOINT,
   SUBSCRIPTION_USAGE_ENDPOINT,
   SUBSCRIPTIONS_CURRENT_ENDPOINT,
@@ -17,6 +18,7 @@ import type {
   RecordUsageResult,
   SimulatedSubscription,
   SubscribeToPlanRequest,
+  SubscriptionAuditEvent,
 } from "../models/subscription-simulation.model";
 
 interface SimulationApiError {
@@ -179,6 +181,33 @@ class SubscriptionSimulationService {
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "The entitlement could not be checked.");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * The immutable lifecycle trail for one subscription, newest first. Read-only and
+   * subscription-specific — there is no tenant-wide audit search, and the response never carries
+   * an actor id or a payment id (see the doc's "financial operation tracing and audit" section).
+   */
+  async getAuditTrail(
+    subscriptionId: string,
+    organizationId?: string,
+    limit: number = AUDIT_TRAIL_DEFAULT_LIMIT,
+  ): Promise<SubscriptionAuditEvent[]> {
+    const query = new URLSearchParams();
+    query.set("limit", String(limit));
+    if (organizationId) {
+      query.set("organizationId", organizationId);
+    }
+
+    const response = await serviceInstances.utitlitiesService.get<
+      SimulationApiResponse<SubscriptionAuditEvent[]>
+    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/audit?${query}`);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "The audit trail could not be loaded.");
     }
 
     return response.data;


### PR DESCRIPTION
## Summary
- The audit endpoint `GET /api/subscriptions/{subscriptionId}/audit?limit=100` (and `...&organizationId={organizationId}&limit=100` for platform-console access to another organization) existed server-side with no client UI — it was only reachable via Swagger/Postman/dev tools.
- Adds an **Audit trail** action to the current-subscription card in the Subscription simulation module, opening a dialog with a table of the subscription's immutable lifecycle events:
  - Time, Operation and stage, Outcome (color-coded badge, tolerant of unrecognized values since these are server-owned free-form strings), Status transition, Amount and currency, Source, Attempt number, Error/failure details, and Correlation/Operation IDs (each copyable via the existing `CopyToClipboardButton`).
  - A limit selector (50/100/250/500, matching the server's `Math.Clamp(limit, 1, 500)`) and a Refresh button.
  - The dialog only fetches once opened (`enabled` gated on `open`), and the copy explicitly states the endpoint's two limitations per the request: it omits actor and payment identifiers, so the UI cannot show who performed an action or link to a payment, and it is subscription-specific rather than a tenant-wide audit search.
- The button is available regardless of subscription status — even a canceled or unpaid subscription's history is worth inspecting.
- New: `SubscriptionAuditEvent` model, `getAuditTrail` service method, `useAuditTrail` hook, `AuditOutcomeBadge` and `AuditTrailDialog` components.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` (scoped to the changed module) passes clean
- [x] `npx vitest run` for the subscription-simulation module — 18 existing tests still pass
- [ ] Manual verification against a live backend: open the audit trail for a subscription with a mix of API- and worker-raised events, confirm formatting and the organization-scoped console path (not run in this environment — no backend credentials available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)