### PR TITLE
feat(subscription): add advance-renewal to the simulation harness

### DIFF
--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -129,6 +129,35 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Forces an immediate renewal attempt, with a scripted payment outcome, without waiting for
+    /// the fee schedule's own due date.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/advance-renewal")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> AdvanceRenewal(
+        string subscriptionId,
+        [FromBody] AdvanceRenewalRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationActionResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var result = await _simulation.AdvanceRenewalAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null

--- a/server/Subscription.DomainService/Simulation/AdvanceRenewalRequest.cs
+++ b/server/Subscription.DomainService/Simulation/AdvanceRenewalRequest.cs
@@ -1,0 +1,21 @@
+namespace Subscription.DomainService.Simulation;
+
+public sealed class AdvanceRenewalRequest
+{
+    public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// Must be 1 in this version. There is no simulated clock: this advances the one renewal
+    /// <see cref="Subscription.DomainService.Services.SubscriptionRenewalService.RenewAsync"/>
+    /// would raise for the fee schedule's current period, not a run of several future periods.
+    /// </summary>
+    public int Periods { get; set; } = 1;
+
+    public SimulatedRenewalOutcome PaymentOutcome { get; set; }
+
+    /// <summary>
+    /// Must be true in this version — there is nothing to schedule against without a simulated
+    /// clock, only an immediate attempt.
+    /// </summary>
+    public bool RunImmediately { get; set; } = true;
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -39,4 +39,14 @@ public interface ISubscriptionSimulationService
         MarkPaymentFailedRequest request,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Forces an immediate renewal attempt for an Active or PastDue subscription, with a scripted
+    /// payment outcome — without waiting for the fee schedule's own due date.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> AdvanceRenewalAsync(
+        string subscriptionId,
+        AdvanceRenewalRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Simulation/SimulatedRenewalOutcome.cs
+++ b/server/Subscription.DomainService/Simulation/SimulatedRenewalOutcome.cs
@@ -1,0 +1,16 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// What the one gateway call an advanced renewal makes should report — success folded in
+/// alongside the same failure vocabulary <see cref="SimulatedPaymentFailureKind"/> uses, since
+/// this single request field has to name either.
+/// </summary>
+public enum SimulatedRenewalOutcome
+{
+    Succeeded,
+    Declined,
+    InsufficientFunds,
+    PaymentMethodExpired,
+    ProviderUnavailable,
+    OutcomeUnknown
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -237,6 +237,69 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
             cancellationToken);
     }
 
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> AdvanceRenewalAsync(
+        string subscriptionId,
+        AdvanceRenewalRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        const string action = "AdvanceRenewal";
+        var startedAtUtc = DateTime.UtcNow;
+
+        if (request.Periods != 1)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_periods_invalid",
+                "Only one period may be advanced at a time in this version.",
+                correlationId,
+                new Dictionary<string, string[]> { ["Periods"] = ["Must be 1."] });
+        }
+
+        if (!request.RunImmediately)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_scheduling_not_supported",
+                "runImmediately=false is not supported yet: there is no simulated clock to " +
+                "schedule against, only an immediate renewal attempt.",
+                correlationId);
+        }
+
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationActionResponse>(
+            subscriptionId, request.OrganizationId, action, correlationId, cancellationToken);
+
+        if (resolveFailure is not null || context is null || subscription is null)
+        {
+            return resolveFailure!;
+        }
+
+        var before = Summarize(subscription);
+        var (succeeded, failureKind) = SplitRenewalOutcome(request.PaymentOutcome);
+
+        var outcome = await SettleRenewalAsync(
+            context, subscription, succeeded, failureKind, errorCode: null,
+            runProcessor: true, correlationId, cancellationToken);
+
+        return await CompleteActionAsync(
+            context, subscriptionId, request.OrganizationId, action, startedAtUtc, before,
+            subscription, outcome, correlationId, cancellationToken);
+    }
+
+    private static (bool Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(
+        SimulatedRenewalOutcome outcome) => outcome switch
+    {
+        SimulatedRenewalOutcome.Succeeded => (true, null),
+        SimulatedRenewalOutcome.Declined => (false, SimulatedPaymentFailureKind.Declined),
+        SimulatedRenewalOutcome.InsufficientFunds => (false, SimulatedPaymentFailureKind.InsufficientFunds),
+        SimulatedRenewalOutcome.PaymentMethodExpired => (false, SimulatedPaymentFailureKind.PaymentMethodExpired),
+        SimulatedRenewalOutcome.ProviderUnavailable => (false, SimulatedPaymentFailureKind.ProviderUnavailable),
+        SimulatedRenewalOutcome.OutcomeUnknown => (false, SimulatedPaymentFailureKind.OutcomeUnknown),
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unrecognized renewal outcome.")
+    };
+
     private async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> MarkPaymentOutcomeAsync(
         string subscriptionId,
         string? organizationId,
@@ -252,55 +315,12 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     {
         var startedAtUtc = DateTime.UtcNow;
 
-        var caller = BlocksContext.GetContext();
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationActionResponse>(
+            subscriptionId, organizationId, action, correlationId, cancellationToken);
 
-        if (!SubscriptionSimulationGuard.IsAuthorized(
-                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        if (resolveFailure is not null || context is null || subscription is null)
         {
-            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
-                PaymentFailureKind.Unavailable,
-                "subscription_simulation_forbidden",
-                "This caller may not use the subscription simulation harness.",
-                correlationId);
-        }
-
-        if (string.IsNullOrWhiteSpace(organizationId))
-        {
-            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_simulation_organization_required",
-                "organizationId is required: the console has no subscription of its own.",
-                correlationId,
-                new Dictionary<string, string[]>
-                {
-                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
-                });
-        }
-
-        var resolution = await _contextResolver.ResolveAsync(
-            correlationId, organizationId, cancellationToken);
-
-        if (!resolution.IsSuccess || resolution.Context is null)
-        {
-            return resolution.ToFailure<SubscriptionSimulationActionResponse>(correlationId);
-        }
-
-        var context = resolution.Context;
-
-        var subscription = await _subscriptions.GetAsync(
-            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken);
-
-        if (subscription is null)
-        {
-            await RecordRunAsync(
-                context, subscriptionId, action, correlationId,
-                "Failed", "subscription_not_found", cancellationToken);
-
-            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
-                PaymentFailureKind.NotFound,
-                "subscription_not_found",
-                "The subscription does not exist.",
-                correlationId);
+            return resolveFailure!;
         }
 
         var before = Summarize(subscription);
@@ -321,6 +341,96 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
                 correlationId), string.Empty)
         };
 
