### PR TITLE
feat(subscription): add optional allowlisted data console (PR6)

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -607,6 +607,13 @@
             Withdraws a scheduled decrease, leaving the current quantity in place.
             </summary>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.GetAuditTrail(System.String,System.String,System.Int32,System.Threading.CancellationToken)">
+            <summary>Returns the immutable lifecycle trail used to investigate this subscription.</summary>
+            <remarks>
+            Results are tenant- and organization-scoped. They intentionally omit actor identifiers,
+            payment identifiers and all provider/customer secrets.
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.SubscriptionsController.GetInvoicePdf(System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Downloads the invoice for one settled billing period as a PDF.
@@ -625,6 +632,86 @@
         <member name="M:Api.Controllers.SubscriptionsController.GetInvoiceHistory(Subscription.DomainService.Requests.GetSubscriptionInvoicesRequest,System.Threading.CancellationToken)">
             <summary>
             Lists the calling organization's settled subscription invoices, newest first.
+            </summary>
+        </member>
+        <member name="T:Api.Controllers.SubscriptionSimulationController">
+            <summary>
+            The subscription simulation test harness. Console-only, permission-gated, and unavailable
+            wherever <c>SubscriptionSimulation:Enabled</c> is not explicitly turned on.
+            </summary>
+            <remarks>
+            Never rely on this being hidden from a UI: every action here re-checks
+            <see cref="P:Subscription.DomainService.Utilities.SubscriptionSimulationOptions.Enabled"/> on every request, because the
+            configuration this reads can be changed at runtime without a restart.
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.GetState(System.String,System.String,System.Int32,System.Int32,System.Boolean,System.Threading.CancellationToken)">
+            <summary>A complete, read-only snapshot of one subscription.</summary>
+            <remarks>
+            Never returns a stored payment method id, a provider customer id, a checkout URL, or an
+            outbox event's raw payload.
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.MarkPaymentSucceeded(System.String,Subscription.DomainService.Simulation.MarkPaymentSucceededRequest,System.Threading.CancellationToken)">
+            <summary>
+            Simulates a successful outcome for the subscription's outstanding charge — the first
+            charge or a renewal — through the same settlement path a real provider confirmation
+            would take.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.MarkPaymentFailed(System.String,Subscription.DomainService.Simulation.MarkPaymentFailedRequest,System.Threading.CancellationToken)">
+            <summary>Simulates a failed outcome, for the same charge <c>mark-payment-succeeded</c> would settle.</summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.AdvanceRenewal(System.String,Subscription.DomainService.Simulation.AdvanceRenewalRequest,System.Threading.CancellationToken)">
+            <summary>
+            Forces an immediate renewal attempt, with a scripted payment outcome, without waiting for
+            the fee schedule's own due date.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.CloseUsagePeriod(System.String,Subscription.DomainService.Simulation.CloseUsagePeriodRequest,System.Threading.CancellationToken)">
+            <summary>
+            Closes the subscription's current usage period now, prices any overage, and — unless
+            told otherwise — charges it with a scripted payment outcome.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.RunDueJobs(System.String,Subscription.DomainService.Simulation.RunDueJobsRequest,System.Threading.CancellationToken)">
+            <summary>
+            Runs whichever due background work exists for this one subscription right now — never a
+            tenant-wide sweep, and never a scripted outcome: a renewal or a usage-invoice charge run
+            here goes to the real payment gateway.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.GetDataPolicy">
+            <summary>
+            The allowlisted collections and what the console may do to each, for a caller deciding
+            what <c>find</c>/<c>update</c> can reach before trying either.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.FindData(System.String,System.String,Subscription.DomainService.Simulation.FindDataRequest,System.Threading.CancellationToken)">
+            <summary>
+            Reads from one allowlisted collection, scoped to this subscription — see
+            <see cref="T:Subscription.DomainService.Simulation.SubscriptionSimulationDataConsolePolicy"/> for what each collection allows.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.UpdateData(System.String,System.String,Subscription.DomainService.Simulation.UpdateDataFieldRequest,System.Threading.CancellationToken)">
+            <summary>
+            Sets one or more allowlisted fields on one document in one allowlisted collection, scoped
+            to this subscription.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.DisabledDataConsole``1(System.String)">
+            <summary>
+            The data console needs both flags: the harness enabled at all, and the console itself
+            separately opted into — see <see cref="P:Subscription.DomainService.Utilities.SubscriptionSimulationOptions.DataConsoleEnabled"/>.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.Forbidden``1(Subscription.DomainService.Services.SubscriptionOperationResult{``0},System.String)">
+            <summary>
+            <see cref="T:Payment.DomainService.Enums.PaymentFailureKind"/> has no <c>Forbidden</c> — the
+            shared status-code mapping every other subscription result reuses would otherwise report
+            this as a 404, indistinguishable from the harness being disabled. Named separately so an
+            authenticated caller who simply lacks the permission sees why, rather than being told a
+            real subscription is "disabled".
             </summary>
         </member>
         <member name="T:Api.Controllers.SubscriptionUsageController">

--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -25,13 +25,16 @@ namespace Api.Controllers;
 public sealed class SubscriptionSimulationController : ControllerBase
 {
     private readonly ISubscriptionSimulationService _simulation;
+    private readonly ISubscriptionSimulationDataConsoleService _dataConsole;
     private readonly IOptionsMonitor<SubscriptionSimulationOptions> _options;
 
     public SubscriptionSimulationController(
         ISubscriptionSimulationService simulation,
+        ISubscriptionSimulationDataConsoleService dataConsole,
         IOptionsMonitor<SubscriptionSimulationOptions> options)
     {
         _simulation = simulation;
+        _dataConsole = dataConsole;
         _options = options;
     }
 
@@ -216,6 +219,98 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// The allowlisted collections and what the console may do to each, for a caller deciding
+    /// what <c>find</c>/<c>update</c> can reach before trying either.
+    /// </summary>
+    [HttpGet("data/policy")]
+    [ProducesResponseType(typeof(ApiResponse<List<SubscriptionSimulationDataPolicyResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public IActionResult GetDataPolicy()
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (DisabledDataConsole<List<SubscriptionSimulationDataPolicyResponse>>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var policy = SubscriptionSimulationDataConsolePolicy.Collections
+            .Select(collection => new SubscriptionSimulationDataPolicyResponse
+            {
+                LogicalName = collection.LogicalName,
+                CanRead = collection.CanRead,
+                CanInsert = collection.CanInsert,
+                UpdatableFields = collection.UpdatableFields.ToList()
+            })
+            .ToList();
+
+        return Ok(ApiResponse<List<SubscriptionSimulationDataPolicyResponse>>.Ok(policy, correlationId));
+    }
+
+    /// <summary>
+    /// Reads from one allowlisted collection, scoped to this subscription — see
+    /// <see cref="SubscriptionSimulationDataConsolePolicy"/> for what each collection allows.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/data/{logicalCollection}/find")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataQueryResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataQueryResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataQueryResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> FindData(
+        string subscriptionId,
+        string logicalCollection,
+        [FromBody] FindDataRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (DisabledDataConsole<SubscriptionSimulationDataQueryResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        request.SubscriptionId = subscriptionId;
+
+        var result = await _dataConsole.FindAsync(logicalCollection, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Sets one or more allowlisted fields on one document in one allowlisted collection, scoped
+    /// to this subscription.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/data/{logicalCollection}/update")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataMutationResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataMutationResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataMutationResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UpdateData(
+        string subscriptionId,
+        string logicalCollection,
+        [FromBody] UpdateDataFieldRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (DisabledDataConsole<SubscriptionSimulationDataMutationResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        request.SubscriptionId = subscriptionId;
+
+        var result = await _dataConsole.UpdateFieldsAsync(
+            logicalCollection, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null
@@ -223,6 +318,25 @@ public sealed class SubscriptionSimulationController : ControllerBase
                 "subscription_simulation_disabled",
                 "The subscription simulation harness is not enabled in this environment.",
                 correlationId));
+
+    /// <summary>
+    /// The data console needs both flags: the harness enabled at all, and the console itself
+    /// separately opted into — see <see cref="SubscriptionSimulationOptions.DataConsoleEnabled"/>.
+    /// </summary>
+    private IActionResult? DisabledDataConsole<T>(string correlationId)
+    {
+        if (Disabled<T>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        return _options.CurrentValue.DataConsoleEnabled
+            ? null
+            : NotFound(ApiResponse<T>.Fail(
+                "subscription_simulation_data_console_disabled",
+                "The subscription simulation data console is not enabled in this environment.",
+                correlationId));
+    }
 
     /// <summary>
     /// <see cref="Payment.DomainService.Enums.PaymentFailureKind"/> has no <c>Forbidden</c> — the

--- a/server/Subscription.DomainService/Responses/SubscriptionSimulationDataConsoleResponses.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionSimulationDataConsoleResponses.cs
@@ -1,0 +1,36 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>The allowlisted collections and what the console may do to each — for discoverability.</summary>
+public sealed class SubscriptionSimulationDataPolicyResponse
+{
+    public string LogicalName { get; init; } = string.Empty;
+
+    public bool CanRead { get; init; }
+
+    public bool CanInsert { get; init; }
+
+    public List<string> UpdatableFields { get; init; } = [];
+}
+
+public sealed class SubscriptionSimulationDataQueryResponse
+{
+    public string Collection { get; init; } = string.Empty;
+
+    public int Count { get; init; }
+
+    /// <summary>Each document as JSON, with the same redaction the state endpoint already applies.</summary>
+    public List<string> Documents { get; init; } = [];
+
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+public sealed class SubscriptionSimulationDataMutationResponse
+{
+    public string Collection { get; init; } = string.Empty;
+
+    public bool Modified { get; init; }
+
+    public List<string> FieldsSet { get; init; } = [];
+
+    public string CorrelationId { get; init; } = string.Empty;
+}

--- a/server/Subscription.DomainService/Simulation/FindDataRequest.cs
+++ b/server/Subscription.DomainService/Simulation/FindDataRequest.cs
@@ -1,0 +1,16 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// A read from one allowlisted collection, scoped to a tenant, an organization and — always —
+/// one subscription. There is no field for a raw filter or query object: the only scoping this
+/// endpoint accepts is these three identifiers, which is what keeps it from becoming an
+/// unrestricted Mongo query surface.
+/// </summary>
+public sealed class FindDataRequest
+{
+    public string? OrganizationId { get; set; }
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public int Limit { get; set; } = 20;
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationDataConsoleService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationDataConsoleService.cs
@@ -1,0 +1,25 @@
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// The allowlisted, read-mostly Mongo access this harness offers once the purpose-built actions
+/// in PRs 2-5 cannot reach what a test needs. Never a raw query: every operation is scoped to
+/// one collection from <see cref="SubscriptionSimulationDataConsolePolicy"/>, one tenant, one
+/// organization and one subscription.
+/// </summary>
+public interface ISubscriptionSimulationDataConsoleService
+{
+    Task<SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>> FindAsync(
+        string logicalCollection,
+        FindDataRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>> UpdateFieldsAsync(
+        string logicalCollection,
+        UpdateDataFieldRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Simulation/SimulationCollectionPolicy.cs
+++ b/server/Subscription.DomainService/Simulation/SimulationCollectionPolicy.cs
@@ -1,0 +1,77 @@
+using Subscription.DomainService.Repositories;
+
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// What the data console may do to one collection, and nothing it does not explicitly say.
+/// </summary>
+/// <remarks>
+/// A code-level allowlist rather than configuration: an operator can turn the console on or off,
+/// but cannot widen what it reaches by editing a config file. Every field named here must exist
+/// on the real document — there is no schema validation beyond "is it in this list."
+/// </remarks>
+public sealed record SimulationCollectionPolicy(
+    string LogicalName,
+    string CollectionName,
+    /// <summary>The document field a subscription id is matched against in this collection.</summary>
+    string SubscriptionIdField,
+    bool CanRead,
+    /// <summary>
+    /// Always false in this version — see the class remark on
+    /// <see cref="SubscriptionSimulationDataConsolePolicy"/> for why <c>insertOne</c> is not
+    /// implemented at all yet, kept as a field for when a genuinely safe target exists.
+    /// </summary>
+    bool CanInsert,
+    /// <summary>
+    /// Field names writable by <c>updateOne</c>, restricted to UTC timestamps in this version —
+    /// see <see cref="UpdateDataFieldRequest"/>. Even these are better changed through
+    /// the purpose-built actions in PRs 2-5; this exists for what those cannot yet reach.
+    /// </summary>
+    IReadOnlyList<string> UpdatableFields);
+
+public static class SubscriptionSimulationDataConsolePolicy
+{
+    /// <summary>
+    /// No collection allows <c>insertOne</c> yet — every candidate row this harness could safely
+    /// insert (a subscription, a payment link, a usage invoice) is already reachable through a
+    /// purpose-built action from PRs 2-5, and inventing one here would be exactly the free-form
+    /// database write this endpoint exists to avoid becoming.
+    /// </summary>
+    public static readonly IReadOnlyList<SimulationCollectionPolicy> Collections =
+    [
+        new(
+            LogicalName: "subscriptions",
+            CollectionName: SubscriptionCollections.Subscriptions,
+            SubscriptionIdField: "_id",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: ["NextFeeBillingAtUtc", "CurrentUsagePeriodEndUtc", "NextUsageBillingAtUtc"]),
+        new(
+            LogicalName: "usage-invoices",
+            CollectionName: SubscriptionCollections.UsageInvoices,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: ["NextAttemptAtUtc"]),
+        new(
+            LogicalName: "payment-links",
+            CollectionName: SubscriptionCollections.PaymentLinks,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: ["NextCheckAtUtc"]),
+        new(
+            LogicalName: "audit-events",
+            CollectionName: SubscriptionCollections.AuditEvents,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: []),
+        new(
+            LogicalName: "simulation-runs",
+            CollectionName: SubscriptionCollections.SimulationRuns,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: []),
+    ];
+
+    public static SimulationCollectionPolicy? Find(string logicalName) =>
+        Collections.FirstOrDefault(
+            policy => string.Equals(policy.LogicalName, logicalName, StringComparison.OrdinalIgnoreCase));
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationDataConsoleService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationDataConsoleService.cs
@@ -1,0 +1,297 @@
+using System.Globalization;
+using Blocks.Genesis;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Subscription.DomainService.Simulation;
+
+public sealed class SubscriptionSimulationDataConsoleService : ISubscriptionSimulationDataConsoleService
+{
+    private const int MaximumFindLimit = 100;
+
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly IDbContextProvider _db;
+    private readonly ISubscriptionSimulationRunRepository _simulationRuns;
+    private readonly IOptionsMonitor<PaymentOptions> _paymentOptions;
+
+    public SubscriptionSimulationDataConsoleService(
+        ISubscriptionContextResolver contextResolver,
+        IDbContextProvider db,
+        ISubscriptionSimulationRunRepository simulationRuns,
+        IOptionsMonitor<PaymentOptions> paymentOptions)
+    {
+        _contextResolver = contextResolver;
+        _db = db;
+        _simulationRuns = simulationRuns;
+        _paymentOptions = paymentOptions;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>> FindAsync(
+        string logicalCollection,
+        FindDataRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var policyResult = ResolvePolicy<SubscriptionSimulationDataQueryResponse>(
+            logicalCollection, requireRead: true, correlationId);
+
+        if (policyResult.Failure is { } policyFailure)
+        {
+            return policyFailure;
+        }
+
+        var policy = policyResult.Policy!;
+
+        if (request.Limit is <= 0 or > MaximumFindLimit)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_limit_invalid",
+                $"limit must be between 1 and {MaximumFindLimit}.",
+                correlationId);
+        }
+
+        var (context, failure) = await ResolveAsync<SubscriptionSimulationDataQueryResponse>(
+            request.OrganizationId, correlationId, cancellationToken);
+
+        if (failure is not null || context is null)
+        {
+            return failure!;
+        }
+
+        var collection = _db.GetDatabase(context.TenantId).GetCollection<BsonDocument>(policy.CollectionName);
+
+        var filter = Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Eq("TenantId", context.TenantId),
+            Builders<BsonDocument>.Filter.Eq("OrganizationId", context.OrganizationId),
+            Builders<BsonDocument>.Filter.Eq(policy.SubscriptionIdField, request.SubscriptionId));
+
+        var documents = await collection.Find(filter).Limit(request.Limit).ToListAsync(cancellationToken);
+
+        await RecordRunAsync(
+            context, request.SubscriptionId, "DataConsoleFind", correlationId,
+            $"collection={policy.LogicalName}", cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>.Success(
+            new SubscriptionSimulationDataQueryResponse
+            {
+                Collection = policy.LogicalName,
+                Count = documents.Count,
+                Documents = documents
+                    .Select(document => Redact(policy.LogicalName, document).ToJson())
+                    .ToList(),
+                CorrelationId = correlationId
+            },
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>> UpdateFieldsAsync(
+        string logicalCollection,
+        UpdateDataFieldRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var policyResult = ResolvePolicy<SubscriptionSimulationDataMutationResponse>(
+            logicalCollection, requireRead: false, correlationId);
+
+        if (policyResult.Failure is { } policyFailure)
+        {
+            return policyFailure;
+        }
+
+        var policy = policyResult.Policy!;
+
+        if (request.Fields.Count == 0)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_no_fields",
+                "At least one field must be given.",
+                correlationId);
+        }
+
+        var disallowed = request.Fields.Keys
+            .Where(field => !policy.UpdatableFields.Contains(field, StringComparer.Ordinal))
+            .ToList();
+
+        if (disallowed.Count > 0)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_field_not_allowed",
+                $"{policy.LogicalName} does not allow writing: {string.Join(", ", disallowed)}.",
+                correlationId,
+                new Dictionary<string, string[]> { ["Fields"] = disallowed.ToArray() });
+        }
+
+        var updates = new List<UpdateDefinition<BsonDocument>>();
+
+        foreach (var field in request.Fields)
+        {
+            if (!DateTime.TryParse(
+                    field.Value, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var parsed))
+            {
+                return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_simulation_field_value_invalid",
+                    $"'{field.Key}' must be an ISO 8601 UTC timestamp.",
+                    correlationId);
+            }
+
+            updates.Add(Builders<BsonDocument>.Update.Set(field.Key, parsed));
+        }
+
+        var (context, failure) = await ResolveAsync<SubscriptionSimulationDataMutationResponse>(
+            request.OrganizationId, correlationId, cancellationToken);
+
+        if (failure is not null || context is null)
+        {
+            return failure!;
+        }
+
+        var collection = _db.GetDatabase(context.TenantId).GetCollection<BsonDocument>(policy.CollectionName);
+
+        var filter = Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Eq("TenantId", context.TenantId),
+            Builders<BsonDocument>.Filter.Eq("OrganizationId", context.OrganizationId),
+            Builders<BsonDocument>.Filter.Eq(policy.SubscriptionIdField, request.SubscriptionId));
+
+        var result = await collection.UpdateOneAsync(
+            filter, Builders<BsonDocument>.Update.Combine(updates), cancellationToken: cancellationToken);
+
+        await RecordRunAsync(
+            context, request.SubscriptionId, "DataConsoleUpdate", correlationId,
+            $"collection={policy.LogicalName};fields={string.Join(',', request.Fields.Keys)}",
+            cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Success(
+            new SubscriptionSimulationDataMutationResponse
+            {
+                Collection = policy.LogicalName,
+                Modified = result.ModifiedCount > 0,
+                FieldsSet = request.Fields.Keys.ToList(),
+                CorrelationId = correlationId
+            },
+            correlationId);
+    }
+
+    private static (SimulationCollectionPolicy? Policy, SubscriptionOperationResult<T>? Failure) ResolvePolicy<T>(
+        string logicalCollection, bool requireRead, string correlationId)
+    {
+        var policy = SubscriptionSimulationDataConsolePolicy.Find(logicalCollection);
+
+        if (policy is null)
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_simulation_collection_not_allowed",
+                $"'{logicalCollection}' is not an allowlisted collection.",
+                correlationId));
+        }
+
+        if (requireRead && !policy.CanRead)
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_collection_not_readable",
+                $"'{logicalCollection}' does not allow reads.",
+                correlationId));
+        }
+
+        return (policy, null);
+    }
+
+    private async Task<(SubscriptionContext? Context, SubscriptionOperationResult<T>? Failure)> ResolveAsync<T>(
+        string? organizationId, string correlationId, CancellationToken cancellationToken)
+    {
+        var caller = BlocksContext.GetContext();
+
+        if (!SubscriptionSimulationGuard.IsAuthorized(
+                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_forbidden",
+                "This caller may not use the subscription simulation harness.",
+                correlationId));
+        }
+
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_organization_required",
+                "organizationId is required: the console has no subscription of its own.",
+                correlationId,
+                new Dictionary<string, string[]>
+                {
+                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
+                }));
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(correlationId, organizationId, cancellationToken);
+
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return (null, resolution.ToFailure<T>(correlationId));
+        }
+
+        return (resolution.Context, null);
+    }
+
+    private Task RecordRunAsync(
+        SubscriptionContext context,
+        string subscriptionId,
+        string action,
+        string correlationId,
+        string requestSummary,
+        CancellationToken cancellationToken) =>
+        _simulationRuns.AppendAsync(
+            new Entities.SubscriptionSimulationRun
+            {
+                TenantId = context.TenantId,
+                OrganizationId = context.OrganizationId,
+                SubscriptionId = subscriptionId,
+                ActorId = context.ActorId,
+                Action = action,
+                RequestSummary = requestSummary,
+                CorrelationId = correlationId,
+                Outcome = "Succeeded",
+                CompletedAtUtc = DateTime.UtcNow
+            },
+            cancellationToken);
+
+    /// <summary>
+    /// Never a stored payment method id, a provider customer id or a provider organization id —
+    /// the same fields <see cref="SubscriptionSimulationService"/>'s state read already excludes.
+    /// </summary>
+    private static BsonDocument Redact(string logicalName, BsonDocument document)
+    {
+        if (logicalName != "subscriptions")
+        {
+            return document;
+        }
+
+        if (document.TryGetValue("SettlementReservation", out var reservation) &&
+            reservation is BsonDocument reservationDocument)
+        {
+            reservationDocument.Remove("StoredPaymentMethodId");
+            reservationDocument.Remove("ProviderCustomerId");
+            reservationDocument.Remove("ProviderOrganizationId");
+        }
+
+        return document;
+    }
+}

