### PR TITLE
feat(subscription): add client UI for the simulation data console (PR6)

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/data-console-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/data-console-dialog.tsx
@@ -1,0 +1,347 @@
+import { AlertCircle, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui-kits/badge/badge";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui-kits/tabs/tabs";
+import { toast } from "@/hooks/use-toast";
+import { useDataConsolePolicy } from "../hooks/use-data-console-policy";
+import { useFindData } from "../hooks/use-find-data";
+import { useUpdateDataFields } from "../hooks/use-update-data-fields";
+import type {
+  SubscriptionSimulationDataMutationResponse,
+  SubscriptionSimulationDataQueryResponse,
+} from "../models/subscription-simulation-harness.model";
+
+const prettyPrint = (json: string): string => {
+  try {
+    return JSON.stringify(JSON.parse(json), null, 2);
+  } catch {
+    return json;
+  }
+};
+
+const FindTab = ({
+  subscriptionId,
+  organizationId,
+  readableCollections,
+}: {
+  subscriptionId: string;
+  organizationId: string | undefined;
+  readableCollections: string[];
+}) => {
+  const { mutateAsync, isPending } = useFindData();
+
+  const [collection, setCollection] = useState(readableCollections[0] ?? "");
+  const [limit, setLimit] = useState("20");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [result, setResult] = useState<SubscriptionSimulationDataQueryResponse | null>(null);
+
+  const submit = async () => {
+    setFormError(null);
+
+    const parsedLimit = Number(limit);
+    if (!collection) {
+      setFormError("Choose a collection.");
+      return;
+    }
+    if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > 100) {
+      setFormError("Limit must be a whole number between 1 and 100.");
+      return;
+    }
+
+    try {
+      const response = await mutateAsync({
+        subscriptionId,
+        logicalCollection: collection,
+        request: { organizationId, subscriptionId, limit: parsedLimit },
+      });
+
+      setResult(response);
+    } catch (error) {
+      setResult(null);
+      setFormError(error instanceof Error ? error.message : "The data could not be read.");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="min-w-48 flex-1 space-y-1.5">
+          <Label htmlFor="data-console-find-collection">Collection</Label>
+          <Select value={collection} onValueChange={setCollection}>
+            <SelectTrigger id="data-console-find-collection">
+              <SelectValue placeholder="Choose a collection" />
+            </SelectTrigger>
+            <SelectContent>
+              {readableCollections.map((name) => (
+                <SelectItem key={name} value={name}>
+                  {name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="w-28 space-y-1.5">
+          <Label htmlFor="data-console-find-limit">Limit</Label>
+          <Input
+            id="data-console-find-limit"
+            type="number"
+            min={1}
+            max={100}
+            value={limit}
+            onChange={(event) => setLimit(event.target.value)}
+          />
+        </div>
+
+        <Button onClick={submit} disabled={isPending || !collection}>
+          {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Find
+        </Button>
+      </div>
+
+      {formError && <p className="text-sm text-destructive">{formError}</p>}
+
+      {result && (
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground">
+            {result.count} document{result.count === 1 ? "" : "s"} from {result.collection}.
+          </p>
+          {result.documents.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              No matching documents.
+            </p>
+          ) : (
+            <div className="max-h-96 space-y-2 overflow-y-auto">
+              {result.documents.map((document, index) => (
+                // eslint-disable-next-line react/no-array-index-key -- documents carry no stable id of their own once redacted
+                <pre key={index} className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+                  {prettyPrint(document)}
+                </pre>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const UpdateTab = ({
+  subscriptionId,
+  organizationId,
+  updatableCollections,
+}: {
+  subscriptionId: string;
+  organizationId: string | undefined;
+  updatableCollections: { logicalName: string; updatableFields: string[] }[];
+}) => {
+  const { mutateAsync, isPending } = useUpdateDataFields();
+
+  const [collectionName, setCollectionName] = useState(updatableCollections[0]?.logicalName ?? "");
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [formError, setFormError] = useState<string | null>(null);
+  const [result, setResult] = useState<SubscriptionSimulationDataMutationResponse | null>(null);
+
+  const collection = updatableCollections.find((entry) => entry.logicalName === collectionName);
+
+  const selectCollection = (name: string) => {
+    setCollectionName(name);
+    setValues({});
+    setFormError(null);
+    setResult(null);
+  };
+
+  const submit = async () => {
+    setFormError(null);
+
+    const fields = Object.fromEntries(
+      Object.entries(values).filter(([, value]) => value.trim().length > 0),
+    );
+
+    if (!collection) {
+      setFormError("Choose a collection.");
+      return;
+    }
+    if (Object.keys(fields).length === 0) {
+      setFormError("Set at least one field.");
+      return;
+    }
+
+    try {
+      const response = await mutateAsync({
+        subscriptionId,
+        logicalCollection: collection.logicalName,
+        request: { organizationId, subscriptionId, fields },
+      });
+
+      setResult(response);
+
+      toast({
+        variant: "success",
+        title: response.modified ? "Field updated" : "Nothing matched",
+        description: response.modified
+          ? `Set ${response.fieldsSet.join(", ")} on ${response.collection}.`
+          : "No document matched this subscription in that collection.",
+      });
+    } catch (error) {
+      setResult(null);
+      setFormError(error instanceof Error ? error.message : "The field could not be updated.");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="data-console-update-collection">Collection</Label>
+        <Select value={collectionName} onValueChange={selectCollection}>
+          <SelectTrigger id="data-console-update-collection">
+            <SelectValue placeholder="Choose a collection" />
+          </SelectTrigger>
+          <SelectContent>
+            {updatableCollections.map((entry) => (
+              <SelectItem key={entry.logicalName} value={entry.logicalName}>
+                {entry.logicalName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {collection && (
+        <div className="space-y-3">
+          {collection.updatableFields.map((field) => (
+            <div className="space-y-1.5" key={field}>
+              <Label htmlFor={`data-console-field-${field}`}>{field}</Label>
+              <Input
+                id={`data-console-field-${field}`}
+                value={values[field] ?? ""}
+                onChange={(event) =>
+                  setValues((current) => ({ ...current, [field]: event.target.value }))
+                }
+                placeholder="ISO 8601 UTC, e.g. 2026-01-01T00:00:00Z"
+              />
+            </div>
+          ))}
+          <p className="text-xs text-muted-foreground">
+            Leave a field blank to leave it unchanged. Every value here is parsed as a UTC
+            timestamp — it is the only type any updatable field on this collection holds.
+          </p>
+        </div>
+      )}
+
+      {formError && <p className="text-sm text-destructive">{formError}</p>}
+
+      {result && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border p-2.5 text-xs">
+          <Badge variant={result.modified ? "success" : "secondary"} className="font-normal">
+            {result.modified ? "Modified" : "No match"}
+          </Badge>
+          <span className="text-muted-foreground">
+            {result.collection}
+            {result.fieldsSet.length > 0 ? ` · ${result.fieldsSet.join(", ")}` : ""}
+          </span>
+        </div>
+      )}
+
+      <Button onClick={submit} disabled={isPending || !collection}>
+        {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+        Update
+      </Button>
+    </div>
+  );
+};
+
+export const DataConsoleDialog = ({
+  subscriptionId,
+  organizationId,
+  open,
+  onOpenChange,
+}: {
+  subscriptionId: string;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { data: policy, error, isError, isLoading } = useDataConsolePolicy(open);
+
+  const readableCollections = (policy ?? [])
+    .filter((entry) => entry.canRead)
+    .map((entry) => entry.logicalName);
+  const updatableCollections = (policy ?? [])
+    .filter((entry) => entry.updatableFields.length > 0)
+    .map((entry) => ({ logicalName: entry.logicalName, updatableFields: entry.updatableFields }));
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] w-[95vw] max-w-3xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Data console</DialogTitle>
+          <DialogDescription>
+            A narrow, allowlisted read/update surface over Mongo for whatever the actions above
+            cannot reach. Never a raw query — every call is scoped server-side to one collection
+            from the allowlist, one tenant, one organization and this one subscription, and every
+            write is restricted to a small set of UTC-timestamp fields.
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-24 w-full rounded-md" />
+          </div>
+        ) : isError ? (
+          <div className="flex flex-col items-start gap-2">
+            <div className="flex items-center gap-2 text-destructive">
+              <AlertCircle className="h-4 w-4" />
+              <span className="font-medium">The data console policy could not be loaded</span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {error instanceof Error
+                ? error.message
+                : "The data console may not be enabled in this environment."}
+            </p>
+          </div>
+        ) : (
+          <Tabs defaultValue="find">
+            <TabsList>
+              <TabsTrigger value="find">Find</TabsTrigger>
+              <TabsTrigger value="update">Update</TabsTrigger>
+            </TabsList>
+            <TabsContent value="find" className="pt-4">
+              <FindTab
+                subscriptionId={subscriptionId}
+                organizationId={organizationId}
+                readableCollections={readableCollections}
+              />
+            </TabsContent>
+            <TabsContent value="update" className="pt-4">
+              <UpdateTab
+                subscriptionId={subscriptionId}
+                organizationId={organizationId}
+                updatableCollections={updatableCollections}
+              />
+            </TabsContent>
+          </Tabs>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/simulation-harness-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/simulation-harness-card.tsx
@@ -34,12 +34,14 @@ export const SimulationHarnessCard = ({
   onAdvanceRenewal,
   onCloseUsagePeriod,
   onRunDueJobs,
+  onOpenDataConsole,
   lastResult,
 }: {
   onSimulatePaymentOutcome: () => void;
   onAdvanceRenewal: () => void;
   onCloseUsagePeriod: () => void;
   onRunDueJobs: () => void;
+  onOpenDataConsole: () => void;
   lastResult: HarnessResult | null;
 }) => (
   <Card className="rounded-xl p-4">
@@ -68,6 +70,9 @@ export const SimulationHarnessCard = ({
         </Button>
         <Button size="sm" variant="outline" onClick={onRunDueJobs}>
           Run due jobs
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onOpenDataConsole}>
+          Data console
         </Button>
       </div>
     </div>

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-data-console-policy.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-data-console-policy.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+/** Fetched only while the data console dialog is open — there's no reason to hold it otherwise. */
+export const useDataConsolePolicy = (enabled: boolean) =>
+  useQuery({
+    queryKey: ["subscription-simulation-data-console-policy"],
+    queryFn: () => subscriptionSimulationHarnessService.getDataPolicy(),
+    enabled,
+    staleTime: 60_000,
+  });

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-find-data.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-find-data.ts
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
+import type { FindDataRequest } from "../models/subscription-simulation-harness.model";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+export const useFindData = () =>
+  useMutation({
+    mutationFn: ({
+      subscriptionId,
+      logicalCollection,
+      request,
+    }: {
+      subscriptionId: string;
+      logicalCollection: string;
+      request: FindDataRequest;
+    }) => subscriptionSimulationHarnessService.findData(subscriptionId, logicalCollection, request),
+  });

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-update-data-fields.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-update-data-fields.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { UpdateDataFieldRequest } from "../models/subscription-simulation-harness.model";
+import { subscriptionSimulationHarnessService } from "../services/subscription-simulation-harness.service";
+
+export const useUpdateDataFields = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      logicalCollection,
+      request,
+    }: {
+      subscriptionId: string;
+      logicalCollection: string;
+      request: UpdateDataFieldRequest;
+    }) =>
+      subscriptionSimulationHarnessService.updateData(subscriptionId, logicalCollection, request),
+    // A field write can touch the same document the integrator-facing read shows (e.g.
+    // NextFeeBillingAtUtc on `subscriptions`), so the current-subscription panel should not go
+    // stale after one.
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation-harness.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation-harness.model.ts
@@ -97,3 +97,45 @@ export interface SubscriptionSimulationJobRunResponse {
   jobs: SubscriptionSimulationJobResultResponse[];
   correlationId: string;
 }
+
+/**
+ * The data console — a narrow, allowlisted read/update surface over Mongo for whatever the
+ * scripted actions above cannot reach. Never a raw query: every call below is scoped server-side
+ * to one collection from this allowlist, one tenant, one organization and one subscription.
+ */
+export interface SubscriptionSimulationDataPolicyResponse {
+  logicalName: string;
+  canRead: boolean;
+  /** Always false in this version — see the server's policy remarks for why. */
+  canInsert: boolean;
+  /** Field names `update` may set on this collection — always parsed as UTC timestamps. */
+  updatableFields: string[];
+}
+
+export interface FindDataRequest {
+  organizationId?: string;
+  subscriptionId: string;
+  limit?: number;
+}
+
+export interface UpdateDataFieldRequest {
+  organizationId?: string;
+  subscriptionId: string;
+  /** Field name to an ISO 8601 UTC timestamp string. */
+  fields: Record<string, string>;
+}
+
+export interface SubscriptionSimulationDataQueryResponse {
+  collection: string;
+  count: number;
+  /** Each document as a JSON string, already redacted the same way the state endpoint is. */
+  documents: string[];
+  correlationId: string;
+}
+
+export interface SubscriptionSimulationDataMutationResponse {
+  collection: string;
+  modified: boolean;
+  fieldsSet: string[];
+  correlationId: string;
+}

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -28,6 +28,7 @@ import { CancelSubscriptionDialog } from "../components/cancel-subscription-dial
 import { ChangePlanDialog } from "../components/change-plan-dialog";
 import { ChangeQuantityDialog } from "../components/change-quantity-dialog";
 import { CloseUsagePeriodDialog } from "../components/close-usage-period-dialog";
+import { DataConsoleDialog } from "../components/data-console-dialog";
 import { useCancelPendingQuantityChange } from "../hooks/use-quantity-change";
 import { CurrentSubscriptionCard } from "../components/current-subscription-card";
 import { PaymentOutcomeDialog } from "../components/payment-outcome-dialog";
@@ -59,6 +60,7 @@ export const SubscriptionSimulationPage = () => {
   const [isAdvancingRenewal, setIsAdvancingRenewal] = useState(false);
   const [isClosingUsagePeriod, setIsClosingUsagePeriod] = useState(false);
   const [isRunningDueJobs, setIsRunningDueJobs] = useState(false);
+  const [isDataConsoleOpen, setIsDataConsoleOpen] = useState(false);
   const [harnessResult, setHarnessResult] = useState<
     SubscriptionSimulationActionResponse | SubscriptionSimulationJobRunResponse | null
   >(null);
@@ -285,6 +287,7 @@ export const SubscriptionSimulationPage = () => {
           onAdvanceRenewal={() => setIsAdvancingRenewal(true)}
           onCloseUsagePeriod={() => setIsClosingUsagePeriod(true)}
           onRunDueJobs={() => setIsRunningDueJobs(true)}
+          onOpenDataConsole={() => setIsDataConsoleOpen(true)}
           lastResult={harnessResult}
         />
       )}
@@ -388,6 +391,15 @@ export const SubscriptionSimulationPage = () => {
           open={isRunningDueJobs}
           onOpenChange={setIsRunningDueJobs}
           onResult={setHarnessResult}
+        />
+      )}
+
+      {isDataConsoleOpen && currentSubscription && (
+        <DataConsoleDialog
+          subscriptionId={currentSubscription.subscriptionId}
+          organizationId={organizationScope}
+          open={isDataConsoleOpen}
+          onOpenChange={setIsDataConsoleOpen}
         />
       )}
     </main>

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation-harness.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation-harness.service.ts
@@ -1,14 +1,19 @@
-import { HttpError } from "@seliseblocks/genesis-os/lib";
+import { HttpError, type RequestBody } from "@seliseblocks/genesis-os/lib";
 import { serviceInstances } from "@/lib/http-client";
 import { SIMULATION_HARNESS_ENDPOINT } from "../constants/subscription-simulation.constants";
 import type {
   AdvanceRenewalRequest,
   CloseUsagePeriodRequest,
+  FindDataRequest,
   MarkPaymentFailedRequest,
   MarkPaymentSucceededRequest,
   RunDueJobsRequest,
   SubscriptionSimulationActionResponse,
+  SubscriptionSimulationDataMutationResponse,
+  SubscriptionSimulationDataPolicyResponse,
+  SubscriptionSimulationDataQueryResponse,
   SubscriptionSimulationJobRunResponse,
+  UpdateDataFieldRequest,
 } from "../models/subscription-simulation-harness.model";
 
 interface HarnessApiError {
@@ -52,6 +57,12 @@ const HARNESS_ERROR_CODES = [
   "subscription_simulation_organization_required",
   "subscription_simulation_scheduling_not_supported",
   "subscription_simulation_periods_not_supported",
+  "subscription_simulation_collection_not_allowed",
+  "subscription_simulation_collection_not_readable",
+  "subscription_simulation_limit_invalid",
+  "subscription_simulation_no_fields",
+  "subscription_simulation_field_not_allowed",
+  "subscription_simulation_field_value_invalid",
 ] as const;
 
 const serialize = (error: unknown): string => {
@@ -149,11 +160,78 @@ class SubscriptionSimulationHarnessService {
     );
   }
 
+  /**
+   * The allowlisted collections and what the console may do to each — for a caller deciding what
+   * `find`/`update` can reach before trying either.
+   */
+  async getDataPolicy(): Promise<SubscriptionSimulationDataPolicyResponse[]> {
+    return this.get(`${SIMULATION_HARNESS_ENDPOINT}/data/policy`, "The data console policy could not be loaded.");
+  }
+
+  async findData(
+    subscriptionId: string,
+    logicalCollection: string,
+    request: FindDataRequest,
+  ): Promise<SubscriptionSimulationDataQueryResponse> {
+    return this.post(
+      `${this.dataPath(subscriptionId, logicalCollection)}/find`,
+      request,
+      "The data could not be read.",
+    );
+  }
+
+  async updateData(
+    subscriptionId: string,
+    logicalCollection: string,
+    request: UpdateDataFieldRequest,
+  ): Promise<SubscriptionSimulationDataMutationResponse> {
+    return this.post(
+      `${this.dataPath(subscriptionId, logicalCollection)}/update`,
+      request,
+      "The field could not be updated.",
+    );
+  }
+
   private subscriptionPath(subscriptionId: string): string {
     return `${SIMULATION_HARNESS_ENDPOINT}/subscriptions/${encodeURIComponent(subscriptionId)}`;
   }
 
-  private async post<TResponse, TRequest>(
+  private dataPath(subscriptionId: string, logicalCollection: string): string {
+    return `${this.subscriptionPath(subscriptionId)}/data/${encodeURIComponent(logicalCollection)}`;
+  }
+
+  private async get<TResponse>(path: string, fallbackMessage: string): Promise<TResponse> {
+    try {
+      const response = await serviceInstances.utitlitiesService.get<
+        HarnessApiResponse<TResponse>
+      >(path);
+
+      if (!response.success || !response.data) {
+        throw new SubscriptionSimulationHarnessError(
+          response.error?.message || fallbackMessage,
+          response.error?.code ?? "unknown",
+        );
+      }
+
+      return response.data;
+    } catch (error) {
+      if (error instanceof SubscriptionSimulationHarnessError) {
+        throw error;
+      }
+
+      if (error instanceof HttpError) {
+        throw new SubscriptionSimulationHarnessError(
+          messageFrom(error, fallbackMessage),
+          harnessErrorCode(error),
+          error.status,
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private async post<TResponse, TRequest extends RequestBody>(
     path: string,
     request: TRequest,
     fallbackMessage: string,


### PR DESCRIPTION
## Summary

Client UI for the last remaining piece of the subscription simulation
harness: the allowlisted data console from server PR6 (#290), which was
previously called out as a deliberate follow-up in #292.

Adds a "Data console" entry point on the existing `SimulationHarnessCard`
that opens a two-tab dialog:

- **Find** — pick an allowlisted, readable collection and a limit
  (1-100), see every matching document as pretty-printed JSON, already
  redacted the same way the harness's other reads are.
- **Update** — pick a collection that has updatable fields, fill in only
  the ones to change (each parsed server-side as an ISO-8601 UTC
  timestamp — the only type any updatable field holds), leave the rest
  blank to leave them untouched.

## Design

- The dialog calls `GET /api/subscription-simulation/data/policy` first
  (cached a minute, fetched only while the dialog is open) so the
  collection pickers only ever offer what the server's allowlist actually
  permits — the client never hardcodes or guesses a collection/field
  name, it reads the same allowlist the server enforces.
- No "insert" tab: PR6's own server-side policy has no collection with
  `canInsert: true`, so there's nothing such a tab could call.
- A field update invalidates `["subscription-simulation-current"]`, the
  same query key every other harness action does — a field like
  `NextFeeBillingAtUtc` on `subscriptions` is also shown on the
  integrator-facing current-subscription panel, which would otherwise go
  stale after an update here.
- Errors specific to this surface
  (`subscription_simulation_collection_not_allowed`,
  `_field_not_allowed`, `_field_value_invalid`, `_limit_invalid`, etc.)
  were added to the harness service's known-error-code list so they
  surface as their real message rather than "unknown."

## Incidental fix

Typechecking this change surfaced a real, previously-unflagged bug in
`subscription-simulation-harness.service.ts`: the private `post` helper's
generic request-body parameter was unconstrained, which isn't actually
assignable to the underlying `HttpClient`'s `RequestBody` type. Fixed by
constraining it to `TRequest extends RequestBody`.

## Test plan

- [x] `npx tsc -b --noEmit`: 0 errors
- [x] `npx eslint` on every new/changed file: 0 errors, 0 warnings
- [ ] Not click-tested against a live backend in this environment (no
      running API/Mongo here) — worth a manual pass before considering
      this done end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)