### PR TITLE
feat(subscription): land PR3-PR6 of the simulation harness on dev

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -607,6 +607,13 @@
             Withdraws a scheduled decrease, leaving the current quantity in place.
             </summary>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.GetAuditTrail(System.String,System.String,System.Int32,System.Threading.CancellationToken)">
+            <summary>Returns the immutable lifecycle trail used to investigate this subscription.</summary>
+            <remarks>
+            Results are tenant- and organization-scoped. They intentionally omit actor identifiers,
+            payment identifiers and all provider/customer secrets.
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.SubscriptionsController.GetInvoicePdf(System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Downloads the invoice for one settled billing period as a PDF.
@@ -625,6 +632,86 @@
         <member name="M:Api.Controllers.SubscriptionsController.GetInvoiceHistory(Subscription.DomainService.Requests.GetSubscriptionInvoicesRequest,System.Threading.CancellationToken)">
             <summary>
             Lists the calling organization's settled subscription invoices, newest first.
+            </summary>
+        </member>
+        <member name="T:Api.Controllers.SubscriptionSimulationController">
+            <summary>
+            The subscription simulation test harness. Console-only, permission-gated, and unavailable
+            wherever <c>SubscriptionSimulation:Enabled</c> is not explicitly turned on.
+            </summary>
+            <remarks>
+            Never rely on this being hidden from a UI: every action here re-checks
+            <see cref="P:Subscription.DomainService.Utilities.SubscriptionSimulationOptions.Enabled"/> on every request, because the
+            configuration this reads can be changed at runtime without a restart.
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.GetState(System.String,System.String,System.Int32,System.Int32,System.Boolean,System.Threading.CancellationToken)">
+            <summary>A complete, read-only snapshot of one subscription.</summary>
+            <remarks>
+            Never returns a stored payment method id, a provider customer id, a checkout URL, or an
+            outbox event's raw payload.
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.MarkPaymentSucceeded(System.String,Subscription.DomainService.Simulation.MarkPaymentSucceededRequest,System.Threading.CancellationToken)">
+            <summary>
+            Simulates a successful outcome for the subscription's outstanding charge — the first
+            charge or a renewal — through the same settlement path a real provider confirmation
+            would take.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.MarkPaymentFailed(System.String,Subscription.DomainService.Simulation.MarkPaymentFailedRequest,System.Threading.CancellationToken)">
+            <summary>Simulates a failed outcome, for the same charge <c>mark-payment-succeeded</c> would settle.</summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.AdvanceRenewal(System.String,Subscription.DomainService.Simulation.AdvanceRenewalRequest,System.Threading.CancellationToken)">
+            <summary>
+            Forces an immediate renewal attempt, with a scripted payment outcome, without waiting for
+            the fee schedule's own due date.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.CloseUsagePeriod(System.String,Subscription.DomainService.Simulation.CloseUsagePeriodRequest,System.Threading.CancellationToken)">
+            <summary>
+            Closes the subscription's current usage period now, prices any overage, and — unless
+            told otherwise — charges it with a scripted payment outcome.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.RunDueJobs(System.String,Subscription.DomainService.Simulation.RunDueJobsRequest,System.Threading.CancellationToken)">
+            <summary>
+            Runs whichever due background work exists for this one subscription right now — never a
+            tenant-wide sweep, and never a scripted outcome: a renewal or a usage-invoice charge run
+            here goes to the real payment gateway.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.GetDataPolicy">
+            <summary>
+            The allowlisted collections and what the console may do to each, for a caller deciding
+            what <c>find</c>/<c>update</c> can reach before trying either.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.FindData(System.String,System.String,Subscription.DomainService.Simulation.FindDataRequest,System.Threading.CancellationToken)">
+            <summary>
+            Reads from one allowlisted collection, scoped to this subscription — see
+            <see cref="T:Subscription.DomainService.Simulation.SubscriptionSimulationDataConsolePolicy"/> for what each collection allows.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.UpdateData(System.String,System.String,Subscription.DomainService.Simulation.UpdateDataFieldRequest,System.Threading.CancellationToken)">
+            <summary>
+            Sets one or more allowlisted fields on one document in one allowlisted collection, scoped
+            to this subscription.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.DisabledDataConsole``1(System.String)">
+            <summary>
+            The data console needs both flags: the harness enabled at all, and the console itself
+            separately opted into — see <see cref="P:Subscription.DomainService.Utilities.SubscriptionSimulationOptions.DataConsoleEnabled"/>.
+            </summary>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionSimulationController.Forbidden``1(Subscription.DomainService.Services.SubscriptionOperationResult{``0},System.String)">
+            <summary>
+            <see cref="T:Payment.DomainService.Enums.PaymentFailureKind"/> has no <c>Forbidden</c> — the
+            shared status-code mapping every other subscription result reuses would otherwise report
+            this as a 404, indistinguishable from the harness being disabled. Named separately so an
+            authenticated caller who simply lacks the permission sees why, rather than being told a
+            real subscription is "disabled".
             </summary>
         </member>
         <member name="T:Api.Controllers.SubscriptionUsageController">

--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -129,6 +129,35 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Forces an immediate renewal attempt, with a scripted payment outcome, without waiting for
+    /// the fee schedule's own due date.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/advance-renewal")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> AdvanceRenewal(
+        string subscriptionId,
+        [FromBody] AdvanceRenewalRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationActionResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var result = await _simulation.AdvanceRenewalAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null

--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -25,13 +25,16 @@ namespace Api.Controllers;
 public sealed class SubscriptionSimulationController : ControllerBase
 {
     private readonly ISubscriptionSimulationService _simulation;
+    private readonly ISubscriptionSimulationDataConsoleService _dataConsole;
     private readonly IOptionsMonitor<SubscriptionSimulationOptions> _options;
 
     public SubscriptionSimulationController(
         ISubscriptionSimulationService simulation,
+        ISubscriptionSimulationDataConsoleService dataConsole,
         IOptionsMonitor<SubscriptionSimulationOptions> options)
     {
         _simulation = simulation;
+        _dataConsole = dataConsole;
         _options = options;
     }
 
@@ -216,6 +219,98 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// The allowlisted collections and what the console may do to each, for a caller deciding
+    /// what <c>find</c>/<c>update</c> can reach before trying either.
+    /// </summary>
+    [HttpGet("data/policy")]
+    [ProducesResponseType(typeof(ApiResponse<List<SubscriptionSimulationDataPolicyResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public IActionResult GetDataPolicy()
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (DisabledDataConsole<List<SubscriptionSimulationDataPolicyResponse>>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var policy = SubscriptionSimulationDataConsolePolicy.Collections
+            .Select(collection => new SubscriptionSimulationDataPolicyResponse
+            {
+                LogicalName = collection.LogicalName,
+                CanRead = collection.CanRead,
+                CanInsert = collection.CanInsert,
+                UpdatableFields = collection.UpdatableFields.ToList()
+            })
+            .ToList();
+
+        return Ok(ApiResponse<List<SubscriptionSimulationDataPolicyResponse>>.Ok(policy, correlationId));
+    }
+
+    /// <summary>
+    /// Reads from one allowlisted collection, scoped to this subscription — see
+    /// <see cref="SubscriptionSimulationDataConsolePolicy"/> for what each collection allows.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/data/{logicalCollection}/find")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataQueryResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataQueryResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataQueryResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> FindData(
+        string subscriptionId,
+        string logicalCollection,
+        [FromBody] FindDataRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (DisabledDataConsole<SubscriptionSimulationDataQueryResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        request.SubscriptionId = subscriptionId;
+
+        var result = await _dataConsole.FindAsync(logicalCollection, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Sets one or more allowlisted fields on one document in one allowlisted collection, scoped
+    /// to this subscription.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/data/{logicalCollection}/update")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataMutationResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataMutationResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationDataMutationResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UpdateData(
+        string subscriptionId,
+        string logicalCollection,
+        [FromBody] UpdateDataFieldRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (DisabledDataConsole<SubscriptionSimulationDataMutationResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        request.SubscriptionId = subscriptionId;
+
+        var result = await _dataConsole.UpdateFieldsAsync(
+            logicalCollection, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null
@@ -223,6 +318,25 @@ public sealed class SubscriptionSimulationController : ControllerBase
                 "subscription_simulation_disabled",
                 "The subscription simulation harness is not enabled in this environment.",
                 correlationId));
+
+    /// <summary>
+    /// The data console needs both flags: the harness enabled at all, and the console itself
+    /// separately opted into — see <see cref="SubscriptionSimulationOptions.DataConsoleEnabled"/>.
+    /// </summary>
+    private IActionResult? DisabledDataConsole<T>(string correlationId)
+    {
+        if (Disabled<T>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        return _options.CurrentValue.DataConsoleEnabled
+            ? null
+            : NotFound(ApiResponse<T>.Fail(
+                "subscription_simulation_data_console_disabled",
+                "The subscription simulation data console is not enabled in this environment.",
+                correlationId));
+    }
 
     /// <summary>
     /// <see cref="Payment.DomainService.Enums.PaymentFailureKind"/> has no <c>Forbidden</c> — the

--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -158,6 +158,35 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Closes the subscription's current usage period now, prices any overage, and — unless
+    /// told otherwise — charges it with a scripted payment outcome.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/close-usage-period")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationActionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CloseUsagePeriod(
+        string subscriptionId,
+        [FromBody] CloseUsagePeriodRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationActionResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var result = await _simulation.CloseUsagePeriodAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null

--- a/server/Api/Controllers/SubscriptionSimulationController.cs
+++ b/server/Api/Controllers/SubscriptionSimulationController.cs
@@ -187,6 +187,35 @@ public sealed class SubscriptionSimulationController : ControllerBase
         return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Runs whichever due background work exists for this one subscription right now — never a
+    /// tenant-wide sweep, and never a scripted outcome: a renewal or a usage-invoice charge run
+    /// here goes to the real payment gateway.
+    /// </summary>
+    [HttpPost("subscriptions/{subscriptionId}/jobs/run-due")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationJobRunResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationJobRunResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionSimulationJobRunResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> RunDueJobs(
+        string subscriptionId,
+        [FromBody] RunDueJobsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        if (Disabled<SubscriptionSimulationJobRunResponse>(correlationId) is { } disabled)
+        {
+            return disabled;
+        }
+
+        var result = await _simulation.RunDueJobsAsync(
+            subscriptionId, request, correlationId, cancellationToken);
+
+        return Forbidden(result, correlationId) ?? result.ToActionResult(correlationId);
+    }
+
     private IActionResult? Disabled<T>(string correlationId) =>
         _options.CurrentValue.Enabled
             ? null

--- a/server/Subscription.DomainService/Outbox/ISubscriptionOutboxProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionOutboxProcessor.cs
@@ -1,3 +1,5 @@
+using Subscription.DomainService.Entities;
+
 namespace Subscription.DomainService.Outbox;
 
 public interface ISubscriptionOutboxProcessor
@@ -7,4 +9,14 @@ public interface ISubscriptionOutboxProcessor
     /// </summary>
     /// <returns>How many were published.</returns>
     Task<int> PublishDueAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes exactly one subscription's own due events, through the same claim-and-lease
+    /// mechanism <see cref="PublishDueAsync"/> uses — for the simulation harness, which must
+    /// never touch another subscription's outbox.
+    /// </summary>
+    /// <returns>How many events were published for this one subscription.</returns>
+    Task<int> PublishDueForSubscriptionAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
@@ -1,3 +1,5 @@
+using Subscription.DomainService.Entities;
+
 namespace Subscription.DomainService.Outbox;
 
 /// <summary>Closes usage periods that have ended and invoices their overage.</summary>
@@ -8,4 +10,23 @@ public interface ISubscriptionUsageRatingProcessor
 
     /// <returns>How many invoices were attempted, whether they charged, retried or were abandoned.</returns>
     Task<int> ChargeDueInvoicesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Closes exactly one subscription's own due periods, as of a caller-supplied instant —
+    /// never the wall clock, and never any other subscription's schedule.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the simulation harness: passing the subscription's own current period end
+    /// (or a moment after it) closes precisely that one period through the same logic
+    /// <see cref="CloseDuePeriodsAsync"/> uses, without waiting for real time to reach it and
+    /// without touching any other subscription the way a tenant-wide sweep would.
+    /// </remarks>
+    /// <returns>How many periods were closed for this one subscription.</returns>
+    Task<int> CloseSubscriptionPeriodsAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>Attempts exactly one invoice's charge, regardless of whether its own retry schedule is due.</summary>
+    Task ChargeInvoiceAsync(SubscriptionUsageInvoice invoice, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionOutboxProcessor.cs
@@ -70,6 +70,26 @@ public sealed class SubscriptionOutboxProcessor : ISubscriptionOutboxProcessor
         return published;
     }
 
+    public async Task<int> PublishDueForSubscriptionAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var published = 0;
+
+        foreach (var pending in DueEventsOf(subscription, now))
+        {
+            if (await PublishAsync(subscription, pending, options, now, cancellationToken))
+            {
+                published++;
+            }
+        }
+
+        return published;
+    }
+
     private static IEnumerable<SubscriptionOutboxEvent> DueEventsOf(
         SubscriptionDetail subscription,
         DateTime now) =>

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -92,6 +92,17 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         return closed;
     }
 
+    public Task<int> CloseSubscriptionPeriodsAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        CancellationToken cancellationToken) =>
+        CloseSubscriptionAsync(subscription, asOfUtc, cancellationToken);
+
+    public Task ChargeInvoiceAsync(
+        SubscriptionUsageInvoice invoice,
+        CancellationToken cancellationToken) =>
+        ChargeInvoiceAsync(invoice, _options.CurrentValue, _time.GetUtcNow().UtcDateTime, cancellationToken);
+
     private Task AuditAsync(
         SubscriptionDetail subscription,
         string stage,

--- a/server/Subscription.DomainService/Responses/SubscriptionSimulationDataConsoleResponses.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionSimulationDataConsoleResponses.cs
@@ -1,0 +1,36 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>The allowlisted collections and what the console may do to each — for discoverability.</summary>
+public sealed class SubscriptionSimulationDataPolicyResponse
+{
+    public string LogicalName { get; init; } = string.Empty;
+
+    public bool CanRead { get; init; }
+
+    public bool CanInsert { get; init; }
+
+    public List<string> UpdatableFields { get; init; } = [];
+}
+
+public sealed class SubscriptionSimulationDataQueryResponse
+{
+    public string Collection { get; init; } = string.Empty;
+
+    public int Count { get; init; }
+
+    /// <summary>Each document as JSON, with the same redaction the state endpoint already applies.</summary>
+    public List<string> Documents { get; init; } = [];
+
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+public sealed class SubscriptionSimulationDataMutationResponse
+{
+    public string Collection { get; init; } = string.Empty;
+
+    public bool Modified { get; init; }
+
+    public List<string> FieldsSet { get; init; } = [];
+
+    public string CorrelationId { get; init; } = string.Empty;
+}

--- a/server/Subscription.DomainService/Responses/SubscriptionSimulationJobRunResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionSimulationJobRunResponse.cs
@@ -1,0 +1,39 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// What running due background work for one subscription actually did — each work type's own
+/// outcome, alongside the complete state left behind.
+/// </summary>
+public sealed class SubscriptionSimulationJobRunResponse
+{
+    public string SimulationRunId { get; init; } = string.Empty;
+
+    public DateTime StartedAtUtc { get; init; }
+
+    public DateTime CompletedAtUtc { get; init; }
+
+    public int Claimed { get; init; }
+
+    public int Completed { get; init; }
+
+    /// <summary>Work types that were asked for but were not actually due — not a failure.</summary>
+    public int NotDue { get; init; }
+
+    public List<SubscriptionSimulationJobResultResponse> Jobs { get; init; } = [];
+
+    public SubscriptionSimulationStateResponse State { get; init; } = new();
+
+    public string CorrelationId { get; init; } = string.Empty;
+}
+
+public sealed class SubscriptionSimulationJobResultResponse
+{
+    public string WorkType { get; init; } = string.Empty;
+
+    /// <summary><c>Completed</c>, <c>NotDue</c> or <c>NotApplicable</c> (the subscription's own state rules it out entirely).</summary>
+    public string Status { get; init; } = string.Empty;
+
+    public string? Detail { get; init; }
+
+    public long DurationMs { get; init; }
+}

--- a/server/Subscription.DomainService/Simulation/AdvanceRenewalRequest.cs
+++ b/server/Subscription.DomainService/Simulation/AdvanceRenewalRequest.cs
@@ -1,0 +1,21 @@
+namespace Subscription.DomainService.Simulation;
+
+public sealed class AdvanceRenewalRequest
+{
+    public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// Must be 1 in this version. There is no simulated clock: this advances the one renewal
+    /// <see cref="Subscription.DomainService.Services.SubscriptionRenewalService.RenewAsync"/>
+    /// would raise for the fee schedule's current period, not a run of several future periods.
+    /// </summary>
+    public int Periods { get; set; } = 1;
+
+    public SimulatedRenewalOutcome PaymentOutcome { get; set; }
+
+    /// <summary>
+    /// Must be true in this version — there is nothing to schedule against without a simulated
+    /// clock, only an immediate attempt.
+    /// </summary>
+    public bool RunImmediately { get; set; } = true;
+}

--- a/server/Subscription.DomainService/Simulation/CloseUsagePeriodRequest.cs
+++ b/server/Subscription.DomainService/Simulation/CloseUsagePeriodRequest.cs
@@ -1,0 +1,20 @@
+namespace Subscription.DomainService.Simulation;
+
+public sealed class CloseUsagePeriodRequest
+{
+    public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// The gateway outcome to script for the overage charge, if <see cref="ChargeInvoice"/> is
+    /// true and the closed period actually produced one. Reuses the same vocabulary
+    /// <see cref="AdvanceRenewalRequest.PaymentOutcome"/> does — a usage invoice is charged
+    /// through the identical <c>ISubscriptionBillingGateway.ChargeAsync</c> call a renewal is.
+    /// </summary>
+    public SimulatedRenewalOutcome PaymentOutcome { get; set; } = SimulatedRenewalOutcome.Succeeded;
+
+    /// <summary>Whether to also charge the overage invoice the close produces, if any.</summary>
+    public bool ChargeInvoice { get; set; } = true;
+
+    /// <summary>Must be true in this version — see <see cref="AdvanceRenewalRequest.RunImmediately"/>.</summary>
+    public bool RunImmediately { get; set; } = true;
+}

--- a/server/Subscription.DomainService/Simulation/FindDataRequest.cs
+++ b/server/Subscription.DomainService/Simulation/FindDataRequest.cs
@@ -1,0 +1,16 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// A read from one allowlisted collection, scoped to a tenant, an organization and — always —
+/// one subscription. There is no field for a raw filter or query object: the only scoping this
+/// endpoint accepts is these three identifiers, which is what keeps it from becoming an
+/// unrestricted Mongo query surface.
+/// </summary>
+public sealed class FindDataRequest
+{
+    public string? OrganizationId { get; set; }
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public int Limit { get; set; } = 20;
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationDataConsoleService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationDataConsoleService.cs
@@ -1,0 +1,25 @@
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// The allowlisted, read-mostly Mongo access this harness offers once the purpose-built actions
+/// in PRs 2-5 cannot reach what a test needs. Never a raw query: every operation is scoped to
+/// one collection from <see cref="SubscriptionSimulationDataConsolePolicy"/>, one tenant, one
+/// organization and one subscription.
+/// </summary>
+public interface ISubscriptionSimulationDataConsoleService
+{
+    Task<SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>> FindAsync(
+        string logicalCollection,
+        FindDataRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>> UpdateFieldsAsync(
+        string logicalCollection,
+        UpdateDataFieldRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -49,4 +49,14 @@ public interface ISubscriptionSimulationService
         AdvanceRenewalRequest request,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Closes the subscription's current usage period as of right now, prices any overage into
+    /// an invoice, and — unless told otherwise — charges it with a scripted payment outcome.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> CloseUsagePeriodAsync(
+        string subscriptionId,
+        CloseUsagePeriodRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -39,4 +39,14 @@ public interface ISubscriptionSimulationService
         MarkPaymentFailedRequest request,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Forces an immediate renewal attempt for an Active or PastDue subscription, with a scripted
+    /// payment outcome — without waiting for the fee schedule's own due date.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> AdvanceRenewalAsync(
+        string subscriptionId,
+        AdvanceRenewalRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/ISubscriptionSimulationService.cs
@@ -59,4 +59,15 @@ public interface ISubscriptionSimulationService
         CloseUsagePeriodRequest request,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Runs whichever due background work exists for this one subscription right now, through
+    /// the real processors and — for a renewal or a usage-invoice charge — the real payment
+    /// gateway, with no outcome scripted. Never a tenant-wide sweep.
+    /// </summary>
+    Task<SubscriptionOperationResult<SubscriptionSimulationJobRunResponse>> RunDueJobsAsync(
+        string subscriptionId,
+        RunDueJobsRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Simulation/RunDueJobsRequest.cs
+++ b/server/Subscription.DomainService/Simulation/RunDueJobsRequest.cs
@@ -1,0 +1,14 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// Runs due background work for exactly one subscription — never a tenant-wide sweep. The
+/// subscription is always the URL's own <c>{subscriptionId}</c>, which is what keeps this from
+/// becoming an unrestricted "run every job for every tenant" action.
+/// </summary>
+public sealed class RunDueJobsRequest
+{
+    public string? OrganizationId { get; set; }
+
+    /// <summary>Empty means every work type this endpoint knows about.</summary>
+    public List<SimulationWorkType> WorkTypes { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Simulation/SimulatedRenewalOutcome.cs
+++ b/server/Subscription.DomainService/Simulation/SimulatedRenewalOutcome.cs
@@ -1,0 +1,16 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// What the one gateway call an advanced renewal makes should report — success folded in
+/// alongside the same failure vocabulary <see cref="SimulatedPaymentFailureKind"/> uses, since
+/// this single request field has to name either.
+/// </summary>
+public enum SimulatedRenewalOutcome
+{
+    Succeeded,
+    Declined,
+    InsufficientFunds,
+    PaymentMethodExpired,
+    ProviderUnavailable,
+    OutcomeUnknown
+}

--- a/server/Subscription.DomainService/Simulation/SimulationCollectionPolicy.cs
+++ b/server/Subscription.DomainService/Simulation/SimulationCollectionPolicy.cs
@@ -1,0 +1,77 @@
+using Subscription.DomainService.Repositories;
+
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// What the data console may do to one collection, and nothing it does not explicitly say.
+/// </summary>
+/// <remarks>
+/// A code-level allowlist rather than configuration: an operator can turn the console on or off,
+/// but cannot widen what it reaches by editing a config file. Every field named here must exist
+/// on the real document — there is no schema validation beyond "is it in this list."
+/// </remarks>
+public sealed record SimulationCollectionPolicy(
+    string LogicalName,
+    string CollectionName,
+    /// <summary>The document field a subscription id is matched against in this collection.</summary>
+    string SubscriptionIdField,
+    bool CanRead,
+    /// <summary>
+    /// Always false in this version — see the class remark on
+    /// <see cref="SubscriptionSimulationDataConsolePolicy"/> for why <c>insertOne</c> is not
+    /// implemented at all yet, kept as a field for when a genuinely safe target exists.
+    /// </summary>
+    bool CanInsert,
+    /// <summary>
+    /// Field names writable by <c>updateOne</c>, restricted to UTC timestamps in this version —
+    /// see <see cref="UpdateDataFieldRequest"/>. Even these are better changed through
+    /// the purpose-built actions in PRs 2-5; this exists for what those cannot yet reach.
+    /// </summary>
+    IReadOnlyList<string> UpdatableFields);
+
+public static class SubscriptionSimulationDataConsolePolicy
+{
+    /// <summary>
+    /// No collection allows <c>insertOne</c> yet — every candidate row this harness could safely
+    /// insert (a subscription, a payment link, a usage invoice) is already reachable through a
+    /// purpose-built action from PRs 2-5, and inventing one here would be exactly the free-form
+    /// database write this endpoint exists to avoid becoming.
+    /// </summary>
+    public static readonly IReadOnlyList<SimulationCollectionPolicy> Collections =
+    [
+        new(
+            LogicalName: "subscriptions",
+            CollectionName: SubscriptionCollections.Subscriptions,
+            SubscriptionIdField: "_id",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: ["NextFeeBillingAtUtc", "CurrentUsagePeriodEndUtc", "NextUsageBillingAtUtc"]),
+        new(
+            LogicalName: "usage-invoices",
+            CollectionName: SubscriptionCollections.UsageInvoices,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: ["NextAttemptAtUtc"]),
+        new(
+            LogicalName: "payment-links",
+            CollectionName: SubscriptionCollections.PaymentLinks,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: ["NextCheckAtUtc"]),
+        new(
+            LogicalName: "audit-events",
+            CollectionName: SubscriptionCollections.AuditEvents,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: []),
+        new(
+            LogicalName: "simulation-runs",
+            CollectionName: SubscriptionCollections.SimulationRuns,
+            SubscriptionIdField: "SubscriptionId",
+            CanRead: true, CanInsert: false,
+            UpdatableFields: []),
+    ];
+
+    public static SimulationCollectionPolicy? Find(string logicalName) =>
+        Collections.FirstOrDefault(
+            policy => string.Equals(policy.LogicalName, logicalName, StringComparison.OrdinalIgnoreCase));
+}

--- a/server/Subscription.DomainService/Simulation/SimulationWorkType.cs
+++ b/server/Subscription.DomainService/Simulation/SimulationWorkType.cs
@@ -1,0 +1,13 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// The background sweeps this harness can run for one subscription immediately, instead of
+/// waiting for the real reconciliation host's own polling interval.
+/// </summary>
+public enum SimulationWorkType
+{
+    Renewal,
+    UsagePeriodClosure,
+    UsageInvoiceCharge,
+    OutboxPublication
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationDataConsoleService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationDataConsoleService.cs
@@ -1,0 +1,297 @@
+using System.Globalization;
+using Blocks.Genesis;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Subscription.DomainService.Simulation;
+
+public sealed class SubscriptionSimulationDataConsoleService : ISubscriptionSimulationDataConsoleService
+{
+    private const int MaximumFindLimit = 100;
+
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly IDbContextProvider _db;
+    private readonly ISubscriptionSimulationRunRepository _simulationRuns;
+    private readonly IOptionsMonitor<PaymentOptions> _paymentOptions;
+
+    public SubscriptionSimulationDataConsoleService(
+        ISubscriptionContextResolver contextResolver,
+        IDbContextProvider db,
+        ISubscriptionSimulationRunRepository simulationRuns,
+        IOptionsMonitor<PaymentOptions> paymentOptions)
+    {
+        _contextResolver = contextResolver;
+        _db = db;
+        _simulationRuns = simulationRuns;
+        _paymentOptions = paymentOptions;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>> FindAsync(
+        string logicalCollection,
+        FindDataRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var policyResult = ResolvePolicy<SubscriptionSimulationDataQueryResponse>(
+            logicalCollection, requireRead: true, correlationId);
+
+        if (policyResult.Failure is { } policyFailure)
+        {
+            return policyFailure;
+        }
+
+        var policy = policyResult.Policy!;
+
+        if (request.Limit is <= 0 or > MaximumFindLimit)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_limit_invalid",
+                $"limit must be between 1 and {MaximumFindLimit}.",
+                correlationId);
+        }
+
+        var (context, failure) = await ResolveAsync<SubscriptionSimulationDataQueryResponse>(
+            request.OrganizationId, correlationId, cancellationToken);
+
+        if (failure is not null || context is null)
+        {
+            return failure!;
+        }
+
+        var collection = _db.GetDatabase(context.TenantId).GetCollection<BsonDocument>(policy.CollectionName);
+
+        var filter = Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Eq("TenantId", context.TenantId),
+            Builders<BsonDocument>.Filter.Eq("OrganizationId", context.OrganizationId),
+            Builders<BsonDocument>.Filter.Eq(policy.SubscriptionIdField, request.SubscriptionId));
+
+        var documents = await collection.Find(filter).Limit(request.Limit).ToListAsync(cancellationToken);
+
+        await RecordRunAsync(
+            context, request.SubscriptionId, "DataConsoleFind", correlationId,
+            $"collection={policy.LogicalName}", cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationDataQueryResponse>.Success(
+            new SubscriptionSimulationDataQueryResponse
+            {
+                Collection = policy.LogicalName,
+                Count = documents.Count,
+                Documents = documents
+                    .Select(document => Redact(policy.LogicalName, document).ToJson())
+                    .ToList(),
+                CorrelationId = correlationId
+            },
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>> UpdateFieldsAsync(
+        string logicalCollection,
+        UpdateDataFieldRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var policyResult = ResolvePolicy<SubscriptionSimulationDataMutationResponse>(
+            logicalCollection, requireRead: false, correlationId);
+
+        if (policyResult.Failure is { } policyFailure)
+        {
+            return policyFailure;
+        }
+
+        var policy = policyResult.Policy!;
+
+        if (request.Fields.Count == 0)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_no_fields",
+                "At least one field must be given.",
+                correlationId);
+        }
+
+        var disallowed = request.Fields.Keys
+            .Where(field => !policy.UpdatableFields.Contains(field, StringComparer.Ordinal))
+            .ToList();
+
+        if (disallowed.Count > 0)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_field_not_allowed",
+                $"{policy.LogicalName} does not allow writing: {string.Join(", ", disallowed)}.",
+                correlationId,
+                new Dictionary<string, string[]> { ["Fields"] = disallowed.ToArray() });
+        }
+
+        var updates = new List<UpdateDefinition<BsonDocument>>();
+
+        foreach (var field in request.Fields)
+        {
+            if (!DateTime.TryParse(
+                    field.Value, CultureInfo.InvariantCulture,
+                    DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var parsed))
+            {
+                return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_simulation_field_value_invalid",
+                    $"'{field.Key}' must be an ISO 8601 UTC timestamp.",
+                    correlationId);
+            }
+
+            updates.Add(Builders<BsonDocument>.Update.Set(field.Key, parsed));
+        }
+
+        var (context, failure) = await ResolveAsync<SubscriptionSimulationDataMutationResponse>(
+            request.OrganizationId, correlationId, cancellationToken);
+
+        if (failure is not null || context is null)
+        {
+            return failure!;
+        }
+
+        var collection = _db.GetDatabase(context.TenantId).GetCollection<BsonDocument>(policy.CollectionName);
+
+        var filter = Builders<BsonDocument>.Filter.And(
+            Builders<BsonDocument>.Filter.Eq("TenantId", context.TenantId),
+            Builders<BsonDocument>.Filter.Eq("OrganizationId", context.OrganizationId),
+            Builders<BsonDocument>.Filter.Eq(policy.SubscriptionIdField, request.SubscriptionId));
+
+        var result = await collection.UpdateOneAsync(
+            filter, Builders<BsonDocument>.Update.Combine(updates), cancellationToken: cancellationToken);
+
+        await RecordRunAsync(
+            context, request.SubscriptionId, "DataConsoleUpdate", correlationId,
+            $"collection={policy.LogicalName};fields={string.Join(',', request.Fields.Keys)}",
+            cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationDataMutationResponse>.Success(
+            new SubscriptionSimulationDataMutationResponse
+            {
+                Collection = policy.LogicalName,
+                Modified = result.ModifiedCount > 0,
+                FieldsSet = request.Fields.Keys.ToList(),
+                CorrelationId = correlationId
+            },
+            correlationId);
+    }
+
+    private static (SimulationCollectionPolicy? Policy, SubscriptionOperationResult<T>? Failure) ResolvePolicy<T>(
+        string logicalCollection, bool requireRead, string correlationId)
+    {
+        var policy = SubscriptionSimulationDataConsolePolicy.Find(logicalCollection);
+
+        if (policy is null)
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_simulation_collection_not_allowed",
+                $"'{logicalCollection}' is not an allowlisted collection.",
+                correlationId));
+        }
+
+        if (requireRead && !policy.CanRead)
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_collection_not_readable",
+                $"'{logicalCollection}' does not allow reads.",
+                correlationId));
+        }
+
+        return (policy, null);
+    }
+
+    private async Task<(SubscriptionContext? Context, SubscriptionOperationResult<T>? Failure)> ResolveAsync<T>(
+        string? organizationId, string correlationId, CancellationToken cancellationToken)
+    {
+        var caller = BlocksContext.GetContext();
+
+        if (!SubscriptionSimulationGuard.IsAuthorized(
+                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_forbidden",
+                "This caller may not use the subscription simulation harness.",
+                correlationId));
+        }
+
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            return (null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_organization_required",
+                "organizationId is required: the console has no subscription of its own.",
+                correlationId,
+                new Dictionary<string, string[]>
+                {
+                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
+                }));
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(correlationId, organizationId, cancellationToken);
+
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return (null, resolution.ToFailure<T>(correlationId));
+        }
+
+        return (resolution.Context, null);
+    }
+
+    private Task RecordRunAsync(
+        SubscriptionContext context,
+        string subscriptionId,
+        string action,
+        string correlationId,
+        string requestSummary,
+        CancellationToken cancellationToken) =>
+        _simulationRuns.AppendAsync(
+            new Entities.SubscriptionSimulationRun
+            {
+                TenantId = context.TenantId,
+                OrganizationId = context.OrganizationId,
+                SubscriptionId = subscriptionId,
+                ActorId = context.ActorId,
+                Action = action,
+                RequestSummary = requestSummary,
+                CorrelationId = correlationId,
+                Outcome = "Succeeded",
+                CompletedAtUtc = DateTime.UtcNow
+            },
+            cancellationToken);
+
+    /// <summary>
+    /// Never a stored payment method id, a provider customer id or a provider organization id —
+    /// the same fields <see cref="SubscriptionSimulationService"/>'s state read already excludes.
+    /// </summary>
+    private static BsonDocument Redact(string logicalName, BsonDocument document)
+    {
+        if (logicalName != "subscriptions")
+        {
+            return document;
+        }
+
+        if (document.TryGetValue("SettlementReservation", out var reservation) &&
+            reservation is BsonDocument reservationDocument)
+        {
+            reservationDocument.Remove("StoredPaymentMethodId");
+            reservationDocument.Remove("ProviderCustomerId");
+            reservationDocument.Remove("ProviderOrganizationId");
+        }
+
+        return document;
+    }
+}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Blocks.Genesis;
 using Microsoft.Extensions.Options;
 using Payment.DomainService.Entities;
@@ -36,6 +37,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     private readonly ISubscriptionRenewalService _renewalService;
     private readonly ISubscriptionSimulatedOutcomeSource _scriptedOutcomes;
     private readonly ISubscriptionUsageRatingProcessor _usageRatingProcessor;
+    private readonly ISubscriptionOutboxProcessor _outboxProcessor;
 
     public SubscriptionSimulationService(
         ISubscriptionContextResolver contextResolver,
@@ -54,7 +56,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         ISubscriptionActivationProcessor activationProcessor,
         ISubscriptionRenewalService renewalService,
         ISubscriptionSimulatedOutcomeSource scriptedOutcomes,
-        ISubscriptionUsageRatingProcessor usageRatingProcessor)
+        ISubscriptionUsageRatingProcessor usageRatingProcessor,
+        ISubscriptionOutboxProcessor outboxProcessor)
     {
         _contextResolver = contextResolver;
         _subscriptions = subscriptions;
@@ -73,6 +76,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         _renewalService = renewalService;
         _scriptedOutcomes = scriptedOutcomes;
         _usageRatingProcessor = usageRatingProcessor;
+        _outboxProcessor = outboxProcessor;
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
@@ -397,6 +401,166 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
             ? $"{periodsClosed} usage period(s) closed and the overage invoice charged."
             : $"{periodsClosed} usage period(s) closed; the overage charge failed and will retry " +
               "on its own schedule.");
+    }
+
+    private static readonly SimulationWorkType[] AllWorkTypes =
+    [
+        SimulationWorkType.Renewal,
+        SimulationWorkType.UsagePeriodClosure,
+        SimulationWorkType.UsageInvoiceCharge,
+        SimulationWorkType.OutboxPublication
+    ];
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationJobRunResponse>> RunDueJobsAsync(
+        string subscriptionId,
+        RunDueJobsRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        const string action = "RunDueJobs";
+        var startedAtUtc = DateTime.UtcNow;
+
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationJobRunResponse>(
+            subscriptionId, request.OrganizationId, action, correlationId, cancellationToken);
+
+        if (resolveFailure is not null || context is null || subscription is null)
+        {
+            return resolveFailure!;
+        }
+
+        var workTypes = request.WorkTypes.Count > 0 ? request.WorkTypes.Distinct() : AllWorkTypes;
+        var now = DateTime.UtcNow;
+        var jobs = new List<SubscriptionSimulationJobResultResponse>();
+
+        foreach (var workType in workTypes)
+        {
+            var stopwatch = Stopwatch.StartNew();
+
+            var (status, detail) = workType switch
+            {
+                SimulationWorkType.Renewal =>
+                    await RunRenewalJobAsync(subscription, now, cancellationToken),
+                SimulationWorkType.UsagePeriodClosure =>
+                    await RunUsageClosureJobAsync(subscription, now, cancellationToken),
+                SimulationWorkType.UsageInvoiceCharge =>
+                    await RunUsageChargeJobAsync(context, subscription, now, cancellationToken),
+                SimulationWorkType.OutboxPublication =>
+                    await RunOutboxJobAsync(subscription, cancellationToken),
+                _ => ("NotApplicable", "Unrecognized work type.")
+            };
+
+            jobs.Add(new SubscriptionSimulationJobResultResponse
+            {
+                WorkType = workType.ToString(),
+                Status = status,
+                Detail = detail,
+                DurationMs = stopwatch.ElapsedMilliseconds
+            });
+        }
+
+        var stateResult = await GetStateAsync(
+            subscriptionId, request.OrganizationId, 100, 100, true, correlationId, cancellationToken);
+
+        await RecordRunAsync(
+            context, subscriptionId, action, correlationId, "Succeeded", null, cancellationToken);
+
+        return SubscriptionOperationResult<SubscriptionSimulationJobRunResponse>.Success(
+            new SubscriptionSimulationJobRunResponse
+            {
+                SimulationRunId = $"sim_{Guid.NewGuid():N}",
+                StartedAtUtc = startedAtUtc,
+                CompletedAtUtc = DateTime.UtcNow,
+                Claimed = jobs.Count,
+                Completed = jobs.Count(job => job.Status == "Completed"),
+                NotDue = jobs.Count(job => job.Status == "NotDue"),
+                Jobs = jobs,
+                State = stateResult.IsSuccess && stateResult.Value is not null
+                    ? stateResult.Value
+                    : new SubscriptionSimulationStateResponse(),
+                CorrelationId = correlationId
+            },
+            correlationId);
+    }
+
+    /// <summary>Real gateway, no outcome scripted — this runs due work, it does not fake an answer.</summary>
+    private async Task<(string Status, string? Detail)> RunRenewalJobAsync(
+        SubscriptionDetail subscription, DateTime now, CancellationToken cancellationToken)
+    {
+        if (subscription.Status is not (SubscriptionStatus.Active or SubscriptionStatus.PastDue))
+        {
+            return ("NotApplicable", "Only an Active or PastDue subscription can renew.");
+        }
+
+        if (subscription.SettlementReservation is not null)
+        {
+            return ("NotDue", "A quantity or plan change is still settling.");
+        }
+
+        if (subscription.NextFeeBillingAtUtc is null || subscription.NextFeeBillingAtUtc > now)
+        {
+            return ("NotDue", "The fee schedule's next billing instant has not arrived yet.");
+        }
+
+        await _renewalService.RenewAsync(subscription, cancellationToken);
+
+        return ("Completed", "The real renewal service ran against the real payment gateway.");
+    }
+
+    private async Task<(string Status, string? Detail)> RunUsageClosureJobAsync(
+        SubscriptionDetail subscription, DateTime now, CancellationToken cancellationToken)
+    {
+        if (subscription.CurrentUsagePeriodEndUtc > now)
+        {
+            return ("NotDue", "The usage period has not ended yet.");
+        }
+
+        var closed = await _usageRatingProcessor.CloseSubscriptionPeriodsAsync(
+            subscription, now, cancellationToken);
+
+        return closed > 0
+            ? ("Completed", $"{closed} usage period(s) closed.")
+            : ("NotDue", "Nothing to close.");
+    }
+
+    /// <summary>Real gateway, no outcome scripted — see <see cref="RunRenewalJobAsync"/>.</summary>
+    private async Task<(string Status, string? Detail)> RunUsageChargeJobAsync(
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var invoices = await _usageInvoices.ListBySubscriptionAsync(
+            context.TenantId, subscription.ItemId, 50, cancellationToken);
+
+        var due = invoices
+            .Where(invoice => invoice.State == SubscriptionUsageInvoiceState.Pending &&
+                (invoice.NextAttemptAtUtc is null || invoice.NextAttemptAtUtc <= now))
+            .ToList();
+
+        if (due.Count == 0)
+        {
+            return ("NotDue", "No pending usage invoice is due for a charge attempt.");
+        }
+
+        foreach (var invoice in due)
+        {
+            await _usageRatingProcessor.ChargeInvoiceAsync(invoice, cancellationToken);
+        }
+
+        return ("Completed", $"{due.Count} usage invoice charge attempt(s) run against the real payment gateway.");
+    }
+
+    private async Task<(string Status, string? Detail)> RunOutboxJobAsync(
+        SubscriptionDetail subscription, CancellationToken cancellationToken)
+    {
+        var published = await _outboxProcessor.PublishDueForSubscriptionAsync(
+            subscription, cancellationToken);
+
+        return published > 0
+            ? ("Completed", $"{published} outbox event(s) published.")
+            : ("NotDue", "No outbox event is due for publication.");
     }
 
     private static (bool Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -237,6 +237,69 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
             cancellationToken);
     }
 
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> AdvanceRenewalAsync(
+        string subscriptionId,
+        AdvanceRenewalRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        const string action = "AdvanceRenewal";
+        var startedAtUtc = DateTime.UtcNow;
+
+        if (request.Periods != 1)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_periods_invalid",
+                "Only one period may be advanced at a time in this version.",
+                correlationId,
+                new Dictionary<string, string[]> { ["Periods"] = ["Must be 1."] });
+        }
+
+        if (!request.RunImmediately)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_scheduling_not_supported",
+                "runImmediately=false is not supported yet: there is no simulated clock to " +
+                "schedule against, only an immediate renewal attempt.",
+                correlationId);
+        }
+
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationActionResponse>(
+            subscriptionId, request.OrganizationId, action, correlationId, cancellationToken);
+
+        if (resolveFailure is not null || context is null || subscription is null)
+        {
+            return resolveFailure!;
+        }
+
+        var before = Summarize(subscription);
+        var (succeeded, failureKind) = SplitRenewalOutcome(request.PaymentOutcome);
+
+        var outcome = await SettleRenewalAsync(
+            context, subscription, succeeded, failureKind, errorCode: null,
+            runProcessor: true, correlationId, cancellationToken);
+
+        return await CompleteActionAsync(
+            context, subscriptionId, request.OrganizationId, action, startedAtUtc, before,
+            subscription, outcome, correlationId, cancellationToken);
+    }
+
+    private static (bool Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(
+        SimulatedRenewalOutcome outcome) => outcome switch
+    {
+        SimulatedRenewalOutcome.Succeeded => (true, null),
+        SimulatedRenewalOutcome.Declined => (false, SimulatedPaymentFailureKind.Declined),
+        SimulatedRenewalOutcome.InsufficientFunds => (false, SimulatedPaymentFailureKind.InsufficientFunds),
+        SimulatedRenewalOutcome.PaymentMethodExpired => (false, SimulatedPaymentFailureKind.PaymentMethodExpired),
+        SimulatedRenewalOutcome.ProviderUnavailable => (false, SimulatedPaymentFailureKind.ProviderUnavailable),
+        SimulatedRenewalOutcome.OutcomeUnknown => (false, SimulatedPaymentFailureKind.OutcomeUnknown),
+        _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "Unrecognized renewal outcome.")
+    };
+
     private async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> MarkPaymentOutcomeAsync(
         string subscriptionId,
         string? organizationId,
@@ -252,55 +315,12 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     {
         var startedAtUtc = DateTime.UtcNow;
 
-        var caller = BlocksContext.GetContext();
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationActionResponse>(
+            subscriptionId, organizationId, action, correlationId, cancellationToken);
 
-        if (!SubscriptionSimulationGuard.IsAuthorized(
-                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        if (resolveFailure is not null || context is null || subscription is null)
         {
-            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
-                PaymentFailureKind.Unavailable,
-                "subscription_simulation_forbidden",
-                "This caller may not use the subscription simulation harness.",
-                correlationId);
-        }
-
-        if (string.IsNullOrWhiteSpace(organizationId))
-        {
-            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_simulation_organization_required",
-                "organizationId is required: the console has no subscription of its own.",
-                correlationId,
-                new Dictionary<string, string[]>
-                {
-                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
-                });
-        }
-
-        var resolution = await _contextResolver.ResolveAsync(
-            correlationId, organizationId, cancellationToken);
-
-        if (!resolution.IsSuccess || resolution.Context is null)
-        {
-            return resolution.ToFailure<SubscriptionSimulationActionResponse>(correlationId);
-        }
-
-        var context = resolution.Context;
-
-        var subscription = await _subscriptions.GetAsync(
-            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken);
-
-        if (subscription is null)
-        {
-            await RecordRunAsync(
-                context, subscriptionId, action, correlationId,
-                "Failed", "subscription_not_found", cancellationToken);
-
-            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
-                PaymentFailureKind.NotFound,
-                "subscription_not_found",
-                "The subscription does not exist.",
-                correlationId);
+            return resolveFailure!;
         }
 
         var before = Summarize(subscription);
@@ -321,6 +341,96 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
                 correlationId), string.Empty)
         };
 
