### PR TITLE
feat(subscription): let the fleet agree the scheduler mode and hand over

### DIFF
--- a/server/Subscription.DomainService/Scheduling/ISubscriptionSchedulerCoordinator.cs
+++ b/server/Subscription.DomainService/Scheduling/ISubscriptionSchedulerCoordinator.cs
@@ -1,0 +1,69 @@
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// The fleet's shared record of which mode background work runs in, in the root database.
+/// </summary>
+/// <remarks>
+/// Storage and nothing else. What to do with what it returns is
+/// <see cref="SubscriptionSchedulerFleetSynchronizer"/>'s decision, so the protocol can be tested
+/// without a database and the database can be tested without the protocol.
+/// </remarks>
+public interface ISubscriptionSchedulerCoordinator
+{
+    Task EnsureIndexesAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reads the mode record and every replica still considered alive, in that order.
+    /// </summary>
+    /// <param name="replicaExpiry">
+    /// How long a replica may go without a heartbeat before the fleet stops waiting for it.
+    /// Evaluated against the <em>database's</em> clock, so a replica whose own clock is wrong cannot
+    /// appear alive when it is gone, or gone while it is still working.
+    /// </param>
+    Task<SchedulerFleetView> ReadFleetAsync(
+        TimeSpan replicaExpiry,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Writes the first record, if there is none. False when another replica got there first.
+    /// </summary>
+    Task<bool> TrySeedAsync(
+        SchedulerRunMode mode,
+        string workerName,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Moves the fleet to a new mode, one generation at a time.
+    /// </summary>
+    /// <remarks>
+    /// Conditional on the generation the caller read, so two replicas proposing the same change at
+    /// the same instant produce one generation rather than two — and a proposal written against a
+    /// record that has since moved fails instead of overwriting a decision it never saw.
+    /// </remarks>
+    Task<bool> TryProposeAsync(
+        SchedulerRunMode mode,
+        long expectedGeneration,
+        string workerName,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes this replica's own state, stamped with the database's clock.
+    /// </summary>
+    Task ReportAsync(
+        string workerName,
+        SchedulerRunMode configuredMode,
+        SchedulerRunMode activeMode,
+        long generation,
+        SchedulerReplicaState state,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Removes this replica's row on a clean shutdown, so it stops holding a mode change up.
+    /// </summary>
+    /// <remarks>
+    /// Best effort by nature — a pod that is killed cannot do this, which is what the expiry window
+    /// is for. Doing it when we can turns the common case of a planned restart from a wait into an
+    /// immediate handover.
+    /// </remarks>
+    Task RemoveAsync(string workerName, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Scheduling/README.md
+++ b/server/Subscription.DomainService/Scheduling/README.md
@@ -67,17 +67,29 @@ caller's discipline. Skipping it would not merely risk a duplicate job — a dup
 the unique index exists is one the index can never afterwards be built over, so the hole would hold
 itself open.
 
-### Rolling deployments
+### Two ways to change the mode
 
-**The mode is consistent within a process, not across a fleet.** Two replicas on different versions,
-or with different configuration, can run in different modes at the same time — and nothing in this
-process can detect that.
+`Subscription:SchedulerCoordinationEnabled` decides which.
 
-### Activation runbook
+| | Coordination **off** (default) | Coordination **on** |
+| --- | --- | --- |
+| Who decides the mode | each process, from its own configuration | the fleet, from one record in the root database |
+| `SchedulerEnabled` means | this process's mode | this process's **vote** |
+| Changing it takes | a full fleet stop and start | a rolling deployment |
+| Mixed modes during a change | possible, for as long as the roll takes | prevented |
+| Root-database dependency | the queue only | the queue and the fleet record |
 
-**Enabling the scheduler requires a full fleet restart, not a rolling one.** Every worker logs its
-mode at warning on startup — `mode: DIRECT` or `mode: QUEUE` — so which mode a replica is in is
-answerable from its logs rather than inferred.
+Off is the behaviour described above: the mode is read once per process, believed immediately, and a
+rolling restart leaves direct-mode and queue-mode replicas side by side. What protects money inside
+that window is the same thing that protects a retry — every handler's provider idempotency key comes
+from persisted identity, a renewal from its period and attempt, a settlement from its reservation —
+so two replicas running one tenant's renewal converge on one charge. That is wasted work and
+duplicated log lines rather than duplicated money, but it is not a window to leave open on purpose.
+
+#### Activation with coordination off
+
+**A full fleet restart, not a rolling one.** Every worker logs its mode at warning on startup, so
+which mode a replica is in is answerable from its logs rather than inferred.
 
 1. Merge and deploy with `SchedulerEnabled` **off**. This is the default, and off means the sweep
    behaves exactly as it did before the queue existed — so a mixed-version fleet is still a fleet
@@ -86,22 +98,102 @@ answerable from its logs rather than inferred.
 3. Stop **all** worker replicas.
 4. Set `SchedulerEnabled=true`.
 5. Start the whole fleet.
-6. Confirm from the logs that every replica reports `mode: QUEUE`, that indexes were established,
+6. Confirm from the logs that every replica reports the queue mode, that indexes were established,
    and that queue depth is draining rather than growing.
 
-A rolling restart at step 3–5 leaves direct-mode and queue-mode replicas running side by side for as
-long as the roll takes.
+A rolling restart at steps 3–5 leaves direct-mode and queue-mode replicas running side by side for as
+long as the roll takes. That is the window coordination closes.
 
-What protects money inside that window is the same thing that protects a retry: every handler's
-provider idempotency key comes from persisted identity — a renewal from its period and attempt, a
-settlement from its reservation. A direct-mode replica and a queue-mode replica running the same
-tenant's renewal therefore converge on one charge, not two. It is wasted work and duplicated log
-lines, not duplicated money.
+### Fleet coordination
 
-Closing the window properly needs coordination this slice does not have: the mode held in the root
-database with a generation counter, and replicas that drain and hand over rather than switching
-independently. Worth doing before the flag is ever flipped on a fleet that cannot take a full
-restart.
+With coordination on, the fleet holds **one** record of the mode in force, and a replica runs what
+that record says rather than what its own configuration says.
+
+`BlocksRootDb.SubscriptionSchedulerMode` — one document: the desired mode, and a **generation** that
+advances once per change. The generation, not the mode, is what replicas coordinate on: a mode alone
+cannot tell "we have always been in Direct" from "we went to Queue and came back", and a replica that
+missed the round trip would believe it was in step.
+
+`BlocksRootDb.SubscriptionSchedulerReplicas` — one document per worker: what it is configured for,
+what it is running, the generation it has reached, whether it is running, draining or drained, and a
+heartbeat.
+
+Every pass, each replica publishes its own row and reads the others'. Three rules follow, and the
+whole guarantee is in the second:
+
+1. **No record yet** — write one from this replica's own configuration. Losing that race is not a
+   failure: the winner's record says what this one would have.
+2. **The record names a generation this replica has not reached** — stop taking new work, wait for
+   whatever it already holds to finish, then report the new generation. Start in the mode the record
+   names only once **no other live replica is behind that generation**. That is the barrier: a rolled
+   pod cannot begin draining the queue while a pod nobody has restarted yet is still executing the
+   same work directly.
+3. **Settled, and every live replica's configuration disagrees with the record in the same
+   direction** — propose the change, conditional on the generation just read. Unanimity is the
+   anti-flap rule: a change takes effect once its deployment has finished rolling, and one pod left
+   on stale configuration can never drag the fleet back. Two replicas proposing at once produce one
+   generation rather than two.
+
+A **draining** replica still blocks. It keeps reporting the generation it is actually still in until
+it holds nothing, because a replica that claimed the new generation while a provider call was open
+would be telling the fleet it had finished when it had not.
+
+So a mode change is: deploy the configuration to every replica, and the fleet takes it up by itself a
+few poll intervals after the last pod comes up. Every step is a warning-level log line — proposed,
+draining, waiting for whom, now running in which mode at which generation.
+
+#### What holds it together, and what it costs
+
+**Timestamps come from the database.** Heartbeats are written with `$currentDate` and liveness is
+evaluated with `$$NOW`, so both sides of the comparison come from one clock. Replicas compare each
+other's heartbeats, and comparing timestamps written by different machines is how a replica that is
+still working comes to look expired.
+
+**An unreachable root database does not stop work.** A replica that cannot read the record keeps
+running in the mode it is already in. No change can be in flight that it does not know about, because
+a change cannot complete without its own acknowledgement — so carrying on is both safe and the only
+option that keeps money moving through a database blip.
+
+**A replica stops itself before the fleet stops waiting for it.** `SchedulerReplicaExpirySeconds`
+(default 900) is how long a silent replica is still waited for; a replica that has not managed to
+write its own row for that window less a margin closes its gate and does nothing. That ordering is
+the whole reason the expiry can be trusted: by the time the others ignore a replica, it has already
+stopped. The cost is real — a root database unreachable for a quarter of an hour pauses background
+work rather than risking two modes at once, which is the same trade the rest of this directory makes.
+
+**A pod that stops politely removes its own row**, so a planned restart is an immediate handover
+rather than a fifteen-minute wait.
+
+**The mode is not authored over HTTP.** It is a platform-wide switch and this service has no
+platform-administrator role — only `[Authorize]`, which every tenant's users satisfy — so an endpoint
+for it would let any authenticated caller stop or start every tenant's billing. Configuration is the
+authoring surface, and the fleet record is only how replicas agree on what it says.
+
+#### Activation with coordination on
+
+1. Deploy with `SchedulerCoordinationEnabled=true` and `SchedulerEnabled` unchanged. Nothing changes
+   mode: the fleet seeds its record from the mode already running.
+2. Confirm from the logs that every replica reports the same generation and mode.
+3. Roll out `SchedulerEnabled=true`. During the roll, replicas configured for Queue keep running
+   Direct, and say so at warning.
+4. When the last pod is up, one replica proposes, every replica drains, and the fleet reports
+   `mode now Queue at generation N`.
+5. Confirm queue depth is draining rather than growing.
+
+Reverting is the same in the other direction, and needs no stop.
+
+#### Not solved
+
+**A replica that is hung rather than dead.** A process that stops heartbeating while still inside a
+provider call becomes invisible to the barrier once its row expires. The self-fence closes this for a
+process that is still *running* — it checks the deadline every pass — but not for one wedged inside a
+single call for longer than the expiry window. The queue's lease and the provider's idempotency key
+are what remain between that and a double charge.
+
+**Payment.** `Payment.DomainService/Scheduling` has the same mode switch and none of this. It matters
+less there, because the mode it replaces is *nothing running* rather than a second executor, so a
+mixed fleet under-recovers rather than double-executes. These mechanics should move with the rest when
+the two schedulers are merged — see that module's README for which direction that goes.
 
 Once the queue is trusted, the sweep's interval can be lengthened
 (`Subscription:ReconciliationPollSeconds`) so it becomes a genuine repair pass rather than a second
@@ -143,6 +235,9 @@ All under `Subscription:`.
 | `SchedulerRetryMaxSeconds` | `3600` | Backoff cap. |
 | `SchedulerCompletedRetentionDays` | `14` | How long completed records are kept. |
 | `SchedulerSweepBucketMinutes` | `5` | The occurrence bucket the repair sweep schedules into. |
+| `SchedulerCoordinationEnabled` | `false` | Whether the fleet agrees the mode through the root database. |
+| `SchedulerCoordinationPollSeconds` | `5` | How often a replica publishes its state and reads the fleet's. Also a handover's step size. |
+| `SchedulerReplicaExpirySeconds` | `900` | How long a silent replica is waited for. A replica fences itself a margin inside this. |
 
 ## Retention
 

--- a/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerCoordinator.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerCoordinator.cs
@@ -1,0 +1,227 @@
+using Blocks.Genesis;
+using MongoDB.Bson;
+using MongoDB.Driver;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// The mode record and the replica roster, in the root database.
+/// </summary>
+/// <remarks>
+/// The same door <see cref="SubscriptionWorkQueue"/> uses, and for the same reason: this is fleet
+/// state, so it cannot live in any one tenant's database.
+/// <para>
+/// Every timestamp that a decision depends on is written by the database rather than by the process
+/// writing it. Replicas compare each other's heartbeats, and comparing timestamps written by
+/// different machines' clocks is how a replica that is still working comes to look expired.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionSchedulerCoordinator : ISubscriptionSchedulerCoordinator
+{
+    private const string ModeCollectionName = "SubscriptionSchedulerMode";
+    private const string ReplicaCollectionName = "SubscriptionSchedulerReplicas";
+    private const string FallbackRootDatabase = "BlocksRootDb";
+
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly IBlocksSecret _secret;
+    private readonly TimeProvider _time;
+
+    private Task? _indexes;
+    private readonly SemaphoreSlim _indexGate = new(1, 1);
+
+    public SubscriptionSchedulerCoordinator(
+        IDbContextProvider dbContextProvider,
+        IBlocksSecret secret,
+        TimeProvider? time = null)
+    {
+        _dbContextProvider = dbContextProvider;
+        _secret = secret;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task EnsureIndexesAsync(CancellationToken cancellationToken)
+    {
+        if (_indexes is { IsCompletedSuccessfully: true })
+        {
+            return;
+        }
+
+        await _indexGate.WaitAsync(cancellationToken);
+
+        try
+        {
+            _indexes ??= CreateIndexesAsync(cancellationToken);
+
+            await _indexes;
+        }
+        catch
+        {
+            // Cleared so the next call retries rather than caching a broken outcome forever.
+            _indexes = null;
+
+            throw;
+        }
+        finally
+        {
+            _indexGate.Release();
+        }
+    }
+
+    public async Task<SchedulerFleetView> ReadFleetAsync(
+        TimeSpan replicaExpiry,
+        CancellationToken cancellationToken)
+    {
+        var record = await Modes()
+            .Find(mode => mode.Id == SubscriptionSchedulerModeRecord.SingletonId)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // Liveness decided by the database's clock, not this process's: $$NOW is evaluated where the
+        // heartbeats were written, so the two sides of the comparison come from one clock.
+        var live = new BsonDocument("$expr", new BsonDocument(
+            "$gte",
+            new BsonArray
+            {
+                "$HeartbeatAtUtc",
+                new BsonDocument("$subtract", new BsonArray
+                {
+                    "$$NOW",
+                    (long)replicaExpiry.TotalMilliseconds
+                })
+            }));
+
+        var replicas = await Replicas()
+            .Find(new BsonDocumentFilterDefinition<SubscriptionSchedulerReplica>(live))
+            .ToListAsync(cancellationToken);
+
+        return new SchedulerFleetView(record, replicas);
+    }
+
+    public async Task<bool> TrySeedAsync(
+        SchedulerRunMode mode,
+        string workerName,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Modes().InsertOneAsync(
+                new SubscriptionSchedulerModeRecord
+                {
+                    Id = SubscriptionSchedulerModeRecord.SingletonId,
+                    DesiredMode = mode,
+                    // One rather than zero, so "never coordinated" and "coordinated once" are
+                    // different values to a replica that has only ever seen its own default.
+                    Generation = 1,
+                    ProposedBy = workerName,
+                    ProposedAtUtc = _time.GetUtcNow().UtcDateTime
+                },
+                cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Another replica seeded it first, which is the expected outcome for all but one member
+            // of a fleet starting at once. Its record is as good as ours would have been.
+            return false;
+        }
+    }
+
+    public async Task<bool> TryProposeAsync(
+        SchedulerRunMode mode,
+        long expectedGeneration,
+        string workerName,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<SubscriptionSchedulerModeRecord>.Filter.And(
+            Builders<SubscriptionSchedulerModeRecord>.Filter.Eq(
+                record => record.Id, SubscriptionSchedulerModeRecord.SingletonId),
+            // Both conditions matter. The generation makes two simultaneous proposals collapse into
+            // one, and the mode makes a proposal for the mode already in force a no-op rather than a
+            // generation the whole fleet has to drain for.
+            Builders<SubscriptionSchedulerModeRecord>.Filter.Eq(
+                record => record.Generation, expectedGeneration),
+            Builders<SubscriptionSchedulerModeRecord>.Filter.Ne(
+                record => record.DesiredMode, mode));
+
+        var update = Builders<SubscriptionSchedulerModeRecord>.Update
+            .Set(record => record.DesiredMode, mode)
+            .Set(record => record.Generation, expectedGeneration + 1)
+            .Set(record => record.ProposedBy, workerName)
+            .Set(record => record.ProposedAtUtc, _time.GetUtcNow().UtcDateTime);
+
+        var result = await Modes().UpdateOneAsync(filter, update, cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task ReportAsync(
+        string workerName,
+        SchedulerRunMode configuredMode,
+        SchedulerRunMode activeMode,
+        long generation,
+        SchedulerReplicaState state,
+        CancellationToken cancellationToken)
+    {
+        var update = Builders<SubscriptionSchedulerReplica>.Update
+            .Set(replica => replica.ConfiguredMode, configuredMode)
+            .Set(replica => replica.ActiveMode, activeMode)
+            .Set(replica => replica.Generation, generation)
+            .Set(replica => replica.State, state)
+            // $currentDate: the heartbeat every other replica's liveness decision rests on is
+            // stamped by the database, so a process with a wrong clock cannot claim to be newer or
+            // older than it is.
+            .CurrentDate(replica => replica.HeartbeatAtUtc)
+            .SetOnInsert(replica => replica.StartedAtUtc, _time.GetUtcNow().UtcDateTime);
+
+        await Replicas().UpdateOneAsync(
+            replica => replica.WorkerName == workerName,
+            update,
+            new UpdateOptions { IsUpsert = true },
+            cancellationToken);
+    }
+
+    public async Task RemoveAsync(string workerName, CancellationToken cancellationToken) =>
+        await Replicas().DeleteOneAsync(
+            replica => replica.WorkerName == workerName,
+            cancellationToken);
+
+    private async Task CreateIndexesAsync(CancellationToken cancellationToken)
+    {
+        var replicas = Replicas();
+
+        // One index, doing two jobs. It serves the liveness query, and its expiry stops the roster
+        // accumulating a row for every pod that ever existed. A second index on the same key would
+        // not be redundant but rejected outright — Mongo refuses an equivalent index under another
+        // name — so asking for both is how neither gets created.
+        //
+        // The expiry is a day, not the liveness window: correctness rests on the heartbeat
+        // comparison in ReadFleetAsync, which does not wait for a TTL monitor to run, and a row that
+        // survives a while after its pod is useful to whoever is asking what used to run here.
+        await replicas.Indexes.CreateOneAsync(
+            new CreateIndexModel<SubscriptionSchedulerReplica>(
+                Builders<SubscriptionSchedulerReplica>.IndexKeys
+                    .Ascending(replica => replica.HeartbeatAtUtc),
+                new CreateIndexOptions
+                {
+                    Name = SubscriptionSchedulerCoordinationIndexNames.ReplicaHeartbeat,
+                    ExpireAfter = TimeSpan.FromDays(1)
+                }),
+            cancellationToken: cancellationToken);
+    }
+
+    private IMongoCollection<SubscriptionSchedulerModeRecord> Modes() =>
+        RootDatabase().GetCollection<SubscriptionSchedulerModeRecord>(ModeCollectionName);
+
+    private IMongoCollection<SubscriptionSchedulerReplica> Replicas() =>
+        RootDatabase().GetCollection<SubscriptionSchedulerReplica>(ReplicaCollectionName);
+
+    private IMongoDatabase RootDatabase()
+    {
+        var rootDatabase = string.IsNullOrWhiteSpace(_secret.RootDatabaseName)
+            ? FallbackRootDatabase
+            : _secret.RootDatabaseName;
+
+        return _dbContextProvider.GetDatabase(_secret.DatabaseConnectionString, rootDatabase);
+    }
+}

--- a/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerFleet.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerFleet.cs
@@ -1,0 +1,152 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>Which of the two ways of doing background work a process is running.</summary>
+public enum SchedulerRunMode
+{
+    /// <summary>The reconciliation sweep executes work itself, as it did before the queue existed.</summary>
+    Direct = 0,
+
+    /// <summary>The sweep only schedules, and the durable queue is drained by the dispatcher.</summary>
+    Queue = 1
+}
+
+/// <summary>Where a replica is in a mode change.</summary>
+public enum SchedulerReplicaState
+{
+    /// <summary>Doing work in <see cref="SubscriptionSchedulerReplica.ActiveMode"/>.</summary>
+    Running = 0,
+
+    /// <summary>Taking no new work, but something started earlier is still finishing.</summary>
+    Draining = 1,
+
+    /// <summary>Doing nothing, and holding nothing. Safe for the fleet to move past.</summary>
+    Drained = 2
+}
+
+/// <summary>
+/// The fleet's one answer to "which mode is subscription background work running in".
+/// </summary>
+/// <remarks>
+/// A single document, so there is nothing to reconcile between copies. <see cref="Generation"/> is
+/// what replicas actually coordinate on: the mode alone cannot distinguish "we have always been in
+/// Direct" from "we were moved to Queue and back", and a replica that missed the round trip would
+/// otherwise believe it was already in step.
+/// </remarks>
+public sealed class SubscriptionSchedulerModeRecord
+{
+    /// <summary>Fixed, so the collection can only ever hold one of these.</summary>
+    public const string SingletonId = "subscription";
+
+    [BsonId]
+    public string Id { get; set; } = SingletonId;
+
+    public SchedulerRunMode DesiredMode { get; set; }
+
+    /// <summary>Incremented once per mode change, and never reused.</summary>
+    public long Generation { get; set; }
+
+    /// <summary>The worker that proposed this generation, for the log trail.</summary>
+    public string ProposedBy { get; set; } = string.Empty;
+
+    public DateTime ProposedAtUtc { get; set; }
+}
+
+/// <summary>
+/// One worker process, as the rest of the fleet sees it.
+/// </summary>
+/// <remarks>
+/// Keyed by worker name, so a pod that restarts reuses its own row rather than accumulating one per
+/// life. Every field here exists to answer a question another replica has to ask before it changes
+/// mode: what are you configured for, what are you actually running, and are you still there.
+/// </remarks>
+public sealed class SubscriptionSchedulerReplica
+{
+    [BsonId]
+    public string WorkerName { get; set; } = string.Empty;
+
+    /// <summary>What this replica's own configuration says it should be running.</summary>
+    public SchedulerRunMode ConfiguredMode { get; set; }
+
+    /// <summary>What it is running now, which is only the same once the fleet has moved.</summary>
+    public SchedulerRunMode ActiveMode { get; set; }
+
+    /// <summary>The generation this replica has reached. Never higher than the record's.</summary>
+    public long Generation { get; set; }
+
+    public SchedulerReplicaState State { get; set; }
+
+    /// <summary>Written with the database's clock, so replica clock skew cannot fake liveness.</summary>
+    public DateTime HeartbeatAtUtc { get; set; }
+
+    public DateTime StartedAtUtc { get; set; }
+}
+
+/// <summary>The record and every replica still considered alive, read together.</summary>
+/// <remarks>
+/// Together, deliberately: deciding whether to move on a record read at one instant and a roster
+/// read at another is deciding on a fleet that never existed.
+/// </remarks>
+public sealed record SchedulerFleetView(
+    SubscriptionSchedulerModeRecord? Record,
+    IReadOnlyList<SubscriptionSchedulerReplica> LiveReplicas)
+{
+    /// <summary>
+    /// Whether this process may run at <paramref name="generation"/> yet.
+    /// </summary>
+    /// <remarks>
+    /// The whole barrier, in one condition: no other live replica may still be behind this
+    /// generation.
+    /// <para>
+    /// State is deliberately not part of the test. A replica reports the new generation only once it
+    /// holds nothing, so <em>behind</em> covers both a replica still running the old mode and one
+    /// still finishing a unit of work it started there — and reading the state instead would let a
+    /// draining replica's last renewal overlap the new mode's first.
+    /// </para>
+    /// <para>
+    /// It covers both cases that matter without telling them apart. Joining a fleet already settled
+    /// here is allowed, because everyone else reports this generation too. Completing a mode change
+    /// is allowed only once the last replica has left the previous one — which is what stops a rolled
+    /// pod from draining the queue while a pod nobody has restarted yet is still executing the same
+    /// work directly.
+    /// </para>
+    /// </remarks>
+    public bool MayActivate(long generation, string exceptWorkerName) =>
+        Blockers(generation, exceptWorkerName).Count == 0;
+
+    /// <summary>Replicas still behind this generation, for the log line that says why.</summary>
+    public IReadOnlyList<string> Blockers(long generation, string exceptWorkerName) =>
+        [.. LiveReplicas
+            .Where(replica =>
+                // Excluded, because a replica cannot be its own reason to wait: its row may still
+                // hold whatever it reported before it drained.
+                !string.Equals(replica.WorkerName, exceptWorkerName, StringComparison.Ordinal) &&
+                replica.Generation < generation)
+            .Select(replica => replica.WorkerName)];
+
+    /// <summary>
+    /// Whether the fleet has finished moving, so a new proposal would not interrupt one.
+    /// </summary>
+    public bool Settled(long generation) =>
+        LiveReplicas.All(replica => replica.Generation == generation);
+
+    /// <summary>
+    /// Whether every live replica is configured for <paramref name="mode"/>.
+    /// </summary>
+    /// <remarks>
+    /// The anti-flap rule. A mode change is proposed only when the whole fleet's configuration
+    /// already agrees, so a change takes effect once its deployment has finished rolling rather than
+    /// the moment the first new pod reports for duty — and a single pod left on stale configuration
+    /// can never drag the fleet back.
+    /// </remarks>
+    public bool UnanimouslyConfiguredFor(SchedulerRunMode mode) =>
+        LiveReplicas.Count > 0 && LiveReplicas.All(replica => replica.ConfiguredMode == mode);
+}
+
+/// <summary>Named so a migration can find them and an operator can recognize them.</summary>
+public static class SubscriptionSchedulerCoordinationIndexNames
+{
+    /// <summary>Serves the liveness query and expires the row. One index, both jobs.</summary>
+    public const string ReplicaHeartbeat = "ix_subsched_replica_heartbeat";
+}

--- a/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerFleetSynchronizer.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerFleetSynchronizer.cs
@@ -1,0 +1,329 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// One pass of the fleet handshake: publish what this replica is doing, and move when the fleet has.
+/// </summary>
+/// <remarks>
+/// The rules, in the order they are applied:
+/// <list type="number">
+/// <item>No record yet — write one from this replica's own configuration and stop for this pass.</item>
+/// <item>
+/// The record names a generation this replica has not reached — stop taking new work, wait for what
+/// it already holds, then report the new generation. Once no other live replica is behind it, run in
+/// the mode the record names. Not the mode this replica was configured for: the record is what the
+/// fleet agreed, and a rolled pod running its own configuration early is the failure being prevented.
+/// </item>
+/// <item>
+/// Settled, and every live replica's configuration disagrees with the record in the same direction —
+/// propose the change. Unanimity is the anti-flap rule: a mode change takes effect when its
+/// deployment has finished rolling, and one pod left on stale configuration cannot drag the fleet
+/// back.
+/// </item>
+/// </list>
+/// <para>
+/// <b>Unreachable coordination does not stop work.</b> A replica that cannot read the record keeps
+/// running in the mode it is already in — no transition can be in flight that it does not know
+/// about, because a transition needs this replica's own acknowledgement to complete. What it must not
+/// do is keep running past the point where the rest of the fleet stops waiting for it, so it stops
+/// itself a safety margin before its own row expires. That ordering is the whole reason a
+/// heartbeat expiry can be trusted: by the time others ignore a replica, it has already stopped.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionSchedulerFleetSynchronizer
+{
+    private const int MinimumExpirySeconds = 60;
+
+    private readonly ISubscriptionSchedulerCoordinator _coordinator;
+    private readonly SubscriptionSchedulerModeGate _gate;
+    private readonly IOptions<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionSchedulerFleetSynchronizer> _logger;
+    private readonly TimeProvider _time;
+
+    /// <summary>When this replica last proved to the fleet that it is here.</summary>
+    /// <remarks>
+    /// A successful report, not a successful read: being able to see the roster is not the same as
+    /// being in it, and it is being in it that stops the others moving on.
+    /// </remarks>
+    private DateTimeOffset _lastReported;
+
+    private long _reportedGeneration = -1;
+    private long _announcedProposalGeneration = -1;
+
+    public SubscriptionSchedulerFleetSynchronizer(
+        ISubscriptionSchedulerCoordinator coordinator,
+        SubscriptionSchedulerModeGate gate,
+        IOptions<SubscriptionOptions> options,
+        ILogger<SubscriptionSchedulerFleetSynchronizer> logger,
+        TimeProvider? time = null)
+    {
+        _coordinator = coordinator;
+        _gate = gate;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+        _lastReported = _time.GetUtcNow();
+    }
+
+    /// <summary>How long a replica may be silent before the fleet stops waiting for it.</summary>
+    public TimeSpan ReplicaExpiry => TimeSpan.FromSeconds(
+        Math.Max(MinimumExpirySeconds, _options.Value.SchedulerReplicaExpirySeconds));
+
+    /// <summary>
+    /// The deadline this replica stops itself at, a margin before the fleet would stop waiting.
+    /// </summary>
+    /// <remarks>
+    /// The margin covers the round trip and the clock the expiry is measured on, which is the
+    /// database's rather than this process's. Shaped like the dispatcher's lease safety margin, and
+    /// for the same reason: an owner has to give up slightly before the world assumes it has.
+    /// </remarks>
+    public TimeSpan SilenceDeadline
+    {
+        get
+        {
+            var expiry = ReplicaExpiry;
+            var margin = TimeSpan.FromTicks(Math.Min(
+                TimeSpan.FromSeconds(60).Ticks,
+                expiry.Ticks / 4));
+
+            return expiry - margin;
+        }
+    }
+
+    public async Task SyncAsync(string workerName, CancellationToken cancellationToken)
+    {
+        SchedulerFleetView view;
+
+        try
+        {
+            view = await _coordinator.ReadFleetAsync(ReplicaExpiry, cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            FenceIfSilentTooLong(exception);
+
+            return;
+        }
+
+        if (view.Record is null)
+        {
+            // Nothing to coordinate with yet. Seeded from this replica's configuration, and losing
+            // the race to seed is not a failure — another replica's record says the same thing this
+            // one would have, or names a mode this replica will drain into on the next pass.
+            var seeded = await _coordinator.TrySeedAsync(
+                _gate.ConfiguredMode, workerName, cancellationToken);
+
+            _logger.LogWarning(
+                "Subscription scheduler fleet record {Outcome} ConfiguredMode={ConfiguredMode} " +
+                "WorkerName={WorkerName}",
+                seeded ? "created" : "was created by another replica",
+                _gate.ConfiguredMode,
+                PaymentLogValue.Label(workerName));
+
+            await ReportAsync(workerName, SchedulerReplicaState.Drained, cancellationToken);
+
+            return;
+        }
+
+        var record = view.Record;
+
+        if (record.Generation != _gate.ActiveGeneration)
+        {
+            await HandOverAsync(workerName, view, record, cancellationToken);
+
+            return;
+        }
+
+        await ReportAsync(workerName, SchedulerReplicaState.Running, cancellationToken);
+        await ProposeIfFleetAgreesAsync(workerName, view, record, cancellationToken);
+    }
+
+    /// <summary>Drops this replica's row so a planned restart does not hold a mode change up.</summary>
+    public async Task WithdrawAsync(string workerName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _coordinator.RemoveAsync(workerName, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            // Best effort by nature: a pod that is killed cannot do this either, which is what the
+            // expiry window is for. Worth a line, never worth failing a shutdown over.
+            _logger.LogWarning(
+                exception,
+                "Subscription scheduler replica row could not be removed on shutdown " +
+                "WorkerName={WorkerName}",
+                PaymentLogValue.Label(workerName));
+        }
+    }
+
+    private async Task HandOverAsync(
+        string workerName,
+        SchedulerFleetView view,
+        SubscriptionSchedulerModeRecord record,
+        CancellationToken cancellationToken)
+    {
+        _gate.Close($"mode change to {record.DesiredMode} at generation {record.Generation}");
+
+        var inFlight = _gate.InFlight;
+
+        if (inFlight > 0)
+        {
+            // Still holding work started in the old mode. Reported at the generation this replica is
+            // actually still in, so the rest of the fleet keeps waiting: a replica that claimed the
+            // new generation here would be telling the others it is finished when it is not.
+            await ReportAsync(workerName, SchedulerReplicaState.Draining, cancellationToken);
+
+            _logger.LogInformation(
+                "Draining before a subscription background work mode change " +
+                "InFlightCount={InFlightCount} FromGeneration={FromGeneration} " +
+                "ToGeneration={ToGeneration}",
+                inFlight,
+                _gate.ActiveGeneration,
+                record.Generation);
+
+            return;
+        }
+
+        await ReportAsync(
+            workerName, SchedulerReplicaState.Drained, cancellationToken, record.Generation);
+
+        if (!view.MayActivate(record.Generation, workerName))
+        {
+            _logger.LogInformation(
+                "Waiting for the rest of the fleet before running subscription background work in " +
+                "{DesiredMode} Generation={Generation} WaitingFor={WaitingFor}",
+                record.DesiredMode,
+                record.Generation,
+                string.Join(",", view.Blockers(record.Generation, workerName)));
+
+            return;
+        }
+
+        _gate.Activate(record.DesiredMode, record.Generation);
+
+        await ReportAsync(workerName, SchedulerReplicaState.Running, cancellationToken);
+    }
+
+    private async Task ProposeIfFleetAgreesAsync(
+        string workerName,
+        SchedulerFleetView view,
+        SubscriptionSchedulerModeRecord record,
+        CancellationToken cancellationToken)
+    {
+        if (record.DesiredMode == _gate.ConfiguredMode)
+        {
+            return;
+        }
+
+        if (!view.Settled(record.Generation))
+        {
+            // A change is still being taken up. Proposing another one now would make every replica
+            // drain again for a generation none of them has finished reaching.
+            return;
+        }
+
+        if (!view.UnanimouslyConfiguredFor(_gate.ConfiguredMode))
+        {
+            // Said once per generation rather than every few seconds: during a rolling deployment
+            // this is the normal state of the world for as long as the roll takes.
+            if (_announcedProposalGeneration != record.Generation)
+            {
+                _announcedProposalGeneration = record.Generation;
+
+                _logger.LogWarning(
+                    "This replica is configured for {ConfiguredMode} but the fleet is running " +
+                    "{DesiredMode}, and will keep running it until every replica's configuration " +
+                    "agrees Generation={Generation} DisagreeingReplicas={DisagreeingReplicas}",
+                    _gate.ConfiguredMode,
+                    record.DesiredMode,
+                    record.Generation,
+                    string.Join(
+                        ",",
+                        view.LiveReplicas
+                            .Where(replica => replica.ConfiguredMode != _gate.ConfiguredMode)
+                            .Select(replica => replica.WorkerName)));
+            }
+
+            return;
+        }
+
+        var proposed = await _coordinator.TryProposeAsync(
+            _gate.ConfiguredMode, record.Generation, workerName, cancellationToken);
+
+        if (proposed)
+        {
+            _logger.LogWarning(
+                "Subscription background work mode change proposed to {DesiredMode} " +
+                "Generation={Generation} ProposedBy={ProposedBy}",
+                _gate.ConfiguredMode,
+                record.Generation + 1,
+                PaymentLogValue.Label(workerName));
+        }
+    }
+
+    private async Task ReportAsync(
+        string workerName,
+        SchedulerReplicaState state,
+        CancellationToken cancellationToken,
+        long? generation = null)
+    {
+        try
+        {
+            await _coordinator.ReportAsync(
+                workerName,
+                _gate.ConfiguredMode,
+                _gate.ActiveMode,
+                generation ?? _gate.ActiveGeneration,
+                state,
+                cancellationToken);
+
+            _lastReported = _time.GetUtcNow();
+            _reportedGeneration = generation ?? _gate.ActiveGeneration;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            FenceIfSilentTooLong(exception);
+        }
+    }
+
+    /// <summary>
+    /// Stops this replica once it can no longer prove the fleet can still see it.
+    /// </summary>
+    private void FenceIfSilentTooLong(Exception exception)
+    {
+        var silence = _time.GetUtcNow() - _lastReported;
+
+        if (silence < SilenceDeadline)
+        {
+            // Still visible as far as anyone knows, and a transition cannot complete without this
+            // replica's own acknowledgement — so carrying on in the current mode is both safe and
+            // the only option that keeps money moving through a database blip.
+            _logger.LogWarning(
+                exception,
+                "Subscription scheduler fleet coordination is unavailable; continuing in " +
+                "{ActiveMode} SilenceSeconds={SilenceSeconds} DeadlineSeconds={DeadlineSeconds}",
+                _gate.ActiveMode,
+                (long)silence.TotalSeconds,
+                (long)SilenceDeadline.TotalSeconds);
+
+            return;
+        }
+
+        _logger.LogError(
+            exception,
+            "Subscription scheduler fleet coordination has been unavailable for longer than this " +
+            "replica's row survives; stopping background work rather than working unseen " +
+            "SilenceSeconds={SilenceSeconds} DeadlineSeconds={DeadlineSeconds} " +
+            "ReportedGeneration={ReportedGeneration}",
+            (long)silence.TotalSeconds,
+            (long)SilenceDeadline.TotalSeconds,
+            _reportedGeneration);
+
+        _gate.Close("fleet coordination unreachable for longer than this replica's row survives");
+    }
+}

--- a/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerMode.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerMode.cs
@@ -32,13 +32,16 @@ public sealed class SubscriptionSchedulerMode
         ArgumentNullException.ThrowIfNull(options);
 
         QueueDriven = options.Value.SchedulerEnabled;
+        CoordinationEnabled = options.Value.SchedulerCoordinationEnabled;
 
         // Logged at startup so the mode a process is running in is answerable from its logs rather
         // than inferred from behaviour, and so a config change that has not been rolled out yet is
         // visibly not in effect.
         logger.LogInformation(
-            "Subscription background work mode fixed for this process QueueDriven={QueueDriven}",
-            QueueDriven);
+            "Subscription background work mode fixed for this process QueueDriven={QueueDriven} " +
+            "CoordinationEnabled={CoordinationEnabled}",
+            QueueDriven,
+            CoordinationEnabled);
     }
 
     /// <summary>
@@ -46,4 +49,15 @@ public sealed class SubscriptionSchedulerMode
     /// False when the sweep executes work itself, as it did before the queue existed.
     /// </summary>
     public bool QueueDriven { get; }
+
+    /// <summary>
+    /// Whether this value is a proposal to the fleet rather than this process's decision.
+    /// </summary>
+    /// <remarks>
+    /// When true, <see cref="SubscriptionSchedulerModeGate"/> is what the hosted services obey, and
+    /// <see cref="QueueDriven"/> is only what this replica asks the fleet for. The reading above
+    /// still happens exactly once, for the same reason: a proposal that changed under a running
+    /// process would be a different proposal on each pass.
+    /// </remarks>
+    public bool CoordinationEnabled { get; }
 }

--- a/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerModeGate.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionSchedulerModeGate.cs
@@ -1,0 +1,209 @@
+using Microsoft.Extensions.Logging;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// Whether this process may do background work right now, and in which mode.
+/// </summary>
+/// <remarks>
+/// <see cref="SubscriptionSchedulerMode"/> answers what this process was <em>configured</em> for,
+/// once, at startup. This answers what it is allowed to <em>do</em>, which is a different question
+/// as soon as there is more than one replica: a pod rolled out with the queue enabled must not start
+/// draining while a pod that has not been restarted yet is still executing the same work directly.
+/// <para>
+/// Both hosted services ask this before every unit of work and hold the ticket while they run it, so
+/// a mode change waits for work already started rather than abandoning it. Asking per unit of work
+/// is safe here in a way that asking configuration per pass was not: what changes this is the
+/// fleet's own agreed generation, and it only advances once every replica has left the previous one.
+/// </para>
+/// <para>
+/// With coordination switched off it is permanently open at the configured mode, which is exactly
+/// what the code did before the fleet record existed.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionSchedulerModeGate
+{
+    private readonly ILogger<SubscriptionSchedulerModeGate> _logger;
+    private readonly object _sync = new();
+
+    private int _inFlight;
+    private bool _open;
+    private SchedulerRunMode _activeMode;
+    private long _activeGeneration;
+    private string _closedReason = "starting up";
+
+    public SubscriptionSchedulerModeGate(
+        SubscriptionSchedulerMode mode,
+        ILogger<SubscriptionSchedulerModeGate> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mode);
+
+        _logger = logger;
+        ConfiguredMode = mode.QueueDriven ? SchedulerRunMode.Queue : SchedulerRunMode.Direct;
+        CoordinationEnabled = mode.CoordinationEnabled;
+        _activeMode = ConfiguredMode;
+
+        // Closed until the fleet has been asked, and open immediately when nobody is coordinating.
+        // A replica that started acting before it knew the fleet's generation would be the exact
+        // failure this exists to prevent, so the safe starting state is doing nothing.
+        _open = !CoordinationEnabled;
+        _activeGeneration = CoordinationEnabled ? -1 : 0;
+    }
+
+    /// <summary>What configuration asked for, unchanged for the life of the process.</summary>
+    public SchedulerRunMode ConfiguredMode { get; }
+
+    public bool CoordinationEnabled { get; }
+
+    public SchedulerRunMode ActiveMode
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _activeMode;
+            }
+        }
+    }
+
+    public long ActiveGeneration
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _activeGeneration;
+            }
+        }
+    }
+
+    public bool IsOpen
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _open;
+            }
+        }
+    }
+
+    /// <summary>Units of work started through this gate and not yet finished.</summary>
+    public int InFlight => Volatile.Read(ref _inFlight);
+
+    /// <summary>
+    /// Takes permission to do one unit of work in <paramref name="mode"/>, or nothing.
+    /// </summary>
+    /// <remarks>
+    /// The ticket must be disposed when the work finishes. A mode change does not complete while one
+    /// is outstanding, which is what makes a handover a handover rather than an interruption.
+    /// </remarks>
+    public SchedulerWorkTicket? TryBegin(SchedulerRunMode mode)
+    {
+        lock (_sync)
+        {
+            if (!_open || _activeMode != mode)
+            {
+                return null;
+            }
+
+            Interlocked.Increment(ref _inFlight);
+
+            return new SchedulerWorkTicket(this);
+        }
+    }
+
+    /// <summary>Opens the gate at a generation the fleet has agreed this process may run at.</summary>
+    public void Activate(SchedulerRunMode mode, long generation)
+    {
+        lock (_sync)
+        {
+            if (_open && _activeMode == mode && _activeGeneration == generation)
+            {
+                return;
+            }
+
+            var wasOpen = _open;
+            var previousMode = _activeMode;
+            var previousGeneration = _activeGeneration;
+
+            _open = true;
+            _activeMode = mode;
+            _activeGeneration = generation;
+            _closedReason = string.Empty;
+
+            // At warning, like the startup mode line, and for the same reason: which mode a replica
+            // is in is the first thing anybody investigating this needs, and inferring it from
+            // behaviour is how the question goes unanswered.
+            _logger.LogWarning(
+                "Subscription background work mode now {Mode} at generation {Generation} " +
+                "PreviousMode={PreviousMode} PreviousGeneration={PreviousGeneration} " +
+                "WasRunning={WasRunning}",
+                mode,
+                generation,
+                previousMode,
+                previousGeneration,
+                wasOpen);
+        }
+    }
+
+    /// <summary>
+    /// Stops this process taking new work, without touching what it is already doing.
+    /// </summary>
+    public void Close(string reason)
+    {
+        lock (_sync)
+        {
+            if (!_open && _closedReason == reason)
+            {
+                return;
+            }
+
+            _open = false;
+            _closedReason = reason;
+
+            _logger.LogWarning(
+                "Subscription background work paused Reason={Reason} Mode={Mode} " +
+                "Generation={Generation} InFlightCount={InFlightCount}",
+                reason,
+                _activeMode,
+                _activeGeneration,
+                InFlight);
+        }
+    }
+
+    /// <summary>Why the gate is closed, for the service that has to report it.</summary>
+    public string ClosedReason
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _closedReason;
+            }
+        }
+    }
+
+    private void Finish() => Interlocked.Decrement(ref _inFlight);
+
+    /// <summary>Permission to do one unit of work, held for as long as the work takes.</summary>
+    public sealed class SchedulerWorkTicket : IDisposable
+    {
+        private readonly SubscriptionSchedulerModeGate _gate;
+        private bool _finished;
+
+        internal SchedulerWorkTicket(SubscriptionSchedulerModeGate gate) => _gate = gate;
+
+        public void Dispose()
+        {
+            if (_finished)
+            {
+                return;
+            }
+
+            _finished = true;
+            _gate.Finish();
+        }
+    }
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -99,6 +99,15 @@ public static class ApplicationServiceCollectionExtensions
         // to agree about which of them executes work, and two reads of configuration can disagree.
         services.AddSingleton<SubscriptionSchedulerMode>();
 
