### PR TITLE
feat(subscription): add simulation harness foundation and read-only state inspector

### DIFF
--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -1,0 +1,92 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Simulation;
+using Subscription.DomainService.Utilities;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// The subscription simulation test harness. Console-only, permission-gated, and unavailable
+/// wherever <c>SubscriptionSimulation:Enabled</c> is not explicitly turned on.
+/// </summary>
+/// <remarks>
+/// Never rely on this being hidden from a UI: every action here re-checks
+/// <see cref="SubscriptionSimulationOptions.Enabled"/> on every request, because the
+/// configuration this reads can be changed at runtime without a restart.
+/// </remarks>
+[ApiController]
+[Authorize]
+[Route("subscription-simulation")]
+public sealed class SubscriptionSimulationController : ControllerBase
+{
+    private readonly ISubscriptionSimulationService _simulation;
+    private readonly IOptionsMonitor<SubscriptionSimulationOptions> _options;
+
+    public SubscriptionSimulationController(
+        ISubscriptionSimulationService simulation,
+        IOptionsMonitor<SubscriptionSimulationOptions> options)
+    {
+        _simulation = simulation;
+        _options = options;
+    }
+
+    /// <summary>A complete, read-only snapshot of one subscription.</summary>
+    /// <remarks>
+    /// Never returns a stored payment method id, a provider customer id, a checkout URL, or an
+    /// outbox event's raw payload.
+    /// </remarks>
+    [HttpGet("subscriptions/{subscriptionId}/state")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationStateResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationStateResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetState(
+        string subscriptionId,
+        [FromQuery] string? organizationId,
+        [FromQuery] int auditLimit,
+        [FromQuery] int paymentLimit,
+        [FromQuery] bool includeBackgroundWork,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (!_options.CurrentValue.Enabled)
+        {
+            return NotFound(ApiResponse<SubscriptionSimulationStateResponse>.Fail(
+                "subscription_simulation_disabled",
+                "The subscription simulation harness is not enabled in this environment.",
+                correlationId));
+        }
+
+        var result = await _simulation.GetStateAsync(
+            subscriptionId,
+            organizationId,
+            auditLimit <= 0 ? 100 : auditLimit,
+            paymentLimit <= 0 ? 100 : paymentLimit,
+            includeBackgroundWork,
+            correlationId,
+            cancellationToken);
+
+        // PaymentFailureKind has no Forbidden — the shared status-code mapping this reuses for
+        // every other subscription result would otherwise report this as a 404, indistinguishable
+        // from the harness being disabled. Named separately so an authorized administrator who
+        // simply lacks the permission sees why, rather than being told a real subscription is
+        // "disabled".
+        if (result is { IsSuccess: false, ErrorCode: "subscription_simulation_forbidden" })
+        {
+            return StatusCode(
+                StatusCodes.Status403Forbidden,
+                ApiResponse<SubscriptionSimulationStateResponse>.Fail(
+                    result.ErrorCode,
+                    result.ErrorMessage ?? "This caller may not use the subscription simulation harness.",
+                    correlationId));
+        }
+
+        return result.ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Program.cs
+++ b/server/Api/Program.cs
@@ -80,7 +80,7 @@ ApplyFrontendRuntimeSettings(builder.Configuration, wwwrootPath);
 
 services.AddSingleton<IVault>(_ => paymentVault);
 services.RegisterPaymentDomainServices(builder.Configuration);
-services.RegisterSubscriptionDomainServices(builder.Configuration);
+services.RegisterSubscriptionDomainServices(builder.Configuration, builder.Environment);
 services.RegisterUtilityServices();
 
 var app = builder.Build();

--- a/server/Api/appsettings.Development.json
+++ b/server/Api/appsettings.Development.json
@@ -29,5 +29,8 @@
     },
     "PublicBaseUrl": "https://dev-utilities.blocksdevelopers.com:5000",
     "IamBaseUrl": "https://dev-iam.blocksdevelopers.com"
+  },
+  "SubscriptionSimulation": {
+    "Enabled": true
   }
 }

--- a/server/Api/appsettings.dev.json
+++ b/server/Api/appsettings.dev.json
@@ -30,5 +30,8 @@
     "PublicBaseUrl": "https://dev-utilities.blocksdevelopers.com",
     "IamBaseUrl": "https://dev-iam.blocksdevelopers.com",
     "VerifyOrganizationWithIam": false
+  },
+  "SubscriptionSimulation": {
+    "Enabled": true
   }
 }

