### PR TITLE
fix(subscription): fix dev-breaking client build error

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation-harness.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation-harness.service.ts
@@ -1,4 +1,4 @@
-import { HttpError } from "@seliseblocks/genesis-os/lib";
+import { HttpError, type RequestBody } from "@seliseblocks/genesis-os/lib";
 import { serviceInstances } from "@/lib/http-client";
 import { SIMULATION_HARNESS_ENDPOINT } from "../constants/subscription-simulation.constants";
 import type {
@@ -153,7 +153,7 @@ class SubscriptionSimulationHarnessService {
     return `${SIMULATION_HARNESS_ENDPOINT}/subscriptions/${encodeURIComponent(subscriptionId)}`;
   }
 
-  private async post<TResponse, TRequest>(
+  private async post<TResponse, TRequest extends RequestBody>(
     path: string,
     request: TRequest,
     fallbackMessage: string,


### PR DESCRIPTION
## Summary

`dev` is currently broken — the client build step fails in CI since #292
merged:

\`\`\`
app/cross-modules/utilities/subscription-simulation/services/subscription-simulation-harness.service.ts(164,15):
error TS2345: Argument of type 'TRequest' is not assignable to parameter of type 'RequestBody'.
  Type 'TRequest' is not assignable to type 'File'.
\`\`\`

## Root cause

The harness service's private `post<TResponse, TRequest>` helper left
`TRequest` unconstrained. `HttpClient.post`'s second parameter is typed
`RequestBody = string | object | Array<unknown> | FormData |
URLSearchParams | Blob | File | null | undefined` — a closed union — so an
arbitrary, unconstrained generic type parameter can never be proven
assignable to it, regardless of what every actual caller passes. This was
a real type error from the moment `post` was introduced; a stale `tsc -b`
incremental build cache on my end let a prior local typecheck pass
without catching it before #292 merged, and I didn't verify against the
literal `npm run build` (`tsc -b && vite build`) CI runs — only against
`tsc -b --noEmit` in isolation.

## Fix

Constrain the generic: `post<TResponse, TRequest extends RequestBody>`.
Every existing request DTO passed to `post` is already a plain object
literal type, so this satisfies the constraint with no call-site changes.

## Test plan

- [x] `cd client && npm run build` (the exact failing CI command) — now
      succeeds
- [x] `npx eslint` on the changed file — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)