+        // Also singletons, and for a stronger reason than convenience: the gate is the one place
+        // that says whether this process may work right now, and a second copy would be a second
+        // opinion. The coordinator and the synchronizer hold per-process state too — the index
+        // guarantee, and when this replica last proved to the fleet that it is here.
+        services.AddSingleton<SubscriptionSchedulerModeGate>();
+        services.AddSingleton<
+            ISubscriptionSchedulerCoordinator, SubscriptionSchedulerCoordinator>();
+        services.AddSingleton<SubscriptionSchedulerFleetSynchronizer>();
+
         // Singleton because a Meter and its instruments are process-wide: created per scope, each
         // would publish its own series and an exporter would see the same counter many times.
         services.AddSingleton<SubscriptionWorkMetrics>();

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -97,6 +97,43 @@ public sealed class SubscriptionOptions
     public bool SchedulerEnabled { get; set; }
 
     /// <summary>
+    /// Whether replicas agree the mode between themselves through the root database.
+    /// </summary>
+    /// <remarks>
+    /// Off by default, which leaves <see cref="SchedulerEnabled"/> exactly as it behaves today: read
+    /// once per process, believed immediately, and safe to change only with a full fleet stop.
+    /// <para>
+    /// Turned on, <see cref="SchedulerEnabled"/> becomes a <em>proposal</em> rather than a decision.
+    /// The fleet holds one record of the mode in force, a replica runs what that record says, and a
+    /// change is taken up only once every replica's configuration agrees and every replica has
+    /// stopped and reported it holds nothing. That makes the mode changeable by a rolling deployment
+    /// instead of a full stop — see Scheduling/README.md.
+    /// </para>
+    /// </remarks>
+    public bool SchedulerCoordinationEnabled { get; set; }
+
+    /// <summary>
+    /// How often a replica publishes its own state and reads the fleet's.
+    /// </summary>
+    /// <remarks>
+    /// This is also how long a handover takes per step, so a mode change costs a few of these rather
+    /// than a deployment window. Two small documents per replica per tick.
+    /// </remarks>
+    public int SchedulerCoordinationPollSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// How long a silent replica is still waited for before the fleet moves without it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately long. A replica that has gone quiet may still be working, so this is the window
+    /// in which a mode change waits rather than risking two modes at once — and fifteen minutes of
+    /// waiting for a pod that is genuinely gone costs a delayed switch, while not waiting costs the
+    /// guarantee the switch exists for. A replica stops itself a margin inside this window, so by
+    /// the time the fleet stops waiting it has already stopped working.
+    /// </remarks>
+    public int SchedulerReplicaExpirySeconds { get; set; } = 900;
+
+    /// <summary>
     /// How often a worker asks the queue for due work.
     /// </summary>
     /// <remarks>

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -86,6 +86,8 @@ IHostBuilder CreateHostBuilder(string[] args) =>
                 SubscriptionReconciliationBackgroundService>();
             services.AddHostedService<
                 SubscriptionWorkSchedulerBackgroundService>();
