### PR TITLE
feat(subscription): add close-usage-period to the simulation harness

### DIFF
--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -158,6 +158,35 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Closes the subscription's current usage period now, prices any overage, and — unless
+    /// told otherwise — charges it with a scripted payment outcome.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/close-usage-period")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CloseUsagePeriod(
+        string subscriptionId,
+        [FromBody] CloseUsagePeriodRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationActionResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var result = await _simulation.CloseUsagePeriodAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null

--- a/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
@@ -1,3 +1,5 @@
+using Subscription.DomainService.Entities;
+
 namespace Subscription.DomainService.Outbox;
 
 /// <summary>Closes usage periods that have ended and invoices their overage.</summary>
@@ -8,4 +10,23 @@ public interface ISubscriptionUsageRatingProcessor
 
     /// <returns>How many invoices were attempted, whether they charged, retried or were abandoned.</returns>
     Task<int> ChargeDueInvoicesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Closes exactly one subscription's own due periods, as of a caller-supplied instant —
+    /// never the wall clock, and never any other subscription's schedule.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the simulation harness: passing the subscription's own current period end
+    /// (or a moment after it) closes precisely that one period through the same logic
+    /// <see cref="CloseDuePeriodsAsync"/> uses, without waiting for real time to reach it and
+    /// without touching any other subscription the way a tenant-wide sweep would.
+    /// </remarks>
+    /// <returns>How many periods were closed for this one subscription.</returns>
+    Task<int> CloseSubscriptionPeriodsAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>Attempts exactly one invoice's charge, regardless of whether its own retry schedule is due.</summary>
+    Task ChargeInvoiceAsync(SubscriptionUsageInvoice invoice, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -92,6 +92,17 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         return closed;
     }
 
+    public Task<int> CloseSubscriptionPeriodsAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        CancellationToken cancellationToken) =>
+        CloseSubscriptionAsync(subscription, asOfUtc, cancellationToken);
+
+    public Task ChargeInvoiceAsync(
+        SubscriptionUsageInvoice invoice,
+        CancellationToken cancellationToken) =>
+        ChargeInvoiceAsync(invoice, _options.CurrentValue, _time.GetUtcNow().UtcDateTime, cancellationToken);
+
     private Task AuditAsync(
         SubscriptionDetail subscription,
         string stage,

--- a/server/Subscription.DomainService/Simulation/CloseUsagePeriodRequest.cs
+++ b/server/Subscription.DomainService/Simulation/CloseUsagePeriodRequest.cs
@@ -1,0 +1,20 @@
+namespace Subscription.DomainService.Simulation;
+
+public sealed class CloseUsagePeriodRequest
+{
+    public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// The gateway outcome to script for the overage charge, if <see cref="ChargeInvoice"/> is
+    /// true and the closed period actually produced one. Reuses the same vocabulary
+    /// <see cref="AdvanceRenewalRequest.PaymentOutcome"/> does — a usage invoice is charged
+    /// through the identical <c>ISubscriptionBillingGateway.ChargeAsync</c> call a renewal is.
+    /// </summary>
+    public SimulatedRenewalOutcome PaymentOutcome { get; set; } = SimulatedRenewalOutcome.Succeeded;
+
+    /// <summary>Whether to also charge the overage invoice the close produces, if any.</summary>
+    public bool ChargeInvoice { get; set; } = true;
+
+    /// <summary>Must be true in this version — see <see cref="AdvanceRenewalRequest.RunImmediately"/>.</summary>
+    public bool RunImmediately { get; set; } = true;
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -49,4 +49,14 @@ public interface ISubscriptionSimulationService
         AdvanceRenewalRequest request,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Closes the subscription's current usage period as of right now, prices any overage into
+    /// an invoice, and — unless told otherwise — charges it with a scripted payment outcome.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> CloseUsagePeriodAsync(
+        string subscriptionId,
+        CloseUsagePeriodRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -11,6 +11,7 @@ using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Simulation;
 
@@ -34,6 +35,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     private readonly ISubscriptionActivationProcessor _activationProcessor;
     private readonly ISubscriptionRenewalService _renewalService;
     private readonly ISubscriptionSimulatedOutcomeSource _scriptedOutcomes;
+    private readonly ISubscriptionUsageRatingProcessor _usageRatingProcessor;
 
     public SubscriptionSimulationService(
         ISubscriptionContextResolver contextResolver,
@@ -51,7 +53,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         IPaymentWebhookStateTransitionService webhookTransitions,
         ISubscriptionActivationProcessor activationProcessor,
         ISubscriptionRenewalService renewalService,
-        ISubscriptionSimulatedOutcomeSource scriptedOutcomes)
+        ISubscriptionSimulatedOutcomeSource scriptedOutcomes,
+        ISubscriptionUsageRatingProcessor usageRatingProcessor)
     {
         _contextResolver = contextResolver;
         _subscriptions = subscriptions;
@@ -69,6 +72,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         _activationProcessor = activationProcessor;
         _renewalService = renewalService;
         _scriptedOutcomes = scriptedOutcomes;
+        _usageRatingProcessor = usageRatingProcessor;
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
@@ -286,6 +290,113 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         return await CompleteActionAsync(
             context, subscriptionId, request.OrganizationId, action, startedAtUtc, before,
             subscription, outcome, correlationId, cancellationToken);
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> CloseUsagePeriodAsync(
+        string subscriptionId,
+        CloseUsagePeriodRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        const string action = "CloseUsagePeriod";
+        var startedAtUtc = DateTime.UtcNow;
+
+        if (!request.RunImmediately)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_scheduling_not_supported",
+                "runImmediately=false is not supported yet: there is no simulated clock to " +
+                "schedule against, only an immediate close.",
+                correlationId);
+        }
+
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationActionResponse>(
+            subscriptionId, request.OrganizationId, action, correlationId, cancellationToken);
+
+        if (resolveFailure is not null || context is null || subscription is null)
+        {
+            return resolveFailure!;
+        }
+
+        var before = Summarize(subscription);
+
+        var outcome = await CloseUsagePeriodInternalAsync(
+            context, subscription, request, correlationId, cancellationToken);
+
+        return await CompleteActionAsync(
+            context, subscriptionId, request.OrganizationId, action, startedAtUtc, before,
+            subscription, outcome, correlationId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Closes the current usage period as of an instant just past its own end — never the wall
+    /// clock, and never any period belonging to another subscription — then, if it produced an
+    /// overage invoice, charges it with the scripted outcome.
+    /// </summary>
+    private async Task<(SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note)>
+        CloseUsagePeriodInternalAsync(
+            SubscriptionContext context,
+            SubscriptionDetail subscription,
+            CloseUsagePeriodRequest request,
+            string correlationId,
+            CancellationToken cancellationToken)
+    {
+        // Captured before the close mutates the subscription's own CurrentUsagePeriodStartUtc in
+        // place — this is the key the invoice the close just produced (if any) was filed under.
+        var closedPeriodKey = PeriodKey.Create(
+            subscription.UsageSchedule.Interval, subscription.CurrentUsagePeriodStartUtc);
+
+        var periodsClosed = await _usageRatingProcessor.CloseSubscriptionPeriodsAsync(
+            subscription, subscription.CurrentUsagePeriodEndUtc.AddSeconds(1), cancellationToken);
+
+        if (periodsClosed == 0)
+        {
+            return (null,
+                "No period was closed — another worker may already be advancing this " +
+                "subscription's usage clock, or its schedule could not be advanced.");
+        }
+
+        var invoice = await _usageInvoices.GetAsync(
+            context.TenantId, subscription.ItemId, closedPeriodKey, cancellationToken);
+
+        if (invoice is null)
+        {
+            return (null,
+                $"{periodsClosed} usage period(s) closed; no overage invoice was produced " +
+                "(usage was within the allowance, or every metered item resets rather than " +
+                "carrying overage into an invoice).");
+        }
+
+        if (invoice.State != SubscriptionUsageInvoiceState.Pending)
+        {
+            return (null,
+                $"{periodsClosed} usage period(s) closed; the invoice is already " +
+                $"{invoice.State} and will not be charged again.");
+        }
+
+        if (!request.ChargeInvoice)
+        {
+            return (null,
+                $"{periodsClosed} usage period(s) closed; a pending overage invoice of " +
+                $"{invoice.TotalAmountMinor} {invoice.CurrencyCode} (minor units) was not charged.");
+        }
+
+        var (succeeded, failureKind) = SplitRenewalOutcome(request.PaymentOutcome);
+
+        _scriptedOutcomes.ScriptNext(new ScriptedChargeOutcome(
+            succeeded ? SimulatedChargeOutcome.Succeeded : MapFailureOutcome(failureKind),
+            succeeded ? null : DefaultErrorCode(failureKind),
+            succeeded ? null : DefaultErrorMessage(failureKind)));
+
+        await _usageRatingProcessor.ChargeInvoiceAsync(invoice, cancellationToken);
+
+        return (null, succeeded
+            ? $"{periodsClosed} usage period(s) closed and the overage invoice charged."
+            : $"{periodsClosed} usage period(s) closed; the overage charge failed and will retry " +
+              "on its own schedule.");
     }
 
     private static (bool Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -48,6 +48,7 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
     private readonly Mock<ISubscriptionActivationProcessor> _activationProcessor = new();
     private readonly Mock<ISubscriptionRenewalService> _renewalService = new();
     private readonly Mock<ISubscriptionSimulatedOutcomeSource> _scriptedOutcomes = new();
+    private readonly Mock<ISubscriptionUsageRatingProcessor> _usageRatingProcessor = new();
 
     public SubscriptionSimulationServiceTests()
     {
@@ -239,7 +240,8 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         _webhookTransitions.Object,
         _activationProcessor.Object,
         _renewalService.Object,
-        _scriptedOutcomes.Object);
+        _scriptedOutcomes.Object,
+        _usageRatingProcessor.Object);
 
     /// <summary>Wires the read-only GetStateAsync collaborators to return an empty-but-valid state, so mark-payment tests can reuse it without re-asserting PR 1's own coverage.</summary>
     private void StubEmptyState(SubscriptionDetail subscription, string organizationId)
@@ -636,5 +638,148 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("subscription_simulation_not_renewable");
+    }
+
+    private static SubscriptionDetail UsageSubscription() => new()
+    {
+        ItemId = SubscriptionId,
+        TenantId = TenantId,
+        OrganizationId = "target-org",
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "EUR",
+        CurrentUsagePeriodStartUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentUsagePeriodEndUtc = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+    };
+
+    [Fact]
+    public async Task Closing_a_usage_period_with_no_overage_charges_nothing()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _usageInvoices
+            .Setup(repo => repo.GetAsync(TenantId, SubscriptionId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageInvoice?)null);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org" };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Closing_a_usage_period_with_overage_scripts_and_charges_the_invoice()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        var invoice = new SubscriptionUsageInvoice
+        {
+            ItemId = "invoice-1", TenantId = TenantId, SubscriptionId = SubscriptionId,
+            State = SubscriptionUsageInvoiceState.Pending, TotalAmountMinor = 500, CurrencyCode = "EUR",
+        };
+        _usageInvoices
+            .Setup(repo => repo.GetAsync(TenantId, SubscriptionId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invoice);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org", PaymentOutcome = SimulatedRenewalOutcome.Succeeded };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.Is<ScriptedChargeOutcome>(o => o.Outcome == SimulatedChargeOutcome.Succeeded)),
+            Times.Once);
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(invoice, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Closing_a_usage_period_does_not_charge_when_chargeInvoice_is_false()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _usageInvoices
+            .Setup(repo => repo.GetAsync(TenantId, SubscriptionId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageInvoice
+            {
+                ItemId = "invoice-1", State = SubscriptionUsageInvoiceState.Pending, TotalAmountMinor = 500,
+            });
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org", ChargeInvoice = false };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Reports_no_change_when_the_period_could_not_be_closed()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org" };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _usageInvoices.Verify(
+            repo => repo.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Refuses_to_defer_a_usage_close_since_there_is_no_simulated_clock()
+    {
+        SetAuthorizedCaller();
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org", RunImmediately = false };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_scheduling_not_supported");
     }
 }


### PR DESCRIPTION
## Summary

PR 4 of the subscription simulation harness. **Stacked on #280** (advance-renewal) — merge order: #279 → #280 → this one.

### What it adds

`POST /api/subscription-simulation/subscriptions/{id}/close-usage-period` — closes the subscription's current usage period immediately, prices any overage into a `SubscriptionUsageInvoice` through the real rating logic, and — unless `chargeInvoice: false` — charges it with a scripted payment outcome.

### Why this one genuinely needed new plumbing (unlike renewal)

PR 3 found that advancing a renewal needed nothing new, because `SubscriptionRenewalService.RenewAsync` doesn't check whether a renewal is actually due — only the sweep's own query does. Usage-period closing is different: reading `SubscriptionUsageRatingProcessor`'s private close loop shows the due-check is baked directly into the closing logic itself (`if (subscription.CurrentUsagePeriodEndUtc > now) break;`), not just the outer sweep query. A subscription whose period hasn't naturally ended yet would make this loop no-op immediately.

Rather than move the subscription's own period boundary with a preliminary "make it due" write (which the task plan's own notes flagged as needing either a persistent simulated clock or a "simpler first version" compromise), the fix is smaller: the processor's private close method already took `now` as a plain parameter, computed once by its caller. Exposing it as `CloseSubscriptionPeriodsAsync(SubscriptionDetail subscription, DateTime asOfUtc, CancellationToken ct)` lets the simulation pass the subscription's own current period end (plus one second) as `asOfUtc` — closing exactly that one period through the **unmodified** real logic, never the wall clock, and never any other subscription's period (the method operates on the one `SubscriptionDetail` object already in hand, not a tenant-wide query). A matching `ChargeInvoiceAsync(invoice, ct)` overload lets the one invoice the close just produced be charged immediately outside the tenant-wide `ChargeDueInvoicesAsync` sweep, reusing PR 2's `ISubscriptionSimulatedOutcomeSource`/`SubscriptionSimulationBillingGateway` to script its outcome — no changes needed there at all, since `SubscriptionUsageRatingProcessor` already charges through the same `ISubscriptionBillingGateway` PR 2's decorator wraps.