+        return await CompleteActionAsync(
+            context, subscriptionId, organizationId, action, startedAtUtc, before, subscription,
+            outcome, correlationId, cancellationToken, simulationRunId);
+    }
+
+    /// <summary>
+    /// Resolves the caller, the organization and the subscription — the prologue shared by every
+    /// mutating simulation action.
+    /// </summary>
+    private async Task<(
+        SubscriptionContext? Context,
+        SubscriptionDetail? Subscription,
+        SubscriptionOperationResult<T>? Failure)> ResolveTargetAsync<T>(
+        string subscriptionId,
+        string? organizationId,
+        string action,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var caller = BlocksContext.GetContext();
+
+        if (!SubscriptionSimulationGuard.IsAuthorized(
+                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        {
+            return (null, null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_forbidden",
+                "This caller may not use the subscription simulation harness.",
+                correlationId));
+        }
+
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            return (null, null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_organization_required",
+                "organizationId is required: the console has no subscription of its own.",
+                correlationId,
+                new Dictionary<string, string[]>
+                {
+                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
+                }));
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, organizationId, cancellationToken);
+
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return (null, null, resolution.ToFailure<T>(correlationId));
+        }
+
+        var context = resolution.Context;
+
+        var subscription = await _subscriptions.GetAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken);
+
+        if (subscription is null)
+        {
+            await RecordRunAsync(
+                context, subscriptionId, action, correlationId,
+                "Failed", "subscription_not_found", cancellationToken);
+
+            return (context, null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "The subscription does not exist.",
+                correlationId));
+        }
+
+        return (context, subscription, null);
+    }
+
+    /// <summary>
+    /// The epilogue shared by every mutating simulation action: report a failure, or reload the
+    /// subscription, assemble the full state and record the run.
+    /// </summary>
+    private async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> CompleteActionAsync(
+        SubscriptionContext context,
+        string subscriptionId,
+        string? organizationId,
+        string action,
+        DateTime startedAtUtc,
+        SubscriptionSimulationSummary before,
+        SubscriptionDetail subscriptionBeforeAction,
+        (SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note) outcome,
+        string correlationId,
+        CancellationToken cancellationToken,
+        string? simulationRunId = null)
+    {
         if (outcome.Failure is { } failure)
         {
             await RecordRunAsync(
@@ -331,7 +441,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         }
 
         var refreshed = await _subscriptions.GetAsync(
-            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken) ?? subscription;
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken)
+            ?? subscriptionBeforeAction;
         var after = Summarize(refreshed);
 
         var stateResult = await GetStateAsync(
@@ -343,7 +454,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Success(
             new SubscriptionSimulationActionResponse
             {
-                SimulationRunId = simulationRunId,
+                SimulationRunId = simulationRunId ?? $"sim_{Guid.NewGuid():N}",
                 Action = action,
                 StartedAtUtc = startedAtUtc,
                 CompletedAtUtc = DateTime.UtcNow,

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -522,4 +522,119 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("subscription_simulation_settlement_in_flight");
     }
+
+    [Fact]
+    public async Task Advancing_a_renewal_scripts_the_gateway_and_runs_the_real_renewal_service()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new AdvanceRenewalRequest
+        {
+            OrganizationId = "target-org",
+            PaymentOutcome = SimulatedRenewalOutcome.Succeeded,
+        };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Action.Should().Be("AdvanceRenewal");
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(
+                It.Is<ScriptedChargeOutcome>(outcome => outcome.Outcome == SimulatedChargeOutcome.Succeeded)),
+            Times.Once);
+        _renewalService.Verify(
+            service => service.RenewAsync(subscription, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(SimulatedRenewalOutcome.Declined, SimulatedChargeOutcome.Rejected)]
+    [InlineData(SimulatedRenewalOutcome.InsufficientFunds, SimulatedChargeOutcome.Rejected)]
+    [InlineData(SimulatedRenewalOutcome.PaymentMethodExpired, SimulatedChargeOutcome.Rejected)]
+    [InlineData(SimulatedRenewalOutcome.ProviderUnavailable, SimulatedChargeOutcome.Unavailable)]
+    [InlineData(SimulatedRenewalOutcome.OutcomeUnknown, SimulatedChargeOutcome.TimedOut)]
+    public async Task Advancing_a_renewal_maps_every_outcome_onto_the_gateway_script(
+        SimulatedRenewalOutcome requested, SimulatedChargeOutcome expected)
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.PastDue,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org", PaymentOutcome = requested };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.Is<ScriptedChargeOutcome>(o => o.Outcome == expected)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Refuses_to_advance_more_than_one_period()
+    {
+        SetAuthorizedCaller();
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org", Periods = 2 };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_periods_invalid");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Refuses_to_defer_scheduling_since_there_is_no_simulated_clock()
+    {
+        SetAuthorizedCaller();
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org", RunImmediately = false };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_scheduling_not_supported");
+    }
+
+    [Fact]
+    public async Task Refuses_to_advance_a_renewal_for_an_incomplete_subscription()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Incomplete,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org" };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_not_renewable");
+    }
 }