--- a/server/Subscription.DomainService/Entities/SubscriptionSimulationRun.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionSimulationRun.cs
@@ -1,0 +1,52 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One call into the subscription simulation harness, kept separately from
+/// <see cref="SubscriptionAuditEvent"/>.
+/// </summary>
+/// <remarks>
+/// A simulation run is a record that a tester or an administrator drove the domain through a
+/// scenario, not that the domain itself did something — the business audit trail still gets its
+/// own <see cref="SubscriptionAuditEvent"/> for the actual operation performed, because that
+/// operation genuinely happened and must appear in the same trail a real caller's would. Mixing
+/// the two would make it impossible to later purge or restrict simulation history without
+/// touching real financial audit records, or to tell, from the business trail alone, that an
+/// action was real.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionSimulationRun
+{
+    [BsonId]
+    public string ItemId { get; set; } = Guid.NewGuid().ToString("N");
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string? SubscriptionId { get; set; }
+
+    /// <summary>The caller who ran the simulation, from the authenticated context — never null.</summary>
+    public string ActorId { get; set; } = string.Empty;
+
+    /// <summary>E.g. <c>InspectState</c>, <c>AdvanceRenewal</c>, <c>MarkPaymentSucceeded</c>.</summary>
+    public string Action { get; set; } = string.Empty;
+
+    /// <summary>What was asked for, as a short human-readable line — not the full request body.</summary>
+    public string? RequestSummary { get; set; }
+
+    public string? BeforeSummary { get; set; }
+
+    public string? AfterSummary { get; set; }
+
+    public string CorrelationId { get; set; } = string.Empty;
+
+    public string Outcome { get; set; } = string.Empty;
+
+    public string? ErrorCode { get; set; }
+
+    public DateTime StartedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime? CompletedAtUtc { get; set; }
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
@@ -8,6 +8,17 @@ public interface ISubscriptionInvoiceHistoryRepository
         int pageSize,
         SubscriptionInvoiceHistoryCursor? after,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The same settled, invoiced payments as <see cref="ListAsync"/>, narrowed to one
+    /// subscription rather than paged across the whole organization.
+    /// </summary>
+    Task<IReadOnlyList<SubscriptionInvoiceHistoryRecord>> ListBySubscriptionAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken);
 }
 
 public sealed record SubscriptionInvoiceHistoryCursor(

--- a/server/Subscription.DomainService/Repositories/ISubscriptionSimulationRunRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionSimulationRunRepository.cs
@@ -1,0 +1,15 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public interface ISubscriptionSimulationRunRepository
+{
+    Task AppendAsync(SubscriptionSimulationRun run, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SubscriptionSimulationRun>> ListAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageInvoiceRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageInvoiceRepository.cs
@@ -21,6 +21,13 @@ public interface ISubscriptionUsageInvoiceRepository
         string periodKey,
         CancellationToken cancellationToken);
 
+    /// <summary>Every usage invoice raised for one subscription, newest period first.</summary>
+    Task<IReadOnlyList<SubscriptionUsageInvoice>> ListBySubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken);
+
     /// <summary>Pending invoices the charge sweep should look at now.</summary>
     Task<IReadOnlyList<SubscriptionUsageInvoice>> ListDueAsync(
         string tenantId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -23,6 +23,7 @@ internal static class SubscriptionCollections
     public const string PaymentLinks = "SubscriptionPaymentLinks";
     public const string UsageInvoices = "SubscriptionUsageInvoices";
     public const string AuditEvents = "SubscriptionAuditEvents";
+    public const string SimulationRuns = "SubscriptionSimulationRuns";
 
     public static IMongoCollection<TDocument> Of<TDocument>(
         IDbContextProvider dbContextProvider,

--- a/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
@@ -1,8 +1,11 @@
+using System.Text.RegularExpressions;
 using Blocks.Genesis;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Repositories;
 
@@ -70,6 +73,46 @@ public sealed class SubscriptionInvoiceHistoryRepository :
         }
 
         return new SubscriptionInvoiceHistoryPage(records, hasMore);
+    }
+
+    public async Task<IReadOnlyList<SubscriptionInvoiceHistoryRecord>> ListBySubscriptionAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        await _payments.EnsureIndexesAsync(tenantId, cancellationToken);
+
+        // Every order id this subscription's charges ever used shares this prefix — the bare
+        // form for the initial charge, a colon-suffixed form for every renewal, plan change,
+        // quantity settlement and usage invoice since (see SubscriptionConstants). A prefix
+        // match therefore finds all of them without knowing which kinds exist yet.
+        var orderIdPrefix = SubscriptionConstants.OrderIdFor(subscriptionId);
+
+        var filter = Builders<PaymentDetail>.Filter.And(
+            BuildFilter(tenantId, organizationId, after: null),
+            Builders<PaymentDetail>.Filter.Regex(
+                payment => payment.OrderId,
+                new BsonRegularExpression($"^{Regex.Escape(orderIdPrefix)}")));
+
+        return await Collection(tenantId)
+            .Find(filter)
+            .Sort(Builders<PaymentDetail>.Sort
+                .Descending(payment => payment.PaymentDate)
+                .Descending(payment => payment.ItemId))
+            .Limit(limit)
+            .Project(payment => new SubscriptionInvoiceHistoryRecord(
+                payment.ItemId,
+                payment.ProviderName,
+                payment.OrderId,
+                payment.Description,
+                payment.PreciseAmount,
+                payment.RefundedAmount,
+                payment.CurrencyCode,
+                payment.PaymentStatus,
+                payment.PaymentDate))
+            .ToListAsync(cancellationToken);
     }
 
     public static FilterDefinition<PaymentDetail> BuildFilter(

--- a/server/Subscription.DomainService/Repositories/SubscriptionSimulationRunRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionSimulationRunRepository.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionSimulationRunRepository : ISubscriptionSimulationRunRepository
+{
+    private readonly IDbContextProvider _db;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionSimulationRunRepository(IDbContextProvider db) => _db = db;
+
+    public async Task AppendAsync(SubscriptionSimulationRun run, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        await EnsureIndexesAsync(run.TenantId, cancellationToken);
+        await Runs(run.TenantId).InsertOneAsync(run, cancellationToken: cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SubscriptionSimulationRun>> ListAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Runs(tenantId)
+            .Find(Builders<SubscriptionSimulationRun>.Filter.And(
+                Builders<SubscriptionSimulationRun>.Filter.Eq(x => x.TenantId, tenantId),
+                Builders<SubscriptionSimulationRun>.Filter.Eq(x => x.OrganizationId, organizationId),
+                Builders<SubscriptionSimulationRun>.Filter.Eq(x => x.SubscriptionId, subscriptionId)))
+            .SortByDescending(x => x.StartedAtUtc)
+            .Limit(Math.Clamp(limit, 1, 500))
+            .ToListAsync(cancellationToken);
+
+    private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId)) return;
+
+        await Runs(tenantId).Indexes.CreateManyAsync([
+            new CreateIndexModel<SubscriptionSimulationRun>(
+                Builders<SubscriptionSimulationRun>.IndexKeys
+                    .Ascending(x => x.TenantId).Ascending(x => x.OrganizationId)
+                    .Ascending(x => x.SubscriptionId).Descending(x => x.StartedAtUtc),
+                new CreateIndexOptions { Name = "ix_subscription_simulation_run_timeline" })
+        ], cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    private IMongoCollection<SubscriptionSimulationRun> Runs(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionSimulationRun>(
+            _db, tenantId, SubscriptionCollections.SimulationRuns);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageInvoiceRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageInvoiceRepository.cs
@@ -68,6 +68,21 @@ public sealed class SubscriptionUsageInvoiceRepository : ISubscriptionUsageInvoi
                     periodKey)))
             .FirstOrDefaultAsync(cancellationToken);
 
+    public async Task<IReadOnlyList<SubscriptionUsageInvoice>> ListBySubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Invoices(tenantId)
+            .Find(Builders<SubscriptionUsageInvoice>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionUsageInvoice>.Filter.Eq(
+                    invoice => invoice.SubscriptionId,
+                    subscriptionId)))
+            .SortByDescending(invoice => invoice.PeriodKey)
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
     public async Task<IReadOnlyList<SubscriptionUsageInvoice>> ListDueAsync(
         string tenantId,
         DateTime dueAtUtc,

--- a/server/Subscription.DomainService/Responses/SubscriptionSimulationStateResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionSimulationStateResponse.cs
@@ -1,0 +1,163 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// A complete, read-only snapshot of one subscription for the simulation harness — everything a
+/// tester needs to see in one call rather than piecing it together from several ordinary
+/// endpoints.
+/// </summary>
+/// <remarks>
+/// Deliberately narrower than the underlying documents. It never carries a stored payment
+/// method id, a provider customer id, a checkout URL, or an outbox event's raw payload — the
+/// same redaction the business audit trail already applies, because this is still a diagnostic
+/// surface an administrator reads, not a database export.
+/// </remarks>
+public sealed class SubscriptionSimulationStateResponse
+{
+    public string SubscriptionId { get; init; } = string.Empty;
+
+    public string TenantId { get; init; } = string.Empty;
+
+    public string OrganizationId { get; init; } = string.Empty;
+
+    public SubscriptionResponse Subscription { get; init; } = new();
+
+    /// <summary>Null when the entitlement read itself failed; the rest of the state is still returned.</summary>
+    public EntitlementSnapshotResponse? Entitlements { get; init; }
+
+    public SimulationSettlementReservationResponse? SettlementReservation { get; init; }
+
+    public SimulationPendingCheckoutResponse? PendingCheckout { get; init; }
+
+    public List<SimulationPaymentResponse> Payments { get; init; } = [];
+
+    public List<SimulationUsageInvoiceResponse> UsageInvoices { get; init; } = [];
+
+    /// <summary>Null when <c>includeBackgroundWork</c> was not requested.</summary>
+    public SimulationBackgroundWorkResponse? BackgroundWork { get; init; }
+
+    public List<SubscriptionAuditEventResponse> AuditEvents { get; init; } = [];
+
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// An increase reserved but not yet settled. Carries none of
+/// <c>StoredPaymentMethodId</c>/<c>ProviderCustomerId</c>/<c>ProviderOrganizationId</c> — the
+/// same fields the financial audit trail excludes.
+/// </summary>
+public sealed class SimulationSettlementReservationResponse
+{
+    public string ReservationId { get; init; } = string.Empty;
+
+    public string Kind { get; init; } = string.Empty;
+
+    public long ChargeAmountMinor { get; init; }
+
+    public DateTime ReservedAtUtc { get; init; }
+
+    public int ReservedAtVersion { get; init; }
+
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>The outstanding checkout link, if the first charge has not settled yet.</summary>
+public sealed class SimulationPendingCheckoutResponse
+{
+    public string PaymentDetailId { get; init; } = string.Empty;
+
+    public string Purpose { get; init; } = string.Empty;
+
+    public string State { get; init; } = string.Empty;
+
+    public int AttemptCount { get; init; }
+
+    public DateTime? NextCheckAtUtc { get; init; }
+
+    public string? LastError { get; init; }
+}
+
+/// <summary>One settled, invoiced payment — never the provider's own invoice or customer id.</summary>
+public sealed class SimulationPaymentResponse
+{
+    public string PaymentDetailId { get; init; } = string.Empty;
+
+    public string ProviderName { get; init; } = string.Empty;
+
+    public string? OrderId { get; init; }
+
+    public string? Description { get; init; }
+
+    public decimal Amount { get; init; }
+
+    public decimal RefundedAmount { get; init; }
+
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public string Status { get; init; } = string.Empty;
+
+    public DateTime IssuedAtUtc { get; init; }
+}
+
+public sealed class SimulationUsageInvoiceResponse
+{
+    public string UsageInvoiceId { get; init; } = string.Empty;
+
+    public string PeriodKey { get; init; } = string.Empty;
+
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public long TotalAmountMinor { get; init; }
+
+    public long TaxAmountMinor { get; init; }
+
+    public string State { get; init; } = string.Empty;
+
+    public int AttemptCount { get; init; }
+
+    public DateTime? NextAttemptAtUtc { get; init; }
+
+    public string? PaymentDetailId { get; init; }
+
+    public string? LastError { get; init; }
+}
+
+/// <summary>
+/// The subscription's own outbox, grouped by status. Never the event's raw payload — only what
+/// a tester needs to tell a stuck job from a healthy one.
+/// </summary>
+public sealed class SimulationBackgroundWorkResponse
+{
+    public int PendingCount { get; init; }
+
+    public int ProcessingCount { get; init; }
+
+    public int RetryScheduledCount { get; init; }
+
+    public int PublishedCount { get; init; }
+
+    /// <summary>The dead letter: an event the outbox has given up retrying.</summary>
+    public int AbandonedCount { get; init; }
+
+    public List<SimulationBackgroundWorkItemResponse> Items { get; init; } = [];
+}
+
+public sealed class SimulationBackgroundWorkItemResponse
+{
+    public string EventId { get; init; } = string.Empty;
+
+    public string EventType { get; init; } = string.Empty;
+
+    public string Status { get; init; } = string.Empty;
+
+    public int AttemptCount { get; init; }
+
+    public DateTime? NextAttemptAtUtc { get; init; }
+
+    public DateTime? LeaseExpiresAtUtc { get; init; }
+
+    public string? LastError { get; init; }
+
+    public string CorrelationId { get; init; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; init; }
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -1,0 +1,25 @@
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Subscription.DomainService.Simulation;
+
+public interface ISubscriptionSimulationService
+{
+    /// <summary>
+    /// A complete, read-only snapshot of one subscription — plan and price, entitlements,
+    /// settlement reservation, pending checkout, settled payments, usage invoices, background
+    /// work and recent audit events — for the simulation harness.
+    /// </summary>
+    /// <param name="organizationId">
+    /// Required. Simulation is console-only, and the console has no subscription of its own to
+    /// inspect — the caller always names whose subscription it means.
+    /// </param>
+    Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
+        string subscriptionId,
+        string? organizationId,
+        int auditLimit,
+        int paymentLimit,
+        bool includeBackgroundWork,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationGuard.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationGuard.cs
@@ -1,0 +1,53 @@
+using Payment.DomainService.Utilities;
+
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// Whether a caller may reach the subscription simulation harness at all.
+/// </summary>
+/// <remarks>
+/// Pure and synchronous, mirroring <see cref="PaymentOrganizationScope"/> — the same reasoning
+/// applies: this is checked before any repository round trip, not after one.
+/// <para>
+/// Two conditions, both required. The platform-console check reuses
+/// <see cref="PaymentOrganizationScope.RequestMayNameOrganization"/> rather than duplicating it,
+/// because simulation must never be reachable by a wider audience than the console override
+/// already is — an ordinary organization's own token must never unlock this surface for its own
+/// subscription. The permission check is additional and deliberate: being the console is
+/// necessary but not sufficient, since every console-authenticated caller would otherwise be
+/// able to rewrite billing history for every tenant it can reach.
+/// </para>
+/// </remarks>
+public static class SubscriptionSimulationGuard
+{
+    /// <summary>
+    /// The claim a caller's token must carry, in its <c>permissions</c> claim collection, to use
+    /// the simulation harness.
+    /// </summary>
+    public const string SimulationAdministratorPermission = "subscription-simulation-administrator";
+
+    /// <summary>
+    /// True only for a console caller whose token also carries
+    /// <see cref="SimulationAdministratorPermission"/>.
+    /// </summary>
+    /// <param name="callerOrganizationId">The organization from the caller's own token — never
+    /// the organization a request names, which is the very thing this decides whether to trust.</param>
+    /// <param name="paymentOptions">Supplies the console's organization identifier.</param>
+    /// <param name="callerPermissions">The caller's own <c>permissions</c> claim values.</param>
+    public static bool IsAuthorized(
+        string? callerOrganizationId,
+        PaymentOptions paymentOptions,
+        IEnumerable<string>? callerPermissions)
+    {
+        ArgumentNullException.ThrowIfNull(paymentOptions);
+
+        if (!PaymentOrganizationScope.RequestMayNameOrganization(callerOrganizationId, paymentOptions))
+        {
+            return false;
+        }
+
+        return callerPermissions?.Contains(
+            SimulationAdministratorPermission,
+            StringComparer.Ordinal) ?? false;
+    }
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -1,0 +1,318 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Subscription.DomainService.Simulation;
+
+public sealed class SubscriptionSimulationService : ISubscriptionSimulationService
+{
+    private const int MaximumLimit = 500;
+
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionResponseMapper _responseMapper;
+    private readonly IEntitlementService _entitlements;
+    private readonly ISubscriptionInvoiceHistoryRepository _invoiceHistory;
+    private readonly ISubscriptionUsageInvoiceRepository _usageInvoices;
+    private readonly ISubscriptionPaymentLinkRepository _paymentLinks;
+    private readonly ISubscriptionAuditRepository _auditEvents;
+    private readonly ISubscriptionSimulationRunRepository _simulationRuns;
+    private readonly IOptionsMonitor<PaymentOptions> _paymentOptions;
+
+    public SubscriptionSimulationService(
+        ISubscriptionContextResolver contextResolver,
+        ISubscriptionRepository subscriptions,
+        ISubscriptionResponseMapper responseMapper,
+        IEntitlementService entitlements,
+        ISubscriptionInvoiceHistoryRepository invoiceHistory,
+        ISubscriptionUsageInvoiceRepository usageInvoices,
+        ISubscriptionPaymentLinkRepository paymentLinks,
+        ISubscriptionAuditRepository auditEvents,
+        ISubscriptionSimulationRunRepository simulationRuns,
+        IOptionsMonitor<PaymentOptions> paymentOptions)
+    {
+        _contextResolver = contextResolver;
+        _subscriptions = subscriptions;
+        _responseMapper = responseMapper;
+        _entitlements = entitlements;
+        _invoiceHistory = invoiceHistory;
+        _usageInvoices = usageInvoices;
+        _paymentLinks = paymentLinks;
+        _auditEvents = auditEvents;
+        _simulationRuns = simulationRuns;
+        _paymentOptions = paymentOptions;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
+        string subscriptionId,
+        string? organizationId,
+        int auditLimit,
+        int paymentLimit,
+        bool includeBackgroundWork,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        // Checked against the caller's own token, never against anything a request names — that
+        // is exactly the question this decides the trustworthiness of.
+        var caller = BlocksContext.GetContext();
+
+        if (!SubscriptionSimulationGuard.IsAuthorized(
+                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_forbidden",
+                "This caller may not use the subscription simulation harness.",
+                correlationId);
+        }
+
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_organization_required",
+                "organizationId is required: the console has no subscription of its own.",
+                correlationId,
+                new Dictionary<string, string[]>
+                {
+                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
+                });
+        }
+
+        if (!IsValidLimit(auditLimit) || !IsValidLimit(paymentLimit))
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_limit_invalid",
+                $"auditLimit and paymentLimit must be between 1 and {MaximumLimit}.",
+                correlationId,
+                new Dictionary<string, string[]>
+                {
+                    ["AuditLimit"] = [$"Must be between 1 and {MaximumLimit}."],
+                    ["PaymentLimit"] = [$"Must be between 1 and {MaximumLimit}."]
+                });
+        }
+
+        // Resolves and, for the console, verifies the named organization actually exists — the
+        // guard above only established who is asking, not that what they asked for is real.
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, organizationId, cancellationToken);
+
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return resolution.ToFailure<SubscriptionSimulationStateResponse>(correlationId);
+        }
+
+        var context = resolution.Context;
+
+        // Scoped by organization here, the same as every ordinary read — a subscription outside
+        // it reports as missing rather than forbidden, so its existence in another organization
+        // is never confirmed.
+        var subscription = await _subscriptions.GetAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken);
+
+        if (subscription is null)
+        {
+            await RecordRunAsync(
+                context, subscriptionId, "InspectState", correlationId,
+                "Failed", "subscription_not_found", cancellationToken);
+
+            return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "The subscription does not exist.",
+                correlationId);
+        }
+
+        var entitlementsResult = await _entitlements.GetAsync(
+            fresh: true, organizationId: context.OrganizationId, correlationId, cancellationToken);
+
+        var payments = await _invoiceHistory.ListBySubscriptionAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, paymentLimit, cancellationToken);
+
+        var usageInvoices = await _usageInvoices.ListBySubscriptionAsync(
+            context.TenantId, subscriptionId, paymentLimit, cancellationToken);
+
+        var pendingCheckout = await _paymentLinks.FindBySubscriptionAsync(
+            context.TenantId, subscriptionId, cancellationToken);
+
+        var auditEvents = await _auditEvents.ListAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, auditLimit, cancellationToken);
+
+        var response = new SubscriptionSimulationStateResponse
+        {
+            SubscriptionId = subscriptionId,
+            TenantId = context.TenantId,
+            OrganizationId = context.OrganizationId,
+            // Never given a checkout URL: this is a diagnostic read, not a way to drive an actual
+            // checkout, and a live URL is one of the values the audit rules already exclude.
+            Subscription = _responseMapper.ToResponse(subscription, checkoutUrl: null),
+            Entitlements = entitlementsResult.IsSuccess ? entitlementsResult.Value : null,
+            SettlementReservation = MapSettlementReservation(subscription.SettlementReservation),
+            PendingCheckout = MapPendingCheckout(pendingCheckout),
+            Payments = payments.Select(MapPayment).ToList(),
+            UsageInvoices = usageInvoices.Select(MapUsageInvoice).ToList(),
+            BackgroundWork = includeBackgroundWork ? MapBackgroundWork(subscription) : null,
+            AuditEvents = auditEvents.Select(MapAuditEvent).ToList(),
+            CorrelationId = correlationId
+        };
+
+        await RecordRunAsync(
+            context, subscriptionId, "InspectState", correlationId,
+            "Succeeded", null, cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Success(
+            response, correlationId);
+    }
+
+    private static bool IsValidLimit(int limit) => limit is > 0 and <= MaximumLimit;
+
+    private async Task RecordRunAsync(
+        SubscriptionContext context,
+        string subscriptionId,
+        string action,
+        string correlationId,
+        string outcome,
+        string? errorCode,
+        CancellationToken cancellationToken)
+    {
+        // Fire-and-observe, like the business audit trail: a simulation run failing to record
+        // itself must never take down the read it is only describing.
+        try
+        {
+            await _simulationRuns.AppendAsync(
+                new SubscriptionSimulationRun
+                {
+                    TenantId = context.TenantId,
+                    OrganizationId = context.OrganizationId,
+                    SubscriptionId = subscriptionId,
+                    ActorId = context.ActorId,
+                    Action = action,
+                    CorrelationId = correlationId,
+                    Outcome = outcome,
+                    ErrorCode = errorCode,
+                    CompletedAtUtc = DateTime.UtcNow
+                },
+                cancellationToken);
+        }
+        catch
+        {
+            // Deliberately swallowed — see the remark above.
+        }
+    }
+
+    private static SimulationSettlementReservationResponse? MapSettlementReservation(
+        SettlementReservation? reservation) =>
+        reservation is null
+            ? null
+            : new SimulationSettlementReservationResponse
+            {
+                ReservationId = reservation.ReservationId,
+                Kind = reservation.Kind.ToString(),
+                ChargeAmountMinor = reservation.ChargeAmountMinor,
+                ReservedAtUtc = reservation.ReservedAtUtc,
+                ReservedAtVersion = reservation.ReservedAtVersion,
+                CorrelationId = reservation.CorrelationId
+            };
+
+    private static SimulationPendingCheckoutResponse? MapPendingCheckout(
+        SubscriptionPaymentLink? link) =>
+        link is null
+            ? null
+            : new SimulationPendingCheckoutResponse
+            {
+                PaymentDetailId = link.PaymentDetailId,
+                Purpose = link.Purpose.ToString(),
+                State = link.State.ToString(),
+                AttemptCount = link.AttemptCount,
+                NextCheckAtUtc = link.NextCheckAtUtc,
+                LastError = link.LastError
+            };
+
+    private static SimulationPaymentResponse MapPayment(
+        SubscriptionInvoiceHistoryRecord record) =>
+        new()
+        {
+            PaymentDetailId = record.PaymentDetailId,
+            ProviderName = record.ProviderName,
+            OrderId = record.OrderId,
+            Description = record.Description,
+            Amount = record.Amount,
+            RefundedAmount = record.RefundedAmount,
+            CurrencyCode = record.CurrencyCode,
+            Status = record.Status,
+            IssuedAtUtc = record.IssuedAtUtc
+        };
+
+    private static SimulationUsageInvoiceResponse MapUsageInvoice(
+        SubscriptionUsageInvoice invoice) =>
+        new()
+        {
+            UsageInvoiceId = invoice.ItemId,
+            PeriodKey = invoice.PeriodKey,
+            CurrencyCode = invoice.CurrencyCode,
+            TotalAmountMinor = invoice.TotalAmountMinor,
+            TaxAmountMinor = invoice.TaxAmountMinor,
+            State = invoice.State.ToString(),
+            AttemptCount = invoice.AttemptCount,
+            NextAttemptAtUtc = invoice.NextAttemptAtUtc,
+            PaymentDetailId = invoice.PaymentDetailId,
+            LastError = invoice.LastError
+        };
+
+    private static SimulationBackgroundWorkResponse MapBackgroundWork(
+        SubscriptionDetail subscription)
+    {
+        var events = subscription.OutboxEvents;
+
+        return new SimulationBackgroundWorkResponse
+        {
+            PendingCount = events.Count(e => e.Status == SubscriptionOutboxStatus.Pending),
+            ProcessingCount = events.Count(e => e.Status == SubscriptionOutboxStatus.Processing),
+            RetryScheduledCount = events.Count(e => e.Status == SubscriptionOutboxStatus.RetryScheduled),
+            PublishedCount = events.Count(e => e.Status == SubscriptionOutboxStatus.Published),
+            AbandonedCount = events.Count(e => e.Status == SubscriptionOutboxStatus.Abandoned),
+            Items = events
+                .OrderByDescending(e => e.CreatedAtUtc)
+                .Select(e => new SimulationBackgroundWorkItemResponse
+                {
+                    EventId = e.EventId,
+                    EventType = e.EventType,
+                    Status = e.Status.ToString(),
+                    AttemptCount = e.AttemptCount,
+                    NextAttemptAtUtc = e.NextAttemptAtUtc,
+                    LeaseExpiresAtUtc = e.LeaseExpiresAtUtc,
+                    LastError = e.LastError,
+                    CorrelationId = e.CorrelationId,
+                    CreatedAtUtc = e.CreatedAtUtc
+                })
+                .ToList()
+        };
+    }
+
+    private static SubscriptionAuditEventResponse MapAuditEvent(SubscriptionAuditEvent auditEvent) =>
+        new()
+        {
+            EventId = auditEvent.ItemId,
+            OperationId = auditEvent.OperationId,
+            CorrelationId = auditEvent.CorrelationId,
+            Operation = auditEvent.Operation,
+            Stage = auditEvent.Stage,
+            Outcome = auditEvent.Outcome,
+            Source = auditEvent.Source,
+            AmountMinor = auditEvent.AmountMinor,
+            CurrencyCode = auditEvent.CurrencyCode,
+            FromStatus = auditEvent.FromStatus,
+            ToStatus = auditEvent.ToStatus,
+            ErrorCode = auditEvent.ErrorCode,
+            FailureKind = auditEvent.FailureKind,
+            Attempt = auditEvent.Attempt,
+            OccurredAtUtc = auditEvent.OccurredAtUtc
+        };
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using FluentValidation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Services;
+using Subscription.DomainService.Simulation;
 using Subscription.DomainService.Validators;
 
 namespace Subscription.DomainService.Utilities;