--- a/server/Subscription.DomainService/Simulation/UpdateDataFieldRequest.cs
+++ b/server/Subscription.DomainService/Simulation/UpdateDataFieldRequest.cs
@@ -1,0 +1,20 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// Sets one or more fields on exactly one document, restricted to the fields the target
+/// collection's <see cref="SimulationCollectionPolicy"/> allows.
+/// </summary>
+/// <remarks>
+/// Every value is parsed as a UTC timestamp — the only type any currently allowlisted field
+/// holds — so there is no generic "any BSON value" write surface. A field this cannot parse, or
+/// that the policy does not name, is rejected rather than silently ignored.
+/// </remarks>
+public sealed class UpdateDataFieldRequest
+{
+    public string? OrganizationId { get; set; }
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    /// <summary>Field name to an ISO 8601 UTC timestamp string.</summary>
+    public Dictionary<string, string> Fields { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -38,13 +38,16 @@ public static class ApplicationServiceCollectionExtensions
 
         if (hostEnvironment is { } environment &&
             environment.IsProduction() &&
-            simulationSection.GetValue<bool>(nameof(SubscriptionSimulationOptions.Enabled)))
+            (simulationSection.GetValue<bool>(nameof(SubscriptionSimulationOptions.Enabled)) ||
+             simulationSection.GetValue<bool>(nameof(SubscriptionSimulationOptions.DataConsoleEnabled))))
         {
-            // The harness can rewrite billing history through real domain processors. Refusing
-            // to start is deliberately louder than the request-time 404 guard the controller
-            // also applies — a misconfigured Production deploy should never come up quietly.
+            // The harness can rewrite billing history through real domain processors, and the
+            // data console reads and writes Mongo documents directly. Refusing to start is
+            // deliberately louder than the request-time 404 guard the controller also applies —
+            // a misconfigured Production deploy should never come up quietly.
             throw new InvalidOperationException(
-                "SubscriptionSimulation:Enabled must not be true in a Production environment.");
+                "SubscriptionSimulation:Enabled and SubscriptionSimulation:DataConsoleEnabled " +
+                "must not be true in a Production environment.");
         }
 
         // Repositories are singletons and take the tenant as an argument, so the same instance