+            services.AddHostedService<
+                SubscriptionSchedulerCoordinationBackgroundService>();
             ApplicationConfigurations.ConfigureWorker(services, GetCombinedMessageConfiguration(secret.MessageConnectionString));
             //ApplicationConfigurations.ConfigureWorker(services, IdentifierConstants.GetMessageConfiguration(secret.MessageConnectionString));
             #endregion

--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -41,18 +41,18 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
-    private readonly SubscriptionSchedulerMode _mode;
+    private readonly SubscriptionSchedulerModeGate _gate;
     private readonly ILogger<SubscriptionReconciliationBackgroundService> _logger;
 
     public SubscriptionReconciliationBackgroundService(
         IServiceScopeFactory scopeFactory,
         IOptionsMonitor<SubscriptionOptions> options,
-        SubscriptionSchedulerMode mode,
+        SubscriptionSchedulerModeGate gate,
         ILogger<SubscriptionReconciliationBackgroundService> logger)
     {
         _scopeFactory = scopeFactory;
         _options = options;
-        _mode = mode;
+        _gate = gate;
         _logger = logger;
     }
 
@@ -67,6 +67,15 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
             try
             {
                 await timer.WaitForNextTickAsync(stoppingToken);
+
+                if (!_gate.IsOpen)
+                {
+                    // Paused by the fleet — mid-handover, or fenced because this replica cannot
+                    // prove the others can still see it. Skipped without a line of its own: the
+                    // coordination service already said why, and repeating it every pass would bury
+                    // the reason under the symptom.
+                    continue;
+                }
 
                 // Asked every pass, not captured at startup. Projects are created at any time
                 // and can subscribe immediately; a roster read once is stale the moment the next
@@ -145,10 +154,21 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
             ["SubscriptionSweepId"] = Guid.NewGuid().ToString("N")
         });
 
