### PR TITLE
feat(subscription): add payment-outcome simulation to the harness

### DIFF
--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Payment.DomainService.Responses;
 using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Simulation;
 using Subscription.DomainService.Utilities;
 
@@ -55,12 +56,9 @@ public sealed class SubscriptionSimulationController : ControllerBase
     {
         var correlationId = HttpContext.TraceIdentifier;
 
-        if (!_options.CurrentValue.Enabled)
+        if (Disabled<SubscriptionSimulationStateResponse>(correlationId) is { } disabled)
         {
-            return NotFound(ApiResponse<SubscriptionSimulationStateResponse>.Fail(
-                "subscription_simulation_disabled",
-                "The subscription simulation harness is not enabled in this environment.",
-                correlationId));
+            return disabled;
         }
 
         var result = await _simulation.GetStateAsync(
@@ -72,21 +70,90 @@ public sealed class SubscriptionSimulationController : ControllerBase
             correlationId,
             cancellationToken);
 
-        // PaymentFailureKind has no Forbidden — the shared status-code mapping this reuses for
-        // every other subscription result would otherwise report this as a 404, indistinguishable
-        // from the harness being disabled. Named separately so an authorized administrator who
-        // simply lacks the permission sees why, rather than being told a real subscription is
-        // "disabled".
-        if (result is { IsSuccess: false, ErrorCode: "subscription_simulation_forbidden" })
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Simulates a successful outcome for the subscription's outstanding charge — the first
+    /// charge or a renewal — through the same settlement path a real provider confirmation
+    /// would take.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/mark-payment-succeeded")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> MarkPaymentSucceeded(
+        string subscriptionId,
+        [FromBody] MarkPaymentSucceededRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationActionResponse>(correlationId) is { } disabled)
         {
-            return StatusCode(
-                StatusCodes.Status403Forbidden,
-                ApiResponse<SubscriptionSimulationStateResponse>.Fail(
-                    result.ErrorCode,
-                    result.ErrorMessage ?? "This caller may not use the subscription simulation harness.",
-                    correlationId));
+            return disabled;
         }
 
-        return result.ToActionResult(correlationId);
+        var result = await _simulation.MarkPaymentSucceededAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
+
+    /// <summary>Simulates a failed outcome, for the same charge <c>mark-payment-succeeded</c> would settle.</summary>
+    [HttpPost("subscriptions/{subscriptionId}/mark-payment-failed")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> MarkPaymentFailed(
+        string subscriptionId,
+        [FromBody] MarkPaymentFailedRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationActionResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var result = await _simulation.MarkPaymentFailedAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
+    private IActionResult? Disabled<T>(string correlationId) =>
+        _options.CurrentValue.Enabled
+            ? null
+            : NotFound(ApiResponse<T>.Fail(
+                "subscription_simulation_disabled",
+                "The subscription simulation harness is not enabled in this environment.",
+                correlationId));
+
+    /// <summary>
+    /// <see cref="Payment.DomainService.Enums.PaymentFailureKind"/> has no <c>Forbidden</c> — the
+    /// shared status-code mapping every other subscription result reuses would otherwise report
+    /// this as a 404, indistinguishable from the harness being disabled. Named separately so an
+    /// authenticated caller who simply lacks the permission sees why, rather than being told a
+    /// real subscription is "disabled".
+    /// </summary>
+    private static IActionResult? Forbidden<T>(
+        SubscriptionOperationResult<T> result,
+        string correlationId) =>
+        result is { IsSuccess: false, ErrorCode: "subscription_simulation_forbidden" }
+            ? new ObjectResult(ApiResponse<T>.Fail(
+                result.ErrorCode,
+                result.ErrorMessage ?? "This caller may not use the subscription simulation harness.",
+                correlationId))
+            {
+                StatusCode = StatusCodes.Status403Forbidden
+            }
+            : null;
 }

--- a/server/Subscription.DomainService/Outbox/ISubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionActivationProcessor.cs
@@ -1,3 +1,5 @@
+using Subscription.DomainService.Entities;
+
 namespace Subscription.DomainService.Outbox;
 
 public interface ISubscriptionActivationProcessor
@@ -7,6 +9,16 @@ public interface ISubscriptionActivationProcessor
     /// </summary>
     /// <returns>How many links were settled.</returns>
     Task<int> ProcessDueAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Settles exactly one link, regardless of whether its own retry schedule says it is due yet.
+    /// </summary>
+    /// <remarks>
+    /// Exists for callers that already hold one specific link and must not touch any other
+    /// subscription's — the simulation harness, in particular, which would otherwise have to run
+    /// the tenant-wide sweep and risk settling an unrelated link a test never asked about.
+    /// </remarks>
+    Task<bool> SettleLinkAsync(SubscriptionPaymentLink link, CancellationToken cancellationToken);
 
     /// <summary>
     /// Finds subscriptions whose first charge was raised but never recorded, and either

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -99,6 +99,11 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         return settled;
     }
 
+    public Task<bool> SettleLinkAsync(
+        SubscriptionPaymentLink link,
+        CancellationToken cancellationToken) =>
+        SettleAsync(link, _options.CurrentValue, _time.GetUtcNow().UtcDateTime, cancellationToken);
+
     public async Task<int> RecoverStaleAsync(
         string tenantId,
         CancellationToken cancellationToken)