+        return await CompleteActionAsync(
+            context, subscriptionId, organizationId, action, startedAtUtc, before, subscription,
+            outcome, correlationId, cancellationToken, simulationRunId);
+    }
+
+    /// <summary>
+    /// Resolves the caller, the organization and the subscription — the prologue shared by every
+    /// mutating simulation action.
+    /// </summary>
+    private async Task<(
+        SubscriptionContext? Context,
+        SubscriptionDetail? Subscription,
+        SubscriptionOperationResult<T>? Failure)> ResolveTargetAsync<T>(
+        string subscriptionId,
+        string? organizationId,
+        string action,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var caller = BlocksContext.GetContext();
+
+        if (!SubscriptionSimulationGuard.IsAuthorized(
+                caller?.OrganizationId, _paymentOptions.CurrentValue, caller?.Permissions))
+        {
+            return (null, null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_simulation_forbidden",
+                "This caller may not use the subscription simulation harness.",
+                correlationId));
+        }
+
+        if (string.IsNullOrWhiteSpace(organizationId))
+        {
+            return (null, null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_organization_required",
+                "organizationId is required: the console has no subscription of its own.",
+                correlationId,
+                new Dictionary<string, string[]>
+                {
+                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
+                }));
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, organizationId, cancellationToken);
+
+        if (!resolution.IsSuccess || resolution.Context is null)
+        {
+            return (null, null, resolution.ToFailure<T>(correlationId));
+        }
+
+        var context = resolution.Context;
+
+        var subscription = await _subscriptions.GetAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken);
+
+        if (subscription is null)
+        {
+            await RecordRunAsync(
+                context, subscriptionId, action, correlationId,
+                "Failed", "subscription_not_found", cancellationToken);
+
+            return (context, null, SubscriptionOperationResult<T>.Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "The subscription does not exist.",
+                correlationId));
+        }
+
+        return (context, subscription, null);
+    }
+
+    /// <summary>
+    /// The epilogue shared by every mutating simulation action: report a failure, or reload the
+    /// subscription, assemble the full state and record the run.
+    /// </summary>
+    private async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> CompleteActionAsync(
+        SubscriptionContext context,
+        string subscriptionId,
+        string? organizationId,
+        string action,
+        DateTime startedAtUtc,
+        SubscriptionSimulationSummary before,
+        SubscriptionDetail subscriptionBeforeAction,
+        (SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note) outcome,
+        string correlationId,
+        CancellationToken cancellationToken,
+        string? simulationRunId = null)
+    {
         if (outcome.Failure is { } failure)
         {
             await RecordRunAsync(
@@ -331,7 +441,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         }
 
         var refreshed = await _subscriptions.GetAsync(
-            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken) ?? subscription;
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken)
+            ?? subscriptionBeforeAction;
         var after = Summarize(refreshed);
 
         var stateResult = await GetStateAsync(
@@ -343,7 +454,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Success(
             new SubscriptionSimulationActionResponse
             {
-                SimulationRunId = simulationRunId,
+                SimulationRunId = simulationRunId ?? $"sim_{Guid.NewGuid():N}",
                 Action = action,
                 StartedAtUtc = startedAtUtc,
                 CompletedAtUtc = DateTime.UtcNow,

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -11,6 +11,7 @@ using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Simulation;
 
@@ -34,6 +35,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     private readonly ISubscriptionActivationProcessor _activationProcessor;
     private readonly ISubscriptionRenewalService _renewalService;
     private readonly ISubscriptionSimulatedOutcomeSource _scriptedOutcomes;
+    private readonly ISubscriptionUsageRatingProcessor _usageRatingProcessor;
 
     public SubscriptionSimulationService(
         ISubscriptionContextResolver contextResolver,
@@ -51,7 +53,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         IPaymentWebhookStateTransitionService webhookTransitions,
         ISubscriptionActivationProcessor activationProcessor,
         ISubscriptionRenewalService renewalService,
-        ISubscriptionSimulatedOutcomeSource scriptedOutcomes)
+        ISubscriptionSimulatedOutcomeSource scriptedOutcomes,
+        ISubscriptionUsageRatingProcessor usageRatingProcessor)
     {
         _contextResolver = contextResolver;
         _subscriptions = subscriptions;
@@ -69,6 +72,7 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         _activationProcessor = activationProcessor;
         _renewalService = renewalService;
         _scriptedOutcomes = scriptedOutcomes;
+        _usageRatingProcessor = usageRatingProcessor;
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionSimulationStateResponse>> GetStateAsync(
@@ -286,6 +290,113 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
         return await CompleteActionAsync(
             context, subscriptionId, request.OrganizationId, action, startedAtUtc, before,
             subscription, outcome, correlationId, cancellationToken);
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionSimulationActionResponse>> CloseUsagePeriodAsync(
+        string subscriptionId,
+        CloseUsagePeriodRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        const string action = "CloseUsagePeriod";
+        var startedAtUtc = DateTime.UtcNow;
+
+        if (!request.RunImmediately)
+        {
+            return SubscriptionOperationResult<SubscriptionSimulationActionResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_simulation_scheduling_not_supported",
+                "runImmediately=false is not supported yet: there is no simulated clock to " +
+                "schedule against, only an immediate close.",
+                correlationId);
+        }
+
+        var (context, subscription, resolveFailure) = await ResolveTargetAsync<SubscriptionSimulationActionResponse>(
+            subscriptionId, request.OrganizationId, action, correlationId, cancellationToken);
+
+        if (resolveFailure is not null || context is null || subscription is null)
+        {
+            return resolveFailure!;
+        }
+
+        var before = Summarize(subscription);
+
+        var outcome = await CloseUsagePeriodInternalAsync(
+            context, subscription, request, correlationId, cancellationToken);
+
+        return await CompleteActionAsync(
+            context, subscriptionId, request.OrganizationId, action, startedAtUtc, before,
+            subscription, outcome, correlationId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Closes the current usage period as of an instant just past its own end — never the wall
+    /// clock, and never any period belonging to another subscription — then, if it produced an
+    /// overage invoice, charges it with the scripted outcome.
+    /// </summary>
+    private async Task<(SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note)>
+        CloseUsagePeriodInternalAsync(
+            SubscriptionContext context,
+            SubscriptionDetail subscription,
+            CloseUsagePeriodRequest request,
+            string correlationId,
+            CancellationToken cancellationToken)
+    {
+        // Captured before the close mutates the subscription's own CurrentUsagePeriodStartUtc in
+        // place — this is the key the invoice the close just produced (if any) was filed under.
+        var closedPeriodKey = PeriodKey.Create(
+            subscription.UsageSchedule.Interval, subscription.CurrentUsagePeriodStartUtc);
+
+        var periodsClosed = await _usageRatingProcessor.CloseSubscriptionPeriodsAsync(
+            subscription, subscription.CurrentUsagePeriodEndUtc.AddSeconds(1), cancellationToken);
+
+        if (periodsClosed == 0)
+        {
+            return (null,
+                "No period was closed — another worker may already be advancing this " +
+                "subscription's usage clock, or its schedule could not be advanced.");
+        }
+
+        var invoice = await _usageInvoices.GetAsync(
+            context.TenantId, subscription.ItemId, closedPeriodKey, cancellationToken);
+
+        if (invoice is null)
+        {
+            return (null,
+                $"{periodsClosed} usage period(s) closed; no overage invoice was produced " +
+                "(usage was within the allowance, or every metered item resets rather than " +
+                "carrying overage into an invoice).");
+        }
+
+        if (invoice.State != SubscriptionUsageInvoiceState.Pending)
+        {
+            return (null,
+                $"{periodsClosed} usage period(s) closed; the invoice is already " +
+                $"{invoice.State} and will not be charged again.");
+        }
+
+        if (!request.ChargeInvoice)
+        {
+            return (null,
+                $"{periodsClosed} usage period(s) closed; a pending overage invoice of " +
+                $"{invoice.TotalAmountMinor} {invoice.CurrencyCode} (minor units) was not charged.");
+        }
+
+        var (succeeded, failureKind) = SplitRenewalOutcome(request.PaymentOutcome);
+
+        _scriptedOutcomes.ScriptNext(new ScriptedChargeOutcome(
+            succeeded ? SimulatedChargeOutcome.Succeeded : MapFailureOutcome(failureKind),
+            succeeded ? null : DefaultErrorCode(failureKind),
+            succeeded ? null : DefaultErrorMessage(failureKind)));
+
+        await _usageRatingProcessor.ChargeInvoiceAsync(invoice, cancellationToken);
+
+        return (null, succeeded
+            ? $"{periodsClosed} usage period(s) closed and the overage invoice charged."
+            : $"{periodsClosed} usage period(s) closed; the overage charge failed and will retry " +
+              "on its own schedule.");
     }
 
     private static (bool Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(

--- a/server/Subscription.DomainService/Simulation/UpdateDataFieldRequest.cs
+++ b/server/Subscription.DomainService/Simulation/UpdateDataFieldRequest.cs
@@ -1,0 +1,20 @@
+namespace Subscription.DomainService.Simulation;
+
+/// <summary>
+/// Sets one or more fields on exactly one document, restricted to the fields the target
+/// collection's <see cref="SimulationCollectionPolicy"/> allows.
+/// </summary>
+/// <remarks>
+/// Every value is parsed as a UTC timestamp — the only type any currently allowlisted field
+/// holds — so there is no generic "any BSON value" write surface. A field this cannot parse, or
+/// that the policy does not name, is rejected rather than silently ignored.
+/// </remarks>
+public sealed class UpdateDataFieldRequest
+{
+    public string? OrganizationId { get; set; }
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    /// <summary>Field name to an ISO 8601 UTC timestamp string.</summary>
+    public Dictionary<string, string> Fields { get; set; } = [];
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -38,13 +38,16 @@ public static class ApplicationServiceCollectionExtensions
 
         if (hostEnvironment is { } environment &&
             environment.IsProduction() &&
-            simulationSection.GetValue<bool>(nameof(SubscriptionSimulationOptions.Enabled)))
+            (simulationSection.GetValue<bool>(nameof(SubscriptionSimulationOptions.Enabled)) ||
+             simulationSection.GetValue<bool>(nameof(SubscriptionSimulationOptions.DataConsoleEnabled))))
         {
-            // The harness can rewrite billing history through real domain processors. Refusing
-            // to start is deliberately louder than the request-time 404 guard the controller
-            // also applies — a misconfigured Production deploy should never come up quietly.
+            // The harness can rewrite billing history through real domain processors, and the
+            // data console reads and writes Mongo documents directly. Refusing to start is
+            // deliberately louder than the request-time 404 guard the controller also applies —
+            // a misconfigured Production deploy should never come up quietly.
             throw new InvalidOperationException(
-                "SubscriptionSimulation:Enabled must not be true in a Production environment.");
+                "SubscriptionSimulation:Enabled and SubscriptionSimulation:DataConsoleEnabled " +
+                "must not be true in a Production environment.");
         }
 
         // Repositories are singletons and take the tenant as an argument, so the same instance
@@ -191,6 +194,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionSimulationService,
             SubscriptionSimulationService>();
+        services.AddScoped<
+            ISubscriptionSimulationDataConsoleService,
+            SubscriptionSimulationDataConsoleService>();
 
         return services;
     }

--- a/server/Subscription.DomainService/Utilities/SubscriptionSimulationOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionSimulationOptions.cs
@@ -16,4 +16,12 @@ public sealed class SubscriptionSimulationOptions
     public const string SectionName = "SubscriptionSimulation";
 
     public bool Enabled { get; set; }
+
+    /// <summary>
+    /// A second, independent gate for the allowlisted data console — the one piece of this
+    /// harness that reads and writes Mongo documents directly rather than going through a
+    /// domain service. Requires <see cref="Enabled"/> as well; this can narrow access further
+    /// within an environment where the harness itself is on, but never widen it.
+    /// </summary>
+    public bool DataConsoleEnabled { get; set; }
 }

--- a/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
@@ -134,6 +134,24 @@ public sealed class SubscriptionServiceRegistrationTests
         act.Should().NotThrow();
     }
 
+    [Fact]
+    public void Registration_refuses_to_enable_the_data_console_in_production()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.RegisterSubscriptionDomainServices(
+            Configuration(new Dictionary<string, string?>
+            {
+                ["SubscriptionSimulation:DataConsoleEnabled"] = "true"
+            }),
+            new FakeHostEnvironment("Production"));
+
+        act.Should().Throw<InvalidOperationException>(
+            "the data console reads and writes Mongo documents directly and must never come up " +
+            "in Production, even with the rest of the harness left off");
+    }
+
     private sealed class FakeHostEnvironment : IHostEnvironment
     {
         public FakeHostEnvironment(string environmentName) => EnvironmentName = environmentName;

--- a/server/XUnitTest/Subscription/SubscriptionSimulationDataConsoleServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationDataConsoleServiceTests.cs
@@ -1,0 +1,245 @@
+using Blocks.Genesis;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Simulation;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// <see cref="SubscriptionSimulationDataConsoleService"/>'s guard, policy and validation surface
+/// — everything that must reject a call before it ever reaches Mongo.
+/// </summary>
+/// <remarks>
+/// None of these tests configure <see cref="IDbContextProvider"/>: every scenario here is
+/// rejected before the service would call it, which is itself part of what is under test — an
+/// unauthorized or malformed call must never reach a database round trip.
+/// </remarks>
+public sealed class SubscriptionSimulationDataConsoleServiceTests : IDisposable
+{
+    private const string ConsoleOrganizationId = "console-org";
+    private const string SubscriptionId = "sub-1";
+    private const string TenantId = "tenant-1";
+    private const string CorrelationId = "corr-1";
+
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<IDbContextProvider> _db = new();
+    private readonly Mock<ISubscriptionSimulationRunRepository> _simulationRuns = new();
+    private readonly Mock<IOptionsMonitor<PaymentOptions>> _paymentOptions = new();
+
+    public SubscriptionSimulationDataConsoleServiceTests() =>
+        _paymentOptions
+            .Setup(options => options.CurrentValue)
+            .Returns(new PaymentOptions { ConsoleOrganizationId = ConsoleOrganizationId });
+
+    public void Dispose() => BlocksContext.ClearContext();
+
+    [Fact]
+    public async Task Find_refuses_a_caller_who_is_not_the_console()
+    {
+        SetCaller(organizationId: "some-other-org", permissions: [SubscriptionSimulationGuard.SimulationAdministratorPermission]);
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_forbidden");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Find_refuses_the_console_without_the_simulation_permission()
+    {
+        SetCaller(organizationId: ConsoleOrganizationId, permissions: []);
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_forbidden");
+    }
+
+    [Fact]
+    public async Task Find_rejects_a_collection_that_is_not_allowlisted()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().FindAsync(
+            "not-a-real-collection",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_collection_not_allowed");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(101)]
+    public async Task Find_rejects_an_out_of_range_limit(int limit)
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId, Limit = limit },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_limit_invalid");
+    }
+
+    [Fact]
+    public async Task Find_requires_an_organization_because_the_console_has_none_of_its_own()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().FindAsync(
+            "subscriptions",
+            new FindDataRequest { OrganizationId = null, SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_organization_required");
+    }
+
+    [Fact]
+    public async Task Update_rejects_a_collection_that_is_not_allowlisted()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "not-a-real-collection",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["NextFeeBillingAtUtc"] = "2026-01-01T00:00:00Z" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_collection_not_allowed");
+    }
+
+    [Fact]
+    public async Task Update_rejects_an_empty_field_set()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest { OrganizationId = "target-org", SubscriptionId = SubscriptionId },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_no_fields");
+    }
+
+    [Fact]
+    public async Task Update_rejects_a_field_the_policy_does_not_allow()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["Status"] = "Active" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_field_not_allowed");
+    }
+
+    [Fact]
+    public async Task Update_rejects_a_value_that_is_not_a_utc_timestamp()
+    {
+        SetAuthorizedCaller();
+
+        var result = await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["NextFeeBillingAtUtc"] = "not-a-date" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_field_value_invalid");
+    }
+
+    [Fact]
+    public async Task Update_validates_fields_before_ever_resolving_the_caller_s_context()
+    {
+        SetAuthorizedCaller();
+
+        await CreateService().UpdateFieldsAsync(
+            "subscriptions",
+            new UpdateDataFieldRequest
+            {
+                OrganizationId = "target-org",
+                SubscriptionId = SubscriptionId,
+                Fields = new Dictionary<string, string> { ["NextFeeBillingAtUtc"] = "not-a-date" }
+            },
+            CorrelationId,
+            CancellationToken.None);
+
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "an unparsable field must be rejected before the harness ever touches the database");
+    }
+
+    private void SetAuthorizedCaller() =>
+        SetCaller(ConsoleOrganizationId, [SubscriptionSimulationGuard.SimulationAdministratorPermission]);
+
+    private static void SetCaller(string? organizationId, IEnumerable<string> permissions) =>
+        BlocksContext.SetContext(BlocksContext.Create(
+            tenantId: TenantId,
+            roles: [],
+            userId: "user-1",
+            isAuthenticated: true,
+            requestUri: null,
+            organizationId: organizationId,
+            expireOn: DateTime.UtcNow.AddHours(1),
+            email: "tester@example.com",
+            permissions: permissions,
+            userName: null,
+            phoneNumber: null,
+            displayName: null,
+            oauthToken: null,
+            originalTenantId: null));
+
+    private SubscriptionSimulationDataConsoleService CreateService() => new(
+        _contextResolver.Object,
+        _db.Object,
+        _simulationRuns.Object,
+        _paymentOptions.Object);
+}

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -48,6 +48,7 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
     private readonly Mock<ISubscriptionActivationProcessor> _activationProcessor = new();
     private readonly Mock<ISubscriptionRenewalService> _renewalService = new();
     private readonly Mock<ISubscriptionSimulatedOutcomeSource> _scriptedOutcomes = new();
+    private readonly Mock<ISubscriptionUsageRatingProcessor> _usageRatingProcessor = new();
 
     public SubscriptionSimulationServiceTests()
     {
@@ -239,7 +240,8 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         _webhookTransitions.Object,
         _activationProcessor.Object,
         _renewalService.Object,
-        _scriptedOutcomes.Object);
+        _scriptedOutcomes.Object,
+        _usageRatingProcessor.Object);
 
     /// <summary>Wires the read-only GetStateAsync collaborators to return an empty-but-valid state, so mark-payment tests can reuse it without re-asserting PR 1's own coverage.</summary>
     private void StubEmptyState(SubscriptionDetail subscription, string organizationId)
