### PR TITLE
feat(subscription): make simulation harness payment outcome optional

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/advance-renewal-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/advance-renewal-dialog.tsx
@@ -24,7 +24,11 @@ import type {
   SubscriptionSimulationActionResponse,
 } from "../models/subscription-simulation-harness.model";
 
-const OUTCOMES: { value: SimulatedRenewalOutcome; label: string }[] = [
+/** Not a server value — selecting this omits `paymentOutcome` so the real gateway decides. */
+const REAL_GATEWAY = "RealGateway" as const;
+
+const OUTCOMES: { value: SimulatedRenewalOutcome | typeof REAL_GATEWAY; label: string }[] = [
+  { value: REAL_GATEWAY, label: "Real payment gateway (no script)" },
   { value: "Succeeded", label: "Succeeded" },
   { value: "Declined", label: "Declined" },
   { value: "InsufficientFunds", label: "Insufficient funds" },
@@ -48,11 +52,15 @@ export const AdvanceRenewalDialog = ({
 }) => {
   const { mutateAsync, isPending } = useAdvanceRenewal();
 
-  const [paymentOutcome, setPaymentOutcome] = useState<SimulatedRenewalOutcome>("Succeeded");
+  const [selection, setSelection] = useState<SimulatedRenewalOutcome | typeof REAL_GATEWAY>(
+    REAL_GATEWAY,
+  );
   const [formError, setFormError] = useState<string | null>(null);
 
   const submit = async () => {
     setFormError(null);
+
+    const paymentOutcome = selection === REAL_GATEWAY ? undefined : selection;
 
     try {
       const result = await mutateAsync({
@@ -63,9 +71,11 @@ export const AdvanceRenewalDialog = ({
       onResult(result);
 
       toast({
-        variant: paymentOutcome === "Succeeded" ? "success" : "destructive",
+        variant: paymentOutcome && paymentOutcome !== "Succeeded" ? "destructive" : "success",
         title: "Renewal advanced",
-        description: `Charged as ${paymentOutcome}.`,
+        description: paymentOutcome
+          ? `Charged as ${paymentOutcome}.`
+          : "Charged against the real payment gateway.",
       });
 
       onOpenChange(false);
@@ -98,8 +108,10 @@ export const AdvanceRenewalDialog = ({
           <div className="space-y-1.5">
             <Label htmlFor="advance-renewal-outcome">Payment outcome</Label>
             <Select
-              value={paymentOutcome}
-              onValueChange={(value) => setPaymentOutcome(value as SimulatedRenewalOutcome)}
+              value={selection}
+              onValueChange={(value) =>
+                setSelection(value as SimulatedRenewalOutcome | typeof REAL_GATEWAY)
+              }
             >
               <SelectTrigger id="advance-renewal-outcome">
                 <SelectValue />
@@ -116,7 +128,10 @@ export const AdvanceRenewalDialog = ({
 
           <p className="text-xs text-muted-foreground">
             Advances the one renewal due for the current fee period — there is no simulated clock,
-            so this cannot run several future periods in one call.
+            so this cannot run several future periods in one call.{" "}
+            {selection === REAL_GATEWAY
+              ? "This will place a real charge against whatever payment provider account is configured (e.g. a Stripe test account)."
+              : "Scripting an outcome here never reaches the real payment gateway."}
           </p>
 
           {formError && <p className="text-sm text-destructive">{formError}</p>}

--- a/client/app/cross-modules/utilities/subscription-simulation/components/close-usage-period-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/close-usage-period-dialog.tsx
@@ -25,7 +25,11 @@ import type {
   SubscriptionSimulationActionResponse,
 } from "../models/subscription-simulation-harness.model";
 
-const OUTCOMES: { value: SimulatedRenewalOutcome; label: string }[] = [
+/** Not a server value — selecting this omits `paymentOutcome` so the real gateway decides. */
+const REAL_GATEWAY = "RealGateway" as const;
+
+const OUTCOMES: { value: SimulatedRenewalOutcome | typeof REAL_GATEWAY; label: string }[] = [
+  { value: REAL_GATEWAY, label: "Real payment gateway (no script)" },
   { value: "Succeeded", label: "Succeeded" },
   { value: "Declined", label: "Declined" },
   { value: "InsufficientFunds", label: "Insufficient funds" },
@@ -49,12 +53,16 @@ export const CloseUsagePeriodDialog = ({
 }) => {
   const { mutateAsync, isPending } = useCloseUsagePeriod();
 
-  const [paymentOutcome, setPaymentOutcome] = useState<SimulatedRenewalOutcome>("Succeeded");
+  const [selection, setSelection] = useState<SimulatedRenewalOutcome | typeof REAL_GATEWAY>(
+    REAL_GATEWAY,
+  );
   const [chargeInvoice, setChargeInvoice] = useState(true);
   const [formError, setFormError] = useState<string | null>(null);
 
   const submit = async () => {
     setFormError(null);
+
+    const paymentOutcome = selection === REAL_GATEWAY ? undefined : selection;
 
     try {
       const result = await mutateAsync({
@@ -67,9 +75,11 @@ export const CloseUsagePeriodDialog = ({
       toast({
         variant: "success",
         title: "Usage period closed",
-        description: chargeInvoice
-          ? `Any overage invoice was charged as ${paymentOutcome}.`
-          : "No overage invoice was charged.",
+        description: !chargeInvoice
+          ? "No overage invoice was charged."
+          : paymentOutcome
+            ? `Any overage invoice was charged as ${paymentOutcome}.`
+            : "Any overage invoice was charged against the real payment gateway.",
       });
 
       onOpenChange(false);
@@ -119,8 +129,10 @@ export const CloseUsagePeriodDialog = ({
             <div className="space-y-1.5">
               <Label htmlFor="close-usage-period-outcome">Payment outcome</Label>
               <Select
-                value={paymentOutcome}
-                onValueChange={(value) => setPaymentOutcome(value as SimulatedRenewalOutcome)}
+                value={selection}
+                onValueChange={(value) =>
+                  setSelection(value as SimulatedRenewalOutcome | typeof REAL_GATEWAY)
+                }
               >
                 <SelectTrigger id="close-usage-period-outcome">
                   <SelectValue />

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation-harness.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation-harness.model.ts
@@ -40,11 +40,13 @@ export interface MarkPaymentFailedRequest {
 
 export interface AdvanceRenewalRequest {
   organizationId?: string;
-  paymentOutcome: SimulatedRenewalOutcome;
+  /** Omitted, the charge goes to the real payment gateway instead of a scripted outcome. */
+  paymentOutcome?: SimulatedRenewalOutcome;
 }
 
 export interface CloseUsagePeriodRequest {
   organizationId?: string;
+  /** Omitted, the charge goes to the real payment gateway instead of a scripted outcome. */
   paymentOutcome?: SimulatedRenewalOutcome;
   chargeInvoice?: boolean;
 }

--- a/server/Subscription.DomainService/Simulation/AdvanceRenewalRequest.cs
+++ b/server/Subscription.DomainService/Simulation/AdvanceRenewalRequest.cs
@@ -11,7 +11,13 @@ public sealed class AdvanceRenewalRequest
     /// </summary>
     public int Periods { get; set; } = 1;
 
-    public SimulatedRenewalOutcome PaymentOutcome { get; set; }
+    /// <summary>
+    /// The gateway outcome to script for this renewal's charge. Omitted (or left null), the
+    /// charge is instead sent to the real payment gateway — the same call a production renewal
+    /// makes — which is how this advances a renewal against a real test-mode provider account
+    /// instead of a scripted result.
+    /// </summary>
+    public SimulatedRenewalOutcome? PaymentOutcome { get; set; }
 
     /// <summary>
     /// Must be true in this version — there is nothing to schedule against without a simulated

--- a/server/Subscription.DomainService/Simulation/CloseUsagePeriodRequest.cs
+++ b/server/Subscription.DomainService/Simulation/CloseUsagePeriodRequest.cs
@@ -9,8 +9,9 @@ public sealed class CloseUsagePeriodRequest
     /// true and the closed period actually produced one. Reuses the same vocabulary
     /// <see cref="AdvanceRenewalRequest.PaymentOutcome"/> does — a usage invoice is charged
     /// through the identical <c>ISubscriptionBillingGateway.ChargeAsync</c> call a renewal is.
+    /// Omitted (or left null), the charge is instead sent to the real payment gateway.
     /// </summary>
-    public SimulatedRenewalOutcome PaymentOutcome { get; set; } = SimulatedRenewalOutcome.Succeeded;
+    public SimulatedRenewalOutcome? PaymentOutcome { get; set; }
 
     /// <summary>Whether to also charge the overage invoice the close produces, if any.</summary>
     public bool ChargeInvoice { get; set; } = true;

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -390,17 +390,24 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
 
         var (succeeded, failureKind) = SplitRenewalOutcome(request.PaymentOutcome);
 
-        _scriptedOutcomes.ScriptNext(new ScriptedChargeOutcome(
-            succeeded ? SimulatedChargeOutcome.Succeeded : MapFailureOutcome(failureKind),
-            succeeded ? null : DefaultErrorCode(failureKind),
-            succeeded ? null : DefaultErrorMessage(failureKind)));
+        if (succeeded is { } isSucceeded)
+        {
+            _scriptedOutcomes.ScriptNext(new ScriptedChargeOutcome(
+                isSucceeded ? SimulatedChargeOutcome.Succeeded : MapFailureOutcome(failureKind),
+                isSucceeded ? null : DefaultErrorCode(failureKind),
+                isSucceeded ? null : DefaultErrorMessage(failureKind)));
+        }
 
         await _usageRatingProcessor.ChargeInvoiceAsync(invoice, cancellationToken);
 
-        return (null, succeeded
-            ? $"{periodsClosed} usage period(s) closed and the overage invoice charged."
-            : $"{periodsClosed} usage period(s) closed; the overage charge failed and will retry " +
-              "on its own schedule.");
+        return (null, succeeded switch
+        {
+            true => $"{periodsClosed} usage period(s) closed and the overage invoice charged.",
+            false => $"{periodsClosed} usage period(s) closed; the overage charge failed and will " +
+                "retry on its own schedule.",
+            null => $"{periodsClosed} usage period(s) closed; the overage invoice was charged " +
+                "against the real payment gateway (no outcome scripted)."
+        });
     }
 
     private static readonly SimulationWorkType[] AllWorkTypes =
@@ -563,9 +570,11 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
             : ("NotDue", "No outbox event is due for publication.");
     }
 
-    private static (bool Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(
-        SimulatedRenewalOutcome outcome) => outcome switch
+    /// <summary>Null in, null out: nothing to script, the real payment gateway decides.</summary>
+    private static (bool? Succeeded, SimulatedPaymentFailureKind? FailureKind) SplitRenewalOutcome(
+        SimulatedRenewalOutcome? outcome) => outcome switch
     {
+        null => (null, null),
         SimulatedRenewalOutcome.Succeeded => (true, null),
         SimulatedRenewalOutcome.Declined => (false, SimulatedPaymentFailureKind.Declined),
         SimulatedRenewalOutcome.InsufficientFunds => (false, SimulatedPaymentFailureKind.InsufficientFunds),
@@ -881,11 +890,15 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
     /// is no separate pending state for a renewal charge to resolve, since production charges it
     /// synchronously in the same call that decides the outcome.
     /// </summary>
+    /// <param name="succeeded">
+    /// Null scripts nothing: the renewal service's own gateway call goes to the real payment
+    /// gateway instead, exactly as a production renewal would.
+    /// </param>
     private async Task<(SubscriptionOperationResult<SubscriptionSimulationActionResponse>? Failure, string Note)>
         SettleRenewalAsync(
             SubscriptionContext context,
             SubscriptionDetail subscription,
-            bool succeeded,
+            bool? succeeded,
             SimulatedPaymentFailureKind? failureKind,
             string? errorCode,
             bool runProcessor,
@@ -917,16 +930,23 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
                 "without actually running it, so nothing was charged.");
         }
 
-        _scriptedOutcomes.ScriptNext(new ScriptedChargeOutcome(
-            succeeded ? SimulatedChargeOutcome.Succeeded : MapFailureOutcome(failureKind),
-            succeeded ? null : errorCode ?? DefaultErrorCode(failureKind),
-            succeeded ? null : DefaultErrorMessage(failureKind)));
+        if (succeeded is { } isSucceeded)
+        {
+            _scriptedOutcomes.ScriptNext(new ScriptedChargeOutcome(
+                isSucceeded ? SimulatedChargeOutcome.Succeeded : MapFailureOutcome(failureKind),
+                isSucceeded ? null : errorCode ?? DefaultErrorCode(failureKind),
+                isSucceeded ? null : DefaultErrorMessage(failureKind)));
+        }
 
         await _renewalService.RenewAsync(subscription, cancellationToken);
 
-        return (null, succeeded
-            ? "The renewal charge succeeded and the period advanced."
-            : "The renewal charge failed; dunning was applied.");
+        return (null, succeeded switch
+        {
+            true => "The renewal charge succeeded and the period advanced.",
+            false => "The renewal charge failed; dunning was applied.",
+            null => "The renewal ran against the real payment gateway (no outcome scripted); " +
+                "check state for the actual result."
+        });
     }
 
     private static SimulatedChargeOutcome MapFailureOutcome(SimulatedPaymentFailureKind? kind) => kind switch

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -591,6 +591,34 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Advancing_a_renewal_with_no_outcome_scripts_nothing_and_uses_the_real_gateway()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = SubscriptionId, TenantId = TenantId, OrganizationId = "target-org",
+            Status = SubscriptionStatus.Active,
+        };
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new AdvanceRenewalRequest { OrganizationId = "target-org", PaymentOutcome = null };
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.IsAny<ScriptedChargeOutcome>()),
+            Times.Never,
+            "omitting the outcome must leave the real gateway call unscripted");
+        _renewalService.Verify(
+            service => service.RenewAsync(subscription, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Refuses_to_advance_more_than_one_period()
     {
         SetAuthorizedCaller();
@@ -712,6 +740,42 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         _scriptedOutcomes.Verify(
             source => source.ScriptNext(It.Is<ScriptedChargeOutcome>(o => o.Outcome == SimulatedChargeOutcome.Succeeded)),
             Times.Once);
+        _usageRatingProcessor.Verify(
+            processor => processor.ChargeInvoiceAsync(invoice, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Closing_a_usage_period_with_no_outcome_scripts_nothing_and_uses_the_real_gateway()
+    {
+        SetAuthorizedCaller();
+        ResolvesContext("target-org");
+        var subscription = UsageSubscription();
+        _subscriptions
+            .Setup(repo => repo.GetAsync(TenantId, "target-org", SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+        _usageRatingProcessor
+            .Setup(processor => processor.CloseSubscriptionPeriodsAsync(
+                subscription, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        var invoice = new SubscriptionUsageInvoice
+        {
+            ItemId = "invoice-1", TenantId = TenantId, SubscriptionId = SubscriptionId,
+            State = SubscriptionUsageInvoiceState.Pending, TotalAmountMinor = 500, CurrencyCode = "EUR",
+        };
+        _usageInvoices
+            .Setup(repo => repo.GetAsync(TenantId, SubscriptionId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invoice);
+        StubEmptyState(subscription, "target-org");
+
+        var request = new CloseUsagePeriodRequest { OrganizationId = "target-org", PaymentOutcome = null };
+        var result = await CreateService().CloseUsagePeriodAsync(
+            SubscriptionId, request, CorrelationId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scriptedOutcomes.Verify(
+            source => source.ScriptNext(It.IsAny<ScriptedChargeOutcome>()),
+            Times.Never,
+            "omitting the outcome must leave the real gateway call unscripted");
         _usageRatingProcessor.Verify(
             processor => processor.ChargeInvoiceAsync(invoice, It.IsAny<CancellationToken>()), Times.Once);
     }


### PR DESCRIPTION
## Summary

Reported: advancing a renewal, closing a usage period, and running due
jobs always forced a scripted payment outcome, with no way to let a
charge actually reach a real payment gateway (e.g. a Stripe test
account) — which is exactly what someone testing against a real provider
integration wants to exercise.

**run-due-jobs needed no change** — `RunDueJobsAsync` never scripts an
outcome (verified: no `ScriptNext` call anywhere in that path), so it
already always hits the real gateway, and its dialog never had a
payment-outcome field to begin with.

**advance-renewal and close-usage-period were the actual gap.** The
gateway (`SubscriptionSimulationBillingGateway`) already supports this —
it only scripts an outcome when one has been set, and falls through to
the real gateway otherwise — but `PaymentOutcome` on both requests was
non-nullable (or defaulted to `Succeeded`), so a scripted outcome was
always sent regardless of intent.

## Changes

- `AdvanceRenewalRequest.PaymentOutcome` and
  `CloseUsagePeriodRequest.PaymentOutcome` are now nullable. Omitted, the
  charge goes to the real gateway instead of a scripted result.
- `SplitRenewalOutcome` takes a nullable outcome and returns `bool?` —
  null in, null out.
- `SettleRenewalAsync`'s `succeeded` parameter is `bool?`; it only calls
  `ScriptNext` when non-null, otherwise the renewal service's own
  gateway call proceeds exactly as production would.
- The usage-invoice charge path in `CloseUsagePeriodInternalAsync`
  mirrors the same conditional scripting.
- Both actions' completion notes now distinguish three outcomes
  (succeeded / failed / ran against the real gateway), not just two.
- Client: both dialogs' outcome picker gained a **"Real payment gateway
  (no script)"** option, now the default, which omits `paymentOutcome`
  from the request instead of always sending `"Succeeded"`.

## Test plan

- [x] `dotnet build Api/Api.csproj --no-incremental`: 0 errors
- [x] `dotnet test XUnitTest` (non-integration): passes, including two
      new tests (one per action) asserting `ScriptNext` is never called
      and the real renewal/charge path still runs when the outcome is
      omitted
- [x] `npx tsc -b --noEmit` / `npx eslint` on the changed client files:
      0 errors

**Depends on #301** (an unrelated, pre-existing ambiguous-enum test-build
break already on `dev`) to get a clean test build — this PR's own
changes don't touch that code, but the test project won't compile
without it.

## Found, not fixed here

Two tests throw a `NullReferenceException` instead of the forbidden
result they assert:
`SubscriptionSimulationServiceTests.Refuses_the_console_without_the_simulation_permission`
and
`SubscriptionSimulationDataConsoleServiceTests.Find_refuses_the_console_without_the_simulation_permission`.
Confirmed **pre-existing on a clean `dev` checkout**, unrelated to this
PR's changes. Live behavior is unaffected — the guard correctly returned
`subscription_simulation_forbidden` against the real dev deployment
during manual testing of this exact feature — so this looks like a
test-harness-only issue (possibly `BlocksContext`'s ambient
`AsyncLocal` not isolating as expected between test methods), invisible
in CI since `ci-dev.yml` sets `RUN_TESTS: "false"`. Worth a follow-up
investigation; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)