-        // The frozen decision, not configuration as it stands this second. Asked per pass, a
-        // reload could have this sweep scheduling work while the scheduler had already decided it
-        // was idle — or executing work the scheduler is also executing.
-        if (_mode.QueueDriven)
+        // The fleet's mode, not configuration as it stands this second, and held for the length of
+        // this tenant's pass. Read and forgotten, a mode change could have this sweep executing work
+        // the queue had already started on — the same subscription renewed twice.
+        var mode = _gate.ActiveMode;
+
+        using var ticket = _gate.TryBegin(mode);
+
+        if (ticket is null)
+        {
+            // Paused, or mid-handover: the mode changed between the two lines above, which is
+            // exactly when doing nothing is the right answer. The next pass picks the tenant up.
+            return;
+        }
+
+        if (mode == SchedulerRunMode.Queue)
         {
             await ScheduleTenantWorkAsync(services, tenantId, stoppingToken);
 

--- a/server/Worker/SubscriptionSchedulerCoordinationBackgroundService.cs
+++ b/server/Worker/SubscriptionSchedulerCoordinationBackgroundService.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Utilities;
+
+namespace Worker;
+
+/// <summary>
+/// Keeps this replica's place in the fleet, and moves it when the fleet moves.
+/// </summary>
+/// <remarks>
+/// A thin loop on purpose: every rule lives in <see cref="SubscriptionSchedulerFleetSynchronizer"/>,
+/// which can be tested without a database, and this decides only how often to ask and what to do
+/// when asking throws.
+/// <para>
+/// It runs beside the sweep and the queue drainer rather than inside either, because both of them
+/// obey the same gate and neither is guaranteed to be running: in direct mode nothing drains, and a
+/// replica whose sweep is mid-pass still has to answer for itself.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionSchedulerCoordinationBackgroundService : BackgroundService
+{
+    private const int MinimumPollSeconds = 1;
+
+    private readonly SubscriptionSchedulerFleetSynchronizer _synchronizer;
+    private readonly ISubscriptionSchedulerCoordinator _coordinator;
+    private readonly SubscriptionSchedulerModeGate _gate;
+    private readonly IOptions<SubscriptionOptions> _options;
+    private readonly ILogger<SubscriptionSchedulerCoordinationBackgroundService> _logger;
+
+    /// <summary>The name this replica is known by in the roster, and in everyone else's logs.</summary>
+    private readonly string _workerName = $"{Environment.MachineName}:{Environment.ProcessId}";
+
+    public SubscriptionSchedulerCoordinationBackgroundService(
+        SubscriptionSchedulerFleetSynchronizer synchronizer,
+        ISubscriptionSchedulerCoordinator coordinator,
+        SubscriptionSchedulerModeGate gate,
+        IOptions<SubscriptionOptions> options,
+        ILogger<SubscriptionSchedulerCoordinationBackgroundService> logger)
+    {
+        _synchronizer = synchronizer;
+        _coordinator = coordinator;
+        _gate = gate;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_gate.CoordinationEnabled)
+        {
+            // Nothing to coordinate with, and nothing written to the root database. The gate is
+            // permanently open at the configured mode, which is what this code did before the fleet
+            // record existed.
+            _logger.LogInformation(
+                "Subscription scheduler fleet coordination is disabled; this process runs " +
+                "{ConfiguredMode} on its own configuration WorkerName={WorkerName}",
+                _gate.ConfiguredMode,
+                PaymentLogValue.Label(_workerName));
+
+            return;
+        }
+
+        _logger.LogWarning(
+            "Subscription scheduler fleet coordination enabled. This replica does no background work " +
+            "until the fleet record says which mode is in force ConfiguredMode={ConfiguredMode} " +
+            "ReplicaExpirySeconds={ReplicaExpirySeconds} WorkerName={WorkerName}",
+            _gate.ConfiguredMode,
+            (long)_synchronizer.ReplicaExpiry.TotalSeconds,
+            PaymentLogValue.Label(_workerName));
+
+        await EnsureIndexesAsync(stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _synchronizer.SyncAsync(_workerName, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception exception)
+            {
+                // The synchronizer already handles an unreachable database, including fencing this
+                // replica when it has been silent too long. Anything reaching here is a bug rather
+                // than an outage, and ending the loop over it would leave the gate wherever it
+                // happened to be with nothing left to move it.
+                _logger.LogError(
+                    exception,
+                    "Subscription scheduler fleet coordination pass failed and will be retried");
+            }
+
+            try
+            {
+                await Task.Delay(PollInterval(), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        // Deliberately not the stopping token: it is already cancelled by the time we get here, and
+        // the point of this call is to hand the fleet a clean handover rather than make it wait out
+        // the expiry window for a pod that stopped politely.
+        using var withdrawal = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        _gate.Close("this replica is shutting down");
+        await _synchronizer.WithdrawAsync(_workerName, withdrawal.Token);
+
+        _logger.LogInformation(
+            "Subscription scheduler fleet coordination stopped WorkerName={WorkerName}",
+            PaymentLogValue.Label(_workerName));
+    }
+
+    /// <summary>
+    /// Creates the roster's indexes, and carries on if it cannot.
+    /// </summary>
+    /// <remarks>
+    /// Not a gate, unlike the work queue's indexes. Nothing here is unique-constrained: the mode
+    /// record is a single fixed key and the roster is keyed by worker name, so a missing index costs
+    /// a collection scan over a handful of small documents rather than a duplicate nobody can undo.
+    /// </remarks>
+    private async Task EnsureIndexesAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await _coordinator.EnsureIndexesAsync(stoppingToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogWarning(
+                exception,
+                "Subscription scheduler coordination indexes could not be created; coordination " +
+                "will run without them");
+        }
+    }
+
+    private TimeSpan PollInterval() => TimeSpan.FromSeconds(
+        Math.Max(MinimumPollSeconds, _options.Value.SchedulerCoordinationPollSeconds));
+}

--- a/server/Worker/SubscriptionWorkSchedulerBackgroundService.cs
+++ b/server/Worker/SubscriptionWorkSchedulerBackgroundService.cs
@@ -26,7 +26,7 @@ public sealed class SubscriptionWorkSchedulerBackgroundService : BackgroundServi
     private readonly ISubscriptionWorkDispatcher _dispatcher;
     private readonly ISubscriptionWorkQueue _queue;
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
-    private readonly SubscriptionSchedulerMode _mode;
+    private readonly SubscriptionSchedulerModeGate _gate;
     private readonly SubscriptionWorkMetrics _metrics;
     private readonly ILogger<SubscriptionWorkSchedulerBackgroundService> _logger;
 
@@ -38,7 +38,7 @@ public sealed class SubscriptionWorkSchedulerBackgroundService : BackgroundServi
         ISubscriptionWorkDispatcher dispatcher,
         ISubscriptionWorkQueue queue,
         IOptionsMonitor<SubscriptionOptions> options,
-        SubscriptionSchedulerMode mode,
+        SubscriptionSchedulerModeGate gate,
         SubscriptionWorkMetrics metrics,
         ILogger<SubscriptionWorkSchedulerBackgroundService> logger)
     {
@@ -46,16 +46,17 @@ public sealed class SubscriptionWorkSchedulerBackgroundService : BackgroundServi
         _dispatcher = dispatcher;
         _queue = queue;
         _options = options;
-        _mode = mode;
+        _gate = gate;
         _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Announced at warning in both directions, and deliberately loud. The mode is fixed per
-        // process, so two replicas can be in different modes during a rolling restart — and the
-        // only way to notice that from outside is for every replica to say which one it is in.
-        if (!_mode.QueueDriven)
+        // Announced at warning in both directions, and deliberately loud: which mode a replica is in
+        // is the first thing anybody investigating this has to know, and behaviour is a poor way to
+        // ask. With coordination off the answer is fixed for the life of the process; with it on the
+        // gate says so as it changes, and this loop stays alive to be told.
+        if (!_gate.CoordinationEnabled && _gate.ConfiguredMode != SchedulerRunMode.Queue)
         {
             _logger.LogWarning(
                 "Subscription background work mode: DIRECT. The reconciliation sweep executes work " +
@@ -66,9 +67,12 @@ public sealed class SubscriptionWorkSchedulerBackgroundService : BackgroundServi
         }
 
         _logger.LogWarning(
-            "Subscription background work mode: QUEUE. This worker drains the durable queue and the " +
-            "sweep only schedules. Enabling this requires a full fleet restart, never a rolling one " +
-            "— see Scheduling/README.md. WorkerName={WorkerName}",
+            "Subscription background work drainer started ConfiguredMode={ConfiguredMode} " +
+            "CoordinationEnabled={CoordinationEnabled}. With coordination off, changing the mode " +
+            "takes a full fleet stop and start; with it on, the fleet agrees the change and hands " +
+            "over by itself — see Scheduling/README.md. WorkerName={WorkerName}",
+            _gate.ConfiguredMode,
+            _gate.CoordinationEnabled,
             PaymentLogValue.Label(_workerName));
 
         if (!await WaitForIndexesAsync(stoppingToken))
@@ -80,13 +84,22 @@ public sealed class SubscriptionWorkSchedulerBackgroundService : BackgroundServi
         {
             try
             {
-                var processed = await _dispatcher.ProcessDueAsync(_workerName, stoppingToken);
+                var processed = await DrainOneBatchAsync(stoppingToken);
+
+                if (processed is null)
+                {
+                    // Not this replica's turn to drain: either the fleet is running in direct mode,
+                    // or a handover is in progress. Waiting is the work.
+                    await Delay(PollInterval(), stoppingToken);
+
+                    continue;
+                }
 
                 if (processed > 0)
                 {
                     _logger.LogInformation(
                         "Subscription work batch drained ProcessedCount={ProcessedCount}",
-                        processed);
+                        processed.Value);
 
                     // Straight back for the next batch while there is a backlog: sleeping a full
                     // interval between batches is what turns a burst into a queue.
@@ -113,6 +126,27 @@ public sealed class SubscriptionWorkSchedulerBackgroundService : BackgroundServi
         }
 
         _logger.LogInformation("Subscription work scheduler stopped");
+    }
+
+    /// <summary>
+    /// Drains one batch if the fleet has this replica draining, and nothing otherwise.
+    /// </summary>
+    /// <remarks>
+    /// Null means "not now" rather than "nothing was due", which the caller has to tell apart: an
+    /// empty queue is a reason to poll again shortly, and a closed gate is a reason to do nothing at
+    /// all. The ticket is held for the batch, so a mode change waits for items already claimed
+    /// instead of abandoning them mid-provider-call.
+    /// </remarks>
+    private async Task<int?> DrainOneBatchAsync(CancellationToken stoppingToken)
+    {
+        using var ticket = _gate.TryBegin(SchedulerRunMode.Queue);
+
+        if (ticket is null)
+        {
+            return null;
+        }
+
+        return await _dispatcher.ProcessDueAsync(_workerName, stoppingToken);
     }
 
     /// <summary>

--- a/server/XUnitTest/Integration/SubscriptionSchedulerCoordinatorIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionSchedulerCoordinatorIntegrationTests.cs
@@ -1,0 +1,255 @@
+using Blocks.Genesis;
+using FluentAssertions;
+using MongoDB.Driver;
+using Moq;
+using Subscription.DomainService.Scheduling;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// The coordination record's guarantees, against a real MongoDB.
+/// </summary>
+/// <remarks>
+/// Three of them are properties of the database rather than of any class, which is why they cannot
+/// be shown with a fake: a single record whichever replica writes first, a generation that advances
+/// once however many replicas propose the same change, and a heartbeat stamped by the database so
+/// that liveness does not depend on every pod's clock agreeing.
+/// <para>
+/// Needs a reachable mongod, or <c>BLOCKS_IT_MONGO</c> pointing at one.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionSchedulerCoordinatorIntegrationTests
+    : IClassFixture<MongoIntegrationFixture>
+{
+    private static readonly TimeSpan Generous = TimeSpan.FromMinutes(15);
+
+    private readonly MongoIntegrationFixture _fixture;
+
+    public SubscriptionSchedulerCoordinatorIntegrationTests(MongoIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+
+        // Emptied per test: the record is a single fixed key and the roster is keyed by worker name,
+        // so without this one test's fleet is the next test's fleet. The class fixture shares one
+        // database across every test in this file.
+        Modes().DeleteMany(FilterDefinition<SubscriptionSchedulerModeRecord>.Empty);
+        Replicas().DeleteMany(FilterDefinition<SubscriptionSchedulerReplica>.Empty);
+    }
+
+    [Fact]
+    public async Task A_fleet_starting_at_once_ends_up_with_one_record()
+    {
+        var coordinator = Coordinator();
+
+        // Concurrently rather than in sequence: sequential calls would pass even if seeding were a
+        // read followed by a write, which is the bug this is here to exclude.
+        var races = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(index =>
+                coordinator.TrySeedAsync(SchedulerRunMode.Direct, $"worker-{index}", default)));
+
+        races.Count(seeded => seeded).Should().Be(1);
+
+        var view = await coordinator.ReadFleetAsync(Generous, default);
+        view.Record!.Generation.Should().Be(1);
+        view.Record.DesiredMode.Should().Be(SchedulerRunMode.Direct);
+    }
+
+    [Fact]
+    public async Task Two_replicas_proposing_the_same_change_advance_the_generation_once()
+    {
+        var coordinator = Coordinator();
+        await coordinator.TrySeedAsync(SchedulerRunMode.Direct, "worker-1", default);
+
+        var races = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(index =>
+                coordinator.TryProposeAsync(
+                    SchedulerRunMode.Queue, expectedGeneration: 1, $"worker-{index}", default)));
+
+        // One generation, not eight. Every generation costs the whole fleet a drain, and eight of
+        // them for one decision would be seven handovers nobody asked for.
+        races.Count(proposed => proposed).Should().Be(1);
+        (await coordinator.ReadFleetAsync(Generous, default)).Record!.Generation.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task A_proposal_against_a_generation_that_has_moved_is_refused()
+    {
+        var coordinator = Coordinator();
+        await coordinator.TrySeedAsync(SchedulerRunMode.Direct, "worker-1", default);
+        await coordinator.TryProposeAsync(SchedulerRunMode.Queue, 1, "worker-1", default);
+
+        // A replica acting on a record it read before somebody else's change. Overwriting here would
+        // discard a decision it never saw.
+        var stale = await coordinator.TryProposeAsync(SchedulerRunMode.Direct, 1, "worker-2", default);
+
+        stale.Should().BeFalse();
+
+        var record = (await coordinator.ReadFleetAsync(Generous, default)).Record!;
+        record.DesiredMode.Should().Be(SchedulerRunMode.Queue);
+        record.Generation.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Proposing_the_mode_already_in_force_costs_the_fleet_nothing()
+    {
+        var coordinator = Coordinator();
+        await coordinator.TrySeedAsync(SchedulerRunMode.Queue, "worker-1", default);
+
+        var proposed = await coordinator.TryProposeAsync(SchedulerRunMode.Queue, 1, "worker-1", default);
+
+        // Otherwise every replica whose configuration matches would propose a generation on every
+        // pass, and the fleet would drain every few seconds forever.
+        proposed.Should().BeFalse();
+        (await coordinator.ReadFleetAsync(Generous, default)).Record!.Generation.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_replica_with_a_wrong_clock_is_still_seen_as_alive()
+    {
+        // The reason heartbeats are stamped with $currentDate. This replica believes it is 2020; if
+        // its own clock reached the document, the rest of the fleet would read it as long expired and
+        // move to a new mode while it was still working.
+        var coordinator = Coordinator(new ControlledTimeProvider(
+            new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero)));
+
+        await coordinator.ReportAsync(
+            "worker-1", SchedulerRunMode.Direct, SchedulerRunMode.Direct, 1,
+            SchedulerReplicaState.Running, default);
+
+        var view = await coordinator.ReadFleetAsync(TimeSpan.FromMinutes(1), default);
+
+        view.LiveReplicas.Should().ContainSingle().Which.WorkerName.Should().Be("worker-1");
+    }
+
+    [Fact]
+    public async Task A_replica_that_has_stopped_reporting_drops_out_of_the_fleet()
+    {
+        var coordinator = Coordinator();
+
+        await coordinator.ReportAsync(
+            "worker-1", SchedulerRunMode.Direct, SchedulerRunMode.Direct, 1,
+            SchedulerReplicaState.Running, default);
+        await coordinator.ReportAsync(
+            "worker-2", SchedulerRunMode.Direct, SchedulerRunMode.Direct, 1,
+            SchedulerReplicaState.Running, default);
+
+        // Backdated in the database rather than waited out, because the window a real deployment uses
+        // is fifteen minutes and the arithmetic is the same either way.
+        await Replicas().UpdateOneAsync(
+            replica => replica.WorkerName == "worker-2",
+            Builders<SubscriptionSchedulerReplica>.Update.Set(
+                replica => replica.HeartbeatAtUtc, DateTime.UtcNow.AddMinutes(-10)));
+
+        var view = await coordinator.ReadFleetAsync(TimeSpan.FromMinutes(1), default);
+
+        view.LiveReplicas.Should().ContainSingle().Which.WorkerName.Should().Be("worker-1");
+
+        // And it is no longer somebody the rest of the fleet waits for — which is only safe because
+        // a replica stops itself a margin inside this same window.
+        view.MayActivate(generation: 2, exceptWorkerName: "worker-1").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_replica_that_is_still_reporting_holds_a_mode_change_up()
+    {
+        var coordinator = Coordinator();
+
+        await coordinator.ReportAsync(
+            "worker-1", SchedulerRunMode.Direct, SchedulerRunMode.Direct, 2,
+            SchedulerReplicaState.Drained, default);
+        await coordinator.ReportAsync(
+            "worker-2", SchedulerRunMode.Direct, SchedulerRunMode.Direct, 1,
+            SchedulerReplicaState.Running, default);
+
+        var view = await coordinator.ReadFleetAsync(Generous, default);
+
+        view.MayActivate(generation: 2, exceptWorkerName: "worker-1").Should().BeFalse();
+        view.Blockers(generation: 2, exceptWorkerName: "worker-1").Should().Equal(["worker-2"]);
+    }
+
+    [Fact]
+    public async Task A_replica_reporting_again_updates_its_state_rather_than_joining_twice()
+    {
+        var coordinator = Coordinator();
+
+        await coordinator.ReportAsync(
+            "worker-1", SchedulerRunMode.Direct, SchedulerRunMode.Direct, 1,
+            SchedulerReplicaState.Running, default);
+
+        var first = (await coordinator.ReadFleetAsync(Generous, default)).LiveReplicas.Single();
+
+        await coordinator.ReportAsync(
+            "worker-1", SchedulerRunMode.Queue, SchedulerRunMode.Direct, 1,
+            SchedulerReplicaState.Draining, default);
+
+        var view = await coordinator.ReadFleetAsync(Generous, default);
+        var replica = view.LiveReplicas.Should().ContainSingle().Subject;
+
+        replica.State.Should().Be(SchedulerReplicaState.Draining);
+        replica.ConfiguredMode.Should().Be(SchedulerRunMode.Queue);
+        // Kept from the first report, so how long a pod has been up is answerable from the roster.
+        replica.StartedAtUtc.Should().Be(first.StartedAtUtc);
+    }
+
+    [Fact]
+    public async Task A_replica_that_stops_politely_leaves_the_roster_immediately()
+    {
+        var coordinator = Coordinator();
+
+        await coordinator.ReportAsync(
+            "worker-1", SchedulerRunMode.Direct, SchedulerRunMode.Direct, 1,
+            SchedulerReplicaState.Running, default);
+        await coordinator.RemoveAsync("worker-1", default);
+
+        // A planned restart otherwise costs the fleet a full expiry window before it can move.
+        (await coordinator.ReadFleetAsync(Generous, default)).LiveReplicas.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Index_creation_is_safe_to_repeat()
+    {
+        var coordinator = Coordinator();
+
+        await coordinator.EnsureIndexesAsync(default);
+        await coordinator.EnsureIndexesAsync(default);
+
+        var index = (await Replicas().Indexes.List().ToListAsync())
+            .Single(candidate =>
+                candidate["name"].AsString ==
+                SubscriptionSchedulerCoordinationIndexNames.ReplicaHeartbeat);
+
+        // Both jobs in one index, which is not a tidiness point: asking for two on the same key is
+        // rejected outright, and the second call has to be a no-op rather than an error worker
+        // startup logs and moves past.
+        index.Contains("expireAfterSeconds").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_empty_fleet_reads_as_empty_rather_than_failing()
+    {
+        // What every worker sees on the first pass in a fresh environment, and the branch that
+        // decides to seed. A throw here would be an outage on startup rather than a first pass.
+        var view = await Coordinator().ReadFleetAsync(Generous, default);
+
+        view.Record.Should().BeNull();
+        view.LiveReplicas.Should().BeEmpty();
+    }
+
+    private IMongoCollection<SubscriptionSchedulerModeRecord> Modes() =>
+        _fixture.Collection<SubscriptionSchedulerModeRecord>("SubscriptionSchedulerMode");
+
+    private IMongoCollection<SubscriptionSchedulerReplica> Replicas() =>
+        _fixture.Collection<SubscriptionSchedulerReplica>("SubscriptionSchedulerReplicas");
+
+    private SubscriptionSchedulerCoordinator Coordinator(TimeProvider? time = null)
+    {
+        var secret = new Mock<IBlocksSecret>();
+        secret.SetupGet(value => value.DatabaseConnectionString)
+            .Returns(MongoIntegrationFixture.ConnectionString);
+        secret.SetupGet(value => value.RootDatabaseName).Returns(_fixture.DatabaseName);
+
+        return new SubscriptionSchedulerCoordinator(
+            _fixture.DbContextProvider, secret.Object, time ?? TimeProvider.System);
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionSchedulerFleetSynchronizerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSchedulerFleetSynchronizerTests.cs
@@ -1,0 +1,429 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The fleet handshake: when a replica may work, and when it has to wait for the others.
+/// </summary>
+/// <remarks>
+/// The property every test here defends is one sentence long — <b>no two replicas execute the same
+/// background work in different modes</b> — and it is the reason changing the mode used to require
+/// stopping every worker. What makes it defensible without a database is that the protocol reads a
+/// view and writes a report, so the interesting states can simply be handed to it.
+/// </remarks>
+public sealed class SubscriptionSchedulerFleetSynchronizerTests
+{
+    private const string Me = "worker-1";
+    private const string Other = "worker-2";
+
+    private readonly Mock<ISubscriptionSchedulerCoordinator> _coordinator = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 24, 12, 0, 0, TimeSpan.Zero));
+
+    private SchedulerFleetView _view = new(null, []);
+
+    public SubscriptionSchedulerFleetSynchronizerTests() =>
+        _coordinator
+            .Setup(coordinator => coordinator.ReadFleetAsync(
+                It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _view);
+
+    [Fact]
+    public async Task A_fleet_with_no_record_gets_one_from_the_first_replica_to_look()
+    {
+        _coordinator
+            .Setup(coordinator => coordinator.TrySeedAsync(
+                It.IsAny<SchedulerRunMode>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var gate = Gate(queueDriven: true);
+
+        await Synchronizer(gate).SyncAsync(Me, default);
+
+        _coordinator.Verify(
+            coordinator => coordinator.TrySeedAsync(
+                SchedulerRunMode.Queue, Me, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Not yet working: the record is written but unread, and acting on what we believe we just
+        // wrote is how a replica that lost the race runs the wrong mode for a pass.
+        gate.IsOpen.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_replica_runs_the_mode_the_fleet_agreed_rather_than_its_own_configuration()
+    {
+        // The whole point. This replica has been rolled out with the queue enabled while the fleet is
+        // still executing directly; running its own configuration now is the double execution that
+        // used to make a mode change need a full stop.
+        _view = View(SchedulerRunMode.Direct, generation: 4);
+
+        var gate = Gate(queueDriven: true);
+
+        await Synchronizer(gate).SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeTrue();
+        gate.ActiveMode.Should().Be(SchedulerRunMode.Direct);
+        gate.ActiveGeneration.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task A_replica_will_not_start_while_another_is_still_behind_the_generation()
+    {
+        // worker-2 has not caught up, so it may still be executing the previous mode. Starting here
+        // would put two modes on the same work at the same instant.
+        _view = View(
+            SchedulerRunMode.Queue,
+            generation: 5,
+            Replica(Other, generation: 4, SchedulerReplicaState.Running));
+
+        var gate = Gate(queueDriven: true);
+
+        await Synchronizer(gate).SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeFalse();
+
+        // And it says so, at the new generation, so it stops being the one everybody waits for.
+        _coordinator.Verify(
+            coordinator => coordinator.ReportAsync(
+                Me, It.IsAny<SchedulerRunMode>(), It.IsAny<SchedulerRunMode>(), 5,
+                SchedulerReplicaState.Drained, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_draining_replica_is_still_waited_for_even_though_it_takes_no_new_work()
+    {
+        // Not Running, and not finished either. Read as "gone" this is the gap the whole barrier
+        // would leak through: the last renewal of the old mode overlapping the first of the new.
+        _view = View(
+            SchedulerRunMode.Queue,
+            generation: 5,
+            Replica(Other, generation: 4, SchedulerReplicaState.Draining));
+
+        var gate = Gate(queueDriven: true);
+
+        await Synchronizer(gate).SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Once_nobody_is_behind_the_new_generation_the_replica_starts_in_the_new_mode()
+    {
+        _view = View(
+            SchedulerRunMode.Queue,
+            generation: 5,
+            Replica(Other, generation: 5, SchedulerReplicaState.Drained));
+
+        var gate = Gate(queueDriven: true);
+
+        await Synchronizer(gate).SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeTrue();
+        gate.ActiveMode.Should().Be(SchedulerRunMode.Queue);
+        gate.ActiveGeneration.Should().Be(5);
+
+        _coordinator.Verify(
+            coordinator => coordinator.ReportAsync(
+                Me, It.IsAny<SchedulerRunMode>(), SchedulerRunMode.Queue, 5,
+                SchedulerReplicaState.Running, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_replica_holding_work_reports_the_generation_it_is_still_in()
+    {
+        // The handover half of the barrier. This replica has a renewal in flight in the old mode, so
+        // it must keep the fleet waiting — reporting the new generation here would tell everybody
+        // else it had finished while a provider call was still open.
+        _view = View(SchedulerRunMode.Direct, generation: 1);
+
+        var gate = Gate(queueDriven: false);
+        var synchronizer = Synchronizer(gate);
+
+        await synchronizer.SyncAsync(Me, default);
+
+        using var ticket = gate.TryBegin(SchedulerRunMode.Direct);
+        ticket.Should().NotBeNull();
+
+        _view = View(SchedulerRunMode.Queue, generation: 2);
+        await synchronizer.SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeFalse("no new work while a mode change is pending");
+        gate.ActiveGeneration.Should().Be(1, "the generation it is still actually in");
+
+        _coordinator.Verify(
+            coordinator => coordinator.ReportAsync(
+                Me, It.IsAny<SchedulerRunMode>(), It.IsAny<SchedulerRunMode>(), 1,
+                SchedulerReplicaState.Draining, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // And once the work finishes, the next pass hands over.
+        ticket!.Dispose();
+        await synchronizer.SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeTrue();
+        gate.ActiveMode.Should().Be(SchedulerRunMode.Queue);
+        gate.ActiveGeneration.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task A_change_is_proposed_only_when_every_live_replica_is_configured_for_it()
+    {
+        // The anti-flap rule. Mid-roll, half the fleet still holds the old configuration, and a
+        // proposal now would move the fleet on the strength of one pod — then back again when a pod
+        // on the old configuration restarts.
+        var gate = Gate(queueDriven: true);
+        var synchronizer = Synchronizer(gate);
+
+        _view = View(
+            SchedulerRunMode.Direct,
+            generation: 3,
+            Replica(Me, generation: 3, SchedulerReplicaState.Running, SchedulerRunMode.Queue),
+            Replica(Other, generation: 3, SchedulerReplicaState.Running, SchedulerRunMode.Direct));
+
+        await Settle(synchronizer, gate, SchedulerRunMode.Direct, generation: 3);
+        await synchronizer.SyncAsync(Me, default);
+
+        _coordinator.Verify(
+            coordinator => coordinator.TryProposeAsync(
+                It.IsAny<SchedulerRunMode>(), It.IsAny<long>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_change_is_proposed_once_the_whole_fleet_holds_the_new_configuration()
+    {
+        var gate = Gate(queueDriven: true);
+        var synchronizer = Synchronizer(gate);
+
+        _view = View(
+            SchedulerRunMode.Direct,
+            generation: 3,
+            Replica(Me, generation: 3, SchedulerReplicaState.Running, SchedulerRunMode.Queue),
+            Replica(Other, generation: 3, SchedulerReplicaState.Running, SchedulerRunMode.Queue));
+
+        await Settle(synchronizer, gate, SchedulerRunMode.Direct, generation: 3);
+        await synchronizer.SyncAsync(Me, default);
+
+        // Against the generation it read, so two replicas proposing the same change at the same
+        // instant produce one generation to drain for rather than two.
+        _coordinator.Verify(
+            coordinator => coordinator.TryProposeAsync(
+                SchedulerRunMode.Queue, 3, Me, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Nothing_is_proposed_while_the_fleet_is_still_taking_up_the_last_change()
+    {
+        // Everybody is configured for Queue and the record already says Queue is coming, but one
+        // replica has not reached it. Another proposal here would restart the drain for a generation
+        // nobody finished reaching.
+        var gate = Gate(queueDriven: true);
+        var synchronizer = Synchronizer(gate);
+
+        await Settle(synchronizer, gate, SchedulerRunMode.Direct, generation: 3);
+
+        // Reachable exactly this way: this replica is already running at 3 when a replica still
+        // working its way up from 2 appears — a pod that has just restarted, or one draining slowly.
+        _view = View(
+            SchedulerRunMode.Direct,
+            generation: 3,
+            Replica(Me, generation: 3, SchedulerReplicaState.Running, SchedulerRunMode.Queue),
+            Replica(Other, generation: 2, SchedulerReplicaState.Draining, SchedulerRunMode.Queue));
+
+        await synchronizer.SyncAsync(Me, default);
+
+        _coordinator.Verify(
+            coordinator => coordinator.TryProposeAsync(
+                It.IsAny<SchedulerRunMode>(), It.IsAny<long>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Coordination_going_down_does_not_stop_work_that_is_already_running()
+    {
+        // A root database blip must not stop billing. Nothing can be flipping that this replica does
+        // not know about, because a flip cannot complete without its own acknowledgement.
+        _view = View(SchedulerRunMode.Direct, generation: 1);
+
+        var gate = Gate(queueDriven: false);
+        var synchronizer = Synchronizer(gate);
+
+        await synchronizer.SyncAsync(Me, default);
+        gate.IsOpen.Should().BeTrue();
+
+        _coordinator
+            .Setup(coordinator => coordinator.ReadFleetAsync(
+                It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("root database unreachable"));
+
+        _time.Advance(TimeSpan.FromMinutes(5));
+        await synchronizer.SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeTrue("five minutes is inside the window the fleet still waits out");
+    }
+
+    [Fact]
+    public async Task A_replica_stops_itself_before_the_fleet_stops_waiting_for_it()
+    {
+        // The ordering the expiry rests on. If a replica could still be working when the others
+        // decide it is gone, the barrier would be a formality — so it gives up first.
+        _view = View(SchedulerRunMode.Direct, generation: 1);
+
+        var gate = Gate(queueDriven: false);
+        var synchronizer = Synchronizer(gate);
+
+        await synchronizer.SyncAsync(Me, default);
+
+        _coordinator
+            .Setup(coordinator => coordinator.ReadFleetAsync(
+                It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("root database unreachable"));
+
+        _time.Advance(synchronizer.SilenceDeadline + TimeSpan.FromSeconds(1));
+        await synchronizer.SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeFalse();
+
+        // And strictly before the fleet's own window, or the two could overlap.
+        synchronizer.SilenceDeadline.Should().BeLessThan(synchronizer.ReplicaExpiry);
+    }
+
+    [Fact]
+    public async Task A_failed_report_counts_as_silence_even_when_the_record_can_still_be_read()
+    {
+        // Reading the roster is not being in it. A replica whose own row has stopped being written is
+        // one the others will stop waiting for, however well it can see them.
+        _view = View(SchedulerRunMode.Direct, generation: 1);
+
+        var gate = Gate(queueDriven: false);
+        var synchronizer = Synchronizer(gate);
+
+        await synchronizer.SyncAsync(Me, default);
+
+        _coordinator
+            .Setup(coordinator => coordinator.ReportAsync(
+                It.IsAny<string>(), It.IsAny<SchedulerRunMode>(), It.IsAny<SchedulerRunMode>(),
+                It.IsAny<long>(), It.IsAny<SchedulerReplicaState>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("root database unreachable"));
+
+        _time.Advance(synchronizer.SilenceDeadline + TimeSpan.FromSeconds(1));
+        await synchronizer.SyncAsync(Me, default);
+
+        gate.IsOpen.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_replica_that_stops_politely_stops_holding_the_fleet_up()
+    {
+        await Synchronizer(Gate(queueDriven: false)).WithdrawAsync(Me, default);
+
+        // Otherwise a planned restart costs the fleet a full expiry window before it can move.
+        _coordinator.Verify(
+            coordinator => coordinator.RemoveAsync(Me, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_shutdown_that_cannot_reach_the_database_still_shuts_down()
+    {
+        _coordinator
+            .Setup(coordinator => coordinator.RemoveAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("root database unreachable"));
+
+        // The expiry window is the fallback for a pod that could not say goodbye, so failing here
+        // would be swapping a delayed handover for a failed shutdown.
+        await Synchronizer(Gate(queueDriven: false))
+            .Invoking(synchronizer => synchronizer.WithdrawAsync(Me, default))
+            .Should().NotThrowAsync();
+    }
+
+    /// <summary>
+    /// Brings a fresh replica up to the fleet's generation, which takes one pass.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not shortcut: a process starts believing nothing, and the first pass is the one
+    /// where it drains, reports and joins. Tests about what a <em>running</em> replica does have to
+    /// go through it, or they are testing the joining path by accident.
+    /// </remarks>
+    private async Task Settle(
+        SubscriptionSchedulerFleetSynchronizer synchronizer,
+        SubscriptionSchedulerModeGate gate,
+        SchedulerRunMode mode,
+        long generation)
+    {
+        var pending = _view;
+
+        _view = View(mode, generation);
+        await synchronizer.SyncAsync(Me, default);
+
+        gate.ActiveGeneration.Should().Be(generation, "the replica has to be running to propose");
+
+        _view = pending;
+    }
+
+    private SubscriptionSchedulerModeGate Gate(bool queueDriven)
+    {
+        var options = Options.Create(new SubscriptionOptions
+        {
+            SchedulerEnabled = queueDriven,
+            SchedulerCoordinationEnabled = true
+        });
+
+        return new SubscriptionSchedulerModeGate(
+            new SubscriptionSchedulerMode(
+                options, NullLogger<SubscriptionSchedulerMode>.Instance),
+            NullLogger<SubscriptionSchedulerModeGate>.Instance);
+    }
+
+    private SubscriptionSchedulerFleetSynchronizer Synchronizer(
+        SubscriptionSchedulerModeGate gate) => new(
+        _coordinator.Object,
+        gate,
+        Options.Create(new SubscriptionOptions
+        {
+            SchedulerEnabled = gate.ConfiguredMode == SchedulerRunMode.Queue,
+            SchedulerCoordinationEnabled = true
+        }),
+        NullLogger<SubscriptionSchedulerFleetSynchronizer>.Instance,
+        _time);
+
+    private static SchedulerFleetView View(
+        SchedulerRunMode desired,
+        long generation,
+        params SubscriptionSchedulerReplica[] replicas) => new(
+        new SubscriptionSchedulerModeRecord
+        {
+            DesiredMode = desired,
+            Generation = generation,
+            ProposedBy = Other,
+            ProposedAtUtc = new DateTime(2026, 8, 24, 11, 0, 0, DateTimeKind.Utc)
+        },
+        replicas);
+
+    private static SubscriptionSchedulerReplica Replica(
+        string workerName,
+        long generation,
+        SchedulerReplicaState state,
+        SchedulerRunMode configured = SchedulerRunMode.Direct) => new()
+    {
+        WorkerName = workerName,
+        ConfiguredMode = configured,
+        ActiveMode = SchedulerRunMode.Direct,
+        Generation = generation,
+        State = state,
+        HeartbeatAtUtc = new DateTime(2026, 8, 24, 11, 59, 55, DateTimeKind.Utc)
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionSchedulerModeGateTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSchedulerModeGateTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The one thing both hosted services ask before doing anything.
+/// </summary>
+/// <remarks>
+/// Small enough to read in a minute, and worth its own tests because two failures here are silent:
+/// a gate that starts open lets a freshly rolled replica work before the fleet has agreed anything,
+/// and a ticket that is not counted lets a handover complete while a provider call is still open.
+/// </remarks>
+public sealed class SubscriptionSchedulerModeGateTests
+{
+    [Fact]
+    public void With_coordination_off_the_gate_is_simply_open_at_the_configured_mode()
+    {
+        // The behaviour that existed before any of this: configuration is the decision, and nothing
+        // can pause the process. Coordination has to be adoptable without changing today's fleet.
+        var gate = Gate(queueDriven: true, coordinationEnabled: false);
+
+        gate.IsOpen.Should().BeTrue();
+        gate.ActiveMode.Should().Be(SchedulerRunMode.Queue);
+        gate.TryBegin(SchedulerRunMode.Queue).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void With_coordination_on_the_gate_starts_shut()
+    {
+        // A replica that worked before it knew the fleet's generation would be the exact failure the
+        // fleet record exists to prevent, so doing nothing is the safe starting state.
+        var gate = Gate(queueDriven: true, coordinationEnabled: true);
+
+        gate.IsOpen.Should().BeFalse();
+        gate.ActiveGeneration.Should().Be(-1, "no generation has been agreed with anybody yet");
+        gate.TryBegin(SchedulerRunMode.Queue).Should().BeNull();
+    }
+
+    [Fact]
+    public void Work_is_refused_for_a_mode_the_process_is_not_in()
+    {
+        var gate = Gate(queueDriven: false, coordinationEnabled: true);
+        gate.Activate(SchedulerRunMode.Direct, 7);
+
+        // The caller reads the mode and then asks for it, so this is the window where the two
+        // disagree. Refusing is what makes that window harmless.
+        gate.TryBegin(SchedulerRunMode.Queue).Should().BeNull();
+        gate.TryBegin(SchedulerRunMode.Direct).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Closing_the_gate_stops_new_work_and_leaves_work_in_flight_alone()
+    {
+        var gate = Gate(queueDriven: false, coordinationEnabled: true);
+        gate.Activate(SchedulerRunMode.Direct, 1);
+
+        var ticket = gate.TryBegin(SchedulerRunMode.Direct);
+        gate.InFlight.Should().Be(1);
+
+        gate.Close("mode change");
+
+        gate.IsOpen.Should().BeFalse();
+        gate.TryBegin(SchedulerRunMode.Direct).Should().BeNull();
+
+        // Still counted. A handover that ignored this would be an interruption: the renewal in this
+        // ticket is mid-provider-call, and the fleet is about to be told nobody is holding anything.
+        gate.InFlight.Should().Be(1);
+
+        ticket!.Dispose();
+        gate.InFlight.Should().Be(0);
+    }
+
+    [Fact]
+    public void A_ticket_disposed_twice_only_counts_once()
+    {
+        // `using` plus an explicit Dispose in a retry path is easy to write by accident, and an
+        // in-flight count that drifts below zero would let a handover complete during live work.
+        var gate = Gate(queueDriven: false, coordinationEnabled: true);
+        gate.Activate(SchedulerRunMode.Direct, 1);
+
+        var first = gate.TryBegin(SchedulerRunMode.Direct);
+        var second = gate.TryBegin(SchedulerRunMode.Direct);
+
+        first!.Dispose();
+        first.Dispose();
+
+        gate.InFlight.Should().Be(1, "the second ticket is still outstanding");
+
+        second!.Dispose();
+        gate.InFlight.Should().Be(0);
+    }
+
+    [Fact]
+    public void Reactivating_at_the_same_generation_changes_nothing()
+    {
+        // Every pass calls this while the fleet is settled, so it has to be idempotent — and the
+        // generation is part of the identity, or a flip away and back would look like no change.
+        var gate = Gate(queueDriven: true, coordinationEnabled: true);
+
+        gate.Activate(SchedulerRunMode.Queue, 4);
+        gate.Activate(SchedulerRunMode.Queue, 4);
+
+        gate.IsOpen.Should().BeTrue();
+        gate.ActiveGeneration.Should().Be(4);
+
+        gate.Activate(SchedulerRunMode.Direct, 5);
+
+        gate.ActiveMode.Should().Be(SchedulerRunMode.Direct);
+        gate.ActiveGeneration.Should().Be(5);
+    }
+
+    [Fact]
+    public void Activating_reopens_a_gate_that_was_closed()
+    {
+        // The recovery path after a database blip fenced this replica: coordination comes back, the
+        // fleet's generation is confirmed, and work resumes without a restart.
+        var gate = Gate(queueDriven: false, coordinationEnabled: true);
+        gate.Activate(SchedulerRunMode.Direct, 1);
+        gate.Close("coordination unreachable");
+
+        gate.Activate(SchedulerRunMode.Direct, 1);
+
+        gate.IsOpen.Should().BeTrue();
+        gate.ClosedReason.Should().BeEmpty();
+    }
+
+    private static SubscriptionSchedulerModeGate Gate(bool queueDriven, bool coordinationEnabled)
+    {
+        var options = Options.Create(new SubscriptionOptions
+        {
+            SchedulerEnabled = queueDriven,
+            SchedulerCoordinationEnabled = coordinationEnabled
+        });
+
+        return new SubscriptionSchedulerModeGate(
+            new SubscriptionSchedulerMode(options, NullLogger<SubscriptionSchedulerMode>.Instance),
+            NullLogger<SubscriptionSchedulerModeGate>.Instance);
+    }
+}


### PR DESCRIPTION
Closes the last open item on #274: **fleet-wide scheduler-mode coordination**, which PR #275 documents as future work and replaces with a mandatory full-stop activation runbook.

**Stacked on #275.** Based on `feat/durable-financial-work-scheduler` because it needs that branch's code — retarget to `dev` once #275 merges.

## The problem

`SchedulerEnabled` is decided per process. A rolling restart therefore runs direct-mode replicas (the sweep executes work) beside queue-mode replicas (the dispatcher executes it), and the same renewal is executed twice. Only provider idempotency stands between that and a second charge, which is why #275 requires a full fleet stop and start to change the mode at all.

## The shape

With `Subscription:SchedulerCoordinationEnabled` on, `SchedulerEnabled` becomes this replica's **vote** rather than its decision.

- `BlocksRootDb.SubscriptionSchedulerMode` — one document: the mode in force, and a **generation** that advances once per change. The generation is what replicas coordinate on: a mode alone cannot tell "we have always been in Direct" from "we went to Queue and came back".
- `BlocksRootDb.SubscriptionSchedulerReplicas` — one row per worker: what it is configured for, what it is running, the generation it has reached, whether it is running/draining/drained, and a heartbeat.

**The barrier is one condition: a replica may run at a generation only when no other live replica is behind it.** That covers both cases without telling them apart — a pod joining a settled fleet (everyone else reports the same generation) and a change completing (only once the last replica has left the previous one).

A **draining** replica keeps reporting the generation it is *still in* until it holds nothing, so its last renewal cannot overlap the new mode's first. Both hosted services now take a ticket from `SubscriptionSchedulerModeGate` per unit of work and hold it while they run it, which is what makes a handover a handover rather than an interruption.

A change is **proposed** only when every live replica's configuration agrees, conditional on the generation just read. That is the anti-flap rule: a flip lands once its deployment has finished rolling, one pod on stale configuration cannot drag the fleet back, and two replicas proposing at once produce one generation rather than two.

So a mode change becomes: deploy the configuration, and the fleet takes it up by itself a few poll intervals after the last pod comes up. Every step is a warning-level log line — proposed, draining, waiting for whom, now running in which mode at which generation.

## Three details that make the timing trustworthy rather than hopeful

- **Timestamps come from the database.** Heartbeats are written with `$currentDate`; liveness is evaluated with `$$NOW`. Replicas compare each other's heartbeats, and comparing timestamps written by two machines' clocks is how a replica that is still working comes to look expired.
- **An unreachable root database does not stop work.** A replica that cannot read the record keeps running in the mode it is in. No change can be in flight that it does not know about, because a change cannot complete without its own acknowledgement — so carrying on is both safe and the only option that keeps money moving through a database blip.
- **A replica stops itself before the fleet stops waiting for it.** `SchedulerReplicaExpirySeconds` (default 900) is how long a silent replica is waited for; a replica that has not written its own row for that window less a margin closes its gate. That ordering is the whole reason the expiry can be trusted: by the time the others ignore a replica, it has already stopped.

The cost of that last one is real and documented: a root database unreachable for a quarter of an hour pauses background work rather than risking two modes at once. That is the same trade the rest of the directory makes.

## Two judgement calls

**Off by default.** Off writes nothing to the root database and leaves the mode exactly as immutable per process as it is today, so this changes no runtime behaviour on merge. The existing full-stop runbook stays in the README beside the coordinated one.

**The mode is not authored over HTTP.** It is a platform-wide switch and this service has no platform-administrator role — only `[Authorize]`, which every tenant's users satisfy — so an endpoint would let any authenticated caller stop or start every tenant's billing. Configuration is the authoring surface; the fleet record is only how replicas agree on what it says.

## A bug the tests found

Two index models on the same key is a `createIndexes` **error**, not a redundancy Mongo tolerates: *"an equivalent index already exists with a different name and options"*. Left as written, every worker would have logged a warning at startup and the replica roster would never have been cleaned up. One index now serves the liveness query and expires the row.

## Tests

- **21 unit tests** over the protocol and the gate: runs the fleet's mode rather than its own configuration; will not start while another replica is behind; a draining replica still blocks; work in flight keeps the fleet waiting and the handover completes when it finishes; proposes only on unanimity and only when settled; an unreachable database does not stop work; the self-fence fires past the deadline; a failed *report* counts as silence even when the record still reads.
- **11 integration tests** against a real MongoDB for the parts that are properties of the database: one record whichever of eight racing replicas writes first, one generation however many propose the same change, a stale proposal refused, a replica with a 2020 clock still seen as alive, an expired replica dropping out, and a still-reporting one holding a change up.
- Full unit suite: **2380 passing**.

## Not solved

- **A replica hung rather than dead.** A process that stops heartbeating while still inside a provider call becomes invisible to the barrier once its row expires. The self-fence closes this for a process that is still running — it checks the deadline every pass — but not for one wedged inside a single call for longer than the expiry window. The queue's lease and the provider's idempotency key are what remain between that and a double charge.
- **Payment.** `Payment.DomainService/Scheduling` (#296) has the same switch and none of this. It matters less there, because the mode it replaces is *nothing running* rather than a second executor, so a mixed fleet under-recovers rather than double-executes. These mechanics should move with the rest when the two schedulers are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
