### PR TITLE
feat(subscription): enable the simulation data console in dev

### DIFF
--- a/server/Api/appsettings.Development.json
+++ b/server/Api/appsettings.Development.json
@@ -31,6 +31,7 @@
     "IamBaseUrl": "https://dev-iam.blocksdevelopers.com"
   },
   "SubscriptionSimulation": {
-    "Enabled": true
+    "Enabled": true,
+    "DataConsoleEnabled": true
   }
 }

--- a/server/Api/appsettings.dev.json
+++ b/server/Api/appsettings.dev.json
@@ -32,6 +32,7 @@
     "VerifyOrganizationWithIam": false
   },
   "SubscriptionSimulation": {
-    "Enabled": true
+    "Enabled": true,
+    "DataConsoleEnabled": true
   }
 }


### PR DESCRIPTION
## Summary

The data console (#290/#293) has been unreachable in dev since it
shipped — reported live:

\`\`\`json
{"error":{"code":"subscription_simulation_data_console_disabled","message":"The subscription simulation data console is not enabled in this environment."}}
\`\`\`

`SubscriptionSimulation:DataConsoleEnabled` is a deliberately separate
flag from `:Enabled` (so the console and the rest of the harness can be
toggled independently), and only `:Enabled` was ever set in dev's
config.

## Change

Adds `"DataConsoleEnabled": true` to `SubscriptionSimulation` in:
- `server/Api/appsettings.dev.json` (the deployed dev environment)
- `server/Api/appsettings.Development.json` (local `dotnet run` with
  the Development environment)

`stg`/`prod` configs are untouched — the data console reads and writes
Mongo documents directly and should stay an explicit per-environment
opt-in, not follow dev automatically.

## Test plan

- [x] Both edited files are valid JSON
- [ ] Not re-verified against the live dev environment from here —
      confirm the "Data console" dialog loads its policy successfully
      once this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)