### PR TITLE
fix(subscription): fix broken simulation harness enum requests

### DIFF
--- a/server/Subscription.DomainService/Enums/SubscriptionPaymentPurpose.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionPaymentPurpose.cs
@@ -1,8 +1,17 @@
+using System.Text.Json.Serialization;
+
 namespace Subscription.DomainService.Enums;
 
 /// <summary>
 /// Why a payment was raised for a subscription.
 /// </summary>
+/// <remarks>
+/// Explicit string conversion — see the remark on
+/// <see cref="Subscription.DomainService.Simulation.SimulatedRenewalOutcome"/> for why a
+/// request-bound enum needs this even though this API's response enums do not: this type is
+/// bound directly from the simulation harness's request bodies.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SubscriptionPaymentPurpose
 {
     /// <summary>The first charge, which activates the subscription.</summary>

--- a/server/Subscription.DomainService/Simulation/SimulatedPaymentFailureKind.cs
+++ b/server/Subscription.DomainService/Simulation/SimulatedPaymentFailureKind.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Subscription.DomainService.Simulation;
 
 /// <summary>
@@ -12,7 +14,12 @@ namespace Subscription.DomainService.Simulation;
 /// they are distinguished here only so a test can name the scenario it means, and the caller's
 /// own <c>errorCode</c> carries the distinction into the audit trail even though the dunning
 /// logic itself does not branch on it.
+/// <para>
+/// Explicit string conversion — see the remark on <see cref="SimulatedRenewalOutcome"/> for why
+/// a request-bound enum needs this even though this API's response enums do not.
+/// </para>
 /// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SimulatedPaymentFailureKind
 {
     Declined,

--- a/server/Subscription.DomainService/Simulation/SimulatedRenewalOutcome.cs
+++ b/server/Subscription.DomainService/Simulation/SimulatedRenewalOutcome.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Subscription.DomainService.Simulation;
 
 /// <summary>
@@ -5,6 +7,13 @@ namespace Subscription.DomainService.Simulation;
 /// alongside the same failure vocabulary <see cref="SimulatedPaymentFailureKind"/> uses, since
 /// this single request field has to name either.
 /// </summary>
+/// <remarks>
+/// Explicit string conversion: unlike this API's response DTOs, which hand-convert an enum to
+/// <c>string</c> before it ever reaches <c>System.Text.Json</c>, this type is bound directly from
+/// a request body, where the default numeric-value handling would otherwise reject the very
+/// string names a caller of this JSON API would naturally send.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SimulatedRenewalOutcome
 {
     Succeeded,

--- a/server/Subscription.DomainService/Simulation/SimulationWorkType.cs
+++ b/server/Subscription.DomainService/Simulation/SimulationWorkType.cs
@@ -1,9 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace Subscription.DomainService.Simulation;
 
 /// <summary>
 /// The background sweeps this harness can run for one subscription immediately, instead of
 /// waiting for the real reconciliation host's own polling interval.
 /// </summary>
+/// <remarks>
+/// Explicit string conversion — see the remark on <see cref="SimulatedRenewalOutcome"/> for why
+/// a request-bound enum needs this even though this API's response enums do not.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SimulationWorkType
 {
     Renewal,


### PR DESCRIPTION
## Summary

Every simulation-harness action that takes an enum in its request body
was broken end to end. Reported live from `dev`: clicking "Advance
renewal" in the new UI (#292/#293) against a real subscription returned:

\`\`\`json
{
  "errors": {
    "request": ["The request field is required."],
    "$.paymentOutcome": ["The JSON value could not be converted to Subscription.DomainService.Simulation.SimulatedRenewalOutcome. Path: $.paymentOutcome | LineNumber: 0 | BytePositionInLine: 85."]
  }
}
\`\`\`

confirmed (via the browser's Network tab) with a correctly-formed request
body already reaching the server — this was never a client bug.

## Root cause

This API's response DTOs hand-convert an enum to `string` before it ever
reaches `System.Text.Json` — e.g.
`SubscriptionSimulationJobResultResponse.WorkType` is declared as a plain
`string`, not the enum type. Nothing here has ever relied on a global
enum-to-string JSON converter, because there isn't one; every other
"stringy" enum you can see in a response got there by hand.

The four simulation-harness enums bound directly from a request body —
`SimulatedRenewalOutcome`, `SimulatedPaymentFailureKind`,
`SimulationWorkType`, `SubscriptionPaymentPurpose` — were left on System.
Text.Json's default numeric enum handling, which rejects the string names
a client sends. Once the enum conversion throws, the whole request object
binds to `null`; `[ApiController]`'s automatic "non-nullable body is
required" check then reports the top-level `request` parameter as
missing, which is what actually surfaced in the response and briefly
looked like a totally different (and more confusing) bug.

This affects **every** harness action that takes one of these enums:
advance-renewal, close-usage-period, mark-payment-succeeded/-failed, and
run-due-jobs — not just advance-renewal, which is simply the one that got
clicked first.

## Fix

Add `[JsonConverter(typeof(JsonStringEnumConverter))]` directly to each
of the four enums, rather than introduce or guess at a global converter
this API has evidently never had elsewhere. `SubscriptionPaymentPurpose`
is also a persisted enum (covered by `SubscriptionEnumStabilityTests`);
this attribute only changes `System.Text.Json` behavior, not the
underlying `(int)` values Mongo/BSON and those stability tests see.

## Test plan

- [x] `dotnet build Api/Api.csproj --no-incremental`: 0 errors
- [x] `dotnet test XUnitTest` (non-integration): 2370 passed, 1 skipped,
      no regressions (including `SubscriptionEnumStabilityTests`)
- [ ] Not re-verified against the live `dev` environment from here — the
      original reporter should retry "Advance renewal" (and the other
      harness actions) once this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)