@@ -636,5 +638,148 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("subscription_simulation_not_renewable");
+    }
+
+    private static SubscriptionDetail UsageSubscription() => new()
+    {
+        ItemId = SubscriptionId,
+        TenantId = TenantId,
+        OrganizationId = "target-org",
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "EUR",
+        CurrentUsagePeriodStartUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentUsagePeriodEndUtc = new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+    };
+
+    [Fact]
+    public async Task Closing_a_usage_period_with_no_overage_charges_nothing()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _usageInvoices
+            .Setup(repo => repo.GetAsync(TenantId, SubscriptionId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageInvoice?)null);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org" };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Closing_a_usage_period_with_overage_scripts_and_charges_the_invoice()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        var invoice = new SubscriptionUsageInvoice
+        {
+            ItemId = "invoice-1", TenantId = TenantId, SubscriptionId = SubscriptionId,
+            State = SubscriptionUsageInvoiceState.Pending, TotalAmountMinor = 500, CurrencyCode = "EUR",
+        };
+        _usageInvoices
+            .Setup(repo => repo.GetAsync(TenantId, SubscriptionId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invoice);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org", PaymentOutcome = SimulatedRenewalOutcome.Succeeded };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.Is<ScriptedChargeOutcome>(o => o.Outcome == SimulatedChargeOutcome.Succeeded)),
+            Times.Once);
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(invoice, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Closing_a_usage_period_does_not_charge_when_chargeInvoice_is_false()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _usageInvoices
+            .Setup(repo => repo.GetAsync(TenantId, SubscriptionId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageInvoice
+            {
+                ItemId = "invoice-1", State = SubscriptionUsageInvoiceState.Pending, TotalAmountMinor = 500,
+            });
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org", ChargeInvoice = false };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Reports_no_change_when_the_period_could_not_be_closed()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org" };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _usageInvoices.Verify(
+            repo => repo.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Refuses_to_defer_a_usage_close_since_there_is_no_simulated_clock()
+    {
+        SetAuthorizedCaller();
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org", RunImmediately = false };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_scheduling_not_supported");
     }
 }

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -49,6 +49,7 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
     private readonly Mock<ISubscriptionRenewalService> _renewalService = new();
     private readonly Mock<ISubscriptionSimulatedOutcomeSource> _scriptedOutcomes = new();
     private readonly Mock<ISubscriptionUsageRatingProcessor> _usageRatingProcessor = new();