--- a/server/Subscription.DomainService/Responses/SubscriptionSimulationActionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionSimulationActionResponse.cs
@@ -1,0 +1,44 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// What a simulation mutation did, alongside the complete state it left behind — the shape every
+/// simulation action (not just the read-only inspector) returns.
+/// </summary>
+public sealed class SubscriptionSimulationActionResponse
+{
+    public string SimulationRunId { get; init; } = string.Empty;
+
+    /// <summary>E.g. <c>MarkPaymentSucceeded</c>, <c>MarkPaymentFailed</c>.</summary>
+    public string Action { get; init; } = string.Empty;
+
+    public DateTime StartedAtUtc { get; init; }
+
+    public DateTime CompletedAtUtc { get; init; }
+
+    public SubscriptionSimulationSummary Before { get; init; } = new();
+
+    public SubscriptionSimulationSummary After { get; init; } = new();
+
+    public SubscriptionSimulationStateResponse State { get; init; } = new();
+
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// The handful of fields worth comparing before and after an action, without repeating the
+/// entire state twice.
+/// </summary>
+public sealed class SubscriptionSimulationSummary
+{
+    public string SubscriptionStatus { get; init; } = string.Empty;
+
+    public DateTime? CurrentPeriodEndUtc { get; init; }
+
+    public DateTime? NextFeeBillingAtUtc { get; init; }
+
+    public int DunningAttemptCount { get; init; }
+
+    public string? LastRenewalPaymentDetailId { get; init; }
+
+    public int Version { get; init; }
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -22,4 +22,21 @@ public interface ISubscriptionSimulationService
         bool includeBackgroundWork,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Simulates a successful outcome for the subscription's outstanding charge, through the
+    /// same settlement path a real provider confirmation would take.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> MarkPaymentSucceededAsync(
+        string subscriptionId,
+        MarkPaymentSucceededRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>Simulates a failed outcome, for the same charge <see cref="MarkPaymentSucceededAsync"/> would settle.</summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> MarkPaymentFailedAsync(
+        string subscriptionId,
+        MarkPaymentFailedRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Simulation/MarkPaymentOutcomeRequest.cs
+++ b/server/Subscription.DomainService/Simulation/MarkPaymentOutcomeRequest.cs
@@ -1,0 +1,40 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Simulation;
+
+public sealed class MarkPaymentSucceededRequest
+{
+    /// <summary>Required — the console has no subscription of its own; see the state endpoint.</summary>
+    public string? OrganizationId { get; set; }
+
+    public SubscriptionPaymentPurpose PaymentPurpose { get; set; }
+
+    /// <summary>
+    /// Stands in for the provider's own reference. Generated when omitted; supplying it lets a
+    /// caller keep the same reference across a retried call and see the real system's dedup key
+    /// resolve identically.
+    /// </summary>
+    public string? ProviderReference { get; set; }
+
+    /// <summary>
+    /// Whether to run the same processor a real settlement would (the activation sweep for
+    /// <see cref="SubscriptionPaymentPurpose.InitialCharge"/>, the renewal service for
+    /// <see cref="SubscriptionPaymentPurpose.Renewal"/>). Defaults to true; false only records
+    /// the settlement fact and reports state, useful for inspecting an intermediate step.
+    /// </summary>
+    public bool RunProcessor { get; set; } = true;
+}
+
+public sealed class MarkPaymentFailedRequest
+{
+    public string? OrganizationId { get; set; }
+
+    public SubscriptionPaymentPurpose PaymentPurpose { get; set; }
+
+    public SimulatedPaymentFailureKind FailureKind { get; set; }
+
+    /// <summary>Overrides the failure kind's default error code, for a scenario naming its own.</summary>
+    public string? ErrorCode { get; set; }
+
+    public bool RunProcessor { get; set; } = true;
+}

--- a/server/Subscription.DomainService/Simulation/SimulatedPaymentFailureKind.cs
+++ b/server/Subscription.DomainService/Simulation/SimulatedPaymentFailureKind.cs
@@ -1,0 +1,30 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// The reasons a tester can script a simulated payment to fail for, in the vocabulary a caller
+/// asks for rather than the narrower one the domain actually distinguishes.
+/// </summary>
+/// <remarks>
+/// The real system only tells apart <c>ProviderRejected</c> (a decline, whatever its reason),
+/// <c>Unavailable</c> (the provider could not be reached) and <c>Timeout</c> (an answer never
+/// came, and the charge may or may not have gone through). <see cref="Declined"/>,
+/// <see cref="InsufficientFunds"/> and <see cref="PaymentMethodExpired"/> all map to the first —
+/// they are distinguished here only so a test can name the scenario it means, and the caller's
+/// own <c>errorCode</c> carries the distinction into the audit trail even though the dunning
+/// logic itself does not branch on it.
+/// </remarks>
+public enum SimulatedPaymentFailureKind
+{
+    Declined,
+    InsufficientFunds,
+    PaymentMethodExpired,
+    ProviderUnavailable,
+
+    /// <summary>
+    /// The provider may have already taken the money; nothing here says either way. Mirrors the
+    /// exact situation a real timeout leaves a renewal in, and — for an initial charge — the
+    /// window <see cref="Outbox.ISubscriptionActivationProcessor.RecoverStaleAsync"/> exists to
+    /// resolve.
+    /// </summary>
+    OutcomeUnknown
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulatedOutcomeSource.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulatedOutcomeSource.cs
@@ -1,0 +1,55 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>What a scripted charge should report, in the gateway's own vocabulary.</summary>
+public enum SimulatedChargeOutcome
+{
+    Succeeded,
+    Rejected,
+    Unavailable,
+
+    /// <summary>The provider may have already taken the money; nothing here says either way.</summary>
+    TimedOut
+}
+
+public sealed record ScriptedChargeOutcome(
+    SimulatedChargeOutcome Outcome,
+    string? ErrorCode,
+    string? ErrorMessage);
+
+/// <summary>
+/// Holds one scripted charge outcome, consumed exactly once.
+/// </summary>
+/// <remarks>
+/// Scoped per request rather than shared across the tenant: it is set immediately before the
+/// one gateway call a simulated renewal makes and consumed by that call alone, so it can never
+/// leak into a renewal a different request triggers. See
+/// <see cref="SubscriptionSimulationBillingGateway"/> for the consumer.
+/// </remarks>
+public interface ISubscriptionSimulatedOutcomeSource
+{
+    void ScriptNext(ScriptedChargeOutcome outcome);
+
+    bool TryConsume(out ScriptedChargeOutcome outcome);
+}
+
+public sealed class SubscriptionSimulatedOutcomeSource : ISubscriptionSimulatedOutcomeSource
+{
+    private ScriptedChargeOutcome? _next;
+
+    public void ScriptNext(ScriptedChargeOutcome outcome) => _next = outcome;
+
+    public bool TryConsume(out ScriptedChargeOutcome outcome)
+    {
+        if (_next is { } value)
+        {
+            outcome = value;
+            _next = null;
+
+            return true;
+        }
+
+        outcome = null!;
+
+        return false;
+    }
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationBillingGateway.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationBillingGateway.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// Wraps the real billing gateway with one escape hatch: when the harness is enabled and a
+/// caller has scripted the next charge's outcome, that outcome is returned instead of placing a
+/// real charge. Every other call — which is every call in production — passes straight through.
+/// </summary>
+/// <remarks>
+/// Registered as the <see cref="ISubscriptionBillingGateway"/> DI entry in place of
+/// <see cref="SubscriptionBillingGatewayResolver"/>, which this holds and delegates to. A caller
+/// with nothing scripted, or a harness that is disabled, sees behaviour identical to the
+/// resolver alone — the check is a config read and a dictionary lookup, not a code path only
+/// present when testing.
+/// </remarks>
+public sealed class SubscriptionSimulationBillingGateway : ISubscriptionBillingGateway
+{
+    private readonly SubscriptionBillingGatewayResolver _real;
+    private readonly ISubscriptionSimulatedOutcomeSource _scripted;
+    private readonly IOptionsMonitor<SubscriptionSimulationOptions> _options;
+
+    public SubscriptionSimulationBillingGateway(
+        SubscriptionBillingGatewayResolver real,
+        ISubscriptionSimulatedOutcomeSource scripted,
+        IOptionsMonitor<SubscriptionSimulationOptions> options)
+    {
+        _real = real;
+        _scripted = scripted;
+        _options = options;
+    }
+
+    public Task<SubscriptionOperationResult<string>> ChargeAsync(
+        SubscriptionChargeRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (_options.CurrentValue.Enabled && _scripted.TryConsume(out var scripted))
+        {
+            return Task.FromResult(scripted.Outcome switch
+            {
+                SimulatedChargeOutcome.Succeeded => SubscriptionOperationResult<string>.Success(
+                    $"sim_pay_{Guid.NewGuid():N}", correlationId),
+                SimulatedChargeOutcome.Rejected => SubscriptionOperationResult<string>.Failure(
+                    PaymentFailureKind.ProviderRejected,
+                    scripted.ErrorCode ?? "subscription_simulated_payment_declined",
+                    scripted.ErrorMessage ?? "Simulated: the provider declined the charge.",
+                    correlationId),
+                SimulatedChargeOutcome.Unavailable => SubscriptionOperationResult<string>.Failure(
+                    PaymentFailureKind.Unavailable,
+                    scripted.ErrorCode ?? "subscription_simulated_payment_unavailable",
+                    scripted.ErrorMessage ?? "Simulated: the payment provider was unreachable.",
+                    correlationId),
+                SimulatedChargeOutcome.TimedOut => SubscriptionOperationResult<string>.Failure(
+                    PaymentFailureKind.Timeout,
+                    scripted.ErrorCode ?? "subscription_simulated_payment_timeout",
+                    scripted.ErrorMessage ??
+                        "Simulated: no answer arrived — the charge may or may not have gone through.",
+                    correlationId),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(scripted), scripted.Outcome, "Unrecognized simulated charge outcome.")
+            });
+        }
+
+        return _real.ChargeAsync(request, idempotencyKey, correlationId, cancellationToken);
+    }
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -1,9 +1,13 @@
 using Blocks.Genesis;
 using Microsoft.Extensions.Options;
+using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Services;
@@ -24,6 +28,12 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     private readonly ISubscriptionAuditRepository _auditEvents;
     private readonly ISubscriptionSimulationRunRepository _simulationRuns;
     private readonly IOptionsMonitor<PaymentOptions> _paymentOptions;
+    private readonly IPaymentRepository _payments;
+    private readonly ICurrencyMinorUnitResolver _minorUnits;
+    private readonly IPaymentWebhookStateTransitionService _webhookTransitions;
+    private readonly ISubscriptionActivationProcessor _activationProcessor;
+    private readonly ISubscriptionRenewalService _renewalService;
+    private readonly ISubscriptionSimulatedOutcomeSource _scriptedOutcomes;
 
     public SubscriptionSimulationService(
         ISubscriptionContextResolver contextResolver,
@@ -35,7 +45,13 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         ISubscriptionPaymentLinkRepository paymentLinks,
         ISubscriptionAuditRepository auditEvents,
         ISubscriptionSimulationRunRepository simulationRuns,
-        IOptionsMonitor<PaymentOptions> paymentOptions)
+        IOptionsMonitor<PaymentOptions> paymentOptions,
+        IPaymentRepository payments,
+        ICurrencyMinorUnitResolver minorUnits,
+        IPaymentWebhookStateTransitionService webhookTransitions,
+        ISubscriptionActivationProcessor activationProcessor,
+        ISubscriptionRenewalService renewalService,
+        ISubscriptionSimulatedOutcomeSource scriptedOutcomes)
     {
         _contextResolver = contextResolver;
         _subscriptions = subscriptions;
@@ -47,6 +63,12 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         _auditEvents = auditEvents;
         _simulationRuns = simulationRuns;
         _paymentOptions = paymentOptions;
+        _payments = payments;
+        _minorUnits = minorUnits;
+        _webhookTransitions = webhookTransitions;
+        _activationProcessor = activationProcessor;
+        _renewalService = renewalService;
+        _scriptedOutcomes = scriptedOutcomes;
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
@@ -170,6 +192,397 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Success(
             response, correlationId);
     }
+
+    public Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> MarkPaymentSucceededAsync(
+        string subscriptionId,
+        MarkPaymentSucceededRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return MarkPaymentOutcomeAsync(
+            subscriptionId,
+            request.OrganizationId,
+            request.PaymentPurpose,
+            succeeded: true,
+            request.ProviderReference,
+            failureKind: null,
+            errorCode: null,
+            request.RunProcessor,
+            "MarkPaymentSucceeded",
+            correlationId,
+            cancellationToken);
+    }
+
+    public Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> MarkPaymentFailedAsync(
+        string subscriptionId,
+        MarkPaymentFailedRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return MarkPaymentOutcomeAsync(
+            subscriptionId,
+            request.OrganizationId,
+            request.PaymentPurpose,
+            succeeded: false,
+            providerReference: null,
+            request.FailureKind,
+            request.ErrorCode,
+            request.RunProcessor,
+            "MarkPaymentFailed",
+            correlationId,
+            cancellationToken);
+    }
+
+    private async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> MarkPaymentOutcomeAsync(
+        string subscriptionId,
+        string? organizationId,
+        SubscriptionPaymentPurpose purpose,
+        bool succeeded,
+        string? providerReference,
+        SimulatedPaymentFailureKind? failureKind,
+        string? errorCode,
+        bool runProcessor,
+        string action,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var startedAtUtc = DateTime.UtcNow;
+
+        var caller = BlocksContext.GetContext();
+
+        if (!SubscriptionSimulationGuard.IsAuthorized(
+                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_forbidden",
+                "This caller may not use the subscription simulation harness.",
+                correlationId);
+        }
+
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_organization_required",
+                "organizationId is required: the console has no subscription of its own.",
+                correlationId,
+                new Dictionary<string, string[]>
+                {
+                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
+                });
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, organizationId, cancellationToken);
+
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return resolution.ToFailure<SubscriptionSimulationActionResponse>(correlationId);
+        }
+
+        var context = resolution.Context;
+
+        var subscription = await _subscriptions.GetAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken);
+
+        if (subscription is null)
+        {
+            await RecordRunAsync(
+                context, subscriptionId, action, correlationId,
+                "Failed", "subscription_not_found", cancellationToken);
+
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "The subscription does not exist.",
+                correlationId);
+        }
+
+        var before = Summarize(subscription);
+        var simulationRunId = $"sim_{Guid.NewGuid():N}";
+
+        (SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note) outcome = purpose switch
+        {
+            SubscriptionPaymentPurpose.InitialCharge => await SettleInitialChargeAsync(
+                context, subscription, succeeded, providerReference, failureKind, errorCode,
+                runProcessor, simulationRunId, correlationId, cancellationToken),
+            SubscriptionPaymentPurpose.Renewal => await SettleRenewalAsync(
+                context, subscription, succeeded, failureKind, errorCode, runProcessor,
+                correlationId, cancellationToken),
+            _ => (SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_purpose_invalid",
+                "Unsupported payment purpose.",
+                correlationId), string.Empty)
+        };
+
+        if (outcome.Failure is { } failure)
+        {
+            await RecordRunAsync(
+                context, subscriptionId, action, correlationId,
+                "Failed", failure.ErrorCode, cancellationToken);
+
+            return failure;
+        }
+
+        var refreshed = await _subscriptions.GetAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken) ?? subscription;
+        var after = Summarize(refreshed);
+
+        var stateResult = await GetStateAsync(
+            subscriptionId, organizationId, 100, 100, true, correlationId, cancellationToken);
+
+        await RecordRunAsync(
+            context, subscriptionId, action, correlationId, "Succeeded", null, cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Success(
+            new SubscriptionSimulationActionResponse
+            {
+                SimulationRunId = simulationRunId,
+                Action = action,
+                StartedAtUtc = startedAtUtc,
+                CompletedAtUtc = DateTime.UtcNow,
+                Before = before,
+                After = after,
+                State = stateResult.IsSuccess && stateResult.Value is not null
+                    ? stateResult.Value
+                    : new SubscriptionSimulationStateResponse(),
+                CorrelationId = correlationId
+            },
+            correlationId);
+    }
+
+    /// <summary>
+    /// Settles the first charge through the real webhook-equivalent write, then — unless
+    /// <paramref name="runProcessor"/> says otherwise — the real activation processor for this
+    /// one link only.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately never populates a card token or provider-customer reference on the simulated
+    /// payload. <see cref="Outbox.SubscriptionActivationProcessor"/> reads a saved card back from
+    /// the payment's own shopper reference afterward, and getting a fake token wrong there risks
+    /// either an exception in code this harness does not own or a card that looks saved but
+    /// silently is not — either is worse than the honest gap this leaves: a subscription
+    /// activated this way has no simulated card, so a subsequently simulated renewal on it needs
+    /// a payment method recorded some other way.
+    /// </remarks>
+    private async Task<(SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note)>
+        SettleInitialChargeAsync(
+            SubscriptionContext context,
+            SubscriptionDetail subscription,
+            bool succeeded,
+            string? providerReference,
+            SimulatedPaymentFailureKind? failureKind,
+            string? errorCode,
+            bool runProcessor,
+            string simulationRunId,
+            string correlationId,
+            CancellationToken cancellationToken)
+    {
+        if (subscription.Status != SubscriptionStatus.Incomplete)
+        {
+            return (Fail<SubscriptionSimulationActionResponse>(
+                PaymentFailureKind.Conflict,
+                "subscription_simulation_already_settled",
+                "This subscription's first charge has already been settled.",
+                correlationId), string.Empty);
+        }
+
+        var link = await _paymentLinks.FindBySubscriptionAsync(
+            context.TenantId, subscription.ItemId, cancellationToken);
+
+        if (link is null ||
+            link.Purpose != SubscriptionPaymentPurpose.InitialCharge ||
+            link.State != SubscriptionPaymentLinkState.Pending)
+        {
+            return (Fail<SubscriptionSimulationActionResponse>(
+                PaymentFailureKind.NotFound,
+                "subscription_simulation_no_pending_payment",
+                "There is no pending initial-charge payment to settle.",
+                correlationId), string.Empty);
+        }
+
+        if (!succeeded && failureKind is SimulatedPaymentFailureKind.ProviderUnavailable
+                or SimulatedPaymentFailureKind.OutcomeUnknown)
+        {
+            // Honest to production: an unreachable or ambiguous provider answer never produces a
+            // webhook at all, so nothing here should move the subscription forward either — the
+            // real system would leave this exact charge pending until either a real webhook
+            // eventually lands or RecoverStaleAsync's grace period expires.
+            return (null,
+                "No webhook was simulated: an unavailable or unknown provider outcome leaves " +
+                "the charge exactly where a real one would — still pending.");
+        }
+
+        var payment = await _payments.GetByIdAsync(
+            context.TenantId, link.PaymentDetailId, cancellationToken);
+
+        if (payment is null)
+        {
+            return (Fail<SubscriptionSimulationActionResponse>(
+                PaymentFailureKind.NotFound,
+                "subscription_simulation_no_pending_payment",
+                "The linked payment record could not be found.",
+                correlationId), string.Empty);
+        }
+
+        if (!_minorUnits.TryConvert(payment.PreciseAmount, payment.CurrencyCode, out var amountMinor))
+        {
+            return (Fail<SubscriptionSimulationActionResponse>(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_amount_conversion_failed",
+                "The payment amount could not be converted to minor units.",
+                correlationId), string.Empty);
+        }
+
+        var reference = providerReference ?? simulationRunId;
+
+        var webhook = new PaymentWebhookInbox
+        {
+            TenantId = context.TenantId,
+            ProviderName = payment.ProviderName,
+            WebhookType = "Simulated",
+            EventCode = succeeded ? "SIMULATED_AUTHORISATION" : "SIMULATED_REFUSAL",
+            Intent = WebhookIntent.Authorization,
+            PspReference = reference,
+            EventDateUtc = DateTime.UtcNow,
+            CorrelationId = correlationId,
+            NormalizedPayload = new PaymentWebhookPayload
+            {
+                PaymentDetailId = payment.ItemId,
+                PspReference = reference,
+                Success = succeeded,
+                FundsCaptured = succeeded ? true : null,
+                AmountMinorUnits = amountMinor,
+                CurrencyCode = payment.CurrencyCode,
+                ProviderFailureCode = succeeded ? null : errorCode ?? DefaultErrorCode(failureKind),
+                ProviderFailureSummary = succeeded ? null : DefaultErrorMessage(failureKind)
+            }
+        };
+
+        try
+        {
+            await _webhookTransitions.ApplyAsync(webhook, cancellationToken);
+        }
+        catch (InvalidOperationException exception)
+        {
+            return (Fail<SubscriptionSimulationActionResponse>(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_settlement_failed",
+                exception.Message,
+                correlationId), string.Empty);
+        }
+
+        if (!runProcessor)
+        {
+            return (null, "The simulated payment outcome was recorded; activation was not run.");
+        }
+
+        await _activationProcessor.SettleLinkAsync(link, cancellationToken);
+
+        return (null, succeeded
+            ? "The subscription activated (or started its trial)."
+            : "The subscription was expired after the simulated decline.");
+    }
+
+    /// <summary>
+    /// Scripts the one gateway call a renewal makes, then runs the real renewal service — there
+    /// is no separate pending state for a renewal charge to resolve, since production charges it
+    /// synchronously in the same call that decides the outcome.
+    /// </summary>
+    private async Task<(SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note)>
+        SettleRenewalAsync(
+            SubscriptionContext context,
+            SubscriptionDetail subscription,
+            bool succeeded,
+            SimulatedPaymentFailureKind? failureKind,
+            string? errorCode,
+            bool runProcessor,
+            string correlationId,
+            CancellationToken cancellationToken)
+    {
+        if (subscription.Status is not (SubscriptionStatus.Active or SubscriptionStatus.PastDue))
+        {
+            return (Fail<SubscriptionSimulationActionResponse>(
+                PaymentFailureKind.Conflict,
+                "subscription_simulation_not_renewable",
+                "Only an Active or PastDue subscription can be renewed.",
+                correlationId), string.Empty);
+        }
+
+        if (subscription.SettlementReservation is not null)
+        {
+            return (Fail<SubscriptionSimulationActionResponse>(
+                PaymentFailureKind.Conflict,
+                "subscription_simulation_settlement_in_flight",
+                "A quantity or plan change is still settling; renewal is deferred until it resolves.",
+                correlationId), string.Empty);
+        }
+
+        if (!runProcessor)
+        {
+            return (null,
+                "runProcessor=false: a renewal has no separate settlement fact to record " +
+                "without actually running it, so nothing was charged.");
+        }
+
+        _scriptedOutcomes.ScriptNext(new ScriptedChargeOutcome(
+            succeeded ? SimulatedChargeOutcome.Succeeded : MapFailureOutcome(failureKind),
+            succeeded ? null : errorCode ?? DefaultErrorCode(failureKind),
+            succeeded ? null : DefaultErrorMessage(failureKind)));
+
+        await _renewalService.RenewAsync(subscription, cancellationToken);
+
+        return (null, succeeded
+            ? "The renewal charge succeeded and the period advanced."
+            : "The renewal charge failed; dunning was applied.");
+    }
+
+    private static SimulatedChargeOutcome MapFailureOutcome(SimulatedPaymentFailureKind? kind) => kind switch
+    {
+        SimulatedPaymentFailureKind.ProviderUnavailable => SimulatedChargeOutcome.Unavailable,
+        SimulatedPaymentFailureKind.OutcomeUnknown => SimulatedChargeOutcome.TimedOut,
+        _ => SimulatedChargeOutcome.Rejected
+    };
+
+    private static string DefaultErrorCode(SimulatedPaymentFailureKind? kind) => kind switch
+    {
+        SimulatedPaymentFailureKind.Declined => "card_declined",
+        SimulatedPaymentFailureKind.InsufficientFunds => "insufficient_funds",
+        SimulatedPaymentFailureKind.PaymentMethodExpired => "expired_card",
+        SimulatedPaymentFailureKind.ProviderUnavailable => "provider_unavailable",
+        SimulatedPaymentFailureKind.OutcomeUnknown => "outcome_unknown",
+        _ => "payment_failed"
+    };
+
+    private static string DefaultErrorMessage(SimulatedPaymentFailureKind? kind) => kind switch
+    {
+        SimulatedPaymentFailureKind.Declined => "Simulated: the card was declined.",
+        SimulatedPaymentFailureKind.InsufficientFunds => "Simulated: insufficient funds.",
+        SimulatedPaymentFailureKind.PaymentMethodExpired => "Simulated: the payment method has expired.",
+        SimulatedPaymentFailureKind.ProviderUnavailable => "Simulated: the payment provider was unreachable.",
+        SimulatedPaymentFailureKind.OutcomeUnknown => "Simulated: no answer arrived from the provider.",
+        _ => "Simulated payment failure."
+    };
+
+    private static SubscriptionSimulationSummary Summarize(SubscriptionDetail subscription) => new()
+    {
+        SubscriptionStatus = subscription.Status.ToString(),
+        CurrentPeriodEndUtc = subscription.CurrentPeriodEndUtc,
+        NextFeeBillingAtUtc = subscription.NextFeeBillingAtUtc,
+        DunningAttemptCount = subscription.DunningAttemptCount,
+        LastRenewalPaymentDetailId = subscription.LastRenewalPaymentDetailId,
+        Version = subscription.Version
+    };
+
+    private static SubscriptionOperationResult<T> Fail<T>(
+        PaymentFailureKind kind, string code, string message, string correlationId) =>
+        SubscriptionOperationResult<T>.Failure(kind, code, message, correlationId);
 
     private static bool IsValidLimit(int limit) => limit is > 0 and <= MaximumLimit;
 

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -167,9 +167,18 @@ public static class ApplicationServiceCollectionExtensions
         // provider name, so neither is the ISubscriptionBillingGateway DI entry on its own.
         services.AddScoped<RecurringChargeBillingGateway>();
         services.AddScoped<StripeInvoiceBillingGateway>();
