### PR TITLE
fix(tests): fix ambiguous BackgroundWorkStatus breaking the test build

### DIFF
--- a/server/XUnitTest/Integration/SubscriptionRenewalCrashRecoveryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRenewalCrashRecoveryIntegrationTests.cs
@@ -157,7 +157,7 @@ public sealed class SubscriptionRenewalCrashRecoveryIntegrationTests
                 "SubscriptionBackgroundWork")
             .Find(item => item.ItemId == work.ItemId)
             .FirstAsync();
-        completed.Status.Should().Be(BackgroundWorkStatus.Completed);
+        completed.Status.Should().Be(global::Subscription.DomainService.Enums.BackgroundWorkStatus.Completed);
         completed.AttemptCount.Should().Be(2);
     }
 

--- a/server/XUnitTest/Subscription/SubscriptionWorkRecoveryServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionWorkRecoveryServiceTests.cs
@@ -221,7 +221,7 @@ public sealed class SubscriptionWorkRecoveryServiceTests
         AggregateId = "sub-1",
         WorkType = SubscriptionWorkType.Renewal,
         WorkKey = "renewal:M20260901T000000Z",
-        Status = BackgroundWorkStatus.DeadLetter,
+        Status = global::Subscription.DomainService.Enums.BackgroundWorkStatus.DeadLetter,
         DueAtUtc = new DateTime(2026, 9, 3, 10, 0, 0, DateTimeKind.Utc),
         UpdatedAtUtc = new DateTime(2026, 9, 3, 11, 0, 0, DateTimeKind.Utc),
         AttemptCount = 5,


### PR DESCRIPTION
## Summary

`dotnet build XUnitTest/XUnitTest.csproj` currently fails on `dev`:

\`\`\`
error CS0104: 'BackgroundWorkStatus' is an ambiguous reference between
'Payment.DomainService.Enums.BackgroundWorkStatus' and
'Subscription.DomainService.Enums.BackgroundWorkStatus'
\`\`\`

introduced by #296 (payment background work queue), which added a second
`BackgroundWorkStatus` enum alongside the pre-existing subscription one
these two test files already referenced unqualified.

## Fix

Both sites assign/compare against `SubscriptionBackgroundWork.Status`,
which is the `Subscription.DomainService.Enums` one — disambiguated with
a fully-qualified (`global::`) reference rather than removing a `using`
that something else in the file may still need. No production code
changed.

This was invisible in CI because `ci-dev.yml` sets `RUN_TESTS: "false"`,
so a broken test build has not been failing the dev pipeline — found
while trying to run the suite locally for an unrelated change.

## Test plan

- [x] `dotnet build XUnitTest/XUnitTest.csproj --no-incremental`: 0
      errors (previously 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)