+    private readonly Mock<ISubscriptionOutboxProcessor> _outboxProcessor = new();
 
     public SubscriptionSimulationServiceTests()
     {
@@ -241,7 +242,8 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         _activationProcessor.Object,
         _renewalService.Object,
         _scriptedOutcomes.Object,
-        _usageRatingProcessor.Object);
+        _usageRatingProcessor.Object,
+        _outboxProcessor.Object);
 
     /// <summary>Wires the read-only GetStateAsync collaborators to return an empty-but-valid state, so mark-payment tests can reuse it without re-asserting PR 1's own coverage.</summary>
     private void StubEmptyState(SubscriptionDetail subscription, string organizationId)
@@ -781,5 +783,125 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("subscription_simulation_scheduling_not_supported");
+    }
+
+    [Fact]
+    public async Task Running_due_jobs_reports_not_due_when_nothing_qualifies()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+            NextFeeBillingAtUtc = DateTime.UtcNow.AddDays(10),
+            CurrentUsagePeriodEndUtc = DateTime.UtcNow.AddDays(10),
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageInvoices
+            .Setup(repo => repo.ListBySubscriptionAsync(TenantId, SubscriptionId, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageInvoice>)[]);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new RunDueJobsRequest { OrganizationId = "target-org" };
+        var result = await CreateService().RunDueJobsAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Jobs.Should().HaveCount(4);
+        result.Value!.Jobs.Should().OnlyContain(job => job.Status == "NotDue");
+        result.Value!.Completed.Should().Be(0);
+        _renewalService.Verify(
+            service => service.RenewAsync(It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "no scripted outcome exists for this path — a real gateway call must never fire when nothing is actually due");
+    }
+
+    [Fact]
+    public async Task Running_due_jobs_runs_only_the_requested_work_types()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+            NextFeeBillingAtUtc = DateTime.UtcNow.AddMinutes(-1),
+            CurrentUsagePeriodEndUtc = DateTime.UtcNow.AddDays(10),
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new RunDueJobsRequest
+        {
+            OrganizationId = "target-org",
+            WorkTypes = [SimulationWorkType.Renewal],
+        };
+        var result = await CreateService().RunDueJobsAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Jobs.Should().ContainSingle().Which.WorkType.Should().Be("Renewal");
+        result.Value!.Jobs[0].Status.Should().Be("Completed");
+        _renewalService.Verify(
+            service => service.RenewAsync(subscription, It.IsAny<CancellationToken>()), Times.Once);
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.IsAny<ScriptedChargeOutcome>()),
+            Times.Never,
+            "running due jobs must go to the real gateway, never a scripted outcome");
+        // 50 is the job's own lookup limit — distinct from the 100 GetStateAsync uses when
+        // assembling the response's trailing state snapshot, which is expected regardless.
+        _usageInvoices.Verify(
+            repo => repo.ListBySubscriptionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), 50, It.IsAny<CancellationToken>()),
+            Times.Never,
+            "only the requested work type should run");
+    }
+
+    [Fact]
+    public async Task Running_due_jobs_publishes_outbox_events_and_charges_due_usage_invoices()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        var dueInvoice = new SubscriptionUsageInvoice
+        {
+            ItemId = "invoice-1", State = SubscriptionUsageInvoiceState.Pending,
+            NextAttemptAtUtc = DateTime.UtcNow.AddMinutes(-1),
+        };
+        _usageInvoices
+            .Setup(repo => repo.ListBySubscriptionAsync(TenantId, SubscriptionId, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageInvoice>)[dueInvoice]);
+        _outboxProcessor
+            .Setup(processor => processor.PublishDueForSubscriptionAsync(subscription, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new RunDueJobsRequest
+        {
+            OrganizationId = "target-org",
+            WorkTypes = [SimulationWorkType.UsageInvoiceCharge, SimulationWorkType.OutboxPublication],
+        };
+        var result = await CreateService().RunDueJobsAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Completed.Should().Be(2);
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(dueInvoice, It.IsAny<CancellationToken>()), Times.Once);
+        _outboxProcessor.Verify(
+            processor => processor.PublishDueForSubscriptionAsync(subscription, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -522,4 +522,119 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("subscription_simulation_settlement_in_flight");
     }
+
+    [Fact]
+    public async Task Advancing_a_renewal_scripts_the_gateway_and_runs_the_real_renewal_service()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new AdvanceRenewalRequest
+        {
+            OrganizationId = "target-org",
+            PaymentOutcome = SimulatedRenewalOutcome.Succeeded,
+        };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Action.Should().Be("AdvanceRenewal");
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(
+                It.Is<ScriptedChargeOutcome>(outcome => outcome.Outcome == SimulatedChargeOutcome.Succeeded)),
+            Times.Once);
+        _renewalService.Verify(
+            service => service.RenewAsync(subscription, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(SimulatedRenewalOutcome.Declined, SimulatedChargeOutcome.Rejected)]
+    [InlineData(SimulatedRenewalOutcome.InsufficientFunds, SimulatedChargeOutcome.Rejected)]
+    [InlineData(SimulatedRenewalOutcome.PaymentMethodExpired, SimulatedChargeOutcome.Rejected)]
+    [InlineData(SimulatedRenewalOutcome.ProviderUnavailable, SimulatedChargeOutcome.Unavailable)]
+    [InlineData(SimulatedRenewalOutcome.OutcomeUnknown, SimulatedChargeOutcome.TimedOut)]
+    public async Task Advancing_a_renewal_maps_every_outcome_onto_the_gateway_script(
+        SimulatedRenewalOutcome requested, SimulatedChargeOutcome expected)
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.PastDue,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org", PaymentOutcome = requested };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.Is<ScriptedChargeOutcome>(o => o.Outcome == expected)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Refuses_to_advance_more_than_one_period()
+    {
+        SetAuthorizedCaller();
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org", Periods = 2 };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_periods_invalid");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Refuses_to_defer_scheduling_since_there_is_no_simulated_clock()
+    {
+        SetAuthorizedCaller();
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org", RunImmediately = false };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_scheduling_not_supported");
+    }
+
+    [Fact]
+    public async Task Refuses_to_advance_a_renewal_for_an_incomplete_subscription()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Incomplete,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org" };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_simulation_not_renewable");
+    }
 }


### PR DESCRIPTION
## Summary

PRs #280, #288, #289 and #290 were each opened stacked on the previous
PR's branch (by design, since each depended on the last), and merged in
sequence. But merging a PR whose base is a feature branch only updates
that feature branch — it does not propagate to `dev` unless something
later merges the tip into `dev`. Since #279's branch was already merged
to `dev` before #280 merged into it, none of #280/#288/#289/#290's
commits ever reached `dev`.

This PR is that missing link: `feat/subscription-simulation-data-console`
(the tip of the stack, containing everything from #280 through #290) into
`dev`, containing:

- PR3 (renewal simulation) — from #280
- PR4 (usage period simulation) — from #288
- PR5 (background job simulation) — from #289
- PR6 (optional allowlisted data console) — from #290

No new code beyond what those four PRs already reviewed and merged — this
is purely landing already-approved work on `dev`.

## Test plan

Unchanged from #280/#288/#289/#290 individually:
- [x] `dotnet build Api/Api.csproj --no-incremental` / `Worker/Worker.csproj` — 0 errors
- [x] `dotnet test XUnitTest` (non-integration): passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)