### PR TITLE
feat(subscription): add scoped run-due-jobs to the simulation harness

### DIFF
--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -187,6 +187,35 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Runs whichever due background work exists for this one subscription right now — never a
+    /// tenant-wide sweep, and never a scripted outcome: a renewal or a usage-invoice charge run
+    /// here goes to the real payment gateway.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/jobs/run-due")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationJobRunResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationJobRunResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationJobRunResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> RunDueJobs(
+        string subscriptionId,
+        [FromBody] RunDueJobsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationJobRunResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var result = await _simulation.RunDueJobsAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null

--- a/server/Subscription.DomainService/Outbox/ISubscriptionOutboxProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionOutboxProcessor.cs
@@ -1,3 +1,5 @@
+using Subscription.DomainService.Entities;
+
 namespace Subscription.DomainService.Outbox;
 
 public interface ISubscriptionOutboxProcessor
@@ -7,4 +9,14 @@ public interface ISubscriptionOutboxProcessor
     /// </summary>
     /// <returns>How many were published.</returns>
     Task<int> PublishDueAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes exactly one subscription's own due events, through the same claim-and-lease
+    /// mechanism <see cref="PublishDueAsync"/> uses — for the simulation harness, which must
+    /// never touch another subscription's outbox.
+    /// </summary>
+    /// <returns>How many events were published for this one subscription.</returns>
+    Task<int> PublishDueForSubscriptionAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
@@ -70,6 +70,26 @@ public sealed class SubscriptionOutboxProcessor : ISubscriptionOutboxProcessor
         return published;
     }
 
+    public async Task<int> PublishDueForSubscriptionAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var published = 0;
+
+        foreach (var pending in DueEventsOf(subscription, now))
+        {
+            if (await PublishAsync(subscription, pending, options, now, cancellationToken))
+            {
+                published++;
+            }
+        }
+
+        return published;
+    }
+
     private static IEnumerable<SubscriptionOutboxEvent> DueEventsOf(
         SubscriptionDetail subscription,
         DateTime now) =>