### PR DESCRIPTION
## Summary

PR 3 of the subscription simulation harness. **Stacked on #279** (payment-outcome simulation) — this PR's base is that branch, not `dev`, because it reuses PR 2's renewal-settlement machinery directly. Merge order: #279 first, then this one (or merge this one into #279's branch and let it ride along — either works, just don't merge this into `dev` before #279 is in).

### What it adds

`POST /api/subscription-simulation/subscriptions/{id}/advance-renewal` — forces an immediate renewal attempt with a scripted payment outcome, without waiting for the fee schedule's own due date.

### Why no simulated-clock abstraction was needed

The task plan's own notes flagged a persistent per-subscription virtual clock as the "more correct" approach but admitted it "can make production code complicated" and suggested a simpler first version. Reading the actual renewal code (as part of PR 2's research) showed the simpler version is *already sufficient*: `SubscriptionRenewalService.RenewAsync` computes whichever billing period `now` falls into via `BillingPeriodCalculator.TryGetPeriod` — it never checks whether the schedule says a renewal is due. That check lives only in the sweep processor's own query, `ISubscriptionRepository.ListDueForRenewalAsync`, which this endpoint never calls. So "advance renewal" is exactly PR 2's `Renewal`-purpose settlement path (scripted gateway outcome → real `RenewAsync`), invoked directly under its own request shape and its own simulation-run action name — no new clock machinery, no due-date manipulation, no risk of touching an unrelated subscription's schedule.

### Scope restrictions (matching the task plan's own "Request restrictions")

- `periods` must be `1` — rejected otherwise with `subscription_simulation_periods_invalid`.
- `runImmediately` must be `true` — `false` is rejected with `subscription_simulation_scheduling_not_supported`, since there's no simulated clock to schedule a later attempt against in this version.
- Only `Active`/`PastDue` subscriptions, and none with a settlement reservation in flight — the same preconditions PR 2's renewal path already enforces, reused rather than re-implemented.
- `paymentOutcome` folds success and every failure kind into one field (`Succeeded`/`Declined`/`InsufficientFunds`/`PaymentMethodExpired`/`ProviderUnavailable`/`OutcomeUnknown`), matching the task plan's example JSON shape, and maps onto the same gateway-outcome vocabulary PR 2 introduced.

### Refactor

Extracted the prologue (authorize → resolve organization → load subscription) and epilogue (reload subscription → assemble full state → record the simulation run) out of `MarkPaymentOutcomeAsync` into `ResolveTargetAsync<T>`/`CompleteActionAsync`, so this endpoint and the two payment-outcome endpoints share one implementation of each instead of growing a third copy. All 27 pre-existing simulation tests pass unchanged after the refactor — confirms it's behavior-preserving.

## Test plan
- [x] `dotnet build` clean across Api, Worker, XUnitTest (0 errors) — full rebuild
- [x] `dotnet test` — 2349 non-integration tests pass (9 new for this PR, 27 pre-existing simulation tests unchanged, zero regressions)
- [x] New tests: successful advance, every failure-outcome-to-gateway-script mapping, `periods != 1` rejected before any repository call, `runImmediately: false` rejected, and renewal refused for a non-renewable (`Incomplete`) subscription
- [ ] Manual verification against a live backend (not run in this environment — no backend/IdP credentials available)

## Follow-ups (per the task plan)
- PR 4: close-usage-period, overage charging
- PR 5: scoped background-job execution
- PR 6 (optional): allowlisted data console
- Client UI for PR 1's state inspector and PRs 2–3's actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)