@@ -15,15 +17,35 @@ public static class ApplicationServiceCollectionExtensions
     /// Registers the subscription capability. Called by both the Api and the Worker, because
     /// the same services back the request path and the background sweeps.
     /// </summary>
+    /// <param name="hostEnvironment">
+    /// Passed so a Production host that somehow has <c>SubscriptionSimulation:Enabled</c> set to
+    /// <c>true</c> fails to start rather than exposing the harness. Optional only so existing
+    /// callers compile unchanged; both actual hosts (Api, Worker) pass their own environment.
+    /// </param>
     public static IServiceCollection RegisterSubscriptionDomainServices(
         this IServiceCollection services,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IHostEnvironment? hostEnvironment = null)
     {
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(configuration);
 
         services.Configure<SubscriptionOptions>(
             configuration.GetSection(SubscriptionOptions.SectionName));
+
+        var simulationSection = configuration.GetSection(SubscriptionSimulationOptions.SectionName);
+        services.Configure<SubscriptionSimulationOptions>(simulationSection);
+
+        if (hostEnvironment is { } environment &&
+            environment.IsProduction() &&
+            simulationSection.GetValue<bool>(nameof(SubscriptionSimulationOptions.Enabled)))
+        {
+            // The harness can rewrite billing history through real domain processors. Refusing
+            // to start is deliberately louder than the request-time 404 guard the controller
+            // also applies — a misconfigured Production deploy should never come up quietly.
+            throw new InvalidOperationException(
+                "SubscriptionSimulation:Enabled must not be true in a Production environment.");
+        }
 
         // Repositories are singletons and take the tenant as an argument, so the same instance
         // serves a request and a background sweep. They hold no per-tenant state beyond the
@@ -51,6 +73,9 @@ public static class ApplicationServiceCollectionExtensions
             SubscriptionInvoiceHistoryRepository>();
         services.AddSingleton<ISubscriptionDiscountRepository, SubscriptionDiscountRepository>();
         services.AddSingleton<ISubscriptionAuditRepository, SubscriptionAuditRepository>();
+        services.AddSingleton<
+            ISubscriptionSimulationRunRepository,
+            SubscriptionSimulationRunRepository>();
 
         // Singleton so the cache is actually shared. Scoped, every request would get an empty
         // one and the hot path would read the database every time regardless.
@@ -154,6 +179,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionUsageRatingProcessor,
             SubscriptionUsageRatingProcessor>();
+        services.AddScoped<
+            ISubscriptionSimulationService,
+            SubscriptionSimulationService>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/SubscriptionSimulationOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionSimulationOptions.cs
@@ -1,0 +1,19 @@
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Gates the subscription simulation test harness — a diagnostic surface that can advance a
+/// subscription's lifecycle without waiting for calendar time.
+/// </summary>
+/// <remarks>
+/// Defaults closed. This is checked twice: once at service registration, where a
+/// <see cref="Enabled"/> of <c>true</c> in a Production <c>IHostEnvironment</c> throws rather
+/// than starts, and again on every request, since remote configuration (this repository loads
+/// config from a Mongo-backed secrets collection) can flip the value after the process has
+/// already started without a restart to catch it at.
+/// </remarks>
+public sealed class SubscriptionSimulationOptions
+{
+    public const string SectionName = "SubscriptionSimulation";
+
+    public bool Enabled { get; set; }
+}

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -73,7 +73,8 @@ IHostBuilder CreateHostBuilder(string[] args) =>
             services.RegisterUtilityServices();
             services.AddSingleton<IVault>(_ => paymentVault);
             services.RegisterPaymentDomainServices(context.Configuration);
-            services.RegisterSubscriptionDomainServices(context.Configuration);
+            services.RegisterSubscriptionDomainServices(
+                context.Configuration, context.HostingEnvironment);
             services.AddHostedService<
                 PaymentReconciliationBackgroundService>();
             services.AddHostedService<

--- a/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Utilities;
@@ -33,6 +34,7 @@ public sealed class SubscriptionServiceRegistrationTests
     [InlineData(typeof(ISubscriptionRepository))]
     [InlineData(typeof(ISubscriptionUsageRepository))]
     [InlineData(typeof(ISubscriptionPaymentLinkRepository))]
+    [InlineData(typeof(ISubscriptionSimulationRunRepository))]
     public void Repositories_are_singletons(Type serviceType)
     {
         var descriptor = Subscriptions()
@@ -71,6 +73,76 @@ public sealed class SubscriptionServiceRegistrationTests
         options.TenantIds.Should().BeEmpty(
             "nothing else discovers tenants, so an omitted tenant is silently skipped by " +
             "every background sweep");
+    }
+
+    [Fact]
+    public void Simulation_is_disabled_by_default()
+    {
+        new SubscriptionSimulationOptions().Enabled.Should().BeFalse(
+            "the harness can rewrite billing history through real domain processors and must " +
+            "never be reachable without an explicit opt-in");
+    }
+
+    [Fact]
+    public void Simulation_options_bind_from_their_own_section()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterSubscriptionDomainServices(Configuration(new Dictionary<string, string?>
+        {
+            ["SubscriptionSimulation:Enabled"] = "true"
+        }));
+
+        var options = services
+            .BuildServiceProvider()
+            .GetRequiredService<IOptions<SubscriptionSimulationOptions>>()
+            .Value;
+
+        options.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Registration_refuses_to_enable_simulation_in_production()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.RegisterSubscriptionDomainServices(
+            Configuration(new Dictionary<string, string?>
+            {
+                ["SubscriptionSimulation:Enabled"] = "true"
+            }),
+            new FakeHostEnvironment("Production"));
+
+        act.Should().Throw<InvalidOperationException>(
+            "a Production deploy with the harness enabled must fail to start, not come up quietly");
+    }
+
+    [Fact]
+    public void Registration_allows_simulation_enabled_outside_production()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.RegisterSubscriptionDomainServices(
+            Configuration(new Dictionary<string, string?>
+            {
+                ["SubscriptionSimulation:Enabled"] = "true"
+            }),
+            new FakeHostEnvironment("Development"));
+
+        act.Should().NotThrow();
+    }
+
+    private sealed class FakeHostEnvironment : IHostEnvironment
+    {
+        public FakeHostEnvironment(string environmentName) => EnvironmentName = environmentName;
+
+        public string EnvironmentName { get; set; }
+        public string ApplicationName { get; set; } = "XUnitTest";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+            new Microsoft.Extensions.FileProviders.NullFileProvider();
     }
 
     private static IServiceCollection Subscriptions()