+        // Also registered as itself, held by SubscriptionSimulationBillingGateway below — the
+        // real charging logic every provider still goes through, scripted outcome or not.
+        services.AddScoped<SubscriptionBillingGatewayResolver>();
+        services.AddScoped<
+            ISubscriptionSimulatedOutcomeSource,
+            SubscriptionSimulatedOutcomeSource>();
+        // The ISubscriptionBillingGateway DI entry itself. Always this decorator, never the bare
+        // resolver: with the harness disabled or nothing scripted it delegates straight through,
+        // so this changes nothing for a real request — see the class remarks.
         services.AddScoped<
             ISubscriptionBillingGateway,
-            SubscriptionBillingGatewayResolver>();
+            SubscriptionSimulationBillingGateway>();
         services.AddScoped<
             ISubscriptionRenewalService,
             SubscriptionRenewalService>();

--- a/server/XUnitTest/Subscription/SubscriptionSimulationBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationBillingGatewayTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Simulation;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// <see cref="SubscriptionSimulationBillingGateway"/>'s own logic — mapping a scripted outcome
+/// onto a gateway result. The pass-through branch (nothing scripted, or the harness disabled)
+/// is not exercised here: the gateway it delegates to,
+/// <see cref="Subscription.DomainService.Services.SubscriptionBillingGatewayResolver"/>, is
+/// sealed and holds two further concrete gateways, so faking it would mean constructing the real
+/// dependency chain rather than testing this class in isolation. That branch is a single
+/// unconditional delegating call, visible by inspection.
+/// </summary>
+public sealed class SubscriptionSimulationBillingGatewayTests
+{
+    private readonly Mock<ISubscriptionSimulatedOutcomeSource> _scripted = new();
+    private readonly Mock<IOptionsMonitor<SubscriptionSimulationOptions>> _options = new();
+
+    public SubscriptionSimulationBillingGatewayTests() =>
+        _options.Setup(o => o.CurrentValue).Returns(new SubscriptionSimulationOptions { Enabled = true });
+
+    [Fact]
+    public async Task Returns_the_scripted_success_without_reaching_the_real_gateway()
+    {
+        Scripts(new ScriptedChargeOutcome(SimulatedChargeOutcome.Succeeded, null, null));
+
+        var result = await CreateGateway().ChargeAsync(
+            request: null!, "key-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(SimulatedChargeOutcome.Rejected, PaymentFailureKind.ProviderRejected)]
+    [InlineData(SimulatedChargeOutcome.Unavailable, PaymentFailureKind.Unavailable)]
+    [InlineData(SimulatedChargeOutcome.TimedOut, PaymentFailureKind.Timeout)]
+    public async Task Maps_every_scripted_failure_to_its_own_failure_kind(
+        SimulatedChargeOutcome scripted, PaymentFailureKind expected)
+    {
+        Scripts(new ScriptedChargeOutcome(scripted, "code", "message"));
+
+        var result = await CreateGateway().ChargeAsync(
+            request: null!, "key-1", "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(expected);
+        result.ErrorCode.Should().Be("code");
+    }
+
+    [Fact]
+    public async Task Does_not_consult_the_script_when_the_harness_is_disabled()
+    {
+        _options.Setup(o => o.CurrentValue).Returns(new SubscriptionSimulationOptions { Enabled = false });
+        Scripts(new ScriptedChargeOutcome(SimulatedChargeOutcome.Succeeded, null, null));
+
+        // With no real gateway to delegate to, this would throw a NullReferenceException if the
+        // disabled harness still reached the passthrough — proving the guard runs first.
+        var act = async () => await CreateGateway().ChargeAsync(
+            request: null!, "key-1", "corr-1", CancellationToken.None);
+
+        await act.Should().ThrowAsync<NullReferenceException>();
+        _scripted.Verify(
+            source => source.TryConsume(out It.Ref<ScriptedChargeOutcome>.IsAny), Times.Never);
+    }
+
+    private void Scripts(ScriptedChargeOutcome outcome) =>
+        _scripted
+            .Setup(source => source.TryConsume(out It.Ref<ScriptedChargeOutcome>.IsAny))
+            .Returns(new TryConsumeCallback((out ScriptedChargeOutcome result) =>
+            {
+                result = outcome;
+                return true;
+            }));
+
+    private SubscriptionSimulationBillingGateway CreateGateway() =>
+        new(real: null!, _scripted.Object, _options.Object);
+
+    private delegate bool TryConsumeCallback(out ScriptedChargeOutcome outcome);
+}

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -2,8 +2,14 @@ using Blocks.Genesis;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
 using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Services;
@@ -36,13 +42,28 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
     private readonly Mock<ISubscriptionAuditRepository> _auditEvents = new();
     private readonly Mock<ISubscriptionSimulationRunRepository> _simulationRuns = new();
     private readonly Mock<IOptionsMonitor<PaymentOptions>> _paymentOptions = new();
+    private readonly Mock<IPaymentRepository> _payments = new();
+    private readonly Mock<ICurrencyMinorUnitResolver> _minorUnits = new();
+    private readonly Mock<IPaymentWebhookStateTransitionService> _webhookTransitions = new();
+    private readonly Mock<ISubscriptionActivationProcessor> _activationProcessor = new();
+    private readonly Mock<ISubscriptionRenewalService> _renewalService = new();
+    private readonly Mock<ISubscriptionSimulatedOutcomeSource> _scriptedOutcomes = new();
 
     public SubscriptionSimulationServiceTests()
     {
         _paymentOptions
             .Setup(options => options.CurrentValue)
             .Returns(new PaymentOptions { ConsoleOrganizationId = ConsoleOrganizationId });
+        _minorUnits
+            .Setup(resolver => resolver.TryConvert(It.IsAny<decimal>(), It.IsAny<string>(), out It.Ref<long>.IsAny))
+            .Returns(new TryConvertCallback((decimal amount, string _, out long minorUnits) =>
+            {
+                minorUnits = (long)(amount * 100);
+                return true;
+            }));
     }
+
+    private delegate bool TryConvertCallback(decimal amount, string currencyCode, out long minorUnits);
 
     public void Dispose() => BlocksContext.ClearContext();
 
@@ -212,5 +233,293 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         _paymentLinks.Object,
         _auditEvents.Object,
         _simulationRuns.Object,
-        _paymentOptions.Object);
+        _paymentOptions.Object,
+        _payments.Object,
+        _minorUnits.Object,
+        _webhookTransitions.Object,
+        _activationProcessor.Object,
+        _renewalService.Object,
+        _scriptedOutcomes.Object);
+
+    /// <summary>Wires the read-only GetStateAsync collaborators to return an empty-but-valid state, so mark-payment tests can reuse it without re-asserting PR 1's own coverage.</summary>
+    private void StubEmptyState(SubscriptionDetail subscription, string organizationId)
+    {
+        _responseMapper
+            .Setup(mapper => mapper.ToResponse(subscription, null))
+            .Returns(new SubscriptionResponse { SubscriptionId = subscription.ItemId });
+        _entitlements
+            .Setup(service => service.GetAsync(true, organizationId, CorrelationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<EntitlementSnapshotResponse>.Success(
+                new EntitlementSnapshotResponse(), CorrelationId));
+        _invoiceHistory
+            .Setup(repo => repo.ListBySubscriptionAsync(
+                TenantId, organizationId, subscription.ItemId, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionInvoiceHistoryRecord>)[]);
+        _usageInvoices
+            .Setup(repo => repo.ListBySubscriptionAsync(TenantId, subscription.ItemId, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageInvoice>)[]);
+        _auditEvents
+            .Setup(repo => repo.ListAsync(TenantId, organizationId, subscription.ItemId, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionAuditEvent>)[]);
+    }
+
+    private static PaymentDetail Payment(string id, decimal amount = 10m, string currency = "EUR") => new()
+    {
+        ItemId = id,
+        PreciseAmount = amount,
+        CurrencyCode = currency,
+        ProviderName = "stripe",
+    };
+
+    private static SubscriptionPaymentLink PendingInitialChargeLink(string paymentId) => new()
+    {
+        ItemId = "link-1",
+        TenantId = TenantId,
+        OrganizationId = "target-org",
+        SubscriptionId = SubscriptionId,
+        PaymentDetailId = paymentId,
+        Purpose = SubscriptionPaymentPurpose.InitialCharge,
+        State = SubscriptionPaymentLinkState.Pending,
+    };
+
+    [Fact]
+    public async Task Marking_an_initial_charge_succeeded_settles_the_webhook_and_runs_activation()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Incomplete,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        var link = PendingInitialChargeLink("pay-1");
+        _paymentLinks
+            .Setup(repo => repo.FindBySubscriptionAsync(TenantId, SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(link);
+        _payments
+            .Setup(repo => repo.GetByIdAsync(TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Payment("pay-1"));
+        _activationProcessor
+            .Setup(processor => processor.SettleLinkAsync(link, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new MarkPaymentSucceededRequest
+        {
+            OrganizationId = "target-org",
+            PaymentPurpose = SubscriptionPaymentPurpose.InitialCharge,
+        };
+        var result = await CreateService().MarkPaymentSucceededAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Action.Should().Be("MarkPaymentSucceeded");
+        _webhookTransitions.Verify(
+            transitions => transitions.ApplyAsync(
+                It.Is<PaymentWebhookInbox>(webhook =>
+                    webhook.NormalizedPayload.PaymentDetailId == "pay-1" &&
+                    webhook.NormalizedPayload.Success == true),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _activationProcessor.Verify(
+            processor => processor.SettleLinkAsync(link, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Marking_an_initial_charge_failed_settles_a_refusal()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Incomplete,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        var link = PendingInitialChargeLink("pay-1");
+        _paymentLinks
+            .Setup(repo => repo.FindBySubscriptionAsync(TenantId, SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(link);
+        _payments
+            .Setup(repo => repo.GetByIdAsync(TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Payment("pay-1"));
+        StubEmptyState(subscription, "target-org");
+
+        var request = new MarkPaymentFailedRequest
+        {
+            OrganizationId = "target-org",
+            PaymentPurpose = SubscriptionPaymentPurpose.InitialCharge,
+            FailureKind = SimulatedPaymentFailureKind.Declined,
+        };
+        var result = await CreateService().MarkPaymentFailedAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _webhookTransitions.Verify(
+            transitions => transitions.ApplyAsync(
+                It.Is<PaymentWebhookInbox>(webhook => webhook.NormalizedPayload.Success == false),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _activationProcessor.Verify(
+            processor => processor.SettleLinkAsync(link, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(SimulatedPaymentFailureKind.ProviderUnavailable)]
+    [InlineData(SimulatedPaymentFailureKind.OutcomeUnknown)]
+    public async Task An_ambiguous_initial_charge_outcome_settles_nothing(SimulatedPaymentFailureKind kind)
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Incomplete,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _paymentLinks
+            .Setup(repo => repo.FindBySubscriptionAsync(TenantId, SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PendingInitialChargeLink("pay-1"));
+        StubEmptyState(subscription, "target-org");
+
+        var request = new MarkPaymentFailedRequest
+        {
+            OrganizationId = "target-org",
+            PaymentPurpose = SubscriptionPaymentPurpose.InitialCharge,
+            FailureKind = kind,
+        };
+        var result = await CreateService().MarkPaymentFailedAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "an unanswered provider leaves the charge exactly where a real one would, which is not a failure of the simulation call itself");
+        _webhookTransitions.Verify(
+            transitions => transitions.ApplyAsync(It.IsAny<PaymentWebhookInbox>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _activationProcessor.Verify(
+            processor => processor.SettleLinkAsync(It.IsAny<SubscriptionPaymentLink>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Refuses_to_settle_an_initial_charge_that_already_settled()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var request = new MarkPaymentSucceededRequest
+        {
+            OrganizationId = "target-org",
+            PaymentPurpose = SubscriptionPaymentPurpose.InitialCharge,
+        };
+        var result = await CreateService().MarkPaymentSucceededAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_already_settled");
+    }
+
+    [Fact]
+    public async Task Marking_a_renewal_succeeded_scripts_the_gateway_and_runs_the_renewal_service()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new MarkPaymentSucceededRequest
+        {
+            OrganizationId = "target-org",
+            PaymentPurpose = SubscriptionPaymentPurpose.Renewal,
+        };
+        var result = await CreateService().MarkPaymentSucceededAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(
+                It.Is<ScriptedChargeOutcome>(outcome => outcome.Outcome == SimulatedChargeOutcome.Succeeded)),
+            Times.Once);
+        _renewalService.Verify(
+            service => service.RenewAsync(subscription, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Refuses_to_renew_an_incomplete_subscription()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Incomplete,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var request = new MarkPaymentFailedRequest
+        {
+            OrganizationId = "target-org",
+            PaymentPurpose = SubscriptionPaymentPurpose.Renewal,
+            FailureKind = SimulatedPaymentFailureKind.Declined,
+        };
+        var result = await CreateService().MarkPaymentFailedAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_not_renewable");
+        _renewalService.Verify(
+            service => service.RenewAsync(It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Defers_a_renewal_while_a_settlement_reservation_is_unresolved()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+            SettlementReservation = new SettlementReservation { ReservationId = "res-1" },
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var request = new MarkPaymentSucceededRequest
+        {
+            OrganizationId = "target-org",
+            PaymentPurpose = SubscriptionPaymentPurpose.Renewal,
+        };
+        var result = await CreateService().MarkPaymentSucceededAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_settlement_in_flight");
+    }
 }


### PR DESCRIPTION
## Summary

PR 2 of the subscription simulation harness (PR 1, #277, merged): payment-outcome simulation.

Adds `POST /api/subscription-simulation/subscriptions/{id}/mark-payment-succeeded` and `.../mark-payment-failed`, each driving a scripted provider outcome through the **real** settlement path — never by writing `PaymentDetail`/`SubscriptionDetail` status fields directly.

### Two genuinely different pipelines, both reused as-is

Research into the actual codebase (not the task-plan's assumptions) showed the settlement path bifurcates by purpose:

- **`InitialCharge`** settles asynchronously in production, via a signed webhook. The simulation builds a synthetic `PaymentWebhookInbox` — using the *real* pending payment's exact amount/currency so the transition service's own validation passes — and applies it through the real `IPaymentWebhookStateTransitionService.ApplyAsync`. This is the same write a real webhook triggers, including its dedup-key/idempotency guard. Then it settles the one held `SubscriptionPaymentLink` through a **new** `ISubscriptionActivationProcessor.SettleLinkAsync(link, ct)` — added because the existing processor only offered a tenant-wide `ProcessDueAsync` sweep, which risked settling an unrelated subscription's link during a test. It's a thin public wrapper around the processor's existing private per-link logic; `ProcessDueAsync` itself is untouched.
- **`Renewal`** charges synchronously in production — there's no pending state to resolve, no webhook involved. A new `SubscriptionSimulationBillingGateway` decorates the real `ISubscriptionBillingGateway`: when the harness is enabled and a caller has scripted the next outcome (via a request-scoped `ISubscriptionSimulatedOutcomeSource`, consumed exactly once), it returns that instead of placing a real charge; otherwise it delegates straight through to the real `SubscriptionBillingGatewayResolver`. It's **always** the registered `ISubscriptionBillingGateway`, in every environment — with the harness disabled or nothing scripted, behavior for a real request is unchanged. The real `ISubscriptionRenewalService.RenewAsync` then runs untouched, so dunning/period-advance logic is exercised exactly as production does it.

### Honest handling of ambiguous outcomes

For `InitialCharge`, `ProviderUnavailable`/`OutcomeUnknown` failure kinds deliberately settle **nothing** — production never raises a webhook for an unreachable or ambiguous provider answer either, so the simulated charge is left exactly where a real one would be (still pending). This matches the task plan's `TimeoutAfterProviderSuccess` intent without faking a recovery-sweep code path that depends on wall-clock staleness the simulation can't cleanly force for a subscription created moments earlier.

### Known, documented scope limit

Initial-charge success activates the subscription but does **not** simulate a saved card — no `ProviderPayerReference`/stored-method token is faked. That data flows through `IStoredPaymentMethodLifecycleService.ApplyAuthorisationTokenAsync`, code this harness doesn't own, and guessing at its expected shape risked either an unhandled exception or state that looks saved but silently isn't. A subscription activated this way therefore has no card, and a subsequently-simulated renewal on it needs a payment method recorded some other way. Flagged in code comments for whoever picks this up next.

`SimulatedPaymentFailureKind` (`Declined`/`InsufficientFunds`/`PaymentMethodExpired`/`ProviderUnavailable`/`OutcomeUnknown`) is deliberately more granular than what the domain's dunning logic actually branches on (it only distinguishes `ProviderRejected`/`Unavailable`/`Timeout`) — the extra granularity exists so a test can name its scenario and have that recorded as the error code, even though today's renewal dunning treats every decline reason identically.

## Test plan
- [x] `dotnet build` clean across Api, Worker, XUnitTest (0 errors) — full rebuild, not incremental
- [x] `dotnet test` — 2340 non-integration tests pass (13 new, zero regressions)
- [x] New tests: initial-charge success (webhook applied + activation settled), initial-charge decline (refusal), ambiguous outcomes settle nothing, already-settled conflict, renewal success (gateway scripted + `RenewAsync` invoked), renewal on a non-renewable status, renewal deferred while a settlement reservation is in flight, and the billing-gateway decorator's outcome mapping in isolation
- [ ] Manual verification against a live backend — full activation→renewal→failure lifecycle with a real console token (not run in this environment — no backend/IdP credentials available)

## Follow-ups (per the task plan)
- PR 3: advance-renewal (forcing a period due without touching the wall clock)
- PR 4: close-usage-period, overage charging
- PR 5: scoped background-job execution
- PR 6 (optional): allowlisted data console
- Client UI for both this PR and PR 1's state inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)