### PR TITLE
feat(subscription): add client UI for the simulation harness actions

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/advance-renewal-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/advance-renewal-dialog.tsx
@@ -1,0 +1,137 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Label } from "@/components/ui-kits/label/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { toast } from "@/hooks/use-toast";
+import { useAdvanceRenewal } from "../hooks/use-advance-renewal";
+import type {
+  SimulatedRenewalOutcome,
+  SubscriptionSimulationActionResponse,
+} from "../models/subscription-simulation-harness.model";
+
+const OUTCOMES: { value: SimulatedRenewalOutcome; label: string }[] = [
+  { value: "Succeeded", label: "Succeeded" },
+  { value: "Declined", label: "Declined" },
+  { value: "InsufficientFunds", label: "Insufficient funds" },
+  { value: "PaymentMethodExpired", label: "Payment method expired" },
+  { value: "ProviderUnavailable", label: "Provider unavailable" },
+  { value: "OutcomeUnknown", label: "Outcome unknown" },
+];
+
+export const AdvanceRenewalDialog = ({
+  subscriptionId,
+  organizationId,
+  open,
+  onOpenChange,
+  onResult,
+}: {
+  subscriptionId: string;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onResult: (result: SubscriptionSimulationActionResponse) => void;
+}) => {
+  const { mutateAsync, isPending } = useAdvanceRenewal();
+
+  const [paymentOutcome, setPaymentOutcome] = useState<SimulatedRenewalOutcome>("Succeeded");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setFormError(null);
+
+    try {
+      const result = await mutateAsync({
+        subscriptionId,
+        request: { organizationId, paymentOutcome },
+      });
+
+      onResult(result);
+
+      toast({
+        variant: paymentOutcome === "Succeeded" ? "success" : "destructive",
+        title: "Renewal advanced",
+        description: `Charged as ${paymentOutcome}.`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : "The renewal could not be advanced.");
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Advance renewal</DialogTitle>
+          <DialogDescription>
+            Sends{" "}
+            <code>POST /api/subscription-simulation/subscriptions/{subscriptionId}/advance-renewal</code>
+            — forces an immediate renewal attempt with a scripted outcome, without waiting for the
+            fee schedule&apos;s own due date.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="advance-renewal-outcome">Payment outcome</Label>
+            <Select
+              value={paymentOutcome}
+              onValueChange={(value) => setPaymentOutcome(value as SimulatedRenewalOutcome)}
+            >
+              <SelectTrigger id="advance-renewal-outcome">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {OUTCOMES.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Advances the one renewal due for the current fee period — there is no simulated clock,
+            so this cannot run several future periods in one call.
+          </p>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Advance renewal
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/close-usage-period-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/close-usage-period-dialog.tsx
@@ -1,0 +1,154 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Label } from "@/components/ui-kits/label/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { toast } from "@/hooks/use-toast";
+import { useCloseUsagePeriod } from "../hooks/use-close-usage-period";
+import type {
+  SimulatedRenewalOutcome,
+  SubscriptionSimulationActionResponse,
+} from "../models/subscription-simulation-harness.model";
+
+const OUTCOMES: { value: SimulatedRenewalOutcome; label: string }[] = [
+  { value: "Succeeded", label: "Succeeded" },
+  { value: "Declined", label: "Declined" },
+  { value: "InsufficientFunds", label: "Insufficient funds" },
+  { value: "PaymentMethodExpired", label: "Payment method expired" },
+  { value: "ProviderUnavailable", label: "Provider unavailable" },
+  { value: "OutcomeUnknown", label: "Outcome unknown" },
+];
+
+export const CloseUsagePeriodDialog = ({
+  subscriptionId,
+  organizationId,
+  open,
+  onOpenChange,
+  onResult,
+}: {
+  subscriptionId: string;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onResult: (result: SubscriptionSimulationActionResponse) => void;
+}) => {
+  const { mutateAsync, isPending } = useCloseUsagePeriod();
+
+  const [paymentOutcome, setPaymentOutcome] = useState<SimulatedRenewalOutcome>("Succeeded");
+  const [chargeInvoice, setChargeInvoice] = useState(true);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setFormError(null);
+
+    try {
+      const result = await mutateAsync({
+        subscriptionId,
+        request: { organizationId, paymentOutcome, chargeInvoice },
+      });
+
+      onResult(result);
+
+      toast({
+        variant: "success",
+        title: "Usage period closed",
+        description: chargeInvoice
+          ? `Any overage invoice was charged as ${paymentOutcome}.`
+          : "No overage invoice was charged.",
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "The usage period could not be closed.",
+      );
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Close usage period</DialogTitle>
+          <DialogDescription>
+            Sends{" "}
+            <code>
+              POST /api/subscription-simulation/subscriptions/{subscriptionId}/close-usage-period
+            </code>
+            — closes the current usage period now, prices any overage, and — unless told
+            otherwise — charges it with a scripted outcome.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="close-usage-period-charge"
+              checked={chargeInvoice}
+              onCheckedChange={(checked) => setChargeInvoice(checked === true)}
+              className="mt-0.5"
+            />
+            <Label htmlFor="close-usage-period-charge" className="font-normal">
+              Also charge the overage invoice this close produces, if any.
+            </Label>
+          </div>
+
+          {chargeInvoice && (
+            <div className="space-y-1.5">
+              <Label htmlFor="close-usage-period-outcome">Payment outcome</Label>
+              <Select
+                value={paymentOutcome}
+                onValueChange={(value) => setPaymentOutcome(value as SimulatedRenewalOutcome)}
+              >
+                <SelectTrigger id="close-usage-period-outcome">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {OUTCOMES.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Close period
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/payment-outcome-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/payment-outcome-dialog.tsx
@@ -1,0 +1,225 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { toast } from "@/hooks/use-toast";
+import { useMarkPaymentFailed } from "../hooks/use-mark-payment-failed";
+import { useMarkPaymentSucceeded } from "../hooks/use-mark-payment-succeeded";
+import type {
+  SimulatedRenewalOutcome,
+  SubscriptionPaymentPurpose,
+  SubscriptionSimulationActionResponse,
+} from "../models/subscription-simulation-harness.model";
+
+const PURPOSES: { value: SubscriptionPaymentPurpose; label: string }[] = [
+  { value: "InitialCharge", label: "Initial charge" },
+  { value: "Renewal", label: "Renewal" },
+];
+
+const OUTCOMES: { value: SimulatedRenewalOutcome; label: string }[] = [
+  { value: "Succeeded", label: "Succeeded" },
+  { value: "Declined", label: "Declined" },
+  { value: "InsufficientFunds", label: "Insufficient funds" },
+  { value: "PaymentMethodExpired", label: "Payment method expired" },
+  { value: "ProviderUnavailable", label: "Provider unavailable" },
+  { value: "OutcomeUnknown", label: "Outcome unknown" },
+];
+
+export const PaymentOutcomeDialog = ({
+  subscriptionId,
+  organizationId,
+  open,
+  onOpenChange,
+  onResult,
+}: {
+  subscriptionId: string;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onResult: (result: SubscriptionSimulationActionResponse) => void;
+}) => {
+  const succeeded = useMarkPaymentSucceeded();
+  const failed = useMarkPaymentFailed();
+  const isPending = succeeded.isPending || failed.isPending;
+
+  const [paymentPurpose, setPaymentPurpose] = useState<SubscriptionPaymentPurpose>("Renewal");
+  const [outcome, setOutcome] = useState<SimulatedRenewalOutcome>("Succeeded");
+  const [providerReference, setProviderReference] = useState("");
+  const [errorCode, setErrorCode] = useState("");
+  const [runProcessor, setRunProcessor] = useState(true);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setFormError(null);
+
+    try {
+      const result =
+        outcome === "Succeeded"
+          ? await succeeded.mutateAsync({
+              subscriptionId,
+              request: {
+                organizationId,
+                paymentPurpose,
+                providerReference: providerReference.trim() || undefined,
+                runProcessor,
+              },
+            })
+          : await failed.mutateAsync({
+              subscriptionId,
+              request: {
+                organizationId,
+                paymentPurpose,
+                failureKind: outcome,
+                errorCode: errorCode.trim() || undefined,
+                runProcessor,
+              },
+            });
+
+      onResult(result);
+
+      toast({
+        variant: outcome === "Succeeded" ? "success" : "destructive",
+        title: outcome === "Succeeded" ? "Payment marked succeeded" : "Payment marked failed",
+        description: `${paymentPurpose} settled as ${outcome}.`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "The payment outcome could not be simulated.",
+      );
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Simulate payment outcome</DialogTitle>
+          <DialogDescription>
+            Sends{" "}
+            <code>
+              POST /api/subscription-simulation/subscriptions/{subscriptionId}/mark-payment-
+              {outcome === "Succeeded" ? "succeeded" : "failed"}
+            </code>
+            — settles the subscription&apos;s outstanding charge through the same path a real
+            provider confirmation would take.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="payment-outcome-purpose">Charge</Label>
+            <Select
+              value={paymentPurpose}
+              onValueChange={(value) => setPaymentPurpose(value as SubscriptionPaymentPurpose)}
+            >
+              <SelectTrigger id="payment-outcome-purpose">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PURPOSES.map((purpose) => (
+                  <SelectItem key={purpose.value} value={purpose.value}>
+                    {purpose.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="payment-outcome-outcome">Outcome</Label>
+            <Select
+              value={outcome}
+              onValueChange={(value) => setOutcome(value as SimulatedRenewalOutcome)}
+            >
+              <SelectTrigger id="payment-outcome-outcome">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {OUTCOMES.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {outcome === "Succeeded" ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="payment-outcome-provider-reference">
+                Provider reference (optional)
+              </Label>
+              <Input
+                id="payment-outcome-provider-reference"
+                value={providerReference}
+                onChange={(event) => setProviderReference(event.target.value)}
+                placeholder="Generated when left blank"
+              />
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              <Label htmlFor="payment-outcome-error-code">Error code (optional)</Label>
+              <Input
+                id="payment-outcome-error-code"
+                value={errorCode}
+                onChange={(event) => setErrorCode(event.target.value)}
+                placeholder="Overrides the outcome's default error code"
+              />
+            </div>
+          )}
+
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="payment-outcome-run-processor"
+              checked={runProcessor}
+              onCheckedChange={(checked) => setRunProcessor(checked === true)}
+              className="mt-0.5"
+            />
+            <Label htmlFor="payment-outcome-run-processor" className="font-normal">
+              Also run the real settlement processor (activation or renewal). Leave unchecked to
+              only record the outcome and inspect the intermediate state.
+            </Label>
+          </div>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Simulate
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/run-due-jobs-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/run-due-jobs-dialog.tsx
@@ -1,0 +1,141 @@
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Label } from "@/components/ui-kits/label/label";
+import { toast } from "@/hooks/use-toast";
+import { useRunDueJobs } from "../hooks/use-run-due-jobs";
+import type {
+  SimulationWorkType,
+  SubscriptionSimulationJobRunResponse,
+} from "../models/subscription-simulation-harness.model";
+
+const WORK_TYPES: { value: SimulationWorkType; label: string }[] = [
+  { value: "Renewal", label: "Renewal" },
+  { value: "UsagePeriodClosure", label: "Usage period closure" },
+  { value: "UsageInvoiceCharge", label: "Usage invoice charge" },
+  { value: "OutboxPublication", label: "Outbox publication" },
+];
+
+export const RunDueJobsDialog = ({
+  subscriptionId,
+  organizationId,
+  open,
+  onOpenChange,
+  onResult,
+}: {
+  subscriptionId: string;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onResult: (result: SubscriptionSimulationJobRunResponse) => void;
+}) => {
+  const { mutateAsync, isPending } = useRunDueJobs();
+
+  const [selected, setSelected] = useState<Set<SimulationWorkType>>(new Set());
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const toggle = (workType: SimulationWorkType, checked: boolean) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (checked) {
+        next.add(workType);
+      } else {
+        next.delete(workType);
+      }
+      return next;
+    });
+  };
+
+  const submit = async () => {
+    setFormError(null);
+
+    try {
+      const result = await mutateAsync({
+        subscriptionId,
+        request: { organizationId, workTypes: Array.from(selected) },
+      });
+
+      onResult(result);
+
+      toast({
+        variant: "success",
+        title: "Due jobs run",
+        description: `${result.completed} completed, ${result.notDue} not due.`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "The due background work could not be run.",
+      );
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Run due jobs</DialogTitle>
+          <DialogDescription>
+            Sends{" "}
+            <code>
+              POST /api/subscription-simulation/subscriptions/{subscriptionId}/jobs/run-due
+            </code>
+            — runs whichever due background work exists for this one subscription right now.
+            Never a tenant-wide sweep, and never a scripted outcome: a renewal or a usage-invoice
+            charge run here goes to the real payment gateway.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Work types</Label>
+            {WORK_TYPES.map((workType) => (
+              <div className="flex items-center gap-2" key={workType.value}>
+                <Checkbox
+                  id={`run-due-jobs-${workType.value}`}
+                  checked={selected.has(workType.value)}
+                  onCheckedChange={(checked) => toggle(workType.value, checked === true)}
+                />
+                <Label htmlFor={`run-due-jobs-${workType.value}`} className="font-normal">
+                  {workType.label}
+                </Label>
+              </div>
+            ))}
+            <p className="text-xs text-muted-foreground">
+              Leave everything unchecked to run every work type this endpoint knows about.
+            </p>
+          </div>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Run due jobs
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/simulation-harness-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/simulation-harness-card.tsx
@@ -1,0 +1,172 @@
+import { Beaker } from "lucide-react";
+import { Badge } from "@/components/ui-kits/badge/badge";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui-kits/table/table";
+import type {
+  SubscriptionSimulationActionResponse,
+  SubscriptionSimulationJobRunResponse,
+} from "../models/subscription-simulation-harness.model";
+
+type HarnessResult = SubscriptionSimulationActionResponse | SubscriptionSimulationJobRunResponse;
+
+const isJobRun = (result: HarnessResult): result is SubscriptionSimulationJobRunResponse =>
+  "jobs" in result;
+
+const formatDate = (isoDate: string | null) =>
+  isoDate ? new Date(isoDate).toLocaleString() : "—";
+
+/**
+ * Test-harness actions, kept in their own card rather than folded into
+ * `CurrentSubscriptionCard`'s button row: these hit a different, console-only controller
+ * (`/api/subscription-simulation/...`) that forces payment outcomes and background work
+ * directly, rather than the integrator-facing API the rest of this screen exercises.
+ */
+export const SimulationHarnessCard = ({
+  onSimulatePaymentOutcome,
+  onAdvanceRenewal,
+  onCloseUsagePeriod,
+  onRunDueJobs,
+  lastResult,
+}: {
+  onSimulatePaymentOutcome: () => void;
+  onAdvanceRenewal: () => void;
+  onCloseUsagePeriod: () => void;
+  onRunDueJobs: () => void;
+  lastResult: HarnessResult | null;
+}) => (
+  <Card className="rounded-xl p-4">
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <div className="flex items-center gap-2">
+          <Beaker className="h-4 w-4 text-muted-foreground" />
+          <h3 className="font-semibold">Simulation harness</h3>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Forces payment outcomes and background work directly, for scenarios the plan catalogue
+          and actions above cannot reach on their own — console-only, and unavailable unless the
+          server has the harness enabled.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button size="sm" variant="outline" onClick={onSimulatePaymentOutcome}>
+          Simulate payment outcome
+        </Button>
+        <Button size="sm" variant="outline" onClick={onAdvanceRenewal}>
+          Advance renewal
+        </Button>
+        <Button size="sm" variant="outline" onClick={onCloseUsagePeriod}>
+          Close usage period
+        </Button>
+        <Button size="sm" variant="outline" onClick={onRunDueJobs}>
+          Run due jobs
+        </Button>
+      </div>
+    </div>
+
+    {lastResult && (
+      <div className="mt-4 space-y-3 border-t pt-3">
+        {isJobRun(lastResult) ? (
+          <>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>Run {lastResult.simulationRunId}</span>
+              <Badge variant="info" className="font-normal">
+                {lastResult.claimed} claimed
+              </Badge>
+              <Badge variant="success" className="font-normal">
+                {lastResult.completed} completed
+              </Badge>
+              <Badge variant="secondary" className="font-normal">
+                {lastResult.notDue} not due
+              </Badge>
+            </div>
+            {lastResult.jobs.length > 0 && (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Work type</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Detail</TableHead>
+                    <TableHead>Duration</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {lastResult.jobs.map((job) => (
+                    <TableRow key={job.workType}>
+                      <TableCell className="text-xs">{job.workType}</TableCell>
+                      <TableCell className="text-xs">{job.status}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {job.detail ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-xs">{job.durationMs} ms</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span>{lastResult.action}</span>
+              <span>Run {lastResult.simulationRunId}</span>
+              <span>{formatDate(lastResult.completedAtUtc)}</span>
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead />
+                  <TableHead>Before</TableHead>
+                  <TableHead>After</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell className="text-xs font-medium">Status</TableCell>
+                  <TableCell className="text-xs">{lastResult.before.subscriptionStatus}</TableCell>
+                  <TableCell className="text-xs">{lastResult.after.subscriptionStatus}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="text-xs font-medium">Current period ends</TableCell>
+                  <TableCell className="text-xs">
+                    {formatDate(lastResult.before.currentPeriodEndUtc)}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {formatDate(lastResult.after.currentPeriodEndUtc)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="text-xs font-medium">Next fee billing</TableCell>
+                  <TableCell className="text-xs">
+                    {formatDate(lastResult.before.nextFeeBillingAtUtc)}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {formatDate(lastResult.after.nextFeeBillingAtUtc)}
+                  </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="text-xs font-medium">Dunning attempts</TableCell>
+                  <TableCell className="text-xs">{lastResult.before.dunningAttemptCount}</TableCell>
+                  <TableCell className="text-xs">{lastResult.after.dunningAttemptCount}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell className="text-xs font-medium">Version</TableCell>
+                  <TableCell className="text-xs">{lastResult.before.version}</TableCell>
+                  <TableCell className="text-xs">{lastResult.after.version}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </div>
+    )}
+  </Card>
+);

--- a/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
@@ -3,6 +3,14 @@ export const SUBSCRIPTIONS_CURRENT_ENDPOINT = "/api/subscriptions/current";
 export const ENTITLEMENTS_ENDPOINT = "/api/entitlements";
 export const SUBSCRIPTION_USAGE_ENDPOINT = "/api/subscription-usage";
 
+/**
+ * The test-harness controller, distinct from the integrator-facing API above: it forces payment
+ * outcomes, renewals and background work directly rather than exercising the client-facing
+ * surface an integration would call. Console-only and unavailable unless the server has both
+ * `SubscriptionSimulation:Enabled` and (for the data console) `:DataConsoleEnabled` turned on.
+ */
+export const SIMULATION_HARNESS_ENDPOINT = "/api/subscription-simulation";
+
 export const AUDIT_TRAIL_DEFAULT_LIMIT = 100;
 /** The server clamps anything above this back down rather than rejecting it. */
 export const AUDIT_TRAIL_MAX_LIMIT = 500;

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-advance-renewal.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-advance-renewal.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { AdvanceRenewalRequest } from "../models/subscription-simulation-harness.model";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+export const useAdvanceRenewal = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: AdvanceRenewalRequest;
+    }) => subscriptionSimulationHarnessService.advanceRenewal(subscriptionId, request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-close-usage-period.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-close-usage-period.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { CloseUsagePeriodRequest } from "../models/subscription-simulation-harness.model";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+export const useCloseUsagePeriod = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: CloseUsagePeriodRequest;
+    }) => subscriptionSimulationHarnessService.closeUsagePeriod(subscriptionId, request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-mark-payment-failed.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-mark-payment-failed.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { MarkPaymentFailedRequest } from "../models/subscription-simulation-harness.model";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+export const useMarkPaymentFailed = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: MarkPaymentFailedRequest;
+    }) => subscriptionSimulationHarnessService.markPaymentFailed(subscriptionId, request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-mark-payment-succeeded.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-mark-payment-succeeded.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { MarkPaymentSucceededRequest } from "../models/subscription-simulation-harness.model";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+export const useMarkPaymentSucceeded = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: MarkPaymentSucceededRequest;
+    }) => subscriptionSimulationHarnessService.markPaymentSucceeded(subscriptionId, request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-run-due-jobs.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-run-due-jobs.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { RunDueJobsRequest } from "../models/subscription-simulation-harness.model";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+export const useRunDueJobs = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: RunDueJobsRequest;
+    }) => subscriptionSimulationHarnessService.runDueJobs(subscriptionId, request),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation-harness.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation-harness.model.ts
@@ -1,0 +1,99 @@
+/**
+ * Types for the test-harness controller (`/api/subscription-simulation/...`) — distinct from
+ * `subscription-simulation.model.ts`, which mirrors the integrator-facing API a real application
+ * would call. Naming mirrors the server's C# types exactly so the two stay easy to cross-reference.
+ */
+
+export type SubscriptionPaymentPurpose = "InitialCharge" | "Renewal";
+
+export type SimulatedPaymentFailureKind =
+  | "Declined"
+  | "InsufficientFunds"
+  | "PaymentMethodExpired"
+  | "ProviderUnavailable"
+  | "OutcomeUnknown";
+
+/** `Succeeded` plus every `SimulatedPaymentFailureKind` value — the outcome vocabulary a renewal or a usage charge scripts. */
+export type SimulatedRenewalOutcome = "Succeeded" | SimulatedPaymentFailureKind;
+
+export type SimulationWorkType =
+  | "Renewal"
+  | "UsagePeriodClosure"
+  | "UsageInvoiceCharge"
+  | "OutboxPublication";
+
+export interface MarkPaymentSucceededRequest {
+  organizationId?: string;
+  paymentPurpose: SubscriptionPaymentPurpose;
+  providerReference?: string;
+  /** Defaults to true server-side when omitted. */
+  runProcessor?: boolean;
+}
+
+export interface MarkPaymentFailedRequest {
+  organizationId?: string;
+  paymentPurpose: SubscriptionPaymentPurpose;
+  failureKind: SimulatedPaymentFailureKind;
+  errorCode?: string;
+  runProcessor?: boolean;
+}
+
+export interface AdvanceRenewalRequest {
+  organizationId?: string;
+  paymentOutcome: SimulatedRenewalOutcome;
+}
+
+export interface CloseUsagePeriodRequest {
+  organizationId?: string;
+  paymentOutcome?: SimulatedRenewalOutcome;
+  chargeInvoice?: boolean;
+}
+
+export interface RunDueJobsRequest {
+  organizationId?: string;
+  /** Empty means every work type the endpoint knows about. */
+  workTypes?: SimulationWorkType[];
+}
+
+/** The handful of fields worth comparing before and after an action, without repeating the entire state twice. */
+export interface SubscriptionSimulationSummary {
+  subscriptionStatus: string;
+  currentPeriodEndUtc: string | null;
+  nextFeeBillingAtUtc: string | null;
+  dunningAttemptCount: number;
+  lastRenewalPaymentDetailId: string | null;
+  version: number;
+}
+
+/** What a simulation mutation did, alongside a before/after comparison. */
+export interface SubscriptionSimulationActionResponse {
+  simulationRunId: string;
+  /** E.g. `MarkPaymentSucceeded`, `MarkPaymentFailed`. */
+  action: string;
+  startedAtUtc: string;
+  completedAtUtc: string;
+  before: SubscriptionSimulationSummary;
+  after: SubscriptionSimulationSummary;
+  correlationId: string;
+}
+
+export interface SubscriptionSimulationJobResultResponse {
+  workType: SimulationWorkType;
+  /** `Completed`, `NotDue` or `NotApplicable` (the subscription's own state rules it out entirely). */
+  status: string;
+  detail: string | null;
+  durationMs: number;
+}
+
+/** What running due background work for one subscription actually did. */
+export interface SubscriptionSimulationJobRunResponse {
+  simulationRunId: string;
+  startedAtUtc: string;
+  completedAtUtc: string;
+  claimed: number;
+  completed: number;
+  /** Work types that were asked for but were not actually due — not a failure. */
+  notDue: number;
+  jobs: SubscriptionSimulationJobResultResponse[];
+  correlationId: string;
+}

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -22,16 +22,25 @@ import {
 import { SubscriptionPlanPageHeader } from "../../subscription/components/subscription-plan-page-header";
 import { useSubscriptionPlans } from "../../subscription/hooks/use-subscription-plans";
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import { AdvanceRenewalDialog } from "../components/advance-renewal-dialog";
 import { AuditTrailDialog } from "../components/audit-trail-dialog";
 import { CancelSubscriptionDialog } from "../components/cancel-subscription-dialog";
 import { ChangePlanDialog } from "../components/change-plan-dialog";
 import { ChangeQuantityDialog } from "../components/change-quantity-dialog";
+import { CloseUsagePeriodDialog } from "../components/close-usage-period-dialog";
 import { useCancelPendingQuantityChange } from "../hooks/use-quantity-change";
 import { CurrentSubscriptionCard } from "../components/current-subscription-card";
+import { PaymentOutcomeDialog } from "../components/payment-outcome-dialog";
+import { RunDueJobsDialog } from "../components/run-due-jobs-dialog";
 import { SimulatedPlanCard } from "../components/simulated-plan-card";
+import { SimulationHarnessCard } from "../components/simulation-harness-card";
 import { SubscribeDialog } from "../components/subscribe-dialog";
 import { UsageSection } from "../components/usage-section";
 import { useCurrentSimulatedSubscription } from "../hooks/use-current-simulated-subscription";
+import type {
+  SubscriptionSimulationActionResponse,
+  SubscriptionSimulationJobRunResponse,
+} from "../models/subscription-simulation-harness.model";
 
 // Reserves the organization's one open signup or live subscription slot — includes Incomplete.
 const GRANTING_STATUSES = new Set(["Incomplete", "Trialing", "Active", "PastDue"]);
@@ -46,6 +55,13 @@ export const SubscriptionSimulationPage = () => {
   const [isChangingPlan, setIsChangingPlan] = useState(false);
   const [isChangingQuantity, setIsChangingQuantity] = useState(false);
   const [isViewingAuditTrail, setIsViewingAuditTrail] = useState(false);
+  const [isSimulatingPaymentOutcome, setIsSimulatingPaymentOutcome] = useState(false);
+  const [isAdvancingRenewal, setIsAdvancingRenewal] = useState(false);
+  const [isClosingUsagePeriod, setIsClosingUsagePeriod] = useState(false);
+  const [isRunningDueJobs, setIsRunningDueJobs] = useState(false);
+  const [harnessResult, setHarnessResult] = useState<
+    SubscriptionSimulationActionResponse | SubscriptionSimulationJobRunResponse | null
+  >(null);
 
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData } = useGetOrganizations({
@@ -263,6 +279,16 @@ export const SubscriptionSimulationPage = () => {
         <UsageSection plan={currentPlan} organizationId={organizationScope} />
       )}
 
+      {currentSubscription && (
+        <SimulationHarnessCard
+          onSimulatePaymentOutcome={() => setIsSimulatingPaymentOutcome(true)}
+          onAdvanceRenewal={() => setIsAdvancingRenewal(true)}
+          onCloseUsagePeriod={() => setIsClosingUsagePeriod(true)}
+          onRunDueJobs={() => setIsRunningDueJobs(true)}
+          lastResult={harnessResult}
+        />
+      )}
+
       {subscribingTo && (
         <SubscribeDialog
           plan={subscribingTo}
@@ -322,6 +348,46 @@ export const SubscriptionSimulationPage = () => {
           organizationId={organizationScope}
           open={isViewingAuditTrail}
           onOpenChange={setIsViewingAuditTrail}
+        />
+      )}
+
+      {isSimulatingPaymentOutcome && currentSubscription && (
+        <PaymentOutcomeDialog
+          subscriptionId={currentSubscription.subscriptionId}
+          organizationId={organizationScope}
+          open={isSimulatingPaymentOutcome}
+          onOpenChange={setIsSimulatingPaymentOutcome}
+          onResult={setHarnessResult}
+        />
+      )}
+
+      {isAdvancingRenewal && currentSubscription && (
+        <AdvanceRenewalDialog
+          subscriptionId={currentSubscription.subscriptionId}
+          organizationId={organizationScope}
+          open={isAdvancingRenewal}
+          onOpenChange={setIsAdvancingRenewal}
+          onResult={setHarnessResult}
+        />
+      )}
+
+      {isClosingUsagePeriod && currentSubscription && (
+        <CloseUsagePeriodDialog
+          subscriptionId={currentSubscription.subscriptionId}
+          organizationId={organizationScope}
+          open={isClosingUsagePeriod}
+          onOpenChange={setIsClosingUsagePeriod}
+          onResult={setHarnessResult}
+        />
+      )}
+
+      {isRunningDueJobs && currentSubscription && (
+        <RunDueJobsDialog
+          subscriptionId={currentSubscription.subscriptionId}
+          organizationId={organizationScope}
+          open={isRunningDueJobs}
+          onOpenChange={setIsRunningDueJobs}
+          onResult={setHarnessResult}
         />
       )}
     </main>

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation-harness.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation-harness.service.ts
@@ -1,0 +1,192 @@
+import { HttpError } from "@seliseblocks/genesis-os/lib";
+import { serviceInstances } from "@/lib/http-client";
+import { SIMULATION_HARNESS_ENDPOINT } from "../constants/subscription-simulation.constants";
+import type {
+  AdvanceRenewalRequest,
+  CloseUsagePeriodRequest,
+  MarkPaymentFailedRequest,
+  MarkPaymentSucceededRequest,
+  RunDueJobsRequest,
+  SubscriptionSimulationActionResponse,
+  SubscriptionSimulationJobRunResponse,
+} from "../models/subscription-simulation-harness.model";
+
+interface HarnessApiError {
+  code: string;
+  message: string;
+  fields?: Record<string, string[]> | null;
+}
+
+interface HarnessApiResponse<T> {
+  success: boolean;
+  data: T | null;
+  error: HarnessApiError | null;
+}
+
+/**
+ * A failed harness call, with the server's own error code kept — in particular
+ * `subscription_simulation_forbidden`, which the controller reports as a real 403 distinct from
+ * every other outcome (which otherwise reads like the subscription itself was not found).
+ */
+export class SubscriptionSimulationHarnessError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = "SubscriptionSimulationHarnessError";
+  }
+}
+
+/**
+ * Known error codes, searched for in the thrown error the same way the integrator-facing
+ * service's `quantityErrorCode` does — the envelope lands in different shapes depending on the
+ * HTTP status, so a code read from one fixed path is silently "unknown" for the others.
+ */
+const HARNESS_ERROR_CODES = [
+  "subscription_simulation_disabled",
+  "subscription_simulation_data_console_disabled",
+  "subscription_simulation_forbidden",
+  "subscription_simulation_not_found",
+  "subscription_simulation_organization_required",
+  "subscription_simulation_scheduling_not_supported",
+  "subscription_simulation_periods_not_supported",
+] as const;
+
+const serialize = (error: unknown): string => {
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error, [
+      "message",
+      "code",
+      "error",
+      "errors",
+      "data",
+      "detail",
+      "title",
+    ] as never);
+  } catch {
+    return String(error);
+  }
+};
+
+const harnessErrorCode = (error: unknown): string => {
+  const haystack = `${serialize(error)} ${error instanceof Error ? error.message : ""}`;
+
+  return HARNESS_ERROR_CODES.find((code) => haystack.includes(code)) ?? "unknown";
+};
+
+const messageFrom = (error: unknown, fallback: string): string => {
+  if (error instanceof HttpError) {
+    const values = Object.values(error.errors ?? {}).flat();
+    const first = values.find((value) => typeof value === "string" && value.trim().length > 0);
+
+    if (first) {
+      return first;
+    }
+  }
+
+  return error instanceof Error && error.message ? error.message : fallback;
+};
+
+class SubscriptionSimulationHarnessService {
+  async markPaymentSucceeded(
+    subscriptionId: string,
+    request: MarkPaymentSucceededRequest,
+  ): Promise<SubscriptionSimulationActionResponse> {
+    return this.post(
+      `${this.subscriptionPath(subscriptionId)}/mark-payment-succeeded`,
+      request,
+      "The payment outcome could not be simulated.",
+    );
+  }
+
+  async markPaymentFailed(
+    subscriptionId: string,
+    request: MarkPaymentFailedRequest,
+  ): Promise<SubscriptionSimulationActionResponse> {
+    return this.post(
+      `${this.subscriptionPath(subscriptionId)}/mark-payment-failed`,
+      request,
+      "The payment outcome could not be simulated.",
+    );
+  }
+
+  async advanceRenewal(
+    subscriptionId: string,
+    request: AdvanceRenewalRequest,
+  ): Promise<SubscriptionSimulationActionResponse> {
+    return this.post(
+      `${this.subscriptionPath(subscriptionId)}/advance-renewal`,
+      request,
+      "The renewal could not be advanced.",
+    );
+  }
+
+  async closeUsagePeriod(
+    subscriptionId: string,
+    request: CloseUsagePeriodRequest,
+  ): Promise<SubscriptionSimulationActionResponse> {
+    return this.post(
+      `${this.subscriptionPath(subscriptionId)}/close-usage-period`,
+      request,
+      "The usage period could not be closed.",
+    );
+  }
+
+  async runDueJobs(
+    subscriptionId: string,
+    request: RunDueJobsRequest,
+  ): Promise<SubscriptionSimulationJobRunResponse> {
+    return this.post(
+      `${this.subscriptionPath(subscriptionId)}/jobs/run-due`,
+      request,
+      "The due background work could not be run.",
+    );
+  }
+
+  private subscriptionPath(subscriptionId: string): string {
+    return `${SIMULATION_HARNESS_ENDPOINT}/subscriptions/${encodeURIComponent(subscriptionId)}`;
+  }
+
+  private async post<TResponse, TRequest>(
+    path: string,
+    request: TRequest,
+    fallbackMessage: string,
+  ): Promise<TResponse> {
+    try {
+      const response = await serviceInstances.utitlitiesService.post<
+        HarnessApiResponse<TResponse>
+      >(path, request);
+
+      if (!response.success || !response.data) {
+        throw new SubscriptionSimulationHarnessError(
+          response.error?.message || fallbackMessage,
+          response.error?.code ?? "unknown",
+        );
+      }
+
+      return response.data;
+    } catch (error) {
+      if (error instanceof SubscriptionSimulationHarnessError) {
+        throw error;
+      }
+
+      if (error instanceof HttpError) {
+        throw new SubscriptionSimulationHarnessError(
+          messageFrom(error, fallbackMessage),
+          harnessErrorCode(error),
+          error.status,
+        );
+      }
+
+      throw error;
+    }
+  }
+}
+
+export const subscriptionSimulationHarnessService = new SubscriptionSimulationHarnessService();


### PR DESCRIPTION
## Summary

Client UI for the mutating actions on the server-side subscription
simulation harness (`/api/subscription-simulation/...`), delivered
server-side in PR2-PR5 (#279, #280, #288, #289) but never given a client
surface until now.

- **Simulate payment outcome** — one dialog handles both
  mark-payment-succeeded and mark-payment-failed: choosing "Succeeded"
  calls the former, any other outcome calls the latter with that value as
  the failure kind.
- **Advance renewal** — scripted outcome, forces the current fee period's
  renewal without waiting for its due date.
- **Close usage period** — closes the current usage period now, optionally
  charging any resulting overage invoice with a scripted outcome.
- **Run due jobs** — runs whichever due background work exists for one
  subscription, with per-work-type checkboxes (none checked = everything).

## Design

- **Kept separate from the existing simulation module's service/model
  files.** `subscription-simulation.service.ts` calls the
  integrator-facing API (`/api/subscriptions`, `/api/entitlements`,
  `/api/subscription-usage`) — a real application's own surface. The
  harness controller is a different, console-only backend for forcing
  outcomes directly. Conflating the two into one file would make it
  unclear which surface a given call hits, so this PR adds
  `subscription-simulation-harness.model.ts` /
  `.service.ts` / one hook per action instead.
- **New "Simulation harness" card**, shown alongside — not folded into —
  the existing current-subscription action row, for the same
  two-surfaces reason, plus that row was already carrying six conditional
  buttons.
- **Matches this module's existing dialog conventions exactly**: plain
  `useState` + inline `formError` (no react-hook-form/zod, consistent
  with every other dialog here), `Loader2` spinner on submit, toast on
  success, a `<code>` snippet in the dialog description naming the exact
  request it sends.
- Every mutation invalidates the same `["subscription-simulation-current"]`
  query key the existing actions do, so the current-subscription panel
  reflects what the harness action actually did.
- A "last result" panel on the new card shows the before/after summary
  (for the four action endpoints) or the per-work-type job results table
  (for run-due-jobs), taken straight from what each response already
  returns.
- `subscription_simulation_forbidden` is recognized as a distinct error
  code (`SubscriptionSimulationHarnessError`), the same way the existing
  service already special-cases quantity-change error codes — the
  controller reports it as a real 403, and treating it like every other
  failure would read as "not found" instead of "not allowed."

## Deliberately not built

The data console (PR6/#290's raw `find`/`update` endpoints) has no UI in
this PR. It's a materially different, higher-risk "arbitrary Mongo field
editor" surface rather than a scripted action — building it speculatively
felt like the wrong default. Happy to build it as a follow-up if wanted.

## Test plan

- [x] `npx tsc -b --noEmit`: 0 errors
- [x] `npx eslint` on every new/changed file: 0 errors, 0 warnings
- [ ] Not click-tested against a live backend in this environment (no
      running API/Mongo here) — needs a manual pass through each dialog
      before this is considered done end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)