--- a/server/XUnitTest/Subscription/SubscriptionSimulationGuardTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationGuardTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Simulation;
+
+namespace XUnitTest.Subscription;
+
+public sealed class SubscriptionSimulationGuardTests
+{
+    private static readonly PaymentOptions Options = new() { ConsoleOrganizationId = "console-org" };
+
+    [Fact]
+    public void Refuses_a_non_console_caller_even_with_the_permission()
+    {
+        SubscriptionSimulationGuard.IsAuthorized(
+                "some-other-org", Options, [SubscriptionSimulationGuard.SimulationAdministratorPermission])
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Refuses_the_console_without_the_permission()
+    {
+        SubscriptionSimulationGuard.IsAuthorized(
+                "console-org", Options, ["some-other-permission"])
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Refuses_the_console_with_no_permissions_at_all()
+    {
+        SubscriptionSimulationGuard.IsAuthorized("console-org", Options, null)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Refuses_a_caller_with_no_organization()
+    {
+        SubscriptionSimulationGuard.IsAuthorized(
+                null, Options, [SubscriptionSimulationGuard.SimulationAdministratorPermission])
+            .Should().BeFalse(
+                "a caller with no organization is a tenant-wide integration, not the console, " +
+                "the same rule PaymentOrganizationScope already applies");
+    }
+
+    [Fact]
+    public void Allows_the_console_with_the_permission()
+    {
+        SubscriptionSimulationGuard.IsAuthorized(
+                "console-org", Options, [SubscriptionSimulationGuard.SimulationAdministratorPermission])
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Refuses_everyone_when_the_console_override_is_turned_off()
+    {
+        var noConsole = new PaymentOptions { ConsoleOrganizationId = "" };
+
+        SubscriptionSimulationGuard.IsAuthorized(
+                "console-org", noConsole, [SubscriptionSimulationGuard.SimulationAdministratorPermission])
+            .Should().BeFalse();
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -1,0 +1,216 @@
+using Blocks.Genesis;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Simulation;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// <see cref="SubscriptionSimulationService"/> in isolation, every collaborator mocked.
+/// </summary>
+/// <remarks>
+/// <see cref="BlocksContext"/> is ambient (an <c>AsyncLocal</c>), so every test sets and clears
+/// it itself rather than relying on ordering between tests — xUnit does not guarantee one test's
+/// context is gone before the next starts on the same thread.
+/// </remarks>
+public sealed class SubscriptionSimulationServiceTests : IDisposable
+{
+    private const string ConsoleOrganizationId = "console-org";
+    private const string SubscriptionId = "sub-1";
+    private const string TenantId = "tenant-1";
+    private const string CorrelationId = "corr-1";
+
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionResponseMapper> _responseMapper = new();
+    private readonly Mock<IEntitlementService> _entitlements = new();
+    private readonly Mock<ISubscriptionInvoiceHistoryRepository> _invoiceHistory = new();
+    private readonly Mock<ISubscriptionUsageInvoiceRepository> _usageInvoices = new();
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _paymentLinks = new();
+    private readonly Mock<ISubscriptionAuditRepository> _auditEvents = new();
+    private readonly Mock<ISubscriptionSimulationRunRepository> _simulationRuns = new();
+    private readonly Mock<IOptionsMonitor<PaymentOptions>> _paymentOptions = new();
+
+    public SubscriptionSimulationServiceTests()
+    {
+        _paymentOptions
+            .Setup(options => options.CurrentValue)
+            .Returns(new PaymentOptions { ConsoleOrganizationId = ConsoleOrganizationId });
+    }
+
+    public void Dispose() => BlocksContext.ClearContext();
+
+    [Fact]
+    public async Task Refuses_a_caller_who_is_not_the_console()
+    {
+        SetCaller(organizationId: "some-other-org", permissions: [SubscriptionSimulationGuard.SimulationAdministratorPermission]);
+
+        var result = await GetStateAsync(organizationId: "target-org");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_forbidden");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "an unauthorized caller must never reach a repository round trip");
+    }
+
+    [Fact]
+    public async Task Refuses_the_console_without_the_simulation_permission()
+    {
+        SetCaller(organizationId: ConsoleOrganizationId, permissions: []);
+
+        var result = await GetStateAsync(organizationId: "target-org");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_forbidden");
+    }
+
+    [Fact]
+    public async Task Requires_an_organization_because_the_console_has_none_of_its_own()
+    {
+        SetAuthorizedCaller();
+
+        var result = await GetStateAsync(organizationId: null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_organization_required");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(501)]
+    public async Task Rejects_an_out_of_range_limit(int limit)
+    {
+        SetAuthorizedCaller();
+
+        var result = await GetStateAsync(organizationId: "target-org", auditLimit: limit);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_limit_invalid");
+    }
+
+    [Fact]
+    public async Task Reports_not_found_rather_than_leaking_that_the_subscription_belongs_elsewhere()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var result = await GetStateAsync(organizationId: "target-org");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_not_found");
+        _simulationRuns.Verify(
+            runs => runs.AppendAsync(
+                It.Is<SubscriptionSimulationRun>(run => run.Outcome == "Failed"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Assembles_the_state_from_every_collaborator_on_the_happy_path()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId,
+            TenantId = TenantId,
+            OrganizationId = "target-org",
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _responseMapper
+            .Setup(mapper => mapper.ToResponse(subscription, null))
+            .Returns(new SubscriptionResponse { SubscriptionId = SubscriptionId });
+        _entitlements
+            .Setup(service => service.GetAsync(true, "target-org", CorrelationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<EntitlementSnapshotResponse>.Success(
+                new EntitlementSnapshotResponse(), CorrelationId));
+        _invoiceHistory
+            .Setup(repo => repo.ListBySubscriptionAsync(
+                TenantId, "target-org", SubscriptionId, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionInvoiceHistoryRecord>)[]);
+        _usageInvoices
+            .Setup(repo => repo.ListBySubscriptionAsync(TenantId, SubscriptionId, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageInvoice>)[]);
+        _paymentLinks
+            .Setup(repo => repo.FindBySubscriptionAsync(TenantId, SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionPaymentLink?)null);
+        _auditEvents
+            .Setup(repo => repo.ListAsync(TenantId, "target-org", SubscriptionId, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionAuditEvent>)[]);
+
+        var result = await GetStateAsync(organizationId: "target-org");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.SubscriptionId.Should().Be(SubscriptionId);
+        result.Value!.TenantId.Should().Be(TenantId);
+        result.Value!.OrganizationId.Should().Be("target-org");
+        result.Value!.Entitlements.Should().NotBeNull();
+        _simulationRuns.Verify(
+            runs => runs.AppendAsync(
+                It.Is<SubscriptionSimulationRun>(run => run.Outcome == "Succeeded"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private void SetAuthorizedCaller() =>
+        SetCaller(ConsoleOrganizationId, [SubscriptionSimulationGuard.SimulationAdministratorPermission]);
+
+    private static void SetCaller(string? organizationId, IEnumerable<string> permissions) =>
+        BlocksContext.SetContext(BlocksContext.Create(
+            tenantId: TenantId,
+            roles: [],
+            userId: "user-1",
+            isAuthenticated: true,
+            requestUri: null,
+            organizationId: organizationId,
+            expireOn: DateTime.UtcNow.AddHours(1),
+            email: "tester@example.com",
+            permissions: permissions,
+            userName: null,
+            phoneNumber: null,
+            displayName: null,
+            oauthToken: null,
+            originalTenantId: null));
+
+    private void ResolvesContext(string organizationId) =>
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(CorrelationId, organizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, organizationId, "user-1", "user-1")));
+
+    private Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
+        string? organizationId,
+        int auditLimit = 100,
+        int paymentLimit = 100) =>
+        CreateService().GetStateAsync(
+            SubscriptionId, organizationId, auditLimit, paymentLimit,
+            includeBackgroundWork: false, CorrelationId, CancellationToken.None);
+
+    private SubscriptionSimulationService CreateService() => new(
+        _contextResolver.Object,
+        _subscriptions.Object,
+        _responseMapper.Object,
+        _entitlements.Object,
+        _invoiceHistory.Object,
+        _usageInvoices.Object,
+        _paymentLinks.Object,
+        _auditEvents.Object,
+        _simulationRuns.Object,
+        _paymentOptions.Object);
+}


### PR DESCRIPTION
## Summary

PR 1 of the purpose-built subscription simulation harness task plan — foundation and read-only state inspection. Later PRs (not in this one) add controlled mutation actions: payment-outcome simulation, advance-renewal, close-usage-period, and scoped background-job execution.

**Safety**
- `SubscriptionSimulationOptions.Enabled` defaults to `false`. `RegisterSubscriptionDomainServices` now takes an optional `IHostEnvironment` and throws at service-registration time if the harness is enabled in a Production environment. The controller additionally re-checks `IOptionsMonitor<SubscriptionSimulationOptions>.CurrentValue.Enabled` on every request — this repo loads config from a Mongo-backed secrets collection, so a value can change without a process restart, and the plan explicitly calls for not relying on a startup check alone.
- `SubscriptionSimulationGuard` requires both: the caller's own token organization equals the platform console (`PaymentOrganizationScope.RequestMayNameOrganization`, reused rather than duplicated), **and** the token carries a `subscription-simulation-administrator` permission claim (`BlocksContext.Permissions`, populated from the JWT `permissions` claim — confirmed by decompiling the referenced Genesis assembly, since nothing in this repo used that claim before). Both conditions are required; being the console alone is not enough.
- The endpoint requires `organizationId` explicitly (the console has no subscription of its own), validates `auditLimit`/`paymentLimit` are within 1–500, and 404s for a subscription outside the resolved organization (same "404 may mean not yours" convention the rest of the module follows) rather than a 403 that would confirm it exists elsewhere.
- `PaymentFailureKind` has no `Forbidden` value, so `subscription_simulation_forbidden` is special-cased in the controller to return a real 403 rather than being silently mapped to a 404 indistinguishable from "harness disabled".

**What the endpoint returns** — `GET /api/subscription-simulation/subscriptions/{subscriptionId}/state?organizationId=&auditLimit=100&paymentLimit=100&includeBackgroundWork=true`:
- The subscription via the existing `ISubscriptionResponseMapper` (no checkout URL — this is a diagnostic read, not a checkout driver)
- Live entitlements (`fresh: true`)
- The settlement reservation, redacted (no stored payment method id / provider customer id / provider organization id — same redaction the business audit trail already applies)
- The pending checkout link, if any
- Settled payments/invoices for this subscription (new `ListBySubscriptionAsync` on `ISubscriptionInvoiceHistoryRepository`, filtering by an order-id prefix regex since every charge type shares `sub:{subscriptionId}` as a prefix)
- Usage invoices (new `ListBySubscriptionAsync` on `ISubscriptionUsageInvoiceRepository`, which had no subscription-scoped read before)
- Background work, derived from the subscription's own embedded outbox array grouped by status (there's no separate job-queue collection in this module) — gated by `includeBackgroundWork`, never including the raw event payload
- Recent audit events, reusing the existing audit repository

**Simulation-run audit** — every call (success or failure) writes to a new `SubscriptionSimulationRuns` collection, deliberately separate from `SubscriptionAuditEvents`: a simulation run records that someone drove the harness, not that a real business operation occurred (mutation PRs will still emit the ordinary business audit event for whatever domain operation they actually triggered, in addition to this).

## Test plan
- [x] `dotnet build` clean across Api, Worker, and XUnitTest (0 errors)
- [x] `dotnet test` — 2327 non-integration tests pass (the 106 pre-existing `XUnitTest.Integration` failures are `mongod` connection failures in this sandbox, unrelated to this change — not run here)
- [x] New unit tests: `SubscriptionSimulationGuardTests` (console+permission combinations) and `SubscriptionSimulationServiceTests` (forbidden, missing organization, invalid limits, not-found, and a full happy-path assembly with every collaborator mocked)
- [x] Registration tests updated: new repository is asserted singleton, options bind from their own section, and both a Production-refuses-to-start and a non-Production-allows-it case are covered
- [ ] Manual verification against a live backend and an actual console-scoped token carrying the new permission claim (not run in this environment — no backend/IdP credentials available)

## Follow-ups (separate PRs, per the task plan)
- PR 2: payment-outcome simulation (success/decline/timeout-after-provider-success)
- PR 3: advance-renewal
- PR 4: close-usage-period
- PR 5: scoped background-job execution
- PR 6 (optional): allowlisted data console
- Client UI: the "View complete state" read-only inspector drawer for the screen this endpoint backs

🤖 Generated with [Claude Code](https://claude.com/claude-code)