### Honest outcomes

The response note distinguishes every real case rather than reporting generic success:
- No invoice produced at all — usage stayed within the allowance (or every metered item is a persistent/"Never"-reset meter, which the existing rating logic already excludes from overage invoicing — this PR changes nothing about that distinction, only exposes the same code per-subscription).
- An invoice that already exists and isn't `Pending` — idempotent no-op, matching `TryCreateAsync`'s own unique-index guard on repeat calls.
- A pending invoice left uncharged when `chargeInvoice: false`.
- A charged or failed invoice when the charge actually ran.

## Test plan
- [x] `dotnet build` clean across Api, Worker, XUnitTest (0 errors) — full rebuild
- [x] `dotnet test` — 2354 non-integration tests pass (5 new, zero regressions); the 14 pre-existing `SubscriptionUsageRatingProcessorTests` pass unchanged, confirming the new public overloads didn't touch the private logic they wrap
- [x] New tests: no-overage close (nothing charged), overage close (scripted and charged), `chargeInvoice: false` (closed but left pending), a period that couldn't be closed (no invoice lookup attempted), and `runImmediately: false` rejected

## Follow-ups (per the task plan)
- PR 5: scoped background-job execution
- PR 6 (optional): allowlisted data console
- Client UI for every action across PRs 1–4

🤖 Generated with [Claude Code](https://claude.com/claude-code)