--- a/server/Subscription.DomainService/Responses/SubscriptionSimulationJobRunResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionSimulationJobRunResponse.cs
@@ -1,0 +1,39 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// What running due background work for one subscription actually did — each work type's own
+/// outcome, alongside the complete state left behind.
+/// </summary>
+public sealed class SubscriptionSimulationJobRunResponse
+{
+    public string SimulationRunId { get; init; } = string.Empty;
+
+    public DateTime StartedAtUtc { get; init; }
+
+    public DateTime CompletedAtUtc { get; init; }
+
+    public int Claimed { get; init; }
+
+    public int Completed { get; init; }
+
+    /// <summary>Work types that were asked for but were not actually due — not a failure.</summary>
+    public int NotDue { get; init; }
+
+    public List<SubscriptionSimulationJobResultResponse> Jobs { get; init; } = [];
+
+    public SubscriptionSimulationStateResponse State { get; init; } = new();
+
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+public sealed class SubscriptionSimulationJobResultResponse
+{
+    public string WorkType { get; init; } = string.Empty;
+
+    /// <summary><c>Completed</c>, <c>NotDue</c> or <c>NotApplicable</c> (the subscription's own state rules it out entirely).</summary>
+    public string Status { get; init; } = string.Empty;
+
+    public string? Detail { get; init; }
+
+    public long DurationMs { get; init; }
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -59,4 +59,15 @@ public interface ISubscriptionSimulationService
         CloseUsagePeriodRequest request,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Runs whichever due background work exists for this one subscription right now, through
+    /// the real processors and — for a renewal or a usage-invoice charge — the real payment
+    /// gateway, with no outcome scripted. Never a tenant-wide sweep.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationJobRunResponse>> RunDueJobsAsync(
+        string subscriptionId,
+        RunDueJobsRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Simulation/RunDueJobsRequest.cs
+++ b/server/Subscription.DomainService/Simulation/RunDueJobsRequest.cs
@@ -1,0 +1,14 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// Runs due background work for exactly one subscription — never a tenant-wide sweep. The
+/// subscription is always the URL's own <c>{subscriptionId}</c>, which is what keeps this from
+/// becoming an unrestricted "run every job for every tenant" action.
+/// </summary>
+public sealed class RunDueJobsRequest
+{
+    public string? OrganizationId { get; set; }
+
+    /// <summary>Empty means every work type this endpoint knows about.</summary>
+    public List<SimulationWorkType> WorkTypes { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Simulation/SimulationWorkType.cs
+++ b/server/Subscription.DomainService/Simulation/SimulationWorkType.cs
@@ -1,0 +1,13 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// The background sweeps this harness can run for one subscription immediately, instead of
+/// waiting for the real reconciliation host's own polling interval.
+/// </summary>
+public enum SimulationWorkType
+{
+    Renewal,
+    UsagePeriodClosure,
+    UsageInvoiceCharge,
+    OutboxPublication
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Blocks.Genesis;
 using Microsoft.Extensions.Options;
 using Payment.DomainService.Entities;
@@ -36,6 +37,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     private readonly ISubscriptionRenewalService _renewalService;
     private readonly ISubscriptionSimulatedOutcomeSource _scriptedOutcomes;
     private readonly ISubscriptionUsageRatingProcessor _usageRatingProcessor;
+    private readonly ISubscriptionOutboxProcessor _outboxProcessor;
 
     public SubscriptionSimulationService(
         ISubscriptionContextResolver contextResolver,
@@ -54,7 +56,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         ISubscriptionActivationProcessor activationProcessor,
         ISubscriptionRenewalService renewalService,
         ISubscriptionSimulatedOutcomeSource scriptedOutcomes,
-        ISubscriptionUsageRatingProcessor usageRatingProcessor)
+        ISubscriptionUsageRatingProcessor usageRatingProcessor,
+        ISubscriptionOutboxProcessor outboxProcessor)
     {
         _contextResolver = contextResolver;
         _subscriptions = subscriptions;
@@ -73,6 +76,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         _renewalService = renewalService;
         _scriptedOutcomes = scriptedOutcomes;
         _usageRatingProcessor = usageRatingProcessor;
+        _outboxProcessor = outboxProcessor;
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
@@ -397,6 +401,166 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
             ? $"{periodsClosed} usage period(s) closed and the overage invoice charged."
             : $"{periodsClosed} usage period(s) closed; the overage charge failed and will retry " +
               "on its own schedule.");
+    }
+
+    private static readonly SimulationWorkType[] AllWorkTypes =
+    [
+        SimulationWorkType.Renewal,
+        SimulationWorkType.UsagePeriodClosure,
+        SimulationWorkType.UsageInvoiceCharge,
+        SimulationWorkType.OutboxPublication
+    ];
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationJobRunResponse>> RunDueJobsAsync(
+        string subscriptionId,
+        RunDueJobsRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        const string action = "RunDueJobs";
+        var startedAtUtc = DateTime.UtcNow;
+
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationJobRunResponse>(
+            subscriptionId, request.OrganizationId, action, correlationId, cancellationToken);
+
+        if (resolveFailure is not null || context is null || subscription is null)
+        {
+            return resolveFailure!;
+        }
+
+        var workTypes = request.WorkTypes.Count > 0 ? request.WorkTypes.Distinct() : AllWorkTypes;
+        var now = DateTime.UtcNow;
+        var jobs = new List<SubscriptionSimulationJobResultResponse>();
+
+        foreach (var workType in workTypes)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            var (status, detail) = workType switch
+            {
+                SimulationWorkType.Renewal =>
+                    await RunRenewalJobAsync(subscription, now, cancellationToken),
+                SimulationWorkType.UsagePeriodClosure =>
+                    await RunUsageClosureJobAsync(subscription, now, cancellationToken),
+                SimulationWorkType.UsageInvoiceCharge =>
+                    await RunUsageChargeJobAsync(context, subscription, now, cancellationToken),
+                SimulationWorkType.OutboxPublication =>
+                    await RunOutboxJobAsync(subscription, cancellationToken),
+                _ => ("NotApplicable", "Unrecognized work type.")
+            };
+
+            jobs.Add(new SubscriptionSimulationJobResultResponse
+            {
+                WorkType = workType.ToString(),
+                Status = status,
+                Detail = detail,
+                DurationMs = stopwatch.ElapsedMilliseconds
+            });
+        }
+
+        var stateResult = await GetStateAsync(
+            subscriptionId, request.OrganizationId, 100, 100, true, correlationId, cancellationToken);
+
+        await RecordRunAsync(
+            context, subscriptionId, action, correlationId, "Succeeded", null, cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationJobRunResponse>.Success(
+            new SubscriptionSimulationJobRunResponse
+            {
+                SimulationRunId = $"sim_{Guid.NewGuid():N}",
+                StartedAtUtc = startedAtUtc,
+                CompletedAtUtc = DateTime.UtcNow,
+                Claimed = jobs.Count,
+                Completed = jobs.Count(job => job.Status == "Completed"),
+                NotDue = jobs.Count(job => job.Status == "NotDue"),
+                Jobs = jobs,
+                State = stateResult.IsSuccess && stateResult.Value is not null
+                    ? stateResult.Value
+                    : new SubscriptionSimulationStateResponse(),
+                CorrelationId = correlationId
+            },
+            correlationId);
+    }
+
+    /// <summary>Real gateway, no outcome scripted — this runs due work, it does not fake an answer.</summary>
+    private async Task<(string Status, string? Detail)> RunRenewalJobAsync(
+        SubscriptionDetail subscription, DateTime now, CancellationToken cancellationToken)
+    {
+        if (subscription.Status is not (SubscriptionStatus.Active or SubscriptionStatus.PastDue))
+        {
+            return ("NotApplicable", "Only an Active or PastDue subscription can renew.");
+        }
+
+        if (subscription.SettlementReservation is not null)
+        {
+            return ("NotDue", "A quantity or plan change is still settling.");
+        }
+
+        if (subscription.NextFeeBillingAtUtc is null || subscription.NextFeeBillingAtUtc > now)
+        {
+            return ("NotDue", "The fee schedule's next billing instant has not arrived yet.");
+        }
+
+        await _renewalService.RenewAsync(subscription, cancellationToken);
+
+        return ("Completed", "The real renewal service ran against the real payment gateway.");
+    }
+
+    private async Task<(string Status, string? Detail)> RunUsageClosureJobAsync(
+        SubscriptionDetail subscription, DateTime now, CancellationToken cancellationToken)
+    {
+        if (subscription.CurrentUsagePeriodEndUtc > now)
+        {
+            return ("NotDue", "The usage period has not ended yet.");
+        }
+
+        var closed = await _usageRatingProcessor.CloseSubscriptionPeriodsAsync(
+            subscription, now, cancellationToken);
+
+        return closed > 0
+            ? ("Completed", $"{closed} usage period(s) closed.")
+            : ("NotDue", "Nothing to close.");
+    }
+
+    /// <summary>Real gateway, no outcome scripted — see <see cref="RunRenewalJobAsync"/>.</summary>
+    private async Task<(string Status, string? Detail)> RunUsageChargeJobAsync(
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var invoices = await _usageInvoices.ListBySubscriptionAsync(
+            context.TenantId, subscription.ItemId, 50, cancellationToken);
+
+        var due = invoices
+            .Where(invoice => invoice.State == SubscriptionUsageInvoiceState.Pending &&
+                (invoice.NextAttemptAtUtc is null || invoice.NextAttemptAtUtc <= now))
+            .ToList();
+
+        if (due.Count == 0)
+        {
+            return ("NotDue", "No pending usage invoice is due for a charge attempt.");
+        }
+
+        foreach (var invoice in due)
+        {
+            await _usageRatingProcessor.ChargeInvoiceAsync(invoice, cancellationToken);
+        }
+
+        return ("Completed", $"{due.Count} usage invoice charge attempt(s) run against the real payment gateway.");
+    }
+
+    private async Task<(string Status, string? Detail)> RunOutboxJobAsync(
+        SubscriptionDetail subscription, CancellationToken cancellationToken)
+    {
+        var published = await _outboxProcessor.PublishDueForSubscriptionAsync(
+            subscription, cancellationToken);
+
+        return published > 0
+            ? ("Completed", $"{published} outbox event(s) published.")
+            : ("NotDue", "No outbox event is due for publication.");
     }
 
     private static (bool Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -49,6 +49,7 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
     private readonly Mock<ISubscriptionRenewalService> _renewalService = new();
     private readonly Mock<ISubscriptionSimulatedOutcomeSource> _scriptedOutcomes = new();
     private readonly Mock<ISubscriptionUsageRatingProcessor> _usageRatingProcessor = new();
+    private readonly Mock<ISubscriptionOutboxProcessor> _outboxProcessor = new();
 
     public SubscriptionSimulationServiceTests()
     {
@@ -241,7 +242,8 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         _activationProcessor.Object,
         _renewalService.Object,
         _scriptedOutcomes.Object,
-        _usageRatingProcessor.Object);
+        _usageRatingProcessor.Object,
+        _outboxProcessor.Object);
 
     /// <summary>Wires the read-only GetStateAsync collaborators to return an empty-but-valid state, so mark-payment tests can reuse it without re-asserting PR 1's own coverage.</summary>
     private void StubEmptyState(SubscriptionDetail subscription, string organizationId)
@@ -781,5 +783,125 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("subscription_simulation_scheduling_not_supported");
+    }
+
+    [Fact]
+    public async Task Running_due_jobs_reports_not_due_when_nothing_qualifies()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+            NextFeeBillingAtUtc = DateTime.UtcNow.AddDays(10),
+            CurrentUsagePeriodEndUtc = DateTime.UtcNow.AddDays(10),
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageInvoices
+            .Setup(repo => repo.ListBySubscriptionAsync(TenantId, SubscriptionId, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageInvoice>)[]);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new RunDueJobsRequest { OrganizationId = "target-org" };
+        var result = await CreateService().RunDueJobsAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Jobs.Should().HaveCount(4);
+        result.Value!.Jobs.Should().OnlyContain(job => job.Status == "NotDue");
+        result.Value!.Completed.Should().Be(0);
+        _renewalService.Verify(
+            service => service.RenewAsync(It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "no scripted outcome exists for this path — a real gateway call must never fire when nothing is actually due");
+    }
+
+    [Fact]
+    public async Task Running_due_jobs_runs_only_the_requested_work_types()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+            NextFeeBillingAtUtc = DateTime.UtcNow.AddMinutes(-1),
+            CurrentUsagePeriodEndUtc = DateTime.UtcNow.AddDays(10),
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new RunDueJobsRequest
+        {
+            OrganizationId = "target-org",
+            WorkTypes = [SimulationWorkType.Renewal],
+        };
+        var result = await CreateService().RunDueJobsAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Jobs.Should().ContainSingle().Which.WorkType.Should().Be("Renewal");
+        result.Value!.Jobs[0].Status.Should().Be("Completed");
+        _renewalService.Verify(
+            service => service.RenewAsync(subscription, It.IsAny<CancellationToken>()), Times.Once);
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.IsAny<ScriptedChargeOutcome>()),
+            Times.Never,
+            "running due jobs must go to the real gateway, never a scripted outcome");
+        // 50 is the job's own lookup limit — distinct from the 100 GetStateAsync uses when
+        // assembling the response's trailing state snapshot, which is expected regardless.
+        _usageInvoices.Verify(
+            repo => repo.ListBySubscriptionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), 50, It.IsAny<CancellationToken>()),
+            Times.Never,
+            "only the requested work type should run");
+    }
+
+    [Fact]
+    public async Task Running_due_jobs_publishes_outbox_events_and_charges_due_usage_invoices()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        var dueInvoice = new SubscriptionUsageInvoice
+        {
+            ItemId = "invoice-1", State = SubscriptionUsageInvoiceState.Pending,
+            NextAttemptAtUtc = DateTime.UtcNow.AddMinutes(-1),
+        };
+        _usageInvoices
+            .Setup(repo => repo.ListBySubscriptionAsync(TenantId, SubscriptionId, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageInvoice>)[dueInvoice]);
+        _outboxProcessor
+            .Setup(processor => processor.PublishDueForSubscriptionAsync(subscription, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new RunDueJobsRequest
+        {
+            OrganizationId = "target-org",
+            WorkTypes = [SimulationWorkType.UsageInvoiceCharge, SimulationWorkType.OutboxPublication],
+        };
+        var result = await CreateService().RunDueJobsAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Completed.Should().Be(2);
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(dueInvoice, It.IsAny<CancellationToken>()), Times.Once);
+        _outboxProcessor.Verify(
+            processor => processor.PublishDueForSubscriptionAsync(subscription, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }


### PR DESCRIPTION
## Summary

PR 5 of the subscription simulation harness. **Stacked on #288** (close-usage-period) — merge order: #279 → #280 → #288 → this one.

### What it adds

`POST /api/subscription-simulation/subscriptions/{id}/jobs/run-due` — runs whichever background work is genuinely due for exactly one subscription, right now, instead of waiting for the real reconciliation host's polling interval.

### Deliberately narrower than the task plan's own sketch — by construction, not by a check

The task plan offered two alternative scopes: `subscriptionId` alone, or `organizationId` plus explicit work types (tenant-wide). This PR implements **only** the subscription-scoped path. There is no tenant-wide variant at all — the URL's `{subscriptionId}` is the sole and mandatory scope, matching the rest of this endpoint family. The plan's own stated restriction ("do not provide an unrestricted 'run every job for every tenant' action") is satisfied structurally rather than by a runtime guard that a future change could loosen.

### No dispatcher exists in this codebase — narrow per-subscription overloads instead

The plan's design assumed a `SubscriptionWorkDispatcher` that could "claim jobs using the real queue lease mechanism." Reading the actual code shows no such thing exists: background processing is four independent sweep processors, each keyed by tenant (`ISubscriptionRenewalProcessor`, `ISubscriptionUsageRatingProcessor`, `ISubscriptionOutboxProcessor`, plus activation from earlier PRs). Rather than introduce a dispatcher abstraction the module doesn't otherwise have, each of the plan's four work types got a narrow, additive public overload on its existing processor that takes one `SubscriptionDetail` instead of a tenant-wide query — the same pattern as PR 2's `SettleLinkAsync` and PR 4's `CloseSubscriptionPeriodsAsync`/`ChargeInvoiceAsync`:

- **Renewal**: checks `NextFeeBillingAtUtc <= now` (the real sweep's own filter) and no settlement reservation in flight, then calls the real `ISubscriptionRenewalService.RenewAsync` — unchanged.
- **UsagePeriodClosure**: checks `CurrentUsagePeriodEndUtc <= now`, then calls PR 4's `CloseSubscriptionPeriodsAsync(subscription, now, ct)`.
- **UsageInvoiceCharge**: lists this subscription's usage invoices, filters to `Pending` ones whose own `NextAttemptAtUtc` has arrived, and charges each via PR 4's `ChargeInvoiceAsync`.
- **OutboxPublication**: new `ISubscriptionOutboxProcessor.PublishDueForSubscriptionAsync(subscription, ct)`, extracted from the existing tenant-wide `PublishDueAsync` — it reuses the *same* private `DueEventsOf`/`PublishAsync` methods, including the real `TryClaimEventAsync` lease mechanism the plan explicitly asked for, just scoped to one subscription's own outbox array instead of a tenant query.

Every work type reports `NotDue` (not an error) when its own due-condition isn't met, and `NotApplicable` when the subscription's state rules it out entirely (e.g. renewal on an `Incomplete` subscription).

### Important distinction from PRs 2–4: nothing is scripted here

Every prior PR in this series fakes a provider outcome. This one does not — a due renewal or usage-invoice charge goes to the **real** `ISubscriptionBillingGateway` with no outcome set, exactly as the real sweep would. This endpoint executes real work sooner; it does not fake an answer. Called this out prominently in code comments and the request/response docs, since in an environment where the harness is enabled, whatever payment provider is configured needs to be pointed at test-mode credentials — this is not a place a real card should ever be on file.

## Test plan
- [x] `dotnet build` clean across Api, Worker, XUnitTest (0 errors) — full rebuild
- [x] `dotnet test` — 2357 non-integration tests pass (3 new, zero regressions)
- [x] New tests: nothing due reports `NotDue` across all four work types with no gateway call made, requesting a subset of work types runs only those, and outbox publication + usage-invoice charging both run and are verified against their real per-subscription methods

## Follow-ups (per the task plan)
- PR 6 (optional): allowlisted data console
- Client UI for every action across PRs 1–5

🤖 Generated with [Claude Code](https://claude.com/claude-code)