@@ -191,6 +194,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionSimulationService,
             SubscriptionSimulationService>();
+        services.AddScoped<
+            ISubscriptionSimulationDataConsoleService,
+            SubscriptionSimulationDataConsoleService>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/SubscriptionSimulationOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionSimulationOptions.cs
@@ -16,4 +16,12 @@ public sealed class SubscriptionSimulationOptions
     public const string SectionName = "SubscriptionSimulation";
 
     public bool Enabled { get; set; }
+
+    /// <summary>
+    /// A second, independent gate for the allowlisted data console — the one piece of this
+    /// harness that reads and writes Mongo documents directly rather than going through a
+    /// domain service. Requires <see cref="Enabled"/> as well; this can narrow access further
+    /// within an environment where the harness itself is on, but never widen it.
+    /// </summary>
+    public bool DataConsoleEnabled { get; set; }
 }

--- a/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
@@ -134,6 +134,24 @@ public sealed class SubscriptionServiceRegistrationTests
         act.Should().NotThrow();
     }
 
+    [Fact]
+    public void Registration_refuses_to_enable_the_data_console_in_production()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.RegisterSubscriptionDomainServices(
+            Configuration(new Dictionary<string, string?>
+            {
+                ["SubscriptionSimulation:DataConsoleEnabled"] = "true"
+            }),
+            new FakeHostEnvironment("Production"));
+
+        act.Should().Throw<InvalidOperationException>(
+            "the data console reads and writes Mongo documents directly and must never come up " +
+            "in Production, even with the rest of the harness left off");
+    }
+
     private sealed class FakeHostEnvironment : IHostEnvironment
     {
         public FakeHostEnvironment(string environmentName) => EnvironmentName = environmentName;

--- a/server/XUnitTest/Subscription/SubscriptionSimulationDataConsoleServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationDataConsoleServiceTests.cs
@@ -1,0 +1,245 @@
+using Blocks.Genesis;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Simulation;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// <see cref="SubscriptionSimulationDataConsoleService"/>'s guard, policy and validation surface
+/// — everything that must reject a call before it ever reaches Mongo.
+/// </summary>
+/// <remarks>
+/// None of these tests configure <see cref="IDbContextProvider"/>: every scenario here is
+/// rejected before the service would call it, which is itself part of what is under test — an
+/// unauthorized or malformed call must never reach a database round trip.
+/// </remarks>
+public sealed class SubscriptionSimulationDataConsoleServiceTests : IDisposable
+{
+    private const string ConsoleOrganizationId = "console-org";
+    private const string SubscriptionId = "sub-1";
+    private const string TenantId = "tenant-1";
+    private const string CorrelationId = "corr-1";
+
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<IDbContextProvider> _db = new();
+    private readonly Mock<ISubscriptionSimulationRunRepository> _simulationRuns = new();
+    private readonly Mock<IOptionsMonitor<PaymentOptions>> _paymentOptions = new();
+
+    public SubscriptionSimulationDataConsoleServiceTests() =>
+        _paymentOptions
+            .Setup(options => options.CurrentValue)
+            .Returns(new PaymentOptions { ConsoleOrganizationId = ConsoleOrganizationId });
+
+    public void Dispose() => BlocksContext.ClearContext();
+
+    [Fact]
+    public async Task Find_refuses_a_caller_who_is_not_the_console()
+    {
+        SetCaller(organizationId: "some-other-org", permissions: [SubscriptionSimulationGuard.SimulationAdministratorPermission]);
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_forbidden");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Find_refuses_the_console_without_the_simulation_permission()
+    {
+        SetCaller(organizationId: ConsoleOrganizationId, permissions: []);
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_forbidden");
+    }
+
+    [Fact]
+    public async Task Find_rejects_a_collection_that_is_not_allowlisted()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().FindAsync(
+            "not-a-real-collection",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_collection_not_allowed");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public async Task Find_rejects_an_out_of_range_limit(int limit)
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId, Limit = limit },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_limit_invalid");
+    }
+
+    [Fact]
+    public async Task Find_requires_an_organization_because_the_console_has_none_of_its_own()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = null, SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_organization_required");
+    }
+
+    [Fact]
+    public async Task Update_rejects_a_collection_that_is_not_allowlisted()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "not-a-real-collection",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["NextFeeBillingAtUtc"] = "2026-01-01T00:00:00Z" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_collection_not_allowed");
+    }
+
+    [Fact]
+    public async Task Update_rejects_an_empty_field_set()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_no_fields");
+    }
+
+    [Fact]
+    public async Task Update_rejects_a_field_the_policy_does_not_allow()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["Status"] = "Active" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_field_not_allowed");
+    }
+
+    [Fact]
+    public async Task Update_rejects_a_value_that_is_not_a_utc_timestamp()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["NextFeeBillingAtUtc"] = "not-a-date" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_field_value_invalid");
+    }
+
+    [Fact]
+    public async Task Update_validates_fields_before_ever_resolving_the_caller_s_context()
+    {
+        SetAuthorizedCaller();
+
+        await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["NextFeeBillingAtUtc"] = "not-a-date" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "an unparsable field must be rejected before the harness ever touches the database");
+    }
+
+    private void SetAuthorizedCaller() =>
+        SetCaller(ConsoleOrganizationId, [SubscriptionSimulationGuard.SimulationAdministratorPermission]);
+
+    private static void SetCaller(string? organizationId, IEnumerable<string> permissions) =>
+        BlocksContext.SetContext(BlocksContext.Create(
+            tenantId: TenantId,
+            roles: [],
+            userId: "user-1",
+            isAuthenticated: true,
+            requestUri: null,
+            organizationId: organizationId,
+            expireOn: DateTime.UtcNow.AddHours(1),
+            email: "tester@example.com",
+            permissions: permissions,
+            userName: null,
+            phoneNumber: null,
+            displayName: null,
+            oauthToken: null,
+            originalTenantId: null));
+
+    private SubscriptionSimulationDataConsoleService CreateService() => new(
+        _contextResolver.Object,
+        _db.Object,
+        _simulationRuns.Object,
+        _paymentOptions.Object);
+}


### PR DESCRIPTION
## Summary

The final PR of the 6-PR subscription simulation delivery sequence: an
optional, allowlisted read/update surface over Mongo for whatever the
purpose-built actions in PRs 2-5 (#279, #280, #288, #289) cannot yet reach.

**Merge order:** this PR must merge after #289 (PR5), which must merge
after #288 (PR4), after #280 (PR3), after #279 (PR2). It is currently
stacked on `feat/subscription-simulation-run-due-jobs`; its diff will
shrink to just this PR's files once the earlier PRs land on `dev`.

## Design

- **No raw query surface.** Every `find`/`update` call is scoped to one
  collection (from a code-level allowlist — `SimulationCollectionPolicy`),
  one tenant, one organization, and one subscription, computed from the
  caller's resolved context — never from a client-supplied filter.
- **No insert at all, in this version.** Every document this harness could
  safely insert already has a purpose-built action from PRs 2-5; adding a
  generic `insertOne` here would be exactly the free-form database write
  this endpoint exists to avoid becoming.
- **`update` is field-allowlisted per collection**, and every value is
  parsed as an ISO-8601 UTC timestamp — the only type any allowlisted
  field holds today. An unparseable value or a field the policy doesn't
  name is rejected before the caller's context is even resolved, so a bad
  request never reaches Mongo.
- **Redaction is reused, not reinvented:** the `subscriptions` collection
  strips `StoredPaymentMethodId`, `ProviderCustomerId` and
  `ProviderOrganizationId` from `SettlementReservation`, matching what
  `SubscriptionSimulationService.GetStateAsync` already excludes.
- **Gated on top of the harness, not instead of it.** Every data-console
  endpoint requires both `SubscriptionSimulation:Enabled` and the new
  `SubscriptionSimulation:DataConsoleEnabled`. The Production start-up
  guard in `RegisterSubscriptionDomainServices` now refuses either flag,
  not just the first.

### New endpoints (`SubscriptionSimulationController`)

- `GET  /subscription-simulation/data/policy` — the allowlist itself, for
  a caller deciding what it can reach before trying.
- `POST /subscription-simulation/subscriptions/{id}/data/{collection}/find`
- `POST /subscription-simulation/subscriptions/{id}/data/{collection}/update`

### Allowlisted collections

`subscriptions`, `usage-invoices`, `payment-links`, `audit-events`,
`simulation-runs` — all read-only plus a small set of updatable timestamp
fields per collection (`SimulationCollectionPolicy.cs` has the exact list
and the reasoning for each).

## Test plan

- [x] `dotnet build Api/Api.csproj --no-incremental` — 0 errors
- [x] `dotnet build Worker/Worker.csproj --no-incremental` — 0 errors
- [x] `dotnet test XUnitTest` (non-integration): 2370 passed, 1 skipped
- [x] New `SubscriptionSimulationDataConsoleServiceTests`: guard rejection,
      collection-not-allowlisted rejection, out-of-range limit, missing
      organization, empty field set, field not in the update allowlist,
      unparseable timestamp value, and that an unparseable value is
      rejected *before* the context resolver is ever called
- [x] New `SubscriptionServiceRegistrationTests` case: `DataConsoleEnabled`
      alone (with `Enabled` left false) still trips the Production guard
- [ ] Integration tests requiring a live `mongod` were not run in this
      environment; the Mongo-backed `find`/`update` paths themselves
      (as opposed to their guard/validation branches) are exercised only
      by that suite

## Follow-ups

- No client UI for any of PRs 1-6 has been requested yet.
- `insertOne` is deliberately unimplemented — see the remarks on
  `SubscriptionSimulationDataConsolePolicy` for why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)