### PR TITLE
feat(subscription): automatic discounts per price

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -71,6 +71,7 @@ export interface PlanBuilderProps {
    */
   onRetirePrice?: (priceId: string) => void;
   onUpdatePriceTax?: (priceId: string, taxPercent?: number, taxMode?: "Exclusive" | "Inclusive") => Promise<void>;
+  onUpdatePriceDiscount?: (priceId: string, discountPercent?: number, combination?: "BestDiscount" | "Additive") => Promise<void>;
   retiringPriceId?: string | null;
   /** Rejecting leaves the draft alone and shows the reason; the caller navigates on success. */
   onSubmit: (values: CreateSubscriptionPlanFormValues) => Promise<void>;
@@ -94,6 +95,7 @@ const PlanBuilderWizard = ({
   existingPrices = [],
   onRetirePrice,
   onUpdatePriceTax,
+  onUpdatePriceDiscount,
   retiringPriceId = null,
   onSubmit,
 }: PlanBuilderProps) => {
@@ -226,6 +228,7 @@ const PlanBuilderWizard = ({
                       existingPrices={existingPrices}
                       onRetirePrice={onRetirePrice}
                       onUpdatePriceTax={onUpdatePriceTax}
+                      onUpdatePriceDiscount={onUpdatePriceDiscount}
                       retiringPriceId={retiringPriceId}
                     />
                   )}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -178,6 +178,11 @@ const PlanBuilderWizard = ({
           : price.quantityItemKey,
       taxRateBasisPoints: price?.taxPercent ? toBasisPoints(price.taxPercent) : null,
       taxMode: price?.taxPercent ? price.taxMode : null,
+      // The review step summarises what will be sold, and a price with 8% off it is not the price
+      // the amount alone says.
+      automaticDiscountBasisPoints: price?.automaticDiscountPercent
+        ? toBasisPoints(price.automaticDiscountPercent)
+        : null,
     })),
   };
 

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.test.tsx
@@ -173,6 +173,79 @@ describe("PlanPriceFields", () => {
     expect(screen.getByText(/\+ 20% tax/)).toBeInTheDocument();
   });
 
+  it("shows what an automatic discount does to the charge", async () => {
+    // The whole reason the preview exists: 8% off 89.00 is a number an author can check against the
+    // pricing page they wrote, and a percentage on its own is not.
+    render(
+      <Harness>
+        <PlanPriceFields />
+      </Harness>,
+    );
+
+    await userEvent.type(screen.getByLabelText(/^Amount$/), "89");
+    await userEvent.type(screen.getByLabelText(/Automatic discount for price 1/), "8");
+
+    const preview = screen.getByTestId("discount-preview-0");
+
+    expect(preview).toHaveTextContent("$7.12");
+    expect(preview).toHaveTextContent("$81.88");
+  });
+
+  it("offers the combination only once there is a discount to combine", async () => {
+    render(
+      <Harness>
+        <PlanPriceFields />
+      </Harness>,
+    );
+
+    expect(
+      screen.queryByLabelText(/Discount combination for price 1/),
+    ).not.toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/Automatic discount for price 1/), "8");
+
+    expect(screen.getByLabelText(/Discount combination for price 1/)).toBeInTheDocument();
+  });
+
+  it("holds no discount at all when the field is cleared", async () => {
+    // The same trap the tax rate walks into: an emptied number input holds "", which coerces to 0,
+    // which authors a discount of nothing rather than no discount.
+    let latest: CreateSubscriptionPlanFormValues | undefined;
+
+    render(
+      <Harness onValues={(values) => { latest = values; }}>
+        <PlanPriceFields />
+      </Harness>,
+    );
+
+    const discount = screen.getByLabelText(/Automatic discount for price 1/);
+
+    await userEvent.type(discount, "8");
+    await userEvent.clear(discount);
+
+    expect(latest?.prices[0]?.automaticDiscountPercent).toBeFalsy();
+    expect(screen.queryByTestId("discount-preview-0")).not.toBeInTheDocument();
+  });
+
+  it("offers a discount editor for prices the plan already has", () => {
+    // Editable, unlike the amount beside it: the discount reaches future subscriptions only, so
+    // changing it cannot contradict anything already sold.
+    render(
+      <Harness>
+        <PlanPriceFields
+          isEditing
+          existingPrices={[price({ automaticDiscountBasisPoints: 800 })]}
+          onUpdatePriceDiscount={async () => {}}
+        />
+      </Harness>,
+    );
+
+    // Named by the price itself, which is also what tells it apart from the draft row's own
+    // field further down the form.
+    expect(screen.getByLabelText(/Automatic discount for €12\.00/)).toHaveValue(8);
+    expect(screen.getByRole("button", { name: /Save discount/ })).toBeInTheDocument();
+  });
+
   it("says nothing about existing prices while creating", () => {
     render(
       <Harness>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -28,6 +28,11 @@ import {
   FLAT_FEE,
 } from "../../schemas/subscription-price.schema";
 import { formatPrice } from "../../utilities/subscription-format";
+import {
+  AUTOMATIC_DISCOUNT_COMBINATION_OPTIONS,
+  describeAutomaticDiscount,
+  type AutomaticDiscountCombination,
+} from "../../utilities/subscription-discount";
 import { describeTax, TAX_MODE_OPTIONS } from "../../utilities/subscription-tax";
 import { CardListItem, CardListShell } from "./card-list-shell";
 
@@ -87,6 +92,89 @@ const ExistingPriceTaxEditor = ({
         }}
       >
         {saving ? "Saving…" : "Save tax"}
+      </Button>
+      {error && <p className="text-xs text-destructive sm:col-span-3">{error}</p>}
+    </div>
+  );
+};
+
+/**
+ * The automatic discount on a price that already exists.
+ *
+ * Its own editor beside the tax one, because they are two endpoints and two decisions: an author
+ * changing a discount has not necessarily changed their mind about VAT. Both are the same deliberate
+ * exception to a price being immutable — they reach future subscriptions only.
+ */
+const ExistingPriceDiscountEditor = ({
+  price,
+  onSave,
+}: {
+  price: PlanPrice;
+  onSave: (
+    priceId: string,
+    discountPercent?: number,
+    combination?: AutomaticDiscountCombination,
+  ) => Promise<void>;
+}) => {
+  const [discountPercent, setDiscountPercent] = useState<string>(
+    price.automaticDiscountBasisPoints ? String(price.automaticDiscountBasisPoints / 100) : "",
+  );
+  const [combination, setCombination] = useState<AutomaticDiscountCombination>(
+    price.quantityDiscountCombination === "Additive" ? "Additive" : "BestDiscount",
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const numericDiscount = discountPercent === "" ? undefined : Number(discountPercent);
+
+  return (
+    <div className="mt-2 grid gap-2 rounded-md border border-dashed p-2 sm:grid-cols-[8rem_13rem_auto]">
+      <Input
+        aria-label={`Automatic discount for ${formatPrice(price)}`}
+        type="number"
+        min={0}
+        max={100}
+        step="0.01"
+        value={discountPercent}
+        placeholder="No discount"
+        onChange={(event) => setDiscountPercent(event.target.value)}
+      />
+      <Select
+        value={combination}
+        onValueChange={(value) => setCombination(value as AutomaticDiscountCombination)}
+      >
+        <SelectTrigger
+          aria-label={`Discount combination for ${formatPrice(price)}`}
+          disabled={!numericDiscount}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {AUTOMATIC_DISCOUNT_COMBINATION_OPTIONS.map((option) => (
+            <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        type="button"
+        size="sm"
+        disabled={
+          saving ||
+          (numericDiscount !== undefined &&
+            (!Number.isFinite(numericDiscount) || numericDiscount < 0 || numericDiscount > 100))
+        }
+        onClick={async () => {
+          setSaving(true);
+          setError(null);
+          try {
+            await onSave(price.priceId, numericDiscount, numericDiscount ? combination : undefined);
+          } catch (reason) {
+            setError(reason instanceof Error ? reason.message : "The discount could not be saved.");
+          } finally {
+            setSaving(false);
+          }
+        }}
+      >
+        {saving ? "Saving\u2026" : "Save discount"}
       </Button>
       {error && <p className="text-xs text-destructive sm:col-span-3">{error}</p>}
     </div>
@@ -198,6 +286,138 @@ const PriceTaxFields = ({ index }: { index: number }) => {
 };
 
 /**
+ * One price's automatic discount, and the whole calculation it takes part in.
+ *
+ * The preview is the point, and it is a different preview from the tax one: "8% off" and "5% for
+ * volume" produce two different totals depending on one selector, and an author cannot check their
+ * own work without seeing which. It prices the default quantity through the band that quantity
+ * selects, so the sentence under the card is the charge a first subscriber would actually see.
+ *
+ * Its own component for the same reason the tax fields are: it watches this row and the plan's
+ * quantity items, and watching those in the list body would re-render every price card on every
+ * keystroke in any of them.
+ */
+const PriceDiscountFields = ({ index }: { index: number }) => {
+  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const price = useWatch({ control, name: `prices.${index}` });
+  const quantityItems = useWatch({ control, name: "quantityItems" });
+
+  const discountPercent =
+    price?.automaticDiscountPercent === undefined || price?.automaticDiscountPercent === null
+      ? undefined
+      : Number(price.automaticDiscountPercent);
+
+  // The item this price multiplies, if any. A flat fee has no quantity and no band, and prices as
+  // one unit — which is exactly what the preview should show for it.
+  const item = (quantityItems ?? []).find(
+    (candidate) => candidate.itemKey && candidate.itemKey === price?.quantityItemKey,
+  );
+  const quantity = item ? Number(item.defaultQuantity) || 1 : 1;
+  const band = (item?.quantityDiscountTiers ?? []).find(
+    (tier) =>
+      quantity >= Number(tier.minimumQuantity) &&
+      (tier.maximumQuantity === undefined || quantity <= Number(tier.maximumQuantity)),
+  );
+
+  const combination: AutomaticDiscountCombination =
+    price?.quantityDiscountCombination === "Additive" ? "Additive" : "BestDiscount";
+
+  const preview = describeAutomaticDiscount({
+    // Coerced for the same reason the tax preview coerces: these come off number inputs as strings
+    // until the resolver copies them, and "100" * 2 is fine while "100" + 8 is not.
+    amount: price?.amount === undefined ? undefined : Number(price.amount),
+    currencyCode: price?.currencyCode ?? "USD",
+    quantity,
+    automaticDiscountPercent: discountPercent,
+    quantityDiscountPercent: band ? Number(band.discountPercent) : 0,
+    combination,
+    taxPercent:
+      price?.taxPercent === undefined || price?.taxPercent === null
+        ? undefined
+        : Number(price.taxPercent),
+    taxMode: price?.taxMode ?? "Exclusive",
+  });
+
+  const discounted = Boolean(discountPercent && discountPercent > 0);
+
+  return (
+    <div className="space-y-2 rounded-md border border-dashed border-border/70 p-2">
+      <p className="text-xs font-medium">Automatic discount</p>
+
+      <div className="grid grid-cols-2 gap-2">
+        <FormField
+          control={control}
+          name={`prices.${index}.automaticDiscountPercent`}
+          render={({ field: inputField }) => (
+            <FormItem>
+              <FormLabel className="text-xs">Automatic discount (%)</FormLabel>
+              <FormControl>
+                <Input
+                  {...inputField}
+                  // Never undefined, or the input goes uncontrolled mid-edit and keeps showing a
+                  // number the form no longer holds.
+                  value={inputField.value ?? ""}
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  placeholder="8"
+                  aria-label={`Automatic discount for price ${index + 1}`}
+                />
+              </FormControl>
+              <FormDescription className="text-xs">
+                Applied without a code, for as long as the subscription stays on this price.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {discounted && (
+          <FormField
+            control={control}
+            name={`prices.${index}.quantityDiscountCombination`}
+            render={({ field: inputField }) => (
+              <FormItem>
+                <FormLabel className="text-xs">Combine with quantity discount</FormLabel>
+                <Select value={inputField.value} onValueChange={inputField.onChange}>
+                  <FormControl>
+                    <SelectTrigger aria-label={`Discount combination for price ${index + 1}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {AUTOMATIC_DISCOUNT_COMBINATION_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription className="text-xs">
+                  {
+                    AUTOMATIC_DISCOUNT_COMBINATION_OPTIONS.find(
+                      (option) => option.value === inputField.value,
+                    )?.hint
+                  }
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+      </div>
+
+      {preview && (
+        <p className="text-xs text-muted-foreground" data-testid={`discount-preview-${index}`}>
+          {preview}
+        </p>
+      )}
+    </div>
+  );
+};
+
+/**
  * The prices the plan will be sold on. A repeatable list rather than one price, because the
  * ordinary case is more than one — a monthly and an annual price are two prices on the same plan,
  * and so is the same plan sold in two currencies.
@@ -207,6 +427,7 @@ export const PlanPriceFields = ({
   existingPrices = [],
   onRetirePrice,
   onUpdatePriceTax,
+  onUpdatePriceDiscount,
   retiringPriceId = null,
 }: {
   isEditing?: boolean;
@@ -222,6 +443,11 @@ export const PlanPriceFields = ({
     priceId: string,
     taxPercent?: number,
     taxMode?: "Exclusive" | "Inclusive",
+  ) => Promise<void>;
+  onUpdatePriceDiscount?: (
+    priceId: string,
+    discountPercent?: number,
+    combination?: AutomaticDiscountCombination,
   ) => Promise<void>;
   retiringPriceId?: string | null;
 }) => {
@@ -270,13 +496,17 @@ export const PlanPriceFields = ({
                   )}
                 </div>
                 {onUpdatePriceTax && <ExistingPriceTaxEditor price={price} onSave={onUpdatePriceTax} />}
+                {onUpdatePriceDiscount && (
+                  <ExistingPriceDiscountEditor price={price} onSave={onUpdatePriceDiscount} />
+                )}
               </li>
             ))}
           </ul>
           <p className="mt-2 text-xs text-muted-foreground">
             Retiring stops a price being sold. Anyone already on it keeps their terms and their
             renewals — a subscription bills from what it was sold on, not from this list. Prices
-            keep immutable amount and cadence terms; only tax metadata for future subscriptions can be edited.
+            keep immutable amount and cadence terms; only tax and automatic-discount metadata can be
+            edited, and only for future subscriptions and future moves onto the price.
           </p>
         </div>
       )}
@@ -391,6 +621,8 @@ export const PlanPriceFields = ({
             />
 
             <PriceTaxFields index={index} />
+
+            <PriceDiscountFields index={index} />
 
             <FormField
               control={control}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -39,12 +39,14 @@ export const StepPricingModel = ({
   existingPrices = [],
   onRetirePrice,
   onUpdatePriceTax,
+  onUpdatePriceDiscount,
   retiringPriceId = null,
 }: {
   isEditing?: boolean;
   existingPrices?: PlanPrice[];
   onRetirePrice?: (priceId: string) => void;
   onUpdatePriceTax?: (priceId: string, taxPercent?: number, taxMode?: "Exclusive" | "Inclusive") => Promise<void>;
+  onUpdatePriceDiscount?: (priceId: string, discountPercent?: number, combination?: "BestDiscount" | "Additive") => Promise<void>;
   retiringPriceId?: string | null;
 }) => {
   const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
@@ -469,6 +471,7 @@ export const StepPricingModel = ({
         existingPrices={existingPrices}
         onRetirePrice={onRetirePrice}
         onUpdatePriceTax={onUpdatePriceTax}
+        onUpdatePriceDiscount={onUpdatePriceDiscount}
         retiringPriceId={retiringPriceId}
       />
     </div>

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -56,6 +56,8 @@ export interface PlanSummaryData {
     /** Summarized by formatPrice, so a reviewer sees whether the amount includes tax. */
     taxRateBasisPoints?: number | null;
     taxMode?: string | null;
+    /** Likewise: an automatic discount changes what the amount above will actually charge. */
+    automaticDiscountBasisPoints?: number | null;
   }[];
   /** A meter's allowance for the length of the trial, replacing the plan's own. */
   trialGrants: { meterKey: string; includedQuantity: number }[];

--- a/client/app/cross-modules/utilities/subscription/hooks/use-update-subscription-price-discount.ts
+++ b/client/app/cross-modules/utilities/subscription/hooks/use-update-subscription-price-discount.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { UpdateSubscriptionPriceDiscountRequest } from "../models/subscription-plan.model";
+import { subscriptionService } from "../services/subscription.service";
+
+export const useUpdateSubscriptionPriceDiscount = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      priceId,
+      request,
+    }: {
+      priceId: string;
+      request: UpdateSubscriptionPriceDiscountRequest;
+    }) => subscriptionService.updatePriceDiscount(priceId, request),
+    onSuccess: (plan) => {
+      queryClient.invalidateQueries({ queryKey: ["subscription-plans"] });
+      queryClient.invalidateQueries({ queryKey: ["subscription-plan", plan.planId] });
+    },
+  });
+};

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -133,6 +133,14 @@ export interface PlanPrice {
    * existed — the server reports those as exclusive, which is how they are charged.
    */
   taxMode?: string | null;
+  /** Basis points off without a code — 800 is 8%. Absent when the price has no automatic discount. */
+  automaticDiscountBasisPoints?: number | null;
+  /**
+   * "BestDiscount" or "Additive" — how that discount meets a volume band. Present whenever there is
+   * an automatic discount; the server reports one authored without a combination as BestDiscount,
+   * which is how it is calculated.
+   */
+  quantityDiscountCombination?: string | null;
 }
 
 export interface SubscriptionPlan {
@@ -275,6 +283,21 @@ export interface CreateSubscriptionPriceRequest {
   /** Basis points. Omitted for an untaxed price; the mode is required whenever this is positive. */
   taxRateBasisPoints?: number;
   taxMode?: string;
+  /** Basis points off without a code. Omitted for no automatic discount. */
+  automaticDiscountBasisPoints?: number;
+  /** Omitted reads as "BestDiscount" on the server — the answer that gives away less. */
+  quantityDiscountCombination?: string;
+}
+
+/**
+ * Changes what an existing price takes off automatically. Reaches future subscriptions and future
+ * moves onto the price only — everyone already on it keeps the terms they were sold.
+ */
+export interface UpdateSubscriptionPriceDiscountRequest {
+  organizationId?: string;
+  /** Zero clears the discount. */
+  automaticDiscountBasisPoints?: number;
+  quantityDiscountCombination?: "BestDiscount" | "Additive";
 }
 
 export interface UpdateSubscriptionPriceTaxRequest {
@@ -295,6 +318,8 @@ export interface SubscriptionDiscount {
   durationPeriods: number | null;
   expiresAtUtc: string | null;
   applicablePlanCodes: string[];
+  /** Absent on discounts stored before price restrictions existed, which are unrestricted by price. */
+  applicablePriceIds?: string[];
   status: "Active" | "Archived";
 }
 
@@ -309,4 +334,6 @@ export interface CreateSubscriptionDiscountRequest {
   durationPeriods?: number;
   expiresAtUtc?: string;
   applicablePlanCodes: string[];
+  /** Narrows the plan list rather than replacing it: both have to match when both are given. */
+  applicablePriceIds: string[];
 }

--- a/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
@@ -11,6 +11,7 @@ import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-pri
 import { useOrganizationScope, withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlan } from "../hooks/use-subscription-plan";
 import { useUpdateSubscriptionPlan } from "../hooks/use-update-subscription-plan";
+import { useUpdateSubscriptionPriceDiscount } from "../hooks/use-update-subscription-price-discount";
 import { useUpdateSubscriptionPriceTax } from "../hooks/use-update-subscription-price-tax";
 import { toBasisPoints } from "../utilities/subscription-tax";
 import { planToFormValues, toUpdatePlanRequest } from "../utilities/plan-form-mapping";
@@ -30,6 +31,7 @@ export const EditSubscriptionPlanPage = () => {
   const { mutateAsync: createPrice, isPending: isPricing } = useCreateSubscriptionPrice();
   const { mutateAsync: archivePrice } = useArchiveSubscriptionPrice();
   const { mutateAsync: updatePriceTax } = useUpdateSubscriptionPriceTax();
+  const { mutateAsync: updatePriceDiscount } = useUpdateSubscriptionPriceDiscount();
   const [retiringPriceId, setRetiringPriceId] = useState<string | null>(null);
 
   const detailPath = withOrganizationScope(
@@ -145,6 +147,26 @@ export const EditSubscriptionPlanPage = () => {
           variant: "success",
           title: "Price tax saved",
           description: "New subscriptions will use this tax configuration; existing subscriptions keep their snapshot.",
+        });
+      }}
+      onUpdatePriceDiscount={async (priceId, discountPercent, combination) => {
+        await updatePriceDiscount({
+          priceId,
+          request: {
+            organizationId: plan.organizationId ?? undefined,
+            // Zero clears it, which is why an absent percentage is sent as zero rather than omitted:
+            // omitting the field would leave the stored discount in place.
+            automaticDiscountBasisPoints: discountPercent
+              ? toBasisPoints(discountPercent)
+              : 0,
+            quantityDiscountCombination: discountPercent ? combination : undefined,
+          },
+        });
+        toast({
+          variant: "success",
+          title: discountPercent ? "Automatic discount saved" : "Automatic discount cleared",
+          description:
+            "New subscriptions and future moves onto this price use it; everyone already on it keeps their snapshot.",
         });
       }}
       onSubmit={async (values) => {

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
@@ -6,9 +6,47 @@ import { Card } from "@/components/ui-kits/card/card";
 import { Input } from "@/components/ui-kits/input/input";
 import { Label } from "@/components/ui-kits/label/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui-kits/select/select";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
 import { useOrganizationScope } from "../hooks/use-organization-scope";
+import { useSubscriptionPlans } from "../hooks/use-subscription-plans";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
 import { subscriptionService } from "../services/subscription.service";
+import { formatPrice } from "../utilities/subscription-format";
+
+/**
+ * What a discount applies to, in one line.
+ *
+ * Names the cadence rather than the identifier: "pro · CHF 145.00 / year" is what somebody authored,
+ * and a price id tells a reader nothing about whether the restriction is the one they meant. A price
+ * that has since been retired is still shown by id, because the restriction is still in force.
+ */
+const describeApplicability = (
+  planCodes: string[],
+  priceIds: string[] | undefined,
+  plans: SubscriptionPlan[],
+): string => {
+  const prices = (priceIds ?? []).map((priceId) => {
+    const match = plans
+      .flatMap((plan) => plan.prices.map((price) => ({ plan, price })))
+      .find((candidate) => candidate.price.priceId === priceId);
+
+    return match ? `${match.plan.code} · ${formatPrice(match.price)}` : priceId;
+  });
+
+  if (planCodes.length === 0 && prices.length === 0) {
+    return "Applies to any plan and any price.";
+  }
+
+  const parts = [
+    planCodes.length > 0 ? `plans: ${planCodes.join(", ")}` : null,
+    prices.length > 0 ? `prices: ${prices.join(", ")}` : null,
+  ].filter(Boolean);
+
+  // "and" rather than "or": both restrictions have to match, which is the part an author is most
+  // likely to get wrong when they set both.
+  return `Restricted to ${parts.join(" and ")}.`;
+};
 
 export const SubscriptionDiscountsPage = () => {
   const { itemId } = useParams();
@@ -22,7 +60,20 @@ export const SubscriptionDiscountsPage = () => {
   const [currencyCode, setCurrencyCode] = useState("USD");
   const [durationPeriods, setDurationPeriods] = useState("");
   const [expiresAtUtc, setExpiresAtUtc] = useState("");
-  const [plans, setPlans] = useState("");
+  const [planCodes, setPlanCodes] = useState<string[]>([]);
+  const [priceIds, setPriceIds] = useState<string[]>([]);
+
+  const catalogue = useSubscriptionPlans(organizationId);
+  const availablePlans = catalogue.data ?? [];
+
+  // Only the prices of the plans that are actually restricted to. A discount aimed at one plan and
+  // a price belonging to another can never match, and offering that pair invites authoring it.
+  const selectablePrices = availablePlans
+    .filter((plan) => planCodes.length === 0 || planCodes.includes(plan.code))
+    .flatMap((plan) => plan.prices.map((price) => ({ plan, price })));
+
+  const toggle = (values: string[], value: string) =>
+    values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value];
 
   const discounts = useQuery({
     queryKey: ["subscription-discounts", organizationId],
@@ -39,10 +90,12 @@ export const SubscriptionDiscountsPage = () => {
       currencyCode: kind === "fixed" ? currencyCode : undefined,
       durationPeriods: durationPeriods ? Number(durationPeriods) : undefined,
       expiresAtUtc: expiresAtUtc ? new Date(expiresAtUtc).toISOString() : undefined,
-      applicablePlanCodes: plans.split(",").map((value) => value.trim()).filter(Boolean),
+      applicablePlanCodes: planCodes,
+      // Both lists narrow, so an empty one is "unrestricted by that" rather than "matches nothing".
+      applicablePriceIds: priceIds,
     }),
     onSuccess: async () => {
-      setCode(""); setDisplayName(""); setPlans("");
+      setCode(""); setDisplayName(""); setPlanCodes([]); setPriceIds([]);
       await queryClient.invalidateQueries({ queryKey: ["subscription-discounts"] });
     },
   });
@@ -65,7 +118,60 @@ export const SubscriptionDiscountsPage = () => {
           <div><Label htmlFor="discount-name">Display name</Label><Input id="discount-name" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Launch offer" /></div>
           <div><Label>Kind</Label><Select value={kind} onValueChange={(value) => setKind(value as "percent" | "fixed")}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="percent">Percentage</SelectItem><SelectItem value="fixed">Fixed amount</SelectItem></SelectContent></Select></div>
           {kind === "percent" ? <div><Label htmlFor="discount-percent">Percent off</Label><Input id="discount-percent" type="number" min={0.01} max={100} value={percent} onChange={(event) => setPercent(event.target.value)} /></div> : <div className="grid grid-cols-2 gap-2"><div><Label htmlFor="discount-amount">Minor units off</Label><Input id="discount-amount" type="number" min={1} value={amountMinor} onChange={(event) => setAmountMinor(event.target.value)} /></div><div><Label htmlFor="discount-currency">Currency</Label><Input id="discount-currency" maxLength={3} value={currencyCode} onChange={(event) => setCurrencyCode(event.target.value.toUpperCase())} /></div></div>}
-          <div><Label htmlFor="discount-plans">Plan codes (optional)</Label><Input id="discount-plans" value={plans} onChange={(event) => setPlans(event.target.value)} placeholder="pro, max-5x" /></div>
+          <fieldset className="space-y-1">
+            <legend className="text-sm font-medium">Plans (optional)</legend>
+            <p className="text-xs text-muted-foreground">Leave every box clear to allow any plan.</p>
+            <div className="max-h-32 space-y-1 overflow-y-auto rounded-md border p-2">
+              {availablePlans.length === 0 && (
+                <p className="text-xs text-muted-foreground">No plans authored yet.</p>
+              )}
+              {availablePlans.map((plan) => (
+                <label key={plan.planId} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={planCodes.includes(plan.code)}
+                    onCheckedChange={() => {
+                      const next = toggle(planCodes, plan.code);
+                      setPlanCodes(next);
+                      // Prices belonging to a plan that is no longer selected cannot match anything,
+                      // so they are dropped rather than left in a state nobody can see or undo.
+                      setPriceIds((current) =>
+                        current.filter((priceId) =>
+                          availablePlans
+                            .filter((candidate) =>
+                              next.length === 0 || next.includes(candidate.code))
+                            .some((candidate) =>
+                              candidate.prices.some((price) => price.priceId === priceId)),
+                        ),
+                      );
+                    }}
+                    aria-label={`Restrict to ${plan.displayName}`}
+                  />
+                  <span>{plan.displayName} <code className="text-xs">{plan.code}</code></span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <fieldset className="space-y-1">
+            <legend className="text-sm font-medium">Prices (optional)</legend>
+            <p className="text-xs text-muted-foreground">
+              Narrows to one cadence or currency — a yearly-only offer, for instance.
+            </p>
+            <div className="max-h-32 space-y-1 overflow-y-auto rounded-md border p-2">
+              {selectablePrices.length === 0 && (
+                <p className="text-xs text-muted-foreground">No prices to choose from.</p>
+              )}
+              {selectablePrices.map(({ plan, price }) => (
+                <label key={price.priceId} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={priceIds.includes(price.priceId)}
+                    onCheckedChange={() => setPriceIds(toggle(priceIds, price.priceId))}
+                    aria-label={`Restrict to ${plan.code} ${formatPrice(price)}`}
+                  />
+                  <span>{plan.code} · {formatPrice(price)}</span>
+                </label>
+              ))}
+            </div>
+          </fieldset>
           <div><Label htmlFor="discount-duration">Duration in billing periods (optional)</Label><Input id="discount-duration" type="number" min={1} value={durationPeriods} onChange={(event) => setDurationPeriods(event.target.value)} /></div>
           <div><Label htmlFor="discount-expiry">Expires at (optional)</Label><Input id="discount-expiry" type="datetime-local" value={expiresAtUtc} onChange={(event) => setExpiresAtUtc(event.target.value)} /></div>
         </div>
@@ -77,7 +183,7 @@ export const SubscriptionDiscountsPage = () => {
         <div className="divide-y">
           {(discounts.data ?? []).map((discount) => (
             <div key={discount.discountId} className="flex items-center justify-between gap-4 p-4">
-              <div><p className="font-medium">{discount.displayName} <code className="text-xs">{discount.code}</code></p><p className="text-xs text-muted-foreground">{discount.percentBasisPoints ? `${discount.percentBasisPoints / 100}% off` : `${discount.amountMinor} ${discount.currencyCode} minor units off`} · {discount.status}</p></div>
+              <div><p className="font-medium">{discount.displayName} <code className="text-xs">{discount.code}</code></p><p className="text-xs text-muted-foreground">{discount.percentBasisPoints ? `${discount.percentBasisPoints / 100}% off` : `${discount.amountMinor} ${discount.currencyCode} minor units off`} · {discount.status}</p><p className="text-xs text-muted-foreground">{describeApplicability(discount.applicablePlanCodes, discount.applicablePriceIds, availablePlans)}</p></div>
               {discount.status === "Active" && <Button variant="ghost" size="sm" onClick={() => archive.mutate(discount.discountId)}>Retire</Button>}
             </div>
           ))}

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.test.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.test.ts
@@ -44,6 +44,44 @@ describe("createSubscriptionPriceSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("defaults the discount combination so an unstated one still means something", () => {
+    // A caller that has never heard of the field — an older client, a script, a fixture — has to keep
+    // describing the price it meant. BestDiscount is the reading that gives away less.
+    const result = createSubscriptionPriceSchema.safeParse({
+      ...defaultSubscriptionPriceFormValues,
+      quantityDiscountCombination: undefined,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.quantityDiscountCombination).toBe("BestDiscount");
+      expect(result.data.automaticDiscountPercent).toBeUndefined();
+    }
+  });
+
+  it("reads a cleared discount input as no discount rather than as zero percent", () => {
+    // A number input that has been emptied holds "", and coercing that gives 0 — which would author
+    // a discount of nothing instead of no discount at all.
+    const result = createSubscriptionPriceSchema.safeParse({
+      ...defaultSubscriptionPriceFormValues,
+      automaticDiscountPercent: "",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.automaticDiscountPercent).toBeUndefined();
+    }
+  });
+
+  it("rejects a discount above a hundred percent", () => {
+    const result = createSubscriptionPriceSchema.safeParse({
+      ...defaultSubscriptionPriceFormValues,
+      automaticDiscountPercent: 101,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("coerces a numeric string amount, matching a text input's value type", () => {
     const result = createSubscriptionPriceSchema.safeParse({
       ...defaultSubscriptionPriceFormValues,

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { AUTOMATIC_DISCOUNT_COMBINATIONS } from "../utilities/subscription-discount";
 import { TAX_MODES } from "../utilities/subscription-tax";
 
 /**
@@ -51,6 +52,27 @@ export const subscriptionPriceFieldsSchema = z.object({
    * older client, a script, a test fixture — therefore keeps describing exactly the price it meant.
    */
   taxMode: z.enum(TAX_MODES).default("Exclusive"),
+  /**
+   * A percentage taken off this price without a code, converted to basis points on submit. Optional
+   * and empty-string-tolerant for the same reasons the tax rate is: a cleared number input holds
+   * `""`, and coercing that to zero would author a discount of nothing rather than no discount.
+   */
+  automaticDiscountPercent: z.preprocess(
+    (value) => (value === "" || value === null || value === undefined ? undefined : value),
+    z.coerce
+      .number()
+      .min(0, "A discount cannot be negative.")
+      .max(100, "A discount cannot exceed 100%.")
+      .optional(),
+  ),
+  /**
+   * How that discount meets a volume band. Defaulted rather than required, because "unstated" has a
+   * safe meaning: take the better of the two and never both, which cannot give away more than the
+   * author wrote.
+   */
+  quantityDiscountCombination: z
+    .enum(AUTOMATIC_DISCOUNT_COMBINATIONS)
+    .default("BestDiscount"),
 });
 
 export const createSubscriptionPriceSchema = subscriptionPriceFieldsSchema;
@@ -65,6 +87,8 @@ export const defaultSubscriptionPriceFormValues: CreateSubscriptionPriceFormValu
   displayPriceNote: "",
   quantityItemKey: FLAT_FEE,
   taxPercent: undefined,
+  automaticDiscountPercent: undefined,
+  quantityDiscountCombination: "BestDiscount",
   // Exclusive by default because it is the reading that matches every price authored before this
   // existed, so an author who ignores this section changes nothing.
   taxMode: "Exclusive",

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
@@ -10,6 +10,7 @@ import type {
   SubscriptionDiscount,
   SubscriptionPlan,
   UpdateSubscriptionPlanRequest,
+  UpdateSubscriptionPriceDiscountRequest,
   UpdateSubscriptionPriceTaxRequest,
 } from "../models/subscription-plan.model";
 
@@ -158,6 +159,23 @@ class SubscriptionService {
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "The price tax could not be saved.");
+    }
+
+    return response.data;
+  }
+
+  async updatePriceDiscount(
+    priceId: string,
+    request: UpdateSubscriptionPriceDiscountRequest,
+  ): Promise<SubscriptionPlan> {
+    const response = await serviceInstances.utitlitiesService.put<
+      SubscriptionApiResponse<SubscriptionPlan>
+    >(`${SUBSCRIPTION_PLAN_PRICES_ENDPOINT}/${encodeURIComponent(priceId)}/discount`, request);
+
+    if (!response.success || !response.data) {
+      throw new Error(
+        response.error?.message || "The automatic discount could not be saved.",
+      );
     }
 
     return response.data;

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -281,3 +281,72 @@ describe("quantity discount combination policy", () => {
     expect(request.quantityDiscountCombinationPolicy).toBeDefined();
   });
 });
+
+describe("automatic price discounts", () => {
+  it("reopens a duplicated price with its discount and combination intact", () => {
+    // Duplicating exists so somebody can start from a plan they already sell. A duplicate that
+    // dropped the 8% yearly discount would quietly author a different product.
+    const values = planToFormValues(
+      storedPlan({
+        prices: [
+          {
+            priceId: "price-yearly",
+            currencyCode: "CHF",
+            unitAmountMinor: 100_000,
+            interval: "Year",
+            intervalCount: 1,
+            quantityItemKey: null,
+            automaticDiscountBasisPoints: 800,
+            quantityDiscountCombination: "Additive",
+          },
+        ],
+      }),
+      { includePrices: true },
+    );
+
+    expect(values.prices[0].automaticDiscountPercent).toBe(8);
+    expect(values.prices[0].quantityDiscountCombination).toBe("Additive");
+  });
+
+  it("reads a discounted price with no combination as the safe one", () => {
+    // How the server calculates it, so a duplicate cannot start giving the volume band away too.
+    const values = planToFormValues(
+      storedPlan({
+        prices: [
+          {
+            priceId: "price-yearly",
+            currencyCode: "CHF",
+            unitAmountMinor: 100_000,
+            interval: "Year",
+            intervalCount: 1,
+            quantityItemKey: null,
+            automaticDiscountBasisPoints: 800,
+          },
+        ],
+      }),
+      { includePrices: true },
+    );
+
+    expect(values.prices[0].quantityDiscountCombination).toBe("BestDiscount");
+  });
+
+  it("leaves an undiscounted price without one", () => {
+    const values = planToFormValues(
+      storedPlan({
+        prices: [
+          {
+            priceId: "price-monthly",
+            currencyCode: "CHF",
+            unitAmountMinor: 10_000,
+            interval: "Month",
+            intervalCount: 1,
+            quantityItemKey: null,
+          },
+        ],
+      }),
+      { includePrices: true },
+    );
+
+    expect(values.prices[0].automaticDiscountPercent).toBeUndefined();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -211,4 +211,12 @@ const planPriceToFormValues = (price: PlanPrice): CreateSubscriptionPriceFormVal
     ? fromBasisPoints(price.taxRateBasisPoints)
     : undefined,
   taxMode: price.taxMode === "Inclusive" ? "Inclusive" : "Exclusive",
+  automaticDiscountPercent: price.automaticDiscountBasisPoints
+    ? fromBasisPoints(price.automaticDiscountBasisPoints)
+    : undefined,
+  // Read as the better-of-the-two when a discounted price carries no combination, matching how the
+  // server calculates it. A duplicate that flipped it to additive would give away the volume band
+  // as well, on a price nobody meant to change.
+  quantityDiscountCombination:
+    price.quantityDiscountCombination === "Additive" ? "Additive" : "BestDiscount",
 });

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.test.ts
@@ -64,6 +64,31 @@ describe("submitPlanWithPrices", () => {
     });
   });
 
+  it("sends an automatic discount with its combination, or neither", async () => {
+    const createPrice = vi.fn().mockResolvedValue(createdPlan());
+
+    await submitPlanWithPrices({
+      planRequest,
+      prices: [
+        price({ automaticDiscountPercent: 8, quantityDiscountCombination: "Additive" }),
+        // No discount, but a combination left over from the form's default. Sending it would
+        // describe how a reduction that does not exist meets a band.
+        price({ quantityDiscountCombination: "Additive" }),
+      ],
+      createPlan: vi.fn().mockResolvedValue(createdPlan()),
+      createPrice,
+    });
+
+    expect(createPrice.mock.calls[0][0]).toMatchObject({
+      automaticDiscountBasisPoints: 800,
+      quantityDiscountCombination: "Additive",
+    });
+    expect(createPrice.mock.calls[1][0]).toMatchObject({
+      automaticDiscountBasisPoints: undefined,
+      quantityDiscountCombination: undefined,
+    });
+  });
+
   it("names the plan's organization on every price", async () => {
     const createPrice = vi.fn().mockResolvedValue(createdPlan("org-x"));
 

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
@@ -58,6 +58,14 @@ export const submitPlanWithPrices = async <TPlanRequest,>({
         // does not apply.
         taxRateBasisPoints: price.taxPercent ? toBasisPoints(price.taxPercent) : undefined,
         taxMode: price.taxPercent ? price.taxMode : undefined,
+        // Both or neither again: a combination without a discount would describe how a reduction
+        // that does not exist meets a band.
+        automaticDiscountBasisPoints: price.automaticDiscountPercent
+          ? toBasisPoints(price.automaticDiscountPercent)
+          : undefined,
+        quantityDiscountCombination: price.automaticDiscountPercent
+          ? price.quantityDiscountCombination
+          : undefined,
       });
     } catch (error) {
       failures.push(

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-discount.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-discount.test.ts
@@ -63,8 +63,10 @@ describe("discount breakdown", () => {
   });
 
   it("truncates a discount rather than rounding it up", () => {
-    // The direction that favours the customer, and the direction the server's bands already take.
-    // Rounding up would take more off than the percentage advertised.
+    // Matching the server, which truncates to stay compatible with the volume bands that came
+    // before it. Truncating a reduction makes the reduction smaller, so this leans very slightly
+    // toward the merchant — the point of asserting it is that the preview leans the same way as the
+    // charge, to the minor unit.
     expect(
       discountBreakdown({
         grossMinor: 999,

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-discount.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-discount.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+
+import { describeAutomaticDiscount, discountBreakdown } from "./subscription-discount";
+
+/**
+ * Currency formatting puts a non-breaking space between the code and the number, which no test
+ * should have to spell. Normalised here so the assertions read the way the sentence does.
+ */
+const plain = (sentence: string | null) => sentence?.replace(/\u00a0/g, " ") ?? null;
+
+/**
+ * The preview arithmetic for automatic discounts, which has to agree with the server's to the cent.
+ *
+ * The figures below are the same ones asserted in `AutomaticPriceDiscountTests` on the server: 8%
+ * for the cadence and 5% for the volume against a gross of 100,000, because that is the pair the two
+ * combinations disagree about — 13% one way, 8% the other.
+ */
+describe("discount breakdown", () => {
+  it("adds the two rates under Additive and applies them once", () => {
+    expect(
+      discountBreakdown({
+        grossMinor: 100_000,
+        automaticBasisPoints: 800,
+        quantityBasisPoints: 500,
+        combination: "Additive",
+      }),
+    ).toEqual({ discountMinor: 13_000, effectiveBasisPoints: 1_300, subtotalMinor: 87_000 });
+  });
+
+  it("takes only the larger rate under BestDiscount", () => {
+    expect(
+      discountBreakdown({
+        grossMinor: 100_000,
+        automaticBasisPoints: 800,
+        quantityBasisPoints: 500,
+        combination: "BestDiscount",
+      }),
+    ).toEqual({ discountMinor: 8_000, effectiveBasisPoints: 800, subtotalMinor: 92_000 });
+  });
+
+  it("caps an additive pair at everything", () => {
+    // A charge must never arrive negative, whatever two rates an author writes.
+    expect(
+      discountBreakdown({
+        grossMinor: 10_000,
+        automaticBasisPoints: 6_000,
+        quantityBasisPoints: 6_000,
+        combination: "Additive",
+      }),
+    ).toEqual({ discountMinor: 10_000, effectiveBasisPoints: 10_000, subtotalMinor: 0 });
+  });
+
+  it("leaves a price with no automatic discount on its band alone", () => {
+    // The state every stored price is in. Its arithmetic must not move.
+    expect(
+      discountBreakdown({
+        grossMinor: 9_999,
+        automaticBasisPoints: 0,
+        quantityBasisPoints: 500,
+        combination: "Additive",
+      }),
+    ).toEqual({ discountMinor: 499, effectiveBasisPoints: 500, subtotalMinor: 9_500 });
+  });
+
+  it("truncates a discount rather than rounding it up", () => {
+    // The direction that favours the customer, and the direction the server's bands already take.
+    // Rounding up would take more off than the percentage advertised.
+    expect(
+      discountBreakdown({
+        grossMinor: 999,
+        automaticBasisPoints: 800,
+        quantityBasisPoints: 0,
+        combination: "BestDiscount",
+      }).discountMinor,
+    ).toBe(79);
+  });
+
+  it("says nothing came off a charge of nothing", () => {
+    expect(
+      discountBreakdown({
+        grossMinor: 0,
+        automaticBasisPoints: 800,
+        quantityBasisPoints: 500,
+        combination: "Additive",
+      }),
+    ).toEqual({ discountMinor: 0, effectiveBasisPoints: 0, subtotalMinor: 0 });
+  });
+});
+
+describe("automatic discount preview", () => {
+  it("prices the default quantity through its band and then taxes the remainder", () => {
+    const sentence = plain(describeAutomaticDiscount({
+      amount: 100,
+      currencyCode: "CHF",
+      quantity: 10,
+      automaticDiscountPercent: 8,
+      quantityDiscountPercent: 5,
+      combination: "Additive",
+      taxPercent: 7.7,
+      taxMode: "Exclusive",
+    }));
+
+    // 10 × CHF 100 is CHF 1,000; 13% off is CHF 130; 7.7% of the CHF 870 left is CHF 66.99.
+    expect(sentence).toContain("CHF 130.00");
+    expect(sentence).toContain("13%");
+    expect(sentence).toContain("CHF 936.99");
+  });
+
+  it("describes an inclusive price as already containing its tax", () => {
+    const sentence = plain(describeAutomaticDiscount({
+      amount: 100,
+      currencyCode: "CHF",
+      quantity: 1,
+      automaticDiscountPercent: 8,
+      quantityDiscountPercent: 0,
+      combination: "BestDiscount",
+      taxPercent: 7.7,
+      taxMode: "Inclusive",
+    }));
+
+    // The customer pays CHF 92.00 — the discounted amount itself — with the tax found inside it,
+    // rather than 92.00 plus tax on top of it.
+    expect(sentence).toContain("= CHF 92.00 including CHF 6.58 tax");
+    expect(sentence).not.toContain("+");
+  });
+
+  it("says nothing when there is no discount to explain", () => {
+    expect(
+      describeAutomaticDiscount({
+        amount: 100,
+        currencyCode: "CHF",
+        quantity: 1,
+        automaticDiscountPercent: undefined,
+        quantityDiscountPercent: 0,
+        combination: "BestDiscount",
+        taxPercent: 7.7,
+        taxMode: "Exclusive",
+      }),
+    ).toBeNull();
+  });
+
+  it("says nothing before an amount has been typed", () => {
+    expect(
+      describeAutomaticDiscount({
+        amount: undefined,
+        currencyCode: "CHF",
+        quantity: 1,
+        automaticDiscountPercent: 8,
+        quantityDiscountPercent: 0,
+        combination: "BestDiscount",
+        taxPercent: undefined,
+        taxMode: "Exclusive",
+      }),
+    ).toBeNull();
+  });
+
+  it("omits the tax clause on an untaxed price", () => {
+    const sentence = plain(describeAutomaticDiscount({
+      amount: 100,
+      currencyCode: "CHF",
+      quantity: 1,
+      automaticDiscountPercent: 8,
+      quantityDiscountPercent: 0,
+      combination: "BestDiscount",
+      taxPercent: undefined,
+      taxMode: "Exclusive",
+    }));
+
+    expect(sentence).toBe("CHF 100.00 − CHF 8.00 (8%) = CHF 92.00");
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-discount.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-discount.ts
@@ -1,0 +1,142 @@
+import { formatMoney, toMinorUnits } from "./subscription-format";
+import { taxBreakdown, toBasisPoints, type TaxMode } from "./subscription-tax";
+
+/** Mirrors the server's `AutomaticDiscountCombination`. Sent as the name, which is what the API accepts. */
+export const AUTOMATIC_DISCOUNT_COMBINATIONS = ["BestDiscount", "Additive"] as const;
+
+export type AutomaticDiscountCombination = (typeof AUTOMATIC_DISCOUNT_COMBINATIONS)[number];
+
+export const AUTOMATIC_DISCOUNT_COMBINATION_OPTIONS: {
+  value: AutomaticDiscountCombination;
+  label: string;
+  hint: string;
+}[] = [
+  {
+    value: "BestDiscount",
+    label: "Use the better discount",
+    hint: "Whichever saves the customer more. Only one of the two ever applies.",
+  },
+  {
+    value: "Additive",
+    label: "Add the percentages",
+    hint: "Both apply — 8% for the cadence plus 5% for the volume is 13% off.",
+  },
+];
+
+const FULL_BASIS_POINTS = 10_000;
+
+/**
+ * What a subscriber pays, and what came off on the way — the same arithmetic the server performs.
+ *
+ * The server is authoritative; this never decides what anybody is charged. It exists because an
+ * author choosing between "use the better discount" and "add the percentages" cannot otherwise see
+ * that the two answers differ by real money, and finding out on a customer's first invoice is the
+ * expensive way to learn which one they picked.
+ *
+ * It follows the server exactly, including the directions things round: discounts truncate (the
+ * direction that favours the customer, and what the existing volume bands already do) and tax
+ * rounds to nearest. A preview that rounded differently would disagree with the charge by a cent,
+ * which is worse than showing nothing.
+ */
+export const discountBreakdown = ({
+  grossMinor,
+  automaticBasisPoints,
+  quantityBasisPoints,
+  combination,
+}: {
+  grossMinor: number;
+  automaticBasisPoints: number;
+  quantityBasisPoints: number;
+  combination: AutomaticDiscountCombination;
+}): { discountMinor: number; effectiveBasisPoints: number; subtotalMinor: number } => {
+  const automatic = Math.min(Math.max(automaticBasisPoints, 0), FULL_BASIS_POINTS);
+  const band = Math.max(quantityBasisPoints, 0);
+
+  if (!Number.isFinite(grossMinor) || grossMinor <= 0 || (automatic === 0 && band === 0)) {
+    const subtotalMinor = Math.max(0, grossMinor);
+
+    return { discountMinor: 0, effectiveBasisPoints: 0, subtotalMinor };
+  }
+
+  const effectiveBasisPoints =
+    automatic === 0
+      ? band
+      : combination === "Additive"
+        ? Math.min(FULL_BASIS_POINTS, automatic + band)
+        : Math.max(automatic, band);
+
+  const discountMinor = Math.floor((grossMinor * effectiveBasisPoints) / FULL_BASIS_POINTS);
+
+  return {
+    discountMinor,
+    effectiveBasisPoints,
+    subtotalMinor: grossMinor - discountMinor,
+  };
+};
+
+/**
+ * The whole calculation under a price card, in the words a person would use.
+ *
+ * One sentence rather than a table, because what an author needs to check is the last number: this
+ * is the figure the customer will be charged, and it is the one they can compare against the
+ * pricing page they wrote. Returns null when there is nothing to say — no amount yet, or nothing
+ * coming off — rather than a sentence about zero.
+ */
+export const describeAutomaticDiscount = ({
+  amount,
+  currencyCode,
+  quantity,
+  automaticDiscountPercent,
+  quantityDiscountPercent,
+  combination,
+  taxPercent,
+  taxMode,
+}: {
+  amount: number | undefined;
+  currencyCode: string;
+  /** The default quantity the price multiplies. One for a flat fee. */
+  quantity: number;
+  automaticDiscountPercent: number | undefined;
+  quantityDiscountPercent: number;
+  combination: AutomaticDiscountCombination;
+  taxPercent: number | undefined;
+  taxMode: TaxMode;
+}): string | null => {
+  if (!amount || !Number.isFinite(amount)) {
+    return null;
+  }
+
+  const units = Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+  const grossMinor = toMinorUnits(amount, currencyCode) * units;
+
+  const { discountMinor, effectiveBasisPoints, subtotalMinor } = discountBreakdown({
+    grossMinor,
+    automaticBasisPoints: automaticDiscountPercent ? toBasisPoints(automaticDiscountPercent) : 0,
+    quantityBasisPoints: quantityDiscountPercent ? toBasisPoints(quantityDiscountPercent) : 0,
+    combination,
+  });
+
+  if (discountMinor <= 0) {
+    return null;
+  }
+
+  const { taxMinor, totalMinor } = taxBreakdown({
+    amountMinor: subtotalMinor,
+    basisPoints: taxPercent ? toBasisPoints(taxPercent) : 0,
+    mode: taxMode,
+  });
+
+  const off = `${formatMoney(grossMinor, currencyCode)} − ${formatMoney(discountMinor, currencyCode)} (${
+    effectiveBasisPoints / 100
+  }%)`;
+
+  // The tax clause is only added when there is tax, and it describes the mode rather than restating
+  // it: an inclusive total already contains its tax, so "+ tax" there would be wrong by the tax.
+  if (taxMinor <= 0) {
+    return `${off} = ${formatMoney(subtotalMinor, currencyCode)}`;
+  }
+
+  return taxMode === "Inclusive"
+    ? `${off} = ${formatMoney(totalMinor, currencyCode)} including ${formatMoney(taxMinor, currencyCode)} tax`
+    : `${off} + ${formatMoney(taxMinor, currencyCode)} tax = ${formatMoney(totalMinor, currencyCode)}`;
+};

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.test.ts
@@ -91,6 +91,47 @@ describe("formatPrice", () => {
 
     expect(description).toContain("per seat");
   });
+
+  it("names an automatic discount, since the amount alone is not what is charged", () => {
+    const description = formatPrice({
+      currencyCode: "CHF",
+      unitAmountMinor: 100_000,
+      interval: "Year",
+      intervalCount: 1,
+      quantityItemKey: null,
+      automaticDiscountBasisPoints: 800,
+    });
+
+    expect(description).toContain("8% off");
+  });
+
+  it("names the discount before the tax, in the order they are applied", () => {
+    const description = formatPrice({
+      currencyCode: "CHF",
+      unitAmountMinor: 100_000,
+      interval: "Year",
+      intervalCount: 1,
+      quantityItemKey: null,
+      automaticDiscountBasisPoints: 800,
+      taxRateBasisPoints: 770,
+      taxMode: "Exclusive",
+    });
+
+    expect(description.indexOf("8% off")).toBeLessThan(description.indexOf("7.7% tax"));
+  });
+
+  it("says nothing about a discount a price does not have", () => {
+    const description = formatPrice({
+      currencyCode: "CHF",
+      unitAmountMinor: 100_000,
+      interval: "Year",
+      intervalCount: 1,
+      quantityItemKey: null,
+      automaticDiscountBasisPoints: 0,
+    });
+
+    expect(description).not.toContain("off");
+  });
 });
 
 describe("formatMeterAllowance", () => {

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
@@ -50,6 +50,7 @@ export const formatPrice = (price: {
   quantityItemKey: string | null;
   taxRateBasisPoints?: number | null;
   taxMode?: string | null;
+  automaticDiscountBasisPoints?: number | null;
 }): string => {
   const amount = formatMoney(price.unitAmountMinor, price.currencyCode);
   const cadence = formatInterval(price.interval, price.intervalCount);
@@ -57,18 +58,25 @@ export const formatPrice = (price: {
     ? `${amount} per ${price.quantityItemKey}, ${cadence}`
     : `${amount} ${cadence}`;
 
+  // Named beside the amount, because a price with 8% off it is not the price the amount says. The
+  // combination is deliberately not named here: it only matters where there is also a volume band,
+  // and this string appears in lists where a reader has no quantity in mind.
+  const discounted = price.automaticDiscountBasisPoints
+    ? `${base}, ${price.automaticDiscountBasisPoints / 100}% off`
+    : base;
+
   // Stated wherever a price is shown, because the number alone does not say whether the customer
   // pays it or pays more than it. A legacy price carrying a rate and no mode is exclusive, which is
   // how the server charges it.
   if (!price.taxRateBasisPoints) {
-    return base;
+    return discounted;
   }
 
   const rate = `${price.taxRateBasisPoints / 100}%`;
 
   return price.taxMode === "Inclusive"
-    ? `${base} (incl. ${rate} tax)`
-    : `${base} + ${rate} tax`;
+    ? `${discounted} (incl. ${rate} tax)`
+    : `${discounted} + ${rate} tax`;
 };
 
 export const formatMeterAllowance = (meter: {

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -567,6 +567,12 @@
             subscription bills from its own copy of the plan's terms, which an edit cannot reach.
             </summary>
         </member>
+        <member name="M:Api.Controllers.SubscriptionPlansController.UpdatePriceDiscount(System.String,Subscription.DomainService.Requests.UpdatePriceDiscountRequest,System.Threading.CancellationToken)">
+            <summary>
+            Sets or clears the automatic discount on a price. Future subscriptions and future moves onto
+            this price only — nobody already on it is repriced.
+            </summary>
+        </member>
         <member name="M:Api.Controllers.SubscriptionPlansController.ArchivePrice(System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Takes a price off the menu.

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -124,6 +124,31 @@ public sealed class SubscriptionPlansController : ControllerBase
         return result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Sets or clears the automatic discount on a price. Future subscriptions and future moves onto
+    /// this price only — nobody already on it is repriced.
+    /// </summary>
+    [HttpPut("prices/{priceId}/discount")]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UpdatePriceDiscount(
+        string priceId,
+        [FromBody] UpdatePriceDiscountRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _catalogue.UpdatePriceDiscountAsync(
+            priceId,
+            request,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
     [HttpPut("prices/{priceId}/tax")]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status400BadRequest)]

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -732,10 +732,37 @@
         the built-in reduction, the promotional reduction and the amount that was then taxed.
         <code>GET /api/subscriptions/invoices</code> carries the same breakdown per settled invoice,
         recorded when the charge was raised rather than recomputed from a catalogue that has since
-        moved. It is absent on three kinds of row: the first charge, which is a hosted checkout and
-        composes no invoice; a plan-change or quantity settlement, whose amount is the difference
-        between two prorated periods and does not decompose into a gross and a reduction; and
-        anything charged before this existed.
+        moved. A renewal and a usage invoice report it in those flat fields. A <strong>plan-change or
+        quantity settlement reports <code>settlement</code> instead</strong>, because its amount is a
+        subtraction rather than a discounted price:
+      </p>
+      <pre><code>"settlement": {
+  "outgoing": {                  // the period being left, part-way through
+    "grossAmountMinor": 1000, "builtInDiscountMinor": 100,
+    "promotionalDiscountMinor": 50, "discountedAmountMinor": 850,
+    "taxAmountMinor": 85, "periodTotalMinor": 935,
+    "proratedValueMinor": 467    // unused value credited back
+  },
+  "target": {                    // the period being joined
+    "grossAmountMinor": 2000, "builtInDiscountMinor": 160,
+    "promotionalDiscountMinor": 0, "discountedAmountMinor": 1840,
+    "taxAmountMinor": 184, "periodTotalMinor": 2024,
+    "proratedValueMinor": 1012   // remaining time charged for
+  },
+  "creditConsumedMinor": 100,
+  "netSettlementMinor": 445      // target prorated − outgoing unused − credit
+}</code></pre>
+      <p>
+        Each side is priced as its own period, with its own discounts and its own tax rate and mode —
+        a change can cross between an inclusive and an exclusive price — and only then prorated.
+        <code>netSettlementMinor</code> is negative where a downgrade banked credit rather than
+        charging, which is why it is not simply the amount charged. The flat renewal fields are absent
+        on these rows, and <code>settlement</code> is absent on renewal rows: they describe the same
+        charge in the only shape that fits it.
+      </p>
+      <p>
+        Absent on two kinds of row either way: the first charge, which is a hosted checkout and
+        composes no invoice, and anything charged before this existed.
       </p>
       <p>
         Provider invoice lines continue to show the discounted subtotal rather than a separate
@@ -1629,7 +1656,9 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             before price applicability existed carry no price list and stay unrestricted by price.
           </p>
           <p class="prose">
-            Both lists are resolved against the catalogue <em>when the discount is authored</em>. A
+            Both lists are resolved against the catalogue <em>when the discount is authored</em>,
+            in the scope of the organization the request names — so the console authoring a customer's
+            discount is validated against that customer's plans, not its own. A
             plan code or price id that does not exist in this scope, or a price belonging to a plan
             the code is not applicable to, is rejected with
             <code>subscription_discount_applicability_invalid</code> — otherwise the discount would be

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1889,6 +1889,25 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
   "issuedAtUtc": "2026-08-16T16:29:00Z",
   "downloadUrl": "/api/subscriptions/invoices/payment-123/pdf"
 }</code></pre>
+          <h4><code>invoiceType</code></h4>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Value</th><th>What it is</th><th><code>periodKey</code></th></tr></thead>
+              <tbody>
+                <tr><td><code>Renewal</code></td><td class="prose">A billing period's own charge.</td><td class="prose">The period.</td></tr>
+                <tr><td><code>Usage</code></td><td class="prose">Metered overage for a closed usage window.</td><td class="prose">The window.</td></tr>
+                <tr><td><code>PlanChange</code></td><td class="prose">A mid-period move to another plan or price. Carries <code>settlement</code>.</td><td class="prose"><code>null</code> — scoped by its reservation, not a period.</td></tr>
+                <tr><td><code>QuantityChange</code></td><td class="prose">A mid-period increase in units. Carries <code>settlement</code>.</td><td class="prose"><code>null</code>.</td></tr>
+                <tr><td><code>Unknown</code></td><td class="prose">A payment this module did not raise, or one whose order id it cannot read.</td><td class="prose"><code>null</code>.</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="prose">
+            Settlements charged before the two kinds were distinguished report
+            <code>QuantityChange</code> whichever they were — the two shared one order-id form, and
+            settled payment records are not rewritten to improve a label. Anything charged since is
+            classified correctly.
+          </p>
           <h4>Returns</h4>
           <p><code>200</code> · <code>400</code> invalid page size or cursor · <code>401</code>.</p>
         </div>

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -496,6 +496,8 @@
       <li><a href="#model">The model</a></li>
       <li><a href="#plan" class="sub">Plan</a></li>
       <li><a href="#price" class="sub">Price</a></li>
+      <li><a href="#tax" class="sub">Tax</a></li>
+      <li><a href="#automatic-discounts" class="sub">Automatic price discounts</a></li>
       <li><a href="#quantity" class="sub">Quantity item</a></li>
       <li><a href="#meter" class="sub">Meter</a></li>
       <li><a href="#entitlement" class="sub">Entitlement</a></li>
@@ -618,6 +620,8 @@
             <tr><td>quantityItemKey</td><td class="type">string?</td><td class="prose"><code>null</code> is a flat fee. Otherwise the amount is multiplied by that item's quantity.</td></tr>
             <tr><td>taxRateBasisPoints</td><td class="type">int?</td><td class="prose">Basis points out of 10,000 — <code>770</code> is 7.7%. Absent means untaxed. Applied after discount, before credit.</td></tr>
             <tr><td>taxMode</td><td class="type">string?</td><td class="prose"><code>Exclusive</code> — the rate is added to <code>unitAmountMinor</code>. <code>Inclusive</code> — <code>unitAmountMinor</code> is what the customer pays and the tax is inside it. Present whenever there is a rate; prices authored before modes existed report <code>Exclusive</code>, which is how they are charged.</td></tr>
+            <tr><td>automaticDiscountBasisPoints</td><td class="type">int?</td><td class="prose">A percentage taken off this price with no code involved — <code>800</code> is 8%. Absent means no automatic discount. Applied to every charge the price produces, for as long as the subscription stays on it.</td></tr>
+            <tr><td>quantityDiscountCombination</td><td class="type">string?</td><td class="prose">How that discount meets the volume band a quantity selects. <code>BestDiscount</code> — the larger of the two, never both. <code>Additive</code> — the two rates added and applied once. Present whenever there is an automatic discount; a discount authored without a combination reports <code>BestDiscount</code>, which is how it is calculated.</td></tr>
           </tbody>
         </table>
       </div>
@@ -664,6 +668,71 @@
         lines still add up to exactly what was charged. The first payment of a subscription is a
         checkout session and produces no invoice at all, so invoice history begins at the first
         renewal; the amount charged is unaffected.
+      </p>
+
+      <h3 id="automatic-discounts">Automatic price discounts</h3>
+      <p>
+        A price can take a percentage off by itself, with nothing typed by the subscriber. This is how
+        a plan sells "8% off if you pay yearly": the yearly price carries
+        <code>automaticDiscountBasisPoints</code>, the monthly price beside it under the same plan
+        carries none, and both remain prices on one plan rather than two products.
+      </p>
+      <p class="prose">
+        It lives on the price rather than the plan because the offer is cadence-specific, and because
+        a plan sold in two currencies has two prices that may not be discounted alike. A missing or
+        zero value is no automatic discount, which is what every price authored before this existed
+        carries.
+      </p>
+      <p>
+        A subscriber can therefore hold two reductions the merchant authored — the price's own
+        discount and the volume band their quantity selects — plus one they redeemed. The two authored
+        ones are settled first, by the <em>price</em>:
+      </p>
+      <ul>
+        <li><code>BestDiscount</code> applies whichever of the two takes off more money, and only that one. The default, and the value a price with no stated combination is calculated as.</li>
+        <li><code>Additive</code> adds the two rates and applies the sum once to the gross. 8% for the cadence plus 5% for the volume is <strong>13% off</strong>, not the 12.6% that applying one after the other would give. The sum is capped at 100%.</li>
+      </ul>
+      <p>
+        The result is the <strong>built-in discount</strong>. The plan's
+        <code>quantityDiscountCombinationPolicy</code> then decides what a promotional code adds to
+        it, exactly as it already decided between a band and a code: <code>BestDiscount</code> takes
+        whichever of the built-in result and the promotion saves more, <code>Stack</code> reduces
+        what the built-in discount left, and <code>QuantityOnly</code> ignores the code — that value
+        now means "built-in discounts only", and its stored wire value is unchanged.
+      </p>
+      <p>
+        The full order of operations, which every money path shares:
+      </p>
+      <ul>
+        <li><strong>Gross</strong> — the price's amount times the quantity it charges for.</li>
+        <li><strong>Built-in discount</strong> — automatic and band, combined as the price says. Truncated to the minor unit, the direction that favours the subscriber.</li>
+        <li><strong>Promotional code</strong> — combined as the plan says.</li>
+        <li><strong>Tax</strong> — once, on the aggregate, on what is left. See <a href="#tax">Tax</a>.</li>
+        <li><strong>Credit</strong> — banked credit pays the bill last, and never reduces the tax.</li>
+      </ul>
+      <p>
+        A promotion that loses is not consumed, and that now includes losing to an automatic discount:
+        three months of "2% off" are not spent on periods where the price's own 8% was larger.
+      </p>
+      <p>
+        The automatic discount is <strong>snapshotted when the subscription is sold</strong>, like the
+        amount, the interval and the tax. Clearing it from the catalogue tomorrow does not raise
+        anybody's renewal, and adding one does not lower anybody's. A plan change snapshots the
+        <em>target</em> price's discount and prorates both sides at their own.
+      </p>
+      <p class="prose">
+        Metered overage is charged by the price the subscription was sold on, so the price's automatic
+        discount applies to an overage invoice too, before its tax. A volume band does not — it prices
+        units of a quantity item, and a meter has none — and a promotional code does not reach usage
+        invoices at all.
+      </p>
+      <p>
+        <strong>Invoices.</strong> A subscription response, a quantity preview and an overage invoice
+        each report what came off: the automatic rate, the combination, the gross, the built-in
+        reduction, the promotional reduction and the amount that was then taxed. Provider invoice
+        lines continue to show the discounted subtotal rather than a separate discount line — the
+        lines have to add up to what was charged, and a gross line plus a reduction line is a
+        different invoice shape than the one this module writes.
       </p>
 
       <h3 id="quantity">Quantity item</h3>
@@ -1279,6 +1348,12 @@ Content-Type: application/json
       <div class="callout">
         <p class="callout-title">A promotional code and a volume band</p>
         <p class="prose">
+          Two combinations, answering two questions. The <em>price</em> settles how its automatic
+          discount meets the volume band — see
+          <a href="#automatic-discounts">Automatic price discounts</a> — and the plan then settles
+          what a redeemed code adds to that result.
+        </p>
+        <p class="prose">
           The plan's <code>quantityDiscountCombinationPolicy</code> decides.
           <code>BestDiscount</code> — the default — applies whichever reduction is larger and does
           not spend the promotion when the band wins, so a customer's three months of "20% off" are
@@ -1459,7 +1534,19 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
 // of which CHF 10.37 is tax.
 { "planId": "9f2c…", "currencyCode": "CHF", "unitAmountMinor": 14500,
   "interval": 2, "intervalCount": 1,
-  "taxRateBasisPoints": 770, "taxMode": "Inclusive" }</code></pre>
+  "taxRateBasisPoints": 770, "taxMode": "Inclusive" }
+
+// Yearly at 8% off, added to any volume band the quantity selects.
+{ "planId": "9f2c…", "currencyCode": "CHF", "unitAmountMinor": 100000,
+  "interval": 3, "intervalCount": 1, "quantityItemKey": "seat",
+  "automaticDiscountBasisPoints": 800,
+  "quantityDiscountCombination": "Additive" }</code></pre>
+          <p class="prose">
+            <code>quantityDiscountCombination</code> may be omitted; it reads as
+            <code>BestDiscount</code>, the answer that cannot give away more than the larger of the
+            two rates authored. A discount outside 0–100% is rejected with
+            <code>subscription_price_discount_invalid</code>.
+          </p>
         </div>
       </div>
 
@@ -1479,6 +1566,21 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       </div>
 
       <div class="endpoint">
+        <div class="endpoint-head"><span class="method">PUT</span><span class="path">/api/subscription-plans/prices/{priceId}/discount</span></div>
+        <div class="endpoint-body">
+          <p>Sets or clears the automatic discount on an existing active price. Future subscriptions and future plan changes onto this price snapshot the new figure; everybody already on it keeps the one they were sold.</p>
+          <h4>Body</h4>
+          <pre><code>{
+  "organizationId": "org-1",              // console only
+  "automaticDiscountBasisPoints": 800,     // 0 clears the discount
+  "quantityDiscountCombination": "Additive" // BestDiscount or Additive; ignored when clearing
+}</code></pre>
+          <h4>Returns</h4>
+          <p><code>200</code> the updated plan · <code>400 subscription_price_discount_invalid</code> · <code>404</code> price unknown · <code>409 subscription_price_discount_conflict</code> when the price changed concurrently.</p>
+        </div>
+      </div>
+
+      <div class="endpoint">
         <div class="endpoint-head"><span class="method">PUT</span><span class="path">/api/subscription-plans/prices/{priceId}/archive</span></div>
         <div class="endpoint-body"><p>Retires a price without changing subscriptions that already hold its snapshot.</p></div>
       </div>
@@ -1486,7 +1588,22 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       <h3>Discount catalogue</h3>
       <div class="endpoint">
         <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscription-discounts</span></div>
-        <div class="endpoint-body"><p>Authors a tenant-wide or organization-scoped percentage/fixed discount. Optional plan-code applicability, expiry and duration are validated at subscribe time.</p></div>
+        <div class="endpoint-body">
+          <p>Authors a tenant-wide or organization-scoped percentage/fixed discount. Optional plan-code and price applicability, expiry and duration are validated at subscribe time.</p>
+          <h4>Applicability</h4>
+          <pre><code>{
+  "code": "yearly8", "displayName": "Yearly launch offer",
+  "kind": 0, "percentBasisPoints": 800,
+  "applicablePlanCodes": ["pro"],          // empty: any plan
+  "applicablePriceIds": ["price-yearly"]   // empty: any price
+}</code></pre>
+          <p class="prose">
+            The two lists <strong>narrow</strong> rather than offering two ways to qualify: when both
+            are populated, both have to match. A code restricted to the yearly price is refused on the
+            monthly one with <code>subscription_discount_not_applicable</code>. Discounts stored
+            before price applicability existed carry no price list and stay unrestricted by price.
+          </p>
+        </div>
       </div>
       <div class="endpoint">
         <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscription-discounts</span></div>
@@ -1898,6 +2015,9 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <tr><td>subscription_plan_change_charge_unresolved</td><td class="prose">The same, for a paid plan change.</td></tr>
             <tr><td>subscription_quantity_discount_tiers_invalid</td><td class="prose">Authoring: bands have a gap, an overlap, or more than one open end.</td></tr>
             <tr><td>subscription_plan_in_use</td><td class="prose">Editing a plan somebody has subscribed to.</td></tr>
+            <tr><td>subscription_price_discount_invalid</td><td class="prose">Authoring: an automatic discount outside 0–100%, or a combination this module does not know.</td></tr>
+            <tr><td>subscription_price_discount_conflict</td><td class="prose">The price changed while its automatic discount was being saved. Re-read the plan and save again.</td></tr>
+            <tr><td>subscription_discount_not_applicable</td><td class="prose">The code is restricted to other plans or other prices. When both restrictions are set, both have to match.</td></tr>
             <tr><td>subscription_organization_missing</td><td class="prose">The caller's organization could not be resolved.</td></tr>
           </tbody>
         </table>

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -705,7 +705,7 @@
       </p>
       <ul>
         <li><strong>Gross</strong> — the price's amount times the quantity it charges for.</li>
-        <li><strong>Built-in discount</strong> — automatic and band, combined as the price says. Truncated to the minor unit, the direction that favours the subscriber.</li>
+        <li><strong>Built-in discount</strong> — automatic and band, combined as the price says. Truncated to the minor unit, matching the volume bands that already existed: a reduction of 5% on 199 takes off 9 rather than 10, so truncation leans very slightly toward the merchant.</li>
         <li><strong>Promotional code</strong> — combined as the plan says.</li>
         <li><strong>Tax</strong> — once, on the aggregate, on what is left. See <a href="#tax">Tax</a>.</li>
         <li><strong>Credit</strong> — banked credit pays the bill last, and never reduces the tax.</li>
@@ -728,11 +728,19 @@
       </p>
       <p>
         <strong>Invoices.</strong> A subscription response, a quantity preview and an overage invoice
-        each report what came off: the automatic rate, the combination, the gross, the built-in
-        reduction, the promotional reduction and the amount that was then taxed. Provider invoice
-        lines continue to show the discounted subtotal rather than a separate discount line — the
-        lines have to add up to what was charged, and a gross line plus a reduction line is a
-        different invoice shape than the one this module writes.
+        each report what came off: the automatic rate, the band's rate, the combination, the gross,
+        the built-in reduction, the promotional reduction and the amount that was then taxed.
+        <code>GET /api/subscriptions/invoices</code> carries the same breakdown per settled invoice,
+        recorded when the charge was raised rather than recomputed from a catalogue that has since
+        moved. It is absent on three kinds of row: the first charge, which is a hosted checkout and
+        composes no invoice; a plan-change or quantity settlement, whose amount is the difference
+        between two prorated periods and does not decompose into a gross and a reduction; and
+        anything charged before this existed.
+      </p>
+      <p>
+        Provider invoice lines continue to show the discounted subtotal rather than a separate
+        discount line — the lines have to add up to what was charged, and a gross line plus a
+        reduction line is a different invoice shape than the one this module writes.
       </p>
 
       <h3 id="quantity">Quantity item</h3>
@@ -1346,6 +1354,23 @@ Content-Type: application/json
       </div>
 
       <div class="callout">
+        <p class="callout-title">A restricted code and a plan change</p>
+        <p class="prose">
+          A subscription keeps its discount across a plan change — but only where the code covers the
+          target. A code authored for one plan or one price is re-checked against the plan and price
+          being moved to, and a move it does not cover is refused with
+          <code>subscription_discount_not_applicable</code> rather than the discount being quietly
+          carried onto a price it was never offered for, or quietly removed. Show the customer the
+          consequence and let them decide: keep the discount, or give it up by cancelling and
+          subscribing again.
+        </p>
+        <p class="prose">
+          An unrestricted code — which is every code authored before either restriction existed —
+          moves with the subscriber, as does one whose duration or expiry has already ended.
+        </p>
+      </div>
+
+      <div class="callout">
         <p class="callout-title">A promotional code and a volume band</p>
         <p class="prose">
           Two combinations, answering two questions. The <em>price</em> settles how its automatic
@@ -1602,6 +1627,21 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             are populated, both have to match. A code restricted to the yearly price is refused on the
             monthly one with <code>subscription_discount_not_applicable</code>. Discounts stored
             before price applicability existed carry no price list and stay unrestricted by price.
+          </p>
+          <p class="prose">
+            Both lists are resolved against the catalogue <em>when the discount is authored</em>. A
+            plan code or price id that does not exist in this scope, or a price belonging to a plan
+            the code is not applicable to, is rejected with
+            <code>subscription_discount_applicability_invalid</code> — otherwise the discount would be
+            accepted and then refuse every redemption, with nothing in that refusal pointing at the
+            typo behind it.
+          </p>
+          <p class="prose">
+            The restriction is copied onto the subscription with the rest of the terms, and it is
+            <strong>re-checked on a plan change</strong>: moving to a plan or price the code does not
+            cover is refused with <code>subscription_discount_not_applicable</code> rather than
+            silently keeping or silently dropping the discount. A discount whose duration is spent or
+            whose expiry has passed reduces nothing and never blocks a move.
           </p>
         </div>
       </div>
@@ -2017,7 +2057,8 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <tr><td>subscription_plan_in_use</td><td class="prose">Editing a plan somebody has subscribed to.</td></tr>
             <tr><td>subscription_price_discount_invalid</td><td class="prose">Authoring: an automatic discount outside 0–100%, or a combination this module does not know.</td></tr>
             <tr><td>subscription_price_discount_conflict</td><td class="prose">The price changed while its automatic discount was being saved. Re-read the plan and save again.</td></tr>
-            <tr><td>subscription_discount_not_applicable</td><td class="prose">The code is restricted to other plans or other prices. When both restrictions are set, both have to match.</td></tr>
+            <tr><td>subscription_discount_not_applicable</td><td class="prose">The code is restricted to other plans or other prices. When both restrictions are set, both have to match. Also returned by a plan change whose target the subscriber's existing discount does not cover — cancel and re-subscribe, or choose a target it covers.</td></tr>
+            <tr><td>subscription_discount_applicability_invalid</td><td class="prose">Authoring: a plan code or price id that does not exist in this scope, or a price on a plan the discount is not applicable to. The message names the offending value.</td></tr>
             <tr><td>subscription_organization_missing</td><td class="prose">The caller's organization could not be resolved.</td></tr>
           </tbody>
         </table>

--- a/server/Payment.DomainService/Entities/PaymentDetail.cs
+++ b/server/Payment.DomainService/Entities/PaymentDetail.cs
@@ -93,11 +93,24 @@ public sealed class PaymentDetail
     public string? SubscriptionTaxMode { get; set; }
 
     /// <summary>
-    /// What the subscription's own discounts took off before tax, and the price's automatic rate that
-    /// contributed to it. Null on payments raised before either existed.
+    /// What this charge was made of before tax: the gross, what the price's own discount and the
+    /// volume band took off between them, and what a promotional code took off after that. Null on
+    /// payments raised before the breakdown was recorded, and on a first charge, which is a hosted
+    /// checkout rather than an invoice this module composes.
     /// </summary>
-    public long? SubscriptionDiscountAmountMinor { get; set; }
+    /// <remarks>
+    /// All three recorded, not one combined figure. "Something came off" cannot be turned back into
+    /// "the price gave 8% and the coupon gave nothing" — and which of the two it was is exactly what
+    /// somebody reading an old invoice needs to know, by which time the catalogue has moved on.
+    /// </remarks>
+    public long? SubscriptionGrossAmountMinor { get; set; }
+    public long? SubscriptionBuiltInDiscountMinor { get; set; }
+    public long? SubscriptionPromotionalDiscountMinor { get; set; }
+
+    /// <summary>The price's automatic rate, and how it met the volume band, as they stood when charged.</summary>
     public int? SubscriptionAutomaticDiscountBasisPoints { get; set; }
+    public int? SubscriptionQuantityDiscountBasisPoints { get; set; }
+    public string? SubscriptionDiscountCombination { get; set; }
 
     public string IdempotencyKey { get; set; } = string.Empty;
     public string RequestHash { get; set; } = string.Empty;

--- a/server/Payment.DomainService/Entities/PaymentDetail.cs
+++ b/server/Payment.DomainService/Entities/PaymentDetail.cs
@@ -112,6 +112,13 @@ public sealed class PaymentDetail
     public int? SubscriptionQuantityDiscountBasisPoints { get; set; }
     public string? SubscriptionDiscountCombination { get; set; }
 
+    /// <summary>
+    /// Set instead of the flat fields above when this payment settles a plan or quantity change,
+    /// whose amount is a subtraction between two prorated periods rather than a discounted price.
+    /// Null on a renewal, which the flat fields describe, and on anything raised before this existed.
+    /// </summary>
+    public SubscriptionSettlementBreakdown? SubscriptionSettlement { get; set; }
+
     public string IdempotencyKey { get; set; } = string.Empty;
     public string RequestHash { get; set; } = string.Empty;
     public string CorrelationId { get; set; } = string.Empty;

--- a/server/Payment.DomainService/Entities/PaymentDetail.cs
+++ b/server/Payment.DomainService/Entities/PaymentDetail.cs
@@ -92,6 +92,13 @@ public sealed class PaymentDetail
     public int? SubscriptionTaxRateBasisPoints { get; set; }
     public string? SubscriptionTaxMode { get; set; }
 
+    /// <summary>
+    /// What the subscription's own discounts took off before tax, and the price's automatic rate that
+    /// contributed to it. Null on payments raised before either existed.
+    /// </summary>
+    public long? SubscriptionDiscountAmountMinor { get; set; }
+    public int? SubscriptionAutomaticDiscountBasisPoints { get; set; }
+
     public string IdempotencyKey { get; set; } = string.Empty;
     public string RequestHash { get; set; } = string.Empty;
     public string CorrelationId { get; set; } = string.Empty;

--- a/server/Payment.DomainService/Entities/SubscriptionSettlementBreakdown.cs
+++ b/server/Payment.DomainService/Entities/SubscriptionSettlementBreakdown.cs
@@ -1,0 +1,61 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Payment.DomainService.Entities;
+
+/// <summary>
+/// How a subscription settlement's amount was arrived at: the period being left, the period being
+/// joined, and what closed the gap.
+/// </summary>
+/// <remarks>
+/// A settlement is not a discounted price — it is a subtraction between two prorated periods, so the
+/// flat gross-and-discount fields a renewal records cannot describe one. A subscriber asking why they
+/// were charged CHF 41.30 mid-month is asking about the two sides, not the remainder.
+/// <para>
+/// Lives in the payment module beside <see cref="PaymentDetail"/> because that is where it is stored,
+/// and stored at all because it cannot be recomputed later: the catalogue moves, and the instant the
+/// change was quoted at is gone.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionSettlementBreakdown
+{
+    /// <summary>The period the subscriber is leaving part-way through.</summary>
+    public SubscriptionSettlementSide Outgoing { get; set; } = new();
+
+    /// <summary>The period they are joining.</summary>
+    public SubscriptionSettlementSide Target { get; set; } = new();
+
+    /// <summary>Banked credit spent against the difference. Zero on a downgrade, which banks more.</summary>
+    public long CreditConsumedMinor { get; set; }
+
+    /// <summary>
+    /// Target prorated value less outgoing unused value less credit. Negative where a downgrade
+    /// banked credit instead of charging, which is why it is not simply the amount charged.
+    /// </summary>
+    public long NetSettlementMinor { get; set; }
+}
+
+/// <summary>One side of a settlement, priced as its own period and then prorated.</summary>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionSettlementSide
+{
+    public long GrossAmountMinor { get; set; }
+
+    /// <summary>The price's automatic discount and the volume band, combined as the price says.</summary>
+    public long BuiltInDiscountMinor { get; set; }
+
+    /// <summary>A promotional code, after the built-in reduction was settled.</summary>
+    public long PromotionalDiscountMinor { get; set; }
+
+    /// <summary>Tax at this side's own rate and mode — a change can cross between the two.</summary>
+    public long TaxAmountMinor { get; set; }
+
+    /// <summary>The whole period, tax included.</summary>
+    public long PeriodTotalMinor { get; set; }
+
+    /// <summary>
+    /// The part of that this settlement counts: unused time on the outgoing side, remaining time on
+    /// the target side.
+    /// </summary>
+    public long ProratedValueMinor { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/Discount.cs
+++ b/server/Subscription.DomainService/Entities/Discount.cs
@@ -15,6 +15,18 @@ public sealed class Discount
     public DiscountTerms Terms { get; set; } = new();
     public string? CurrencyCode { get; set; }
     public List<string> ApplicablePlanCodes { get; set; } = [];
+
+    /// <summary>
+    /// The prices this code may be used on. Empty is unrestricted by price, which is what every
+    /// discount stored before this existed carries.
+    /// </summary>
+    /// <remarks>
+    /// Price identifiers rather than cadences, because a plan can sell two yearly prices in two
+    /// currencies and a promotion often means exactly one of them. Combined with
+    /// <see cref="ApplicablePlanCodes"/> by <em>and</em>: naming both narrows twice rather than
+    /// offering two ways to qualify.
+    /// </remarks>
+    public List<string> ApplicablePriceIds { get; set; } = [];
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
 }

--- a/server/Subscription.DomainService/Entities/DiscountTerms.cs
+++ b/server/Subscription.DomainService/Entities/DiscountTerms.cs
@@ -28,4 +28,19 @@ public sealed class DiscountTerms
     public int? DurationPeriods { get; set; }
 
     public DateTime? ExpiresAtUtc { get; set; }
+
+    /// <summary>
+    /// The plans this code was authored for, copied from the catalogue entry. Empty is unrestricted.
+    /// </summary>
+    /// <remarks>
+    /// Snapshotted rather than looked up, for the reason every other term here is: the catalogue
+    /// entry can be retired or re-scoped, and the subscriber has to be judged by the offer they
+    /// accepted. Carried so a <em>later</em> move to another plan or price can be checked against the
+    /// same restriction the redemption was — without this, a monthly-only code keeps discounting an
+    /// annual price after a plan change, because nothing downstream can tell it was restricted.
+    /// </remarks>
+    public List<string> ApplicablePlanCodes { get; set; } = [];
+
+    /// <summary>The prices this code was authored for. Empty is unrestricted.</summary>
+    public List<string> ApplicablePriceIds { get; set; } = [];
 }

--- a/server/Subscription.DomainService/Entities/Price.cs
+++ b/server/Subscription.DomainService/Entities/Price.cs
@@ -56,6 +56,24 @@ public sealed class Price
     /// </remarks>
     public TaxMode? TaxMode { get; set; }
 
+    /// <summary>
+    /// A percentage taken off this price automatically, in basis points out of 10,000 — 800 is 8%.
+    /// Null or zero is no automatic discount.
+    /// </summary>
+    /// <remarks>
+    /// On the price rather than the plan because it is a cadence-specific offer: "8% for paying
+    /// yearly" is a property of the yearly price, and the monthly price beside it under the same plan
+    /// has none. Applied without a code, to every charge this price produces, for as long as the
+    /// subscription stays on it.
+    /// </remarks>
+    public int? AutomaticDiscountBasisPoints { get; set; }
+
+    /// <summary>
+    /// How <see cref="AutomaticDiscountBasisPoints"/> meets the volume band a subscriber's quantity
+    /// selects. Null reads as <see cref="Enums.AutomaticDiscountCombination.BestDiscount"/>.
+    /// </summary>
+    public AutomaticDiscountCombination? QuantityDiscountCombination { get; set; }
+
 
     public CatalogueStatus Status { get; set; } = CatalogueStatus.Draft;
 

--- a/server/Subscription.DomainService/Entities/PriceSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PriceSnapshot.cs
@@ -39,6 +39,17 @@ public sealed class PriceSnapshot
     /// </remarks>
     public TaxMode? TaxMode { get; set; }
 
+    /// <summary>
+    /// The automatic discount as sold, in basis points. Snapshotted for the same reason the
+    /// amount is: editing the catalogue must not reprice anybody already subscribed.
+    /// </summary>
+    public int? AutomaticDiscountBasisPoints { get; set; }
+
+    /// <summary>
+    /// How the automatic discount met the volume band, as sold. Null reads as
+    /// <see cref="Enums.AutomaticDiscountCombination.BestDiscount"/>.
+    /// </summary>
+    public AutomaticDiscountCombination? QuantityDiscountCombination { get; set; }
 
     public int PriceVersion { get; set; }
 

--- a/server/Subscription.DomainService/Entities/SettlementReservation.cs
+++ b/server/Subscription.DomainService/Entities/SettlementReservation.cs
@@ -1,4 +1,5 @@
 using MongoDB.Bson.Serialization.Attributes;
+using Payment.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
 
@@ -76,6 +77,17 @@ public sealed class SettlementReservation
     public string? ProviderCustomerId { get; set; }
 
     public string StoredPaymentMethodId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How the charge was arrived at, snapshotted with everything else about the attempt.
+    /// </summary>
+    /// <remarks>
+    /// Held here for the same reason the card and the target terms are: a replay has to record
+    /// <em>that</em> attempt. Recomputing the proration at settlement time would price it against a
+    /// different instant, and possibly an edited catalogue, producing an explanation of a charge that
+    /// nobody was quoted.
+    /// </remarks>
+    public SubscriptionSettlementBreakdown? Settlement { get; set; }
 
     /// <summary>What to write when a quantity increase settles. Null for any other kind.</summary>
     public ReservedQuantityChange? QuantityChange { get; set; }

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageInvoice.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageInvoice.cs
@@ -49,6 +49,21 @@ public sealed class SubscriptionUsageInvoice
 
     public TaxMode? TaxMode { get; set; }
 
+    /// <summary>
+    /// The price's automatic discount at the moment this invoice was raised, in basis points. Null
+    /// when the price carries none.
+    /// </summary>
+    /// <remarks>
+    /// Recorded beside the tax rate, and for the same reason: an invoice has to be able to explain
+    /// its own total after the catalogue has moved on.
+    /// </remarks>
+    public int? AutomaticDiscountBasisPoints { get; set; }
+
+    /// <summary>
+    /// What that discount took off the summed overage, before tax. Zero when there is none.
+    /// </summary>
+    public long DiscountAmountMinor { get; set; }
+
     public List<UsageInvoiceLine> Lines { get; set; } = [];
 
     public SubscriptionUsageInvoiceState State { get; set; } =

--- a/server/Subscription.DomainService/Enums/AutomaticDiscountCombination.cs
+++ b/server/Subscription.DomainService/Enums/AutomaticDiscountCombination.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// What happens when a price's own automatic discount meets the quantity band a subscriber's
+/// volume selects.
+/// </summary>
+/// <remarks>
+/// Stated on the price rather than decided in the calculator, for the same reason
+/// <see cref="QuantityDiscountCombinationPolicy"/> is stated on the plan: it is a commercial choice,
+/// and left implicit the answer becomes whichever order the arithmetic happens to run in. The two
+/// are different questions about different pairs — this one is "8% for paying yearly, plus 5% for
+/// buying fifty seats"; that one is "and what about the coupon they typed".
+/// <para>
+/// <see cref="BestDiscount"/> is zero so a price authored before this existed, or one sent by a
+/// caller that has never heard of it, reads back as the conservative answer: whichever single
+/// reduction is larger, never both.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AutomaticDiscountCombination
+{
+    /// <summary>
+    /// The larger of the two reductions, and only that one. The default, and the safe answer.
+    /// </summary>
+    /// <remarks>
+    /// Compared as money rather than as basis points, because the two rates are not always applied
+    /// to the same base — and it is the money the subscriber notices.
+    /// </remarks>
+    BestDiscount = 0,
+
+    /// <summary>
+    /// Both rates, added together and applied once to the gross amount. 8% for the year plus 5% for
+    /// the volume is 13% off, capped at 100%.
+    /// </summary>
+    /// <remarks>
+    /// Added rather than compounded: 8% then 5% of what is left is 12.6%, which is not the number
+    /// anybody wrote on the pricing page. Capped because two generous bands can otherwise sum past
+    /// everything, and a charge must never arrive negative.
+    /// </remarks>
+    Additive = 1
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -421,8 +421,15 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 TaxAmountMinor = invoice.TaxAmountMinor,
                 TaxRateBasisPoints = invoice.TaxRateBasisPoints,
                 TaxMode = invoice.TaxMode,
+                // From the invoice, which recorded what it was raised under. No band and no
+                // promotion reach a usage invoice, so the built-in reduction is the whole of it.
+                GrossAmountMinor = invoice.Lines.Sum(line => line.AmountMinor),
+                BuiltInDiscountMinor = invoice.DiscountAmountMinor,
                 AutomaticDiscountBasisPoints = invoice.AutomaticDiscountBasisPoints,
-                DiscountAmountMinor = invoice.DiscountAmountMinor,
+                // No combination, deliberately. Nothing was combined: a volume band prices units of
+                // a quantity item and a meter has none, so naming one here would report a decision
+                // this invoice never made — and possibly the wrong one, since the price's own
+                // combination played no part in it.
                 CurrencyCode = invoice.CurrencyCode,
                 OrderId = SubscriptionConstants.UsageInvoiceOrderIdFor(
                     invoice.SubscriptionId,

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -286,14 +286,30 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             });
         }
 
+        var overage = lines.Sum(line => line.AmountMinor);
+
+        // The price's automatic discount applies to what the price charges, and overage is one of
+        // the things it charges: a subscriber on an 8%-off yearly price is 8% off on this invoice
+        // too. On the aggregate, for the same reason tax is.
+        //
+        // Through the shared calculator with no band, rather than a percentage worked out here.
+        // A volume band prices seats and has no meaning for metered units, so the band is empty —
+        // and with no band both combination policies agree, which is why this needs no branch.
+        var builtIn = BuiltInDiscountCalculator.Resolve(
+            overage,
+            new QuantityDiscountOutcome(null, 0, overage, 0, overage),
+            subscription.Price.AutomaticDiscountBasisPoints,
+            subscription.Price.QuantityDiscountCombination);
+
         // Tax is on the aggregate, not per meter — the same "one charge, not one per meter"
         // scope this invoice already keeps for the charge itself, and the reason a meter that
         // overages by half a cent cannot cost the subscriber a full one.
         //
         // The rate and mode are the subscription's snapshotted price, so overage is taxed the way
-        // the thing it is overage *on* was sold.
+        // the thing it is overage *on* was sold. After the discount, never before: tax is owed on
+        // what is actually charged.
         var breakdown = SubscriptionAmountCalculator.TaxBreakdownFor(
-            lines.Sum(line => line.AmountMinor),
+            builtIn.SubtotalMinor,
             subscription.Price.TaxRateBasisPoints,
             subscription.Price.TaxMode);
 
@@ -313,6 +329,9 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 TaxAmountMinor = breakdown.TaxAmountMinor,
                 TaxRateBasisPoints = subscription.Price.TaxRateBasisPoints,
                 TaxMode = subscription.Price.TaxMode,
+                AutomaticDiscountBasisPoints =
+                    SubscriptionDiscountPresentation.RateOf(subscription.Price),
+                DiscountAmountMinor = builtIn.DiscountAmountMinor,
                 Lines = lines,
                 State = total > 0
                     ? SubscriptionUsageInvoiceState.Pending
@@ -402,6 +421,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 TaxAmountMinor = invoice.TaxAmountMinor,
                 TaxRateBasisPoints = invoice.TaxRateBasisPoints,
                 TaxMode = invoice.TaxMode,
+                AutomaticDiscountBasisPoints = invoice.AutomaticDiscountBasisPoints,
+                DiscountAmountMinor = invoice.DiscountAmountMinor,
                 CurrencyCode = invoice.CurrencyCode,
                 OrderId = SubscriptionConstants.UsageInvoiceOrderIdFor(
                     invoice.SubscriptionId,

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -324,10 +324,13 @@ alongside the amount, so a subscription response, a quantity preview and an invo
 figure is what it is rather than leaving a client to reverse-engineer it from a total. A promotion
 that lost is still not consumed — losing to an automatic discount counts as losing.
 
-Discounts **truncate** to the minor unit, the direction that favours the subscriber and the one
-`QuantityDiscountCalculator`'s bands already took. A price with no automatic discount goes through
-`BuiltInDiscountCalculator` and comes out with its band's own arithmetic untouched, to the minor
-unit — which is the state every stored price is in.
+Discounts **truncate** to the minor unit, matching `QuantityDiscountCalculator`'s existing bands
+exactly. Note which way that leans: truncating a reduction makes the reduction *smaller*, so it
+favours the merchant by up to one minor unit — 5% of 199 takes off 9 rather than 10. It is kept
+because a plan already charging a 5% band must not start charging it differently, not because it is
+the generous direction. A price with no automatic discount goes through `BuiltInDiscountCalculator`
+and comes out with its band's own arithmetic untouched, to the minor unit — which is the state every
+stored price is in.
 
 Both fields are snapshotted at signup and at plan change, like the amount and the tax:
 `PUT /api/subscription-plans/prices/{priceId}/discount` reaches future subscriptions and future
@@ -595,12 +598,22 @@ catalogue later cannot move an existing subscriber's reset window. Plan changes 
 fee and usage schedules from the change instant and permit monthly/annual moves when currency is
 unchanged.
 
+`DiscountTerms` snapshots the applicability lists alongside the amounts, and
+`SubscriptionPlanChangeService` re-asks `SubscriptionDiscountApplicability` before moving anybody: a
+code authored for the monthly price must not follow a subscriber onto the annual one. Refused rather
+than dropped — removing a promotion changes what they pay every period from here on, and an operation
+they asked for a *price* quote on is the wrong place to do that silently. A discount whose duration is
+spent or whose expiry has passed reduces nothing, so it never blocks a move.
+
 `FamilyCode` and `FamilyRank` group ordinary plans into ordered product levels. A level remains a
 plan—there is no second tier entity. Prices may carry `DisplayPriceNote` for authored presentation
 such as "$17/month, billed annually".
 
 Discounts are authored at `/api/subscription-discounts`, optionally scoped to an organization and
-optionally restricted to plan codes, price identifiers, or both. The two restrictions **narrow**
+optionally restricted to plan codes, price identifiers, or both. Both lists are resolved against the
+catalogue as the discount is authored — an identifier that does not exist in scope, or a price on a
+plan the code does not cover, is refused with `subscription_discount_applicability_invalid`, because
+the alternative is a discount that stores cleanly and then refuses every redemption. The two restrictions **narrow**
 rather than offering two ways to qualify: with both set, both have to match, so a code aimed at the
 yearly price is refused on the monthly one. A discount stored before price applicability existed
 carries no price list and stays unrestricted by price. Unknown, retired, expired, inapplicable, and

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -321,7 +321,14 @@ not a question anybody authoring a catalogue is asking.
 
 `PeriodCharge` reports `GrossAmountMinor`, `BuiltInDiscountMinor` and `PromotionalDiscountMinor`
 alongside the amount, so a subscription response, a quantity preview and an invoice can say why the
-figure is what it is rather than leaving a client to reverse-engineer it from a total. A promotion
+figure is what it is rather than leaving a client to reverse-engineer it from a total. A **settlement**
+— a plan change or a quantity increase — cannot be described that way: its amount is the difference
+between two prorated periods, so `SubscriptionProrationCalculator` returns a `ProrationBreakdown`
+carrying both sides (each with its own gross, discounts, tax, period total and prorated value), the
+credit consumed and the net. It is snapshotted onto the `SettlementReservation` when the change is
+quoted — recomputing it at settlement time would price it at a different instant, possibly against an
+edited catalogue — travels on the charge request, and is stored on `PaymentDetail.SubscriptionSettlement`
+for invoice history. The flat fields and the settlement are alternatives, never both. A promotion
 that lost is still not consumed — losing to an automatic discount counts as losing.
 
 Discounts **truncate** to the minor unit, matching `QuantityDiscountCalculator`'s existing bands

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -291,6 +291,52 @@ A payment with no `CustomerOrganizationId` — one recorded before the subscribe
 refused rather than shown to whoever asks. Absent, another organization's, and not-a-subscription
 all return the same not-found, so the refusal cannot be used to enumerate a tenant's payments.
 
+## Automatic price discounts
+
+A price can reduce itself. `PriceSnapshot.AutomaticDiscountBasisPoints` is a percentage taken off
+every charge that price produces, with no code redeemed and no subscriber action — the mechanism
+behind "8% off if you pay yearly".
+
+It is on the **price**, not the plan, because the offer is cadence-specific: the yearly price
+carries it and the monthly price beside it under the same plan does not. Two prices, one plan, one
+product. A plan sold in two currencies has the same freedom, and neither case needs a second plan
+that somebody would have to be moved between.
+
+Three reductions can therefore meet on one charge, and there are two combinations because they
+answer two different questions:
+
+1. `BuiltInDiscountCalculator` settles the two the **merchant** authored — the price's automatic
+   discount and the volume band the quantity selects — the way
+   `PriceSnapshot.QuantityDiscountCombination` says. `BestDiscount` takes whichever reduces the
+   charge by more money and only that one; `Additive` adds the two rates and applies the sum once,
+   so 8% plus 5% is 13% rather than the 12.6% sequential application would give. Capped at 100%,
+   because two generous rates must not arrive at a negative charge.
+2. `PlanSnapshot.QuantityDiscountCombinationPolicy` then settles what a **redeemed code** adds to
+   that result, exactly as it already settled band-versus-code. `QuantityOnly` now means "built-in
+   discounts only"; its stored wire value is unchanged, so an existing plan means what it always
+   did.
+
+Collapsing the two into one policy would make a cadence discount negotiate with a coupon, which is
+not a question anybody authoring a catalogue is asking.
+
+`PeriodCharge` reports `GrossAmountMinor`, `BuiltInDiscountMinor` and `PromotionalDiscountMinor`
+alongside the amount, so a subscription response, a quantity preview and an invoice can say why the
+figure is what it is rather than leaving a client to reverse-engineer it from a total. A promotion
+that lost is still not consumed — losing to an automatic discount counts as losing.
+
+Discounts **truncate** to the minor unit, the direction that favours the subscriber and the one
+`QuantityDiscountCalculator`'s bands already took. A price with no automatic discount goes through
+`BuiltInDiscountCalculator` and comes out with its band's own arithmetic untouched, to the minor
+unit — which is the state every stored price is in.
+
+Both fields are snapshotted at signup and at plan change, like the amount and the tax:
+`PUT /api/subscription-plans/prices/{priceId}/discount` reaches future subscriptions and future
+moves onto the price, and nobody already on it is repriced either way. Metered overage is charged
+by the price the subscription was sold on, so the automatic discount reaches an overage invoice too
+(recorded on `SubscriptionUsageInvoice.DiscountAmountMinor`), before its tax. A volume band does not
+— it prices units of a quantity item and a meter has none — and a promotional code still does not
+reach usage invoices at all.
+
 ## Tax
 
 `PriceSnapshot.TaxRateBasisPoints` and `PriceSnapshot.TaxMode` — manual, not jurisdiction-derived.
@@ -326,7 +372,8 @@ exclusive, integer-truncation calculation (CHF 11.16 in that example), so deploy
 cannot silently alter an existing subscriber's charge. Choosing a mode on a new or updated
 catalogue price opts future subscriptions into the rounded calculation.
 
-The pipeline is **gross → discount → tax → credit**. Tax is computed on the *discounted* amount,
+The pipeline is **gross → built-in discount → promotional discount → tax → credit**, with the two
+discount stages as described under [automatic price discounts](#automatic-price-discounts). Tax is computed on the *discounted* amount,
 not gross — the same base the customer is actually being asked to pay. A banked credit is then
 consumed against the tax-inclusive total: a credit offsets what the subscriber owes including
 tax, it does not shrink the taxable base. A mid-period plan change taxes each side of the
@@ -553,8 +600,11 @@ plan—there is no second tier entity. Prices may carry `DisplayPriceNote` for a
 such as "$17/month, billed annually".
 
 Discounts are authored at `/api/subscription-discounts`, optionally scoped to an organization and
-optionally restricted to plan codes. Unknown, retired, expired, inapplicable, and wrong-currency
-fixed discounts are rejected. Accepted terms are copied onto the subscription, so retiring the
+optionally restricted to plan codes, price identifiers, or both. The two restrictions **narrow**
+rather than offering two ways to qualify: with both set, both have to match, so a code aimed at the
+yearly price is refused on the monthly one. A discount stored before price applicability existed
+carries no price list and stays unrestricted by price. Unknown, retired, expired, inapplicable, and
+wrong-currency fixed discounts are rejected. Accepted terms are copied onto the subscription, so retiring the
 catalogue entry never changes an existing subscriber's renewal.
 
 ## Invoice boundary

--- a/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
@@ -75,6 +75,22 @@ public interface ISubscriptionCatalogueRepository
         DateTime updatedAtUtc,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Rewrites a price's automatic discount, compare-and-set on its version.
+    /// </summary>
+    /// <remarks>
+    /// Reaches future snapshots only. Anyone already subscribed holds their own copy of these two
+    /// values and is charged from it, so clearing a discount here never repossesses one already sold.
+    /// </remarks>
+    Task<bool> TryUpdatePriceAutomaticDiscountAsync(
+        string tenantId,
+        string priceId,
+        int expectedVersion,
+        int? automaticDiscountBasisPoints,
+        AutomaticDiscountCombination? combination,
+        DateTime updatedAtUtc,
+        CancellationToken cancellationToken);
+
     Task<bool> TrySetPriceMirrorAsync(
         string tenantId,
         string priceId,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
@@ -40,8 +40,12 @@ public sealed record SubscriptionInvoiceHistoryRecord(
     long? CreditAmountMinor = null,
     int? TaxRateBasisPoints = null,
     string? TaxMode = null,
-    long? DiscountAmountMinor = null,
-    int? AutomaticDiscountBasisPoints = null);
+    long? GrossAmountMinor = null,
+    long? BuiltInDiscountMinor = null,
+    long? PromotionalDiscountMinor = null,
+    int? AutomaticDiscountBasisPoints = null,
+    int? QuantityDiscountBasisPoints = null,
+    string? DiscountCombination = null);
 
 public sealed record SubscriptionInvoiceHistoryPage(
     IReadOnlyList<SubscriptionInvoiceHistoryRecord> Items,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
@@ -39,7 +39,9 @@ public sealed record SubscriptionInvoiceHistoryRecord(
     long? TaxAmountMinor = null,
     long? CreditAmountMinor = null,
     int? TaxRateBasisPoints = null,
-    string? TaxMode = null);
+    string? TaxMode = null,
+    long? DiscountAmountMinor = null,
+    int? AutomaticDiscountBasisPoints = null);
 
 public sealed record SubscriptionInvoiceHistoryPage(
     IReadOnlyList<SubscriptionInvoiceHistoryRecord> Items,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionInvoiceHistoryRepository.cs
@@ -1,3 +1,5 @@
+using Payment.DomainService.Entities;
+
 namespace Subscription.DomainService.Repositories;
 
 public interface ISubscriptionInvoiceHistoryRepository
@@ -45,7 +47,8 @@ public sealed record SubscriptionInvoiceHistoryRecord(
     long? PromotionalDiscountMinor = null,
     int? AutomaticDiscountBasisPoints = null,
     int? QuantityDiscountBasisPoints = null,
-    string? DiscountCombination = null);
+    string? DiscountCombination = null,
+    SubscriptionSettlementBreakdown? Settlement = null);
 
 public sealed record SubscriptionInvoiceHistoryPage(
     IReadOnlyList<SubscriptionInvoiceHistoryRecord> Items,

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -259,6 +259,35 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
         return result.ModifiedCount == 1;
     }
 
+    public async Task<bool> TryUpdatePriceAutomaticDiscountAsync(
+        string tenantId,
+        string priceId,
+        int expectedVersion,
+        int? automaticDiscountBasisPoints,
+        AutomaticDiscountCombination? combination,
+        DateTime updatedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var result = await Prices(tenantId).UpdateOneAsync(
+            Builders<Price>.Filter.And(
+                Builders<Price>.Filter.Eq(price => price.TenantId, tenantId),
+                Builders<Price>.Filter.Eq(price => price.ItemId, priceId),
+                Builders<Price>.Filter.Eq(price => price.Version, expectedVersion),
+                Builders<Price>.Filter.Eq(price => price.Status, CatalogueStatus.Active)),
+            Builders<Price>.Update
+                .Set(price => price.AutomaticDiscountBasisPoints, automaticDiscountBasisPoints)
+                // Cleared with the rate it describes, so a price with no discount cannot carry a
+                // stale answer to how that discount combines with a band.
+                .Set(
+                    price => price.QuantityDiscountCombination,
+                    automaticDiscountBasisPoints > 0 ? combination : null)
+                .Set(price => price.LastUpdatedDateUtc, updatedAtUtc)
+                .Inc(price => price.Version, 1),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     public async Task<bool> TrySetPriceMirrorAsync(
         string tenantId,
         string priceId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
@@ -74,7 +74,8 @@ public sealed class SubscriptionInvoiceHistoryRepository :
                 payment.SubscriptionPromotionalDiscountMinor,
                 payment.SubscriptionAutomaticDiscountBasisPoints,
                 payment.SubscriptionQuantityDiscountBasisPoints,
-                payment.SubscriptionDiscountCombination))
+                payment.SubscriptionDiscountCombination,
+                payment.SubscriptionSettlement))
             .ToListAsync(cancellationToken);
 
         var hasMore = records.Count > pageSize;
@@ -133,7 +134,8 @@ public sealed class SubscriptionInvoiceHistoryRepository :
                 payment.SubscriptionPromotionalDiscountMinor,
                 payment.SubscriptionAutomaticDiscountBasisPoints,
                 payment.SubscriptionQuantityDiscountBasisPoints,
-                payment.SubscriptionDiscountCombination))
+                payment.SubscriptionDiscountCombination,
+                payment.SubscriptionSettlement))
             .ToListAsync(cancellationToken);
     }
 

--- a/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
@@ -68,7 +68,9 @@ public sealed class SubscriptionInvoiceHistoryRepository :
                 payment.SubscriptionTaxAmountMinor,
                 payment.SubscriptionCreditAmountMinor,
                 payment.SubscriptionTaxRateBasisPoints,
-                payment.SubscriptionTaxMode))
+                payment.SubscriptionTaxMode,
+                payment.SubscriptionDiscountAmountMinor,
+                payment.SubscriptionAutomaticDiscountBasisPoints))
             .ToListAsync(cancellationToken);
 
         var hasMore = records.Count > pageSize;
@@ -121,7 +123,9 @@ public sealed class SubscriptionInvoiceHistoryRepository :
                 payment.SubscriptionTaxAmountMinor,
                 payment.SubscriptionCreditAmountMinor,
                 payment.SubscriptionTaxRateBasisPoints,
-                payment.SubscriptionTaxMode))
+                payment.SubscriptionTaxMode,
+                payment.SubscriptionDiscountAmountMinor,
+                payment.SubscriptionAutomaticDiscountBasisPoints))
             .ToListAsync(cancellationToken);
     }
 

--- a/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionInvoiceHistoryRepository.cs
@@ -69,8 +69,12 @@ public sealed class SubscriptionInvoiceHistoryRepository :
                 payment.SubscriptionCreditAmountMinor,
                 payment.SubscriptionTaxRateBasisPoints,
                 payment.SubscriptionTaxMode,
-                payment.SubscriptionDiscountAmountMinor,
-                payment.SubscriptionAutomaticDiscountBasisPoints))
+                payment.SubscriptionGrossAmountMinor,
+                payment.SubscriptionBuiltInDiscountMinor,
+                payment.SubscriptionPromotionalDiscountMinor,
+                payment.SubscriptionAutomaticDiscountBasisPoints,
+                payment.SubscriptionQuantityDiscountBasisPoints,
+                payment.SubscriptionDiscountCombination))
             .ToListAsync(cancellationToken);
 
         var hasMore = records.Count > pageSize;
@@ -124,8 +128,12 @@ public sealed class SubscriptionInvoiceHistoryRepository :
                 payment.SubscriptionCreditAmountMinor,
                 payment.SubscriptionTaxRateBasisPoints,
                 payment.SubscriptionTaxMode,
-                payment.SubscriptionDiscountAmountMinor,
-                payment.SubscriptionAutomaticDiscountBasisPoints))
+                payment.SubscriptionGrossAmountMinor,
+                payment.SubscriptionBuiltInDiscountMinor,
+                payment.SubscriptionPromotionalDiscountMinor,
+                payment.SubscriptionAutomaticDiscountBasisPoints,
+                payment.SubscriptionQuantityDiscountBasisPoints,
+                payment.SubscriptionDiscountCombination))
             .ToListAsync(cancellationToken);
     }
 

--- a/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
@@ -14,4 +14,6 @@ public sealed class CreateDiscountRequest
     public int? DurationPeriods { get; set; }
     public DateTime? ExpiresAtUtc { get; set; }
     public List<string> ApplicablePlanCodes { get; set; } = [];
+    /// <summary>Empty is unrestricted by price. Narrows with the plan list, not instead of it.</summary>
+    public List<string> ApplicablePriceIds { get; set; } = [];
 }

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -45,4 +45,16 @@ public sealed class CreatePriceRequest
     /// </remarks>
     public TaxMode? TaxMode { get; set; }
 
+    /// <summary>
+    /// A percentage off this price, applied without a code, in basis points — 800 is 8%.
+    /// Omitted or zero is no automatic discount.
+    /// </summary>
+    public int? AutomaticDiscountBasisPoints { get; set; }
+
+    /// <summary>
+    /// How that discount meets a volume band. Omitted reads as <c>BestDiscount</c>, which takes
+    /// the larger of the two and never both — the answer that cannot give away more than the
+    /// author realised.
+    /// </summary>
+    public AutomaticDiscountCombination? QuantityDiscountCombination { get; set; }
 }

--- a/server/Subscription.DomainService/Requests/UpdatePriceDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/UpdatePriceDiscountRequest.cs
@@ -1,0 +1,31 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Requests;
+
+/// <summary>
+/// Changes what a price takes off automatically, leaving its amount and cadence alone.
+/// </summary>
+/// <remarks>
+/// A price's commercial terms are immutable once it exists, because every subscription sold on it
+/// references them. This is the deliberate exception, alongside tax: it reaches future snapshots and
+/// future moves onto the price only, and nobody already subscribed is repriced by it.
+/// </remarks>
+public sealed class UpdatePriceDiscountRequest
+{
+    /// <summary>
+    /// The organization whose plan this price belongs to. Ignored unless the caller is the console —
+    /// everyone else edits their own organization's prices, whatever this says.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// Basis points off, out of 10,000. Zero or null clears the automatic discount.
+    /// </summary>
+    public int? AutomaticDiscountBasisPoints { get; set; }
+
+    /// <summary>
+    /// How that discount meets a volume band. Ignored when the discount is being cleared, since
+    /// there is then nothing for it to combine with.
+    /// </summary>
+    public AutomaticDiscountCombination? QuantityDiscountCombination { get; set; }
+}

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -13,5 +13,6 @@ public sealed class DiscountResponse
     public int? DurationPeriods { get; init; }
     public DateTime? ExpiresAtUtc { get; init; }
     public List<string> ApplicablePlanCodes { get; init; } = [];
+    public List<string> ApplicablePriceIds { get; init; } = [];
     public string Status { get; init; } = string.Empty;
 }

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -193,4 +193,13 @@ public sealed class PlanPriceResponse
     /// two the amount is.
     /// </summary>
     public string? TaxMode { get; init; }
+
+    /// <summary>Basis points off without a code — 800 is 8%. Absent when the price has none.</summary>
+    public int? AutomaticDiscountBasisPoints { get; init; }
+
+    /// <summary>
+    /// "BestDiscount" or "Additive". Reported for any price carrying an automatic discount, since the
+    /// two answers differ by real money once a volume band is also in play.
+    /// </summary>
+    public string? QuantityDiscountCombination { get; init; }
 }

--- a/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
+++ b/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
@@ -87,6 +87,38 @@ public sealed class QuantityChangeResponse
     /// <summary>"Exclusive" or "Inclusive", so a client can say which the amount already contains.</summary>
     public string? TaxMode { get; init; }
 
+    /// <summary>Basis points taken off automatically by the price itself. Null when it has none.</summary>
+    public int? AutomaticDiscountBasisPoints { get; init; }
+
+    /// <summary>
+    /// "BestDiscount" or "Additive" — how the automatic discount met the volume band. Null when
+    /// there is no automatic discount to combine.
+    /// </summary>
+    public string? QuantityDiscountCombination { get; init; }
+
+    /// <summary>The charge before any reduction, so the ones below have something to be off of.</summary>
+    public long GrossAmountMinor { get; init; }
+
+    /// <summary>
+    /// What the automatic discount and the volume band took off between them, already combined the
+    /// way the price says to. Zero when neither applied.
+    /// </summary>
+    public long BuiltInDiscountMinor { get; init; }
+
+    /// <summary>
+    /// What the subscriber's promotional code took off, after the built-in reduction was settled.
+    /// Zero when there is no code, or when the plan's policy left it unused.
+    /// </summary>
+    public long PromotionalDiscountMinor { get; init; }
+
+    /// <summary>
+    /// What is left to tax: gross less both reductions above. The same figure
+    /// <see cref="NetAmountMinor"/> reports for a tax-exclusive price, stated separately because for
+    /// an inclusive one the net is below it by the tax inside.
+    /// </summary>
+    public long DiscountedAmountMinor { get; init; }
+
+
     /// <summary>
     /// Whether a promotional discount is part of the figures above, so a client can say why the
     /// unit price is below the band's own arithmetic rather than leaving it unexplained.

--- a/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
@@ -42,13 +42,38 @@ public sealed class SubscriptionInvoiceHistoryItemResponse
     public string? TaxMode { get; init; }
 
     /// <summary>
-    /// Basis points the price took off automatically. Null on a fee invoice, whose figures come from
-    /// the payment provider rather than from this module's own calculation.
+    /// What this invoice was made of before tax. Null together on a first charge (a hosted checkout
+    /// composes no invoice), on a plan-change or quantity settlement (the amount there is the
+    /// difference between two prorated periods, which does not decompose into a gross and a
+    /// reduction), and on payments raised before the breakdown was recorded.
     /// </summary>
+    /// <remarks>
+    /// Reported separately rather than as one reduction, because "CHF 13.00 came off" cannot be
+    /// turned back into "the price gave 8%, the band gave 5%, the coupon gave nothing" — and that is
+    /// the question somebody reading a months-old invoice is actually asking.
+    /// </remarks>
+    public long? GrossAmountMinor { get; init; }
+
+    /// <summary>What the price's automatic discount and the volume band took off between them.</summary>
+    public long? BuiltInDiscountMinor { get; init; }
+
+    /// <summary>What a promotional code took off after that.</summary>
+    public long? PromotionalDiscountMinor { get; init; }
+
+    /// <summary>What was left to tax: gross less both reductions above.</summary>
+    public long? DiscountedAmountMinor { get; init; }
+
+    /// <summary>Basis points the price took off automatically. Null when it had none.</summary>
     public int? AutomaticDiscountBasisPoints { get; init; }
 
-    /// <summary>What that discount took off this invoice, before tax. Null where it does not apply.</summary>
-    public long? DiscountAmountMinor { get; init; }
+    /// <summary>The band's rate, when the quantity selected one.</summary>
+    public int? QuantityDiscountBasisPoints { get; init; }
+
+    /// <summary>
+    /// "BestDiscount" or "Additive" — how the two authored reductions met, so a reader can tell a
+    /// charge that combined them from one that chose between them.
+    /// </summary>
+    public string? QuantityDiscountCombination { get; init; }
 
     /// <summary>
     /// An authenticated application endpoint, never Stripe's bearer-style document URL.

--- a/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
@@ -42,10 +42,10 @@ public sealed class SubscriptionInvoiceHistoryItemResponse
     public string? TaxMode { get; init; }
 
     /// <summary>
-    /// What this invoice was made of before tax. Null together on a first charge (a hosted checkout
-    /// composes no invoice), on a plan-change or quantity settlement (the amount there is the
-    /// difference between two prorated periods, which does not decompose into a gross and a
-    /// reduction), and on payments raised before the breakdown was recorded.
+    /// What this invoice was made of before tax. Null together on a plan-change or quantity
+    /// settlement, which reports <see cref="Settlement"/> instead — its amount is the difference
+    /// between two prorated periods and has two sides rather than one. Also null on a first charge (a
+    /// hosted checkout composes no invoice) and on payments raised before the breakdown existed.
     /// </summary>
     /// <remarks>
     /// Reported separately rather than as one reduction, because "CHF 13.00 came off" cannot be
@@ -76,9 +76,66 @@ public sealed class SubscriptionInvoiceHistoryItemResponse
     public string? QuantityDiscountCombination { get; init; }
 
     /// <summary>
+    /// How a settlement's amount was arrived at, on a plan-change or quantity invoice. Null on a
+    /// renewal, which the flat fields above describe.
+    /// </summary>
+    /// <remarks>
+    /// A settlement is a subtraction, so it is reported as one: the period being left, the period
+    /// being joined, and what closed the gap. A subscriber charged mid-month is asking about the two
+    /// sides, not the remainder.
+    /// </remarks>
+    public SubscriptionSettlementResponse? Settlement { get; init; }
+
+    /// <summary>
     /// An authenticated application endpoint, never Stripe's bearer-style document URL.
     /// </summary>
     public string DownloadUrl { get; init; } = string.Empty;
+}
+
+/// <summary>Both sides of a settlement, and what closed the gap between them.</summary>
+public sealed class SubscriptionSettlementResponse
+{
+    /// <summary>The period the subscriber left part-way through.</summary>
+    public SubscriptionSettlementSideResponse Outgoing { get; init; } = new();
+
+    /// <summary>The period they joined.</summary>
+    public SubscriptionSettlementSideResponse Target { get; init; } = new();
+
+    /// <summary>Banked credit spent against the difference.</summary>
+    public long CreditConsumedMinor { get; init; }
+
+    /// <summary>
+    /// Target prorated value less outgoing unused value less credit. Negative where a downgrade
+    /// banked credit rather than charging, which is why it is not simply the amount charged.
+    /// </summary>
+    public long NetSettlementMinor { get; init; }
+}
+
+/// <summary>One side of a settlement, priced as its own period and then prorated.</summary>
+public sealed class SubscriptionSettlementSideResponse
+{
+    public long GrossAmountMinor { get; init; }
+
+    /// <summary>The price's automatic discount and the volume band, combined as that price says.</summary>
+    public long BuiltInDiscountMinor { get; init; }
+
+    /// <summary>A promotional code, after the built-in reduction was settled.</summary>
+    public long PromotionalDiscountMinor { get; init; }
+
+    /// <summary>Tax at this side's own rate and mode — a change can cross between the two.</summary>
+    public long TaxAmountMinor { get; init; }
+
+    /// <summary>The whole period, tax included.</summary>
+    public long PeriodTotalMinor { get; init; }
+
+    /// <summary>
+    /// The part of that this settlement counted: unused time on the outgoing side, remaining time on
+    /// the target side.
+    /// </summary>
+    public long ProratedValueMinor { get; init; }
+
+    /// <summary>What was taxed: gross less both reductions above.</summary>
+    public long DiscountedAmountMinor { get; init; }
 }
 
 public sealed class SubscriptionInvoiceHistoryPageInfoResponse

--- a/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionInvoiceHistoryResponse.cs
@@ -42,6 +42,15 @@ public sealed class SubscriptionInvoiceHistoryItemResponse
     public string? TaxMode { get; init; }
 
     /// <summary>
+    /// Basis points the price took off automatically. Null on a fee invoice, whose figures come from
+    /// the payment provider rather than from this module's own calculation.
+    /// </summary>
+    public int? AutomaticDiscountBasisPoints { get; init; }
+
+    /// <summary>What that discount took off this invoice, before tax. Null where it does not apply.</summary>
+    public long? DiscountAmountMinor { get; init; }
+
+    /// <summary>
     /// An authenticated application endpoint, never Stripe's bearer-style document URL.
     /// </summary>
     public string DownloadUrl { get; init; } = string.Empty;

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -72,6 +72,38 @@ public sealed class SubscriptionResponse
     /// </summary>
     public string? TaxMode { get; init; }
 
+    /// <summary>Basis points taken off automatically by the price itself. Null when it has none.</summary>
+    public int? AutomaticDiscountBasisPoints { get; init; }
+
+    /// <summary>
+    /// "BestDiscount" or "Additive" — how the automatic discount met the volume band. Null when
+    /// there is no automatic discount to combine.
+    /// </summary>
+    public string? QuantityDiscountCombination { get; init; }
+
+    /// <summary>The charge before any reduction, so the ones below have something to be off of.</summary>
+    public long GrossAmountMinor { get; init; }
+
+    /// <summary>
+    /// What the automatic discount and the volume band took off between them, already combined the
+    /// way the price says to. Zero when neither applied.
+    /// </summary>
+    public long BuiltInDiscountMinor { get; init; }
+
+    /// <summary>
+    /// What the subscriber's promotional code took off, after the built-in reduction was settled.
+    /// Zero when there is no code, or when the plan's policy left it unused.
+    /// </summary>
+    public long PromotionalDiscountMinor { get; init; }
+
+    /// <summary>
+    /// What is left to tax: gross less both reductions above. The same figure
+    /// <see cref="NetAmountMinor"/> reports for a tax-exclusive price, stated separately because for
+    /// an inclusive one the net is below it by the tax inside.
+    /// </summary>
+    public long DiscountedAmountMinor { get; init; }
+
+
     /// <summary>
     /// Where to send the customer to pay. Present only while the first charge is outstanding.
     /// </summary>

--- a/server/Subscription.DomainService/Responses/SubscriptionSimulationStateResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionSimulationStateResponse.cs
@@ -119,6 +119,12 @@ public sealed class SimulationUsageInvoiceResponse
     /// <summary>"Exclusive" or "Inclusive", for a harness that has to show the same figures a UI does.</summary>
     public string? TaxMode { get; init; }
 
+    /// <summary>The price's automatic discount when this invoice was raised. Null when it had none.</summary>
+    public int? AutomaticDiscountBasisPoints { get; init; }
+
+    /// <summary>What that discount took off the summed overage, before tax.</summary>
+    public long DiscountAmountMinor { get; init; }
+
     public string State { get; init; } = string.Empty;
 
     public int AttemptCount { get; init; }

--- a/server/Subscription.DomainService/Services/BuiltInDiscountCalculator.cs
+++ b/server/Subscription.DomainService/Services/BuiltInDiscountCalculator.cs
@@ -117,12 +117,17 @@ public static class BuiltInDiscountCalculator
     /// A percentage of an amount, in exact integer arithmetic, truncated.
     /// </summary>
     /// <remarks>
-    /// Truncated deliberately, which is the direction that favours the subscriber and matches
-    /// <see cref="QuantityDiscountCalculator"/>'s existing bands — a discount and a tax are not the
-    /// same kind of number, and rounding a reduction up would take more off than was advertised.
+    /// Truncated to match <see cref="QuantityDiscountCalculator"/>'s existing bands exactly, so a
+    /// plan that has been charging a 5% band one way does not start charging it another. Be clear
+    /// about which way that leans: truncating a <em>reduction</em> makes the reduction smaller, so it
+    /// favours the merchant by up to one minor unit — 5% of 199 takes off 9 rather than the 10 a
+    /// rounded rate would. Compatibility with money already being charged is the reason to keep it,
+    /// not fairness.
+    /// <para>
     /// Widened for the multiplication for the same reason every other calculation here is: an amount
     /// times a basis-point rate overflows a <see cref="long"/> well before the amounts involved look
     /// unreasonable.
+    /// </para>
     /// </remarks>
     private static long DiscountOn(long amountMinor, int basisPoints) =>
         (long)((Int128)amountMinor * basisPoints / FullBasisPoints);

--- a/server/Subscription.DomainService/Services/BuiltInDiscountCalculator.cs
+++ b/server/Subscription.DomainService/Services/BuiltInDiscountCalculator.cs
@@ -1,0 +1,155 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// The reduction a subscriber gets without typing anything: the price's own automatic discount and
+/// the volume band their quantity selects, combined the way the price says to.
+/// </summary>
+/// <remarks>
+/// Pure and static, like the other calculators here. Its own type rather than a branch inside
+/// <see cref="SubscriptionAmountCalculator"/>, because "how much comes off before a coupon is even
+/// considered" is one question with one answer, and every money path — signup, renewal, quantity
+/// preview, proration, usage overage — has to get the same one.
+/// <para>
+/// A monthly price with no automatic discount and a plan with no bands resolves to no reduction and
+/// prices exactly as it did before any of this existed. That is the case almost every stored price
+/// is in, so it is the case that must be arithmetically untouched.
+/// </para>
+/// </remarks>
+public static class BuiltInDiscountCalculator
+{
+    private const int FullBasisPoints = 10_000;
+
+    /// <param name="grossAmountMinor">
+    /// The undiscounted charge — <see cref="SubscriptionAmountCalculator.GrossAmountMinor"/>, passed
+    /// in rather than read off <paramref name="band"/> so the caller keeps one gross for the whole
+    /// calculation.
+    /// </param>
+    /// <param name="band">
+    /// The volume band the quantity selects, already resolved. Its own reduction is used verbatim
+    /// when it wins, so a plan that had bands before automatic discounts existed charges the same
+    /// figure to the minor unit.
+    /// </param>
+    /// <param name="automaticBasisPoints">
+    /// The price's automatic discount. Null or zero is no automatic discount, which is what every
+    /// price authored before this existed carries.
+    /// </param>
+    /// <param name="combination">
+    /// How the two meet. Null reads as <see cref="AutomaticDiscountCombination.BestDiscount"/> — the
+    /// conservative answer, and the one a caller that omitted the field almost certainly meant.
+    /// </param>
+    public static BuiltInDiscount Resolve(
+        long grossAmountMinor,
+        QuantityDiscountOutcome band,
+        int? automaticBasisPoints,
+        AutomaticDiscountCombination? combination)
+    {
+        var automatic = Math.Clamp(automaticBasisPoints ?? 0, 0, FullBasisPoints);
+        var bandBasisPoints = Math.Max(0, band.DiscountBasisPoints);
+        var bandDiscount = Math.Max(0, band.DiscountAmountMinor);
+
+        if (grossAmountMinor <= 0 || (automatic == 0 && bandDiscount == 0))
+        {
+            return new BuiltInDiscount(
+                grossAmountMinor,
+                automatic,
+                bandBasisPoints,
+                0,
+                0,
+                grossAmountMinor);
+        }
+
+        if (automatic == 0)
+        {
+            // The band alone, with its own arithmetic rather than a recomputation of it: a plan
+            // that priced a band one way before this existed must not start rounding it another.
+            return new BuiltInDiscount(
+                grossAmountMinor,
+                0,
+                bandBasisPoints,
+                bandBasisPoints,
+                bandDiscount,
+                Math.Max(0, grossAmountMinor - bandDiscount));
+        }
+
+        if ((combination ?? AutomaticDiscountCombination.BestDiscount) ==
+            AutomaticDiscountCombination.Additive)
+        {
+            // One rate, applied once. Adding the rates and taking a single percentage is what an
+            // author who wrote "8% + 5% = 13%" means; applying them in sequence gives 12.6% and no
+            // way to explain the missing 0.4 on an invoice.
+            var combined = Math.Min(FullBasisPoints, automatic + bandBasisPoints);
+            var discount = DiscountOn(grossAmountMinor, combined);
+
+            return new BuiltInDiscount(
+                grossAmountMinor,
+                automatic,
+                bandBasisPoints,
+                combined,
+                discount,
+                grossAmountMinor - discount);
+        }
+
+        var automaticDiscount = DiscountOn(grossAmountMinor, automatic);
+
+        // Compared as money, and ties go to the automatic discount. Neither can be consumed the way
+        // a promotional code can, so which one wins a tie changes nothing a subscriber can see —
+        // but reporting the price's own rate keeps the breakdown consistent with what was authored.
+        return bandDiscount > automaticDiscount
+            ? new BuiltInDiscount(
+                grossAmountMinor,
+                automatic,
+                bandBasisPoints,
+                bandBasisPoints,
+                bandDiscount,
+                Math.Max(0, grossAmountMinor - bandDiscount))
+            : new BuiltInDiscount(
+                grossAmountMinor,
+                automatic,
+                bandBasisPoints,
+                automatic,
+                automaticDiscount,
+                grossAmountMinor - automaticDiscount);
+    }
+
+    /// <summary>
+    /// A percentage of an amount, in exact integer arithmetic, truncated.
+    /// </summary>
+    /// <remarks>
+    /// Truncated deliberately, which is the direction that favours the subscriber and matches
+    /// <see cref="QuantityDiscountCalculator"/>'s existing bands — a discount and a tax are not the
+    /// same kind of number, and rounding a reduction up would take more off than was advertised.
+    /// Widened for the multiplication for the same reason every other calculation here is: an amount
+    /// times a basis-point rate overflows a <see cref="long"/> well before the amounts involved look
+    /// unreasonable.
+    /// </remarks>
+    private static long DiscountOn(long amountMinor, int basisPoints) =>
+        (long)((Int128)amountMinor * basisPoints / FullBasisPoints);
+}
+
+/// <summary>
+/// What came off a charge before any promotional code was considered, and where it came from.
+/// </summary>
+/// <remarks>
+/// Carries both rates and the one that was actually applied, not only the money, because an invoice
+/// has to be able to explain a figure months later — by which time the catalogue will have moved.
+/// <see cref="SubtotalMinor"/> is always <see cref="GrossAmountMinor"/> less
+/// <see cref="DiscountAmountMinor"/>, by construction rather than by a second calculation.
+/// </remarks>
+/// <param name="GrossAmountMinor">The charge before any reduction.</param>
+/// <param name="AutomaticBasisPoints">The price's automatic discount, as authored. Zero when it has none.</param>
+/// <param name="QuantityBasisPoints">The band's rate. Zero when the quantity selected no band.</param>
+/// <param name="EffectiveBasisPoints">
+/// The rate that produced <see cref="DiscountAmountMinor"/> — one of the two, or their sum under
+/// <see cref="AutomaticDiscountCombination.Additive"/>. Zero when nothing was taken off.
+/// </param>
+/// <param name="DiscountAmountMinor">What came off.</param>
+/// <param name="SubtotalMinor">What is left to apply a promotion, and then tax, to.</param>
+public readonly record struct BuiltInDiscount(
+    long GrossAmountMinor,
+    int AutomaticBasisPoints,
+    int QuantityBasisPoints,
+    int EffectiveBasisPoints,
+    long DiscountAmountMinor,
+    long SubtotalMinor);

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -11,15 +11,18 @@ namespace Subscription.DomainService.Services;
 public sealed class DiscountCatalogueService : IDiscountCatalogueService
 {
     private readonly ISubscriptionDiscountRepository _discounts;
+    private readonly ISubscriptionCatalogueRepository _catalogue;
     private readonly ISubscriptionContextResolver _context;
     private readonly IValidator<CreateDiscountRequest> _validator;
 
     public DiscountCatalogueService(
         ISubscriptionDiscountRepository discounts,
+        ISubscriptionCatalogueRepository catalogue,
         ISubscriptionContextResolver context,
         IValidator<CreateDiscountRequest> validator)
     {
         _discounts = discounts;
+        _catalogue = catalogue;
         _context = context;
         _validator = validator;
     }
@@ -35,6 +38,11 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         if (invalid is not null) return invalid;
 
         var context = resolution.Context!;
+
+        var applicability = await CheckApplicabilityAsync(
+            request, context, correlationId, cancellationToken);
+        if (applicability is not null) return applicability;
+
         var discount = new Discount
         {
             TenantId = context.TenantId,
@@ -61,6 +69,86 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
                 "A discount with this code already exists at this scope.", correlationId);
         return SubscriptionOperationResult<DiscountResponse>.Success(Map(discount), correlationId);
     }
+
+    /// <summary>
+    /// Checks that the plans and prices a discount is restricted to actually exist, in this caller's
+    /// scope, and agree with each other. Null when they do.
+    /// </summary>
+    /// <remarks>
+    /// A restriction naming something that does not exist is a discount that can never be redeemed:
+    /// every attempt is refused with <c>subscription_discount_not_applicable</c>, and nothing about
+    /// that error tells the author their code has a typo in it. The portal picks from a list and
+    /// cannot make the mistake; an API client, a script, or a copied identifier from another
+    /// environment can, so it is refused where the author can still fix it.
+    /// <para>
+    /// A price is also checked against the plan list when both are given, because with both narrowing
+    /// each other a price belonging to an unlisted plan matches nothing — the same unredeemable
+    /// discount, arrived at by a different mistake.
+    /// </para>
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<DiscountResponse>?> CheckApplicabilityAsync(
+        CreateDiscountRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (request.ApplicablePlanCodes.Count == 0 && request.ApplicablePriceIds.Count == 0)
+        {
+            // Unrestricted, which is the ordinary case and has nothing to resolve.
+            return null;
+        }
+
+        // The plans this caller can actually sell, which is the same list a subscribe request is
+        // resolved against — the discount cannot be more applicable than the catalogue it points at.
+        var plans = await _catalogue.ListPlansAsync(
+            context.TenantId, context.OrganizationId, cancellationToken);
+
+        var unknownPlan = request.ApplicablePlanCodes.Find(code =>
+            !plans.Any(plan => string.Equals(plan.Code, code, StringComparison.Ordinal)));
+
+        if (unknownPlan is not null)
+        {
+            return Invalid($"No plan with the code '{unknownPlan}' is available here.", correlationId);
+        }
+
+        foreach (var priceId in request.ApplicablePriceIds)
+        {
+            var price = await _catalogue.GetPriceAsync(context.TenantId, priceId, cancellationToken);
+
+            // Visible to this caller means: on a plan this caller can see. A price id from another
+            // organization reads as unknown rather than as forbidden, so the refusal cannot be used
+            // to confirm that somebody else's price exists.
+            var plan = price is null
+                ? null
+                : plans.FirstOrDefault(candidate => candidate.ItemId == price.PlanId);
+
+            if (plan is null)
+            {
+                return Invalid($"No price '{priceId}' is available here.", correlationId);
+            }
+
+            if (request.ApplicablePlanCodes.Count > 0 &&
+                !request.ApplicablePlanCodes.Contains(plan.Code, StringComparer.Ordinal))
+            {
+                return Invalid(
+                    $"The price '{priceId}' belongs to the plan '{plan.Code}', which this discount "
+                        + "is not applicable to. Both restrictions have to match, so this discount "
+                        + "could never be redeemed.",
+                    correlationId);
+            }
+        }
+
+        return null;
+    }
+
+    private static SubscriptionOperationResult<DiscountResponse> Invalid(
+        string message,
+        string correlationId) =>
+        SubscriptionOperationResult<DiscountResponse>.Failure(
+            PaymentFailureKind.Validation,
+            "subscription_discount_applicability_invalid",
+            message,
+            correlationId);
 
     public async Task<SubscriptionOperationResult<IReadOnlyList<DiscountResponse>>> ListAsync(
         string? organizationId, string correlationId, CancellationToken cancellationToken)

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -43,6 +43,7 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
             DisplayName = request.DisplayName.Trim(),
             CurrencyCode = request.CurrencyCode?.Trim().ToUpperInvariant(),
             ApplicablePlanCodes = request.ApplicablePlanCodes.Distinct(StringComparer.Ordinal).ToList(),
+            ApplicablePriceIds = request.ApplicablePriceIds.Distinct(StringComparer.Ordinal).ToList(),
             Terms = new DiscountTerms
             {
                 Code = request.Code.Trim().ToLowerInvariant(),
@@ -94,6 +95,7 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         PercentBasisPoints = item.Terms.PercentBasisPoints, AmountMinor = item.Terms.AmountMinor,
         CurrencyCode = item.CurrencyCode, DurationPeriods = item.Terms.DurationPeriods,
         ExpiresAtUtc = item.Terms.ExpiresAtUtc, ApplicablePlanCodes = [.. item.ApplicablePlanCodes],
+        ApplicablePriceIds = [.. item.ApplicablePriceIds],
         Status = item.Status.ToString()
     };
 }

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -30,7 +30,12 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
     public async Task<SubscriptionOperationResult<DiscountResponse>> CreateAsync(
         CreateDiscountRequest request, string correlationId, CancellationToken cancellationToken)
     {
-        var resolution = await _context.ResolveAsync(correlationId, null, cancellationToken);
+        // Resolved against the organization the request names, the way listing and archiving already
+        // are. Passing null here asked "who is calling" and then stored the answer to a different
+        // question: the console authoring a discount for a customer had its restrictions validated
+        // against the console's own catalogue, where that customer's plans do not appear.
+        var resolution = await _context.ResolveAsync(
+            correlationId, request.OrganizationId, cancellationToken);
         if (!resolution.IsSuccess) return resolution.ToFailure<DiscountResponse>(correlationId);
         var invalid = await SubscriptionValidation.CheckAsync<CreateDiscountRequest, DiscountResponse>(
             _validator, request, "subscription_discount_invalid", "The discount is invalid.",
@@ -46,7 +51,13 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         var discount = new Discount
         {
             TenantId = context.TenantId,
-            OrganizationId = string.IsNullOrWhiteSpace(request.OrganizationId) ? null : request.OrganizationId,
+            // Null is tenant-wide, which is a scope rather than an organization and has to survive
+            // resolution. Otherwise the *resolved* organization, never the requested one: the
+            // resolver honours a named organization only for the console, so anyone else naming
+            // somebody else's ends up scoped to their own instead of writing into it.
+            OrganizationId = string.IsNullOrWhiteSpace(request.OrganizationId)
+                ? null
+                : context.OrganizationId,
             Code = request.Code.Trim().ToLowerInvariant(),
             DisplayName = request.DisplayName.Trim(),
             CurrencyCode = request.CurrencyCode?.Trim().ToUpperInvariant(),

--- a/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
@@ -45,6 +45,19 @@ public interface IPlanCatalogueService
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Sets or clears a price's automatic discount. Answers with the plan as it now stands.
+    /// </summary>
+    /// <remarks>
+    /// Future-facing, like the tax editor beside it: a new subscription and a plan change onto this
+    /// price snapshot the new figure, and every existing subscriber keeps the one they were sold.
+    /// </remarks>
+    Task<SubscriptionOperationResult<PlanResponse>> UpdatePriceDiscountAsync(
+        string priceId,
+        UpdatePriceDiscountRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
     Task<SubscriptionOperationResult<PlanResponse>> UpdatePriceTaxAsync(
         string priceId,
         UpdatePriceTaxRequest request,

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -257,6 +257,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             QuantityItemKey = request.QuantityItemKey,
             TaxRateBasisPoints = request.TaxRateBasisPoints,
             TaxMode = request.TaxMode,
+            AutomaticDiscountBasisPoints = request.AutomaticDiscountBasisPoints > 0
+                ? request.AutomaticDiscountBasisPoints
+                : null,
+            QuantityDiscountCombination = request.AutomaticDiscountBasisPoints > 0
+                ? request.QuantityDiscountCombination
+                    ?? AutomaticDiscountCombination.BestDiscount
+                : null,
             Status = CatalogueStatus.Active
         };
 
@@ -345,6 +352,94 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             "Subscription price archived TenantHash={TenantHash} PlanHash={PlanHash} CorrelationId={CorrelationId}",
             PaymentLogValue.Hash(context.TenantId),
             PaymentLogValue.Hash(plan.ItemId),
+            correlationId);
+
+        return await GetPlanAsync(
+            plan.ItemId,
+            context.OrganizationId,
+            correlationId,
+            cancellationToken);
+    }
+
+    public async Task<SubscriptionOperationResult<PlanResponse>> UpdatePriceDiscountAsync(
+        string priceId,
+        UpdatePriceDiscountRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.AutomaticDiscountBasisPoints is < 0 or > 10_000 ||
+            request.QuantityDiscountCombination is { } combination &&
+            !Enum.IsDefined(combination))
+        {
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_price_discount_invalid",
+                "An automatic discount must be between 0% and 100%, "
+                    + "and combine with a volume band in a way this module knows.",
+                correlationId);
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            request.OrganizationId,
+            cancellationToken);
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<PlanResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        var price = await _catalogue.GetPriceAsync(context.TenantId, priceId, cancellationToken);
+        if (price is null)
+        {
+            return NotFound(correlationId);
+        }
+
+        var plan = await _catalogue.GetPlanAsync(context.TenantId, price.PlanId, cancellationToken);
+        if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
+        {
+            return NotFound(correlationId);
+        }
+
+        // Zero and null are the same instruction — no automatic discount — and are stored the same
+        // way, so a cleared discount reads back as absent rather than as a discount of nothing.
+        var basisPoints = request.AutomaticDiscountBasisPoints > 0
+            ? request.AutomaticDiscountBasisPoints
+            : null;
+
+        if (!await _catalogue.TryUpdatePriceAutomaticDiscountAsync(
+                context.TenantId,
+                priceId,
+                price.Version,
+                basisPoints,
+                basisPoints > 0
+                    ? request.QuantityDiscountCombination
+                        ?? AutomaticDiscountCombination.BestDiscount
+                    : null,
+                DateTime.UtcNow,
+                cancellationToken))
+        {
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_price_discount_conflict",
+                "The price changed while its automatic discount was being saved.",
+                correlationId);
+        }
+
+        _logger.LogInformation(
+            "Subscription price automatic discount updated TenantHash={TenantHash} "
+                + "PriceHash={PriceHash} BasisPoints={BasisPoints} Combination={Combination} "
+                + "CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(priceId),
+            basisPoints ?? 0,
+            PaymentLogValue.Label(
+                (basisPoints > 0
+                    ? request.QuantityDiscountCombination
+                        ?? AutomaticDiscountCombination.BestDiscount
+                    : AutomaticDiscountCombination.BestDiscount).ToString()),
             correlationId);
 
         return await GetPlanAsync(

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -117,6 +117,16 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     // suggest a tax there is none of.
                     TaxMode = price.TaxRateBasisPoints > 0
                         ? (price.TaxMode ?? Enums.TaxMode.Exclusive).ToString()
+                        : null,
+                    AutomaticDiscountBasisPoints = price.AutomaticDiscountBasisPoints > 0
+                        ? price.AutomaticDiscountBasisPoints
+                        : null,
+                    // Reported as BestDiscount when a discount was authored without one, because
+                    // that is how it is calculated. Absent when there is no automatic discount, where
+                    // a combination would describe a decision nobody has to make.
+                    QuantityDiscountCombination = price.AutomaticDiscountBasisPoints > 0
+                        ? (price.QuantityDiscountCombination
+                            ?? Enums.AutomaticDiscountCombination.BestDiscount).ToString()
                         : null
                 })
                 .ToList()

--- a/server/Subscription.DomainService/Services/SettlementCharge.cs
+++ b/server/Subscription.DomainService/Services/SettlementCharge.cs
@@ -31,6 +31,7 @@ internal static class SettlementCharge
         CurrencyCode = subscription.CurrencyCode,
         OrderId = SubscriptionConstants.SettlementOrderIdFor(
             subscription.ItemId,
+            reservation.Kind,
             reservation.ReservationId),
         Description = Describe(subscription, reservation),
         // From the reservation, which recorded it when the change was quoted — not from the

--- a/server/Subscription.DomainService/Services/SettlementCharge.cs
+++ b/server/Subscription.DomainService/Services/SettlementCharge.cs
@@ -1,3 +1,4 @@
+using Payment.DomainService.Entities;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Utilities;
@@ -31,7 +32,46 @@ internal static class SettlementCharge
         OrderId = SubscriptionConstants.SettlementOrderIdFor(
             subscription.ItemId,
             reservation.ReservationId),
-        Description = Describe(subscription, reservation)
+        Description = Describe(subscription, reservation),
+        // From the reservation, which recorded it when the change was quoted — not from the
+        // subscription as it stands now, which the settlement is about to change.
+        Settlement = reservation.Settlement
+    };
+
+    /// <summary>
+    /// The proration's own arithmetic in the shape a payment record stores.
+    /// </summary>
+    /// <remarks>
+    /// Here rather than at each reservation site, so a plan change and a quantity change cannot
+    /// describe the same kind of charge differently. Returns null for an outcome that prorated
+    /// nothing — a malformed period, where there are no two sides to report.
+    /// </remarks>
+    public static SubscriptionSettlementBreakdown? BreakdownOf(ProrationOutcome outcome)
+    {
+        var breakdown = outcome.Breakdown;
+
+        if (breakdown == default)
+        {
+            return null;
+        }
+
+        return new SubscriptionSettlementBreakdown
+        {
+            Outgoing = SideOf(breakdown.Outgoing),
+            Target = SideOf(breakdown.Target),
+            CreditConsumedMinor = breakdown.CreditConsumedMinor,
+            NetSettlementMinor = breakdown.NetSettlementMinor
+        };
+    }
+
+    private static SubscriptionSettlementSide SideOf(ProrationSide side) => new()
+    {
+        GrossAmountMinor = side.GrossAmountMinor,
+        BuiltInDiscountMinor = side.BuiltInDiscountMinor,
+        PromotionalDiscountMinor = side.PromotionalDiscountMinor,
+        TaxAmountMinor = side.TaxAmountMinor,
+        PeriodTotalMinor = side.PeriodTotalMinor,
+        ProratedValueMinor = side.ProratedValueMinor
     };
 
     public static string KeyFor(SubscriptionDetail subscription, SettlementReservation reservation) =>

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -484,10 +484,21 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             SubscriptionTaxMode = request.TaxRateBasisPoints > 0
                 ? (request.TaxMode ?? TaxMode.Exclusive).ToString()
                 : null,
-            SubscriptionDiscountAmountMinor = request.DiscountAmountMinor > 0
-                ? request.DiscountAmountMinor
+            // Recorded whenever the caller composed the charge, which is every renewal, plan-change
+            // settlement and usage invoice. A gross of zero means nothing was passed, and a null
+            // reads back as "this payment predates the breakdown" rather than "nothing came off".
+            SubscriptionGrossAmountMinor = request.GrossAmountMinor > 0
+                ? request.GrossAmountMinor
+                : null,
+            SubscriptionBuiltInDiscountMinor = request.GrossAmountMinor > 0
+                ? request.BuiltInDiscountMinor
+                : null,
+            SubscriptionPromotionalDiscountMinor = request.GrossAmountMinor > 0
+                ? request.PromotionalDiscountMinor
                 : null,
             SubscriptionAutomaticDiscountBasisPoints = request.AutomaticDiscountBasisPoints,
+            SubscriptionQuantityDiscountBasisPoints = request.QuantityDiscountBasisPoints,
+            SubscriptionDiscountCombination = request.DiscountCombination,
             ProviderMerchantAccount = provider.MerchantId,
             MerchantId = provider.MerchantId,
             IdempotencyKey = paymentIdempotencyKey,

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -484,6 +484,10 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             SubscriptionTaxMode = request.TaxRateBasisPoints > 0
                 ? (request.TaxMode ?? TaxMode.Exclusive).ToString()
                 : null,
+            SubscriptionDiscountAmountMinor = request.DiscountAmountMinor > 0
+                ? request.DiscountAmountMinor
+                : null,
+            SubscriptionAutomaticDiscountBasisPoints = request.AutomaticDiscountBasisPoints,
             ProviderMerchantAccount = provider.MerchantId,
             MerchantId = provider.MerchantId,
             IdempotencyKey = paymentIdempotencyKey,

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -499,6 +499,7 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             SubscriptionAutomaticDiscountBasisPoints = request.AutomaticDiscountBasisPoints,
             SubscriptionQuantityDiscountBasisPoints = request.QuantityDiscountBasisPoints,
             SubscriptionDiscountCombination = request.DiscountCombination,
+            SubscriptionSettlement = request.Settlement,
             ProviderMerchantAccount = provider.MerchantId,
             MerchantId = provider.MerchantId,
             IdempotencyKey = paymentIdempotencyKey,

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -72,19 +72,27 @@ public static class SubscriptionAmountCalculator
     }
 
     /// <summary>
-    /// A period's cost after both reductions a subscription can hold: its quantity's volume band
-    /// and its promotional code, combined the way its plan says to.
+    /// A period's cost after every reduction a subscription can hold: the price's own automatic
+    /// discount, its quantity's volume band, and its promotional code — the first two combined the
+    /// way the price says to, and the result combined with the code the way the plan says to.
     /// </summary>
     /// <remarks>
-    /// Every money path goes through here so a band cannot be applied twice, or forgotten once.
+    /// Every money path goes through here so a reduction cannot be applied twice, or forgotten once.
     /// Exposed to proration for the same reason <see cref="ApplyDiscount"/> is: a plan change has
     /// to price a hypothetical target exactly as a renewal prices the current subscription.
     /// <para>
+    /// Two combinations, deliberately, because they answer different questions.
+    /// <see cref="BuiltInDiscountCalculator"/> settles what a subscriber gets without asking — a
+    /// cadence discount and a volume band, both authored by the merchant — and the plan's
+    /// <see cref="QuantityDiscountCombinationPolicy"/> then settles what a code they typed adds to
+    /// it. Collapsing the two would make "8% for paying yearly" negotiate with a coupon.
+    /// </para>
+    /// <para>
     /// <see cref="PeriodCharge.DiscountApplied"/> reports the <em>promotion</em> only, never the
-    /// band. It exists to count periods against
-    /// <see cref="DiscountTerms.DurationPeriods"/>, and a promotion that lost to a volume band has
-    /// reduced nothing — spending a customer's three months of "20% off" on periods where the band
-    /// was larger would expire it without them ever seeing it.
+    /// built-in reduction. It exists to count periods against
+    /// <see cref="DiscountTerms.DurationPeriods"/>, and a promotion that lost to a volume band or a
+    /// cadence discount has reduced nothing — spending a customer's three months of "20% off" on
+    /// periods where the built-in discount was larger would expire it without them ever seeing it.
     /// </para>
     /// </remarks>
     internal static PeriodCharge DiscountedAmountMinor(
@@ -99,18 +107,31 @@ public static class SubscriptionAmountCalculator
         ArgumentNullException.ThrowIfNull(price);
 
         var gross = GrossAmountMinor(price, quantityItems);
-        var band = QuantityDiscountCalculator.ResolveFrom(plan, price, quantityItems);
-        var bandDiscount = band.DiscountAmountMinor;
+        var builtIn = BuiltInDiscountCalculator.Resolve(
+            gross,
+            QuantityDiscountCalculator.ResolveFrom(plan, price, quantityItems),
+            price.AutomaticDiscountBasisPoints,
+            price.QuantityDiscountCombination);
 
         switch (plan.QuantityDiscountCombinationPolicy)
         {
             case QuantityDiscountCombinationPolicy.QuantityOnly:
-                return new PeriodCharge(Math.Max(0, gross - bandDiscount), false);
+                // "Built-in discounts only" — the stored name predates there being more than one of
+                // them, and the wire value is kept so an existing plan means what it always did.
+                return new PeriodCharge(builtIn.SubtotalMinor, false, GrossAmountMinor: gross,
+                    BuiltInDiscountMinor: builtIn.DiscountAmountMinor);
 
             case QuantityDiscountCombinationPolicy.Stack:
             {
-                var afterBand = Math.Max(0, gross - bandDiscount);
-                return ApplyDiscount(afterBand, discount, periodsApplied, nowUtc);
+                var stacked = ApplyDiscount(
+                    builtIn.SubtotalMinor, discount, periodsApplied, nowUtc);
+
+                return stacked with
+                {
+                    GrossAmountMinor = gross,
+                    BuiltInDiscountMinor = builtIn.DiscountAmountMinor,
+                    PromotionalDiscountMinor = builtIn.SubtotalMinor - stacked.AmountMinor
+                };
             }
 
             default:
@@ -118,11 +139,16 @@ public static class SubscriptionAmountCalculator
                 var promotional = ApplyDiscount(gross, discount, periodsApplied, nowUtc);
                 var promotionalDiscount = gross - promotional.AmountMinor;
 
-                // Ties go to the promotion, so a band worth the same as a code does not silently
-                // stop the code being consumed.
-                return bandDiscount > promotionalDiscount
-                    ? new PeriodCharge(Math.Max(0, gross - bandDiscount), false)
-                    : promotional;
+                // Ties go to the promotion, so a built-in reduction worth the same as a code does
+                // not silently stop the code being consumed.
+                return builtIn.DiscountAmountMinor > promotionalDiscount
+                    ? new PeriodCharge(builtIn.SubtotalMinor, false, GrossAmountMinor: gross,
+                        BuiltInDiscountMinor: builtIn.DiscountAmountMinor)
+                    : promotional with
+                    {
+                        GrossAmountMinor = gross,
+                        PromotionalDiscountMinor = promotionalDiscount
+                    };
             }
         }
     }
@@ -307,10 +333,20 @@ public readonly record struct TaxBreakdown(
 /// <see cref="NetAmountMinor"/> and <see cref="TaxAmountMinor"/> describe the charge before any
 /// credit was spent against it, because that is the split an invoice has to show: a credit pays a
 /// bill, it does not change what the bill was for.
+/// <para>
+/// <see cref="GrossAmountMinor"/>, <see cref="BuiltInDiscountMinor"/> and
+/// <see cref="PromotionalDiscountMinor"/> are what the charge is made of, so a subscriber can be
+/// told why they are paying what they are paying: gross, less the two kinds of reduction, is the
+/// amount that was then taxed. Reported rather than recomputed, because recomputing a discount from
+/// a total requires knowing which of several combinations produced it.
+/// </para>
 /// </remarks>
 public readonly record struct PeriodCharge(
     long AmountMinor,
     bool DiscountApplied,
     long CreditConsumedMinor = 0,
     long TaxAmountMinor = 0,
-    long NetAmountMinor = 0);
+    long NetAmountMinor = 0,
+    long GrossAmountMinor = 0,
+    long BuiltInDiscountMinor = 0,
+    long PromotionalDiscountMinor = 0);

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -225,7 +225,7 @@ public static class SubscriptionAmountCalculator
     /// count of periods it has already reduced, an expiry date on the wall clock — either can
     /// end it independently of the other.
     /// </summary>
-    private static bool DiscountStillActive(
+    internal static bool DiscountStillActive(
         DiscountTerms discount,
         int periodsApplied,
         DateTime nowUtc) =>

--- a/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
@@ -63,4 +63,21 @@ public sealed class SubscriptionChargeRequest
 
     /// <summary>Banked subscription credit applied after tax, shown as an invoice reduction.</summary>
     public long CreditConsumedMinor { get; set; }
+
+    /// <summary>
+    /// The price's automatic discount, in basis points, for the payment record. Null when it has
+    /// none.
+    /// </summary>
+    /// <remarks>
+    /// Recorded rather than displayed. <see cref="AmountMinor"/> is already net of it, so a provider
+    /// invoice showing it as a line would need the gross above it too; what this is for is a
+    /// subscriber's own invoice history being able to say why the figure is what it is.
+    /// </remarks>
+    public int? AutomaticDiscountBasisPoints { get; set; }
+
+    /// <summary>
+    /// What every automatic reduction took off before tax — the price's own discount and the volume
+    /// band, combined. Zero when nothing did.
+    /// </summary>
+    public long DiscountAmountMinor { get; set; }
 }

--- a/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
@@ -65,19 +65,29 @@ public sealed class SubscriptionChargeRequest
     public long CreditConsumedMinor { get; set; }
 
     /// <summary>
-    /// The price's automatic discount, in basis points, for the payment record. Null when it has
-    /// none.
+    /// What this charge is made of before tax: the gross, what the price's automatic discount and the
+    /// volume band took off between them, and what a promotional code took off after that.
     /// </summary>
     /// <remarks>
-    /// Recorded rather than displayed. <see cref="AmountMinor"/> is already net of it, so a provider
-    /// invoice showing it as a line would need the gross above it too; what this is for is a
-    /// subscriber's own invoice history being able to say why the figure is what it is.
+    /// Recorded rather than displayed. <see cref="AmountMinor"/> is already net of all of it, so a
+    /// provider invoice showing a reduction as a line would need the gross above it too; what this is
+    /// for is the subscriber's own invoice history being able to explain the figure years later.
     /// </remarks>
+    public long GrossAmountMinor { get; set; }
+
+    public long BuiltInDiscountMinor { get; set; }
+
+    public long PromotionalDiscountMinor { get; set; }
+
+    /// <summary>The price's automatic rate. Null when it has none.</summary>
     public int? AutomaticDiscountBasisPoints { get; set; }
 
+    /// <summary>The band's rate, when the quantity selected one. Null otherwise.</summary>
+    public int? QuantityDiscountBasisPoints { get; set; }
+
     /// <summary>
-    /// What every automatic reduction took off before tax — the price's own discount and the volume
-    /// band, combined. Zero when nothing did.
+    /// "BestDiscount" or "Additive" — how the two authored reductions met. Null when the price has no
+    /// automatic discount, where there is nothing to combine.
     /// </summary>
-    public long DiscountAmountMinor { get; set; }
+    public string? DiscountCombination { get; set; }
 }

--- a/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionChargeRequest.cs
@@ -1,3 +1,4 @@
+using Payment.DomainService.Entities;
 using Subscription.DomainService.Enums;
 
 namespace Subscription.DomainService.Services;
@@ -90,4 +91,11 @@ public sealed class SubscriptionChargeRequest
     /// automatic discount, where there is nothing to combine.
     /// </summary>
     public string? DiscountCombination { get; set; }
+
+    /// <summary>
+    /// Sent instead of the fields above when this charge settles a plan or quantity change. The two
+    /// are alternatives, not companions: a settlement's amount is the difference between two prorated
+    /// periods, which no single gross-and-discount pair describes.
+    /// </summary>
+    public SubscriptionSettlementBreakdown? Settlement { get; set; }
 }

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -252,23 +252,13 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 "The discount code has expired.",
                 correlationId);
 
-        if (discount.ApplicablePlanCodes.Count > 0 &&
-            !discount.ApplicablePlanCodes.Contains(plan.Code, StringComparer.Ordinal))
+        // One rule, shared with the plan-change path, so a restriction cannot be enforced at signup
+        // and forgotten the first time the subscriber moves.
+        if (!SubscriptionDiscountApplicability.Permits(discount, plan.Code, price.ItemId))
             return SubscriptionOperationResult<DiscountTerms?>.Failure(
                 PaymentFailureKind.Validation,
                 "subscription_discount_not_applicable",
-                "The discount does not apply to this plan.",
-                correlationId);
-
-        // Narrows the plan restriction rather than offering a second way to qualify, so a code
-        // restricted to a plan *and* a price needs both to match. A code aimed at the yearly price
-        // is refused on the monthly one, which is the whole point of authoring it that way.
-        if (discount.ApplicablePriceIds.Count > 0 &&
-            !discount.ApplicablePriceIds.Contains(price.ItemId, StringComparer.Ordinal))
-            return SubscriptionOperationResult<DiscountTerms?>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_discount_not_applicable",
-                "The discount does not apply to this price.",
+                "The discount does not apply to this plan and price.",
                 correlationId);
 
         if (discount.Terms.Kind == DiscountKind.FixedAmount &&
@@ -288,7 +278,11 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 PercentBasisPoints = terms.PercentBasisPoints,
                 AmountMinor = terms.AmountMinor,
                 DurationPeriods = terms.DurationPeriods,
-                ExpiresAtUtc = terms.ExpiresAtUtc
+                ExpiresAtUtc = terms.ExpiresAtUtc,
+                // Copied so the restriction outlives the redemption. A plan change re-asks the same
+                // question, and it can only do so against terms that remember the answer.
+                ApplicablePlanCodes = [.. discount.ApplicablePlanCodes],
+                ApplicablePriceIds = [.. discount.ApplicablePriceIds]
             },
             correlationId);
     }

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -164,6 +164,8 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             PaymentLogValue.Label(subscription.Status.ToString()),
             correlationId);
 
+        LogDiscountsApplied(subscription, correlationId);
+
         // A first charge that is never paid has to be noticed by something. Announced here rather
         // than discovered by a roster pass, and best effort inside the scheduler: a subscription
         // that exists must not be reported as failed because its recovery could not be booked.
@@ -258,6 +260,17 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 "The discount does not apply to this plan.",
                 correlationId);
 
+        // Narrows the plan restriction rather than offering a second way to qualify, so a code
+        // restricted to a plan *and* a price needs both to match. A code aimed at the yearly price
+        // is refused on the monthly one, which is the whole point of authoring it that way.
+        if (discount.ApplicablePriceIds.Count > 0 &&
+            !discount.ApplicablePriceIds.Contains(price.ItemId, StringComparer.Ordinal))
+            return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_discount_not_applicable",
+                "The discount does not apply to this price.",
+                correlationId);
+
         if (discount.Terms.Kind == DiscountKind.FixedAmount &&
             !string.Equals(discount.CurrencyCode, price.CurrencyCode, StringComparison.Ordinal))
             return SubscriptionOperationResult<DiscountTerms?>.Failure(
@@ -277,6 +290,53 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 DurationPeriods = terms.DurationPeriods,
                 ExpiresAtUtc = terms.ExpiresAtUtc
             },
+            correlationId);
+    }
+
+    /// <summary>
+    /// What reduced this subscription's charge, and where each reduction came from.
+    /// </summary>
+    /// <remarks>
+    /// Money that came off has to be explainable months later, by which time the catalogue will have
+    /// moved and the price may not even be on sale. Written once at signup, against the snapshot the
+    /// subscription actually holds, so the record cannot disagree with what is charged. Nothing
+    /// customer-identifying: the plan and the price are hashed exactly as they are everywhere else
+    /// in this module, and the numbers are terms rather than personal data.
+    /// </remarks>
+    private void LogDiscountsApplied(SubscriptionDetail subscription, string correlationId)
+    {
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            subscription,
+            _time.GetUtcNow().UtcDateTime);
+
+        if (charge.BuiltInDiscountMinor == 0 &&
+            charge.PromotionalDiscountMinor == 0 &&
+            subscription.Price.AutomaticDiscountBasisPoints is null or 0)
+        {
+            // Nothing came off, so there is nothing to explain. A line here would be noise on the
+            // overwhelming majority of subscriptions.
+            return;
+        }
+
+        _logger.LogInformation(
+            "Subscription discounts applied SubscriptionHash={SubscriptionHash} "
+                + "PriceHash={PriceHash} AutomaticBasisPoints={AutomaticBasisPoints} "
+                + "Combination={Combination} PromotionPolicy={PromotionPolicy} "
+                + "PromotionCode={PromotionCode} GrossMinor={GrossMinor} "
+                + "BuiltInDiscountMinor={BuiltInDiscountMinor} "
+                + "PromotionalDiscountMinor={PromotionalDiscountMinor} "
+                + "CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Hash(subscription.Price.PriceId),
+            subscription.Price.AutomaticDiscountBasisPoints ?? 0,
+            PaymentLogValue.Label(
+                SubscriptionDiscountPresentation.Describe(subscription.Price) ?? "None"),
+            PaymentLogValue.Label(
+                subscription.Plan.QuantityDiscountCombinationPolicy.ToString()),
+            PaymentLogValue.Label(subscription.Discount?.Code ?? "None"),
+            charge.GrossAmountMinor,
+            charge.BuiltInDiscountMinor,
+            charge.PromotionalDiscountMinor,
             correlationId);
     }
 

--- a/server/Subscription.DomainService/Services/SubscriptionDiscountApplicability.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionDiscountApplicability.cs
@@ -1,0 +1,66 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Whether a discount may be used against a given plan and price.
+/// </summary>
+/// <remarks>
+/// One place, because the question is asked twice about the same discount at two different moments —
+/// when a code is redeemed at signup, and again when a subscriber moves to a different price. Two
+/// implementations of "does this code apply here" is how a monthly-only coupon comes to be honoured
+/// on an annual price: the second caller simply never asks.
+/// <para>
+/// The two lists <em>narrow</em>. Empty is unrestricted by that dimension, which is what every
+/// discount authored before either restriction existed carries; populated, it must match. When both
+/// are populated both must match, so naming a plan and a price is a narrower offer rather than two
+/// ways to qualify.
+/// </para>
+/// </remarks>
+public static class SubscriptionDiscountApplicability
+{
+    public static bool Permits(
+        IReadOnlyCollection<string> applicablePlanCodes,
+        IReadOnlyCollection<string> applicablePriceIds,
+        string planCode,
+        string priceId)
+    {
+        ArgumentNullException.ThrowIfNull(applicablePlanCodes);
+        ArgumentNullException.ThrowIfNull(applicablePriceIds);
+
+        return (applicablePlanCodes.Count == 0 ||
+                applicablePlanCodes.Contains(planCode, StringComparer.Ordinal)) &&
+               (applicablePriceIds.Count == 0 ||
+                applicablePriceIds.Contains(priceId, StringComparer.Ordinal));
+    }
+
+    /// <summary>Against the catalogue entry, as a code is being redeemed.</summary>
+    public static bool Permits(Discount discount, string planCode, string priceId)
+    {
+        ArgumentNullException.ThrowIfNull(discount);
+
+        return Permits(
+            discount.ApplicablePlanCodes,
+            discount.ApplicablePriceIds,
+            planCode,
+            priceId);
+    }
+
+    /// <summary>
+    /// Against the terms copied onto a subscription, as it is being moved somewhere else.
+    /// </summary>
+    /// <remarks>
+    /// Reads the snapshot, never the catalogue: a discount retired or re-scoped since the subscriber
+    /// redeemed it must be judged by the offer they actually accepted.
+    /// </remarks>
+    public static bool Permits(DiscountTerms terms, string planCode, string priceId)
+    {
+        ArgumentNullException.ThrowIfNull(terms);
+
+        return Permits(
+            terms.ApplicablePlanCodes,
+            terms.ApplicablePriceIds,
+            planCode,
+            priceId);
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionDiscountPresentation.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionDiscountPresentation.cs
@@ -1,0 +1,45 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// How a price's automatic discount is named to a caller.
+/// </summary>
+/// <remarks>
+/// One place, for the reason <see cref="SubscriptionTaxPresentation"/> is one place: the rule has an
+/// edge that every response carrying it would otherwise get slightly differently. A price with a
+/// discount and no stored combination is calculated as <see cref="AutomaticDiscountCombination.BestDiscount"/>,
+/// so that is what is reported; a price with no automatic discount reports nothing at all, since
+/// naming a combination for a discount that does not exist invites a client to explain a reduction
+/// of zero.
+/// </remarks>
+public static class SubscriptionDiscountPresentation
+{
+    public static string? Describe(
+        int? automaticDiscountBasisPoints,
+        AutomaticDiscountCombination? combination) =>
+        automaticDiscountBasisPoints > 0
+            ? (combination ?? AutomaticDiscountCombination.BestDiscount).ToString()
+            : null;
+
+    public static string? Describe(PriceSnapshot price)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+
+        return Describe(price.AutomaticDiscountBasisPoints, price.QuantityDiscountCombination);
+    }
+
+    /// <summary>
+    /// The rate itself, reported only when there is one — so a client is never handed a discount of
+    /// zero basis points to render.
+    /// </summary>
+    public static int? RateOf(PriceSnapshot price)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+
+        return price.AutomaticDiscountBasisPoints > 0
+            ? price.AutomaticDiscountBasisPoints
+            : null;
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
@@ -116,8 +116,19 @@ public sealed class SubscriptionInvoiceHistoryService :
             NetAmountMinor = invoice.NetAmountMinor,
             TaxAmountMinor = invoice.TaxAmountMinor,
             CreditAmountMinor = invoice.CreditAmountMinor,
+            GrossAmountMinor = invoice.GrossAmountMinor,
+            BuiltInDiscountMinor = invoice.BuiltInDiscountMinor,
+            PromotionalDiscountMinor = invoice.PromotionalDiscountMinor,
+            // Derived here rather than stored: it is exactly gross less the two reductions, and a
+            // fourth number that could disagree with the three it comes from is a liability.
+            DiscountedAmountMinor = invoice.GrossAmountMinor is { } gross
+                ? gross
+                    - (invoice.BuiltInDiscountMinor ?? 0)
+                    - (invoice.PromotionalDiscountMinor ?? 0)
+                : null,
             AutomaticDiscountBasisPoints = invoice.AutomaticDiscountBasisPoints,
-            DiscountAmountMinor = invoice.DiscountAmountMinor,
+            QuantityDiscountBasisPoints = invoice.QuantityDiscountBasisPoints,
+            QuantityDiscountCombination = invoice.DiscountCombination,
             TaxRateBasisPoints = invoice.TaxRateBasisPoints,
             TaxMode = invoice.TaxMode,
             DownloadUrl = downloadUrl

--- a/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
@@ -1,3 +1,4 @@
+using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
@@ -129,11 +130,42 @@ public sealed class SubscriptionInvoiceHistoryService :
             AutomaticDiscountBasisPoints = invoice.AutomaticDiscountBasisPoints,
             QuantityDiscountBasisPoints = invoice.QuantityDiscountBasisPoints,
             QuantityDiscountCombination = invoice.DiscountCombination,
+            Settlement = SettlementOf(invoice.Settlement),
             TaxRateBasisPoints = invoice.TaxRateBasisPoints,
             TaxMode = invoice.TaxMode,
             DownloadUrl = downloadUrl
         };
     }
+
+    /// <summary>
+    /// A stored settlement breakdown as a caller sees it. Null stays null: a renewal has no two sides.
+    /// </summary>
+    private static SubscriptionSettlementResponse? SettlementOf(
+        SubscriptionSettlementBreakdown? settlement) =>
+        settlement is null
+            ? null
+            : new SubscriptionSettlementResponse
+            {
+                Outgoing = SideOf(settlement.Outgoing),
+                Target = SideOf(settlement.Target),
+                CreditConsumedMinor = settlement.CreditConsumedMinor,
+                NetSettlementMinor = settlement.NetSettlementMinor
+            };
+
+    private static SubscriptionSettlementSideResponse SideOf(SubscriptionSettlementSide side) => new()
+    {
+        GrossAmountMinor = side.GrossAmountMinor,
+        BuiltInDiscountMinor = side.BuiltInDiscountMinor,
+        PromotionalDiscountMinor = side.PromotionalDiscountMinor,
+        TaxAmountMinor = side.TaxAmountMinor,
+        PeriodTotalMinor = side.PeriodTotalMinor,
+        ProratedValueMinor = side.ProratedValueMinor,
+        // Derived, like the renewal's own: gross less both reductions is what was taxed, and a stored
+        // fourth number could contradict the three it comes from.
+        DiscountedAmountMinor = side.GrossAmountMinor
+            - side.BuiltInDiscountMinor
+            - side.PromotionalDiscountMinor
+    };
 
     private static (string? SubscriptionId, string InvoiceType, string? PeriodKey) ParseOrderId(
         string? orderId)

--- a/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
@@ -116,6 +116,8 @@ public sealed class SubscriptionInvoiceHistoryService :
             NetAmountMinor = invoice.NetAmountMinor,
             TaxAmountMinor = invoice.TaxAmountMinor,
             CreditAmountMinor = invoice.CreditAmountMinor,
+            AutomaticDiscountBasisPoints = invoice.AutomaticDiscountBasisPoints,
+            DiscountAmountMinor = invoice.DiscountAmountMinor,
             TaxRateBasisPoints = invoice.TaxRateBasisPoints,
             TaxMode = invoice.TaxMode,
             DownloadUrl = downloadUrl

--- a/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionInvoiceHistoryService.cs
@@ -167,6 +167,9 @@ public sealed class SubscriptionInvoiceHistoryService :
             - side.PromotionalDiscountMinor
     };
 
+    private static bool Names(string segment, string suffix) =>
+        suffix.StartsWith($"{segment}:", StringComparison.Ordinal);
+
     private static (string? SubscriptionId, string InvoiceType, string? PeriodKey) ParseOrderId(
         string? orderId)
     {
@@ -185,19 +188,34 @@ public sealed class SubscriptionInvoiceHistoryService :
 
         var subscriptionId = value[..separator];
         var suffix = value[(separator + 1)..];
-        if (suffix.StartsWith("planchange:", StringComparison.Ordinal))
+
+        // Matched against the same constants the writer uses, so the two cannot drift. A settlement
+        // carries no period key: it is scoped by its reservation, and reporting that id as a period
+        // would put an opaque guid where a client expects "2026-09".
+        if (Names(SubscriptionConstants.PlanChangeSegment, suffix) ||
+            Names(SubscriptionConstants.LegacyPlanChangeSegment, suffix))
         {
             return (subscriptionId, "PlanChange", null);
         }
 
-        if (suffix.StartsWith("usage:", StringComparison.Ordinal))
+        // The legacy spelling covers both kinds — it is what they shared before they were told
+        // apart — so a plan change charged back then reads as a quantity change. The alternative is
+        // guessing, and guessing about somebody's invoice is worse than being coarse about it.
+        if (Names(SubscriptionConstants.QuantitySegment, suffix) ||
+            Names(SubscriptionConstants.LegacySettlementSegment, suffix))
         {
-            var periodKey = suffix["usage:".Length..];
+            return (subscriptionId, "QuantityChange", null);
+        }
+
+        if (Names(SubscriptionConstants.UsageSegment, suffix))
+        {
+            var periodKey = suffix[(SubscriptionConstants.UsageSegment.Length + 1)..];
             return string.IsNullOrWhiteSpace(periodKey)
                 ? (subscriptionId, "Usage", null)
                 : (subscriptionId, "Usage", periodKey);
         }
 
+        // What is left is a renewal, whose suffix *is* its period key.
         return (subscriptionId, "Renewal", suffix);
     }
 

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -308,6 +308,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 NewCreditBalanceMinor = outcome.NewCreditBalanceMinor
             },
             ChargeAmountMinor = outcome.ChargeMinor,
+            Settlement = SettlementCharge.BreakdownOf(outcome),
             BillingAccountId = subscription.BillingAccountId,
             ProviderName = account.ProviderName,
             ProviderOrganizationId = account.ProviderOrganizationId,

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -171,6 +171,18 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         }
 
         var (plan, price) = terms.Value;
+
+        if (!DiscountSurvives(subscription, plan, price))
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_discount_not_applicable",
+                "The discount on this subscription does not apply to the plan or price being "
+                    + "moved to. Cancel the subscription and start a new one to change onto it, "
+                    + "or choose a target the discount covers.",
+                correlationId);
+        }
+
         var quantities = SubscriptionQuantityBuilder.Build(request.Quantities, plan, price);
 
         if (quantities is null)
@@ -202,6 +214,40 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             : await ChargeAndApplyAsync(
                 subscription, newPlan, newPrice, quantities, newSchedule, now,
                 correlationId, cancellationToken);
+    }
+
+    /// <summary>
+    /// Whether the subscriber's promotional discount may follow them to the target plan and price.
+    /// </summary>
+    /// <remarks>
+    /// A plan change keeps the subscription's discount — that is the point of snapshotting it — but a
+    /// code authored for the monthly price must not end up reducing the annual one. The restriction
+    /// is read from the terms copied at redemption rather than from the catalogue, so a discount
+    /// retired or re-scoped since then is judged by the offer the subscriber actually accepted.
+    /// <para>
+    /// Refused rather than silently dropped. Removing the promotion would change what the subscriber
+    /// pays every period from here on, and doing that inside an operation they asked for a
+    /// <em>price</em> quote on is the kind of surprise that shows up as a support ticket months
+    /// later. Refusing puts the consequence in front of them first.
+    /// </para>
+    /// <para>
+    /// Only asked of a discount that is still reducing charges. One whose duration is spent or whose
+    /// expiry has passed reduces nothing, so blocking a plan change over its restrictions would be
+    /// enforcing an offer that has already ended.
+    /// </para>
+    /// </remarks>
+    private bool DiscountSurvives(SubscriptionDetail subscription, Plan plan, Price price)
+    {
+        if (subscription.Discount is not { } discount ||
+            !SubscriptionAmountCalculator.DiscountStillActive(
+                discount,
+                subscription.DiscountPeriodsApplied,
+                _time.GetUtcNow().UtcDateTime))
+        {
+            return true;
+        }
+
+        return SubscriptionDiscountApplicability.Permits(discount, plan.Code, price.ItemId);
     }
 
     private async Task<SubscriptionOperationResult<SubscriptionResponse>> ChargeAndApplyAsync(

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -95,9 +95,33 @@ public static class SubscriptionProrationCalculator
         var rawDelta = newRemainingCost - oldRemainingValue;
         var netAfterCredit = rawDelta - subscription.CreditBalanceMinor;
 
+        // Reported, not recomputed later. Every figure below was needed to reach the charge, and an
+        // invoice for a settlement cannot be explained from the charge alone: "CHF 41.30" is the
+        // remainder of a subtraction between two prorated periods, and a subscriber asking why is
+        // asking about the two sides, not the remainder.
+        var breakdown = new ProrationBreakdown(
+            new ProrationSide(
+                oldDiscounted.GrossAmountMinor,
+                oldDiscounted.BuiltInDiscountMinor,
+                oldDiscounted.PromotionalDiscountMinor,
+                oldTaxInclusive - oldDiscounted.AmountMinor,
+                oldTaxInclusive,
+                oldRemainingValue),
+            new ProrationSide(
+                newDiscounted.GrossAmountMinor,
+                newDiscounted.BuiltInDiscountMinor,
+                newDiscounted.PromotionalDiscountMinor,
+                newTaxInclusive - newDiscounted.AmountMinor,
+                newTaxInclusive,
+                newRemainingCost),
+            // What the credit balance actually paid for. A downgrade has a negative delta and spends
+            // nothing — the credit grows instead, which the outcome below already carries.
+            Math.Clamp(rawDelta, 0, Math.Max(0, subscription.CreditBalanceMinor)),
+            netAfterCredit);
+
         return netAfterCredit > 0
-            ? new ProrationOutcome(netAfterCredit, 0)
-            : new ProrationOutcome(0, -netAfterCredit);
+            ? new ProrationOutcome(netAfterCredit, 0, breakdown)
+            : new ProrationOutcome(0, -netAfterCredit, breakdown);
     }
 
     /// <summary>
@@ -119,4 +143,46 @@ public static class SubscriptionProrationCalculator
 /// The credit balance to write back — either fully consumed (zero) or increased by an amount a
 /// downgrade could not immediately spend.
 /// </param>
-public readonly record struct ProrationOutcome(long ChargeMinor, long NewCreditBalanceMinor);
+/// <param name="Breakdown">
+/// The two sides the charge came from, for the payment record. Default when the period was malformed
+/// and nothing could be prorated.
+/// </param>
+public readonly record struct ProrationOutcome(
+    long ChargeMinor,
+    long NewCreditBalanceMinor,
+    ProrationBreakdown Breakdown = default);
+
+/// <summary>
+/// One side of a settlement: what a period costs, and how much of that this instant is worth.
+/// </summary>
+/// <param name="GrossAmountMinor">The period before any reduction.</param>
+/// <param name="BuiltInDiscountMinor">What the price's automatic discount and the volume band took off.</param>
+/// <param name="PromotionalDiscountMinor">What a promotional code took off after that.</param>
+/// <param name="TaxAmountMinor">Tax on what was left, at this side's own rate and mode.</param>
+/// <param name="PeriodTotalMinor">The whole period, tax included — gross less discounts, plus tax.</param>
+/// <param name="ProratedValueMinor">
+/// The part of that this settlement counts: unused time on the outgoing side, remaining time on the
+/// target side.
+/// </param>
+public readonly record struct ProrationSide(
+    long GrossAmountMinor,
+    long BuiltInDiscountMinor,
+    long PromotionalDiscountMinor,
+    long TaxAmountMinor,
+    long PeriodTotalMinor,
+    long ProratedValueMinor);
+
+/// <summary>
+/// Both sides of a settlement and what closed the gap between them.
+/// </summary>
+/// <remarks>
+/// A settlement is a subtraction, so a single gross-and-discount pair cannot describe it: the
+/// subscriber is leaving one priced period part-way through and joining another, and both have their
+/// own discounts and their own tax. <see cref="NetSettlementMinor"/> is target prorated value less
+/// outgoing unused value less credit — negative when a downgrade banks credit rather than charging.
+/// </remarks>
+public readonly record struct ProrationBreakdown(
+    ProrationSide Outgoing,
+    ProrationSide Target,
+    long CreditConsumedMinor,
+    long NetSettlementMinor);

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -355,6 +355,7 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 NewCreditBalanceMinor = outcome.NewCreditBalanceMinor
             },
             ChargeAmountMinor = outcome.ChargeMinor,
+            Settlement = SettlementCharge.BreakdownOf(outcome),
             BillingAccountId = subscription.BillingAccountId,
             ProviderName = account.ProviderName,
             ProviderOrganizationId = account.ProviderOrganizationId,

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -768,6 +768,16 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
             CreditConsumedMinor = renewal.CreditConsumedMinor,
             TaxRateBasisPoints = subscription.Price.TaxRateBasisPoints,
             TaxMode = SubscriptionTaxPresentation.Describe(subscription.Price),
+            AutomaticDiscountBasisPoints =
+                SubscriptionDiscountPresentation.RateOf(subscription.Price),
+            QuantityDiscountCombination =
+                SubscriptionDiscountPresentation.Describe(subscription.Price),
+            GrossAmountMinor = renewal.GrossAmountMinor,
+            BuiltInDiscountMinor = renewal.BuiltInDiscountMinor,
+            PromotionalDiscountMinor = renewal.PromotionalDiscountMinor,
+            DiscountedAmountMinor = renewal.GrossAmountMinor
+                - renewal.BuiltInDiscountMinor
+                - renewal.PromotionalDiscountMinor,
             PromotionApplied = renewal.DiscountApplied,
             ChargePaymentDetailId = paymentDetailId,
             PendingQuantityChange = QuantityResponseMapper.Pending(pending)

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -161,10 +161,17 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                     CreditConsumedMinor = charge.CreditConsumedMinor,
                     // What came off before tax, from the same calculation the amount came from, so
                     // the payment record can explain its own total later.
+                    GrossAmountMinor = charge.GrossAmountMinor,
+                    BuiltInDiscountMinor = charge.BuiltInDiscountMinor,
+                    PromotionalDiscountMinor = charge.PromotionalDiscountMinor,
                     AutomaticDiscountBasisPoints =
                         SubscriptionDiscountPresentation.RateOf(subscription.Price),
-                    DiscountAmountMinor =
-                        charge.BuiltInDiscountMinor + charge.PromotionalDiscountMinor,
+                    QuantityDiscountBasisPoints = QuantityDiscountCalculator.ResolveFrom(
+                        subscription.Plan,
+                        subscription.Price,
+                        subscription.QuantityItems).Tier?.DiscountBasisPoints,
+                    DiscountCombination =
+                        SubscriptionDiscountPresentation.Describe(subscription.Price),
                     CurrencyCode = subscription.CurrencyCode,
                     OrderId = orderId,
                     Description = $"{subscription.Plan.DisplayName} renewal"

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -159,6 +159,12 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                     TaxRateBasisPoints = subscription.Price.TaxRateBasisPoints,
                     TaxMode = subscription.Price.TaxMode,
                     CreditConsumedMinor = charge.CreditConsumedMinor,
+                    // What came off before tax, from the same calculation the amount came from, so
+                    // the payment record can explain its own total later.
+                    AutomaticDiscountBasisPoints =
+                        SubscriptionDiscountPresentation.RateOf(subscription.Price),
+                    DiscountAmountMinor =
+                        charge.BuiltInDiscountMinor + charge.PromotionalDiscountMinor,
                     CurrencyCode = subscription.CurrencyCode,
                     OrderId = orderId,
                     Description = $"{subscription.Plan.DisplayName} renewal"

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -59,6 +59,16 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             NetAmountMinor = recurring.NetAmountMinor,
             TaxRateBasisPoints = subscription.Price.TaxRateBasisPoints,
             TaxMode = SubscriptionTaxPresentation.Describe(subscription.Price),
+            AutomaticDiscountBasisPoints =
+                SubscriptionDiscountPresentation.RateOf(subscription.Price),
+            QuantityDiscountCombination =
+                SubscriptionDiscountPresentation.Describe(subscription.Price),
+            GrossAmountMinor = recurring.GrossAmountMinor,
+            BuiltInDiscountMinor = recurring.BuiltInDiscountMinor,
+            PromotionalDiscountMinor = recurring.PromotionalDiscountMinor,
+            DiscountedAmountMinor = recurring.GrossAmountMinor
+                - recurring.BuiltInDiscountMinor
+                - recurring.PromotionalDiscountMinor,
             CheckoutUrl = checkoutUrl,
             Version = subscription.Version
         };

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -102,6 +102,10 @@ internal static class SubscriptionSnapshotBuilder
             // Snapshotted with the rate, for the same reason the rate is: editing the catalogue's
             // tax must not reprice anybody already subscribed.
             TaxMode = price.TaxMode,
+            // Likewise: an 8% yearly discount is part of what the subscriber bought, so
+            // clearing it from the catalogue tomorrow leaves them holding it.
+            AutomaticDiscountBasisPoints = price.AutomaticDiscountBasisPoints,
+            QuantityDiscountCombination = price.QuantityDiscountCombination,
             PriceVersion = price.Version
         };
     }

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -1085,6 +1085,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
             TaxRateBasisPoints = invoice.TaxRateBasisPoints,
             TaxMode = SubscriptionTaxPresentation.Describe(
                 invoice.TaxRateBasisPoints, invoice.TaxMode),
+            AutomaticDiscountBasisPoints = invoice.AutomaticDiscountBasisPoints,
+            DiscountAmountMinor = invoice.DiscountAmountMinor,
             State = invoice.State.ToString(),
             AttemptCount = invoice.AttemptCount,
             NextAttemptAtUtc = invoice.NextAttemptAtUtc,

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -1,6 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
 
+using Subscription.DomainService.Enums;
+
 namespace Subscription.DomainService.Utilities;
 
 public static class SubscriptionConstants
@@ -85,31 +87,74 @@ public static class SubscriptionConstants
     public static string RenewalKeyFor(string subscriptionId, string periodKey, int attempt) =>
         DeterministicKey($"sub-renew:{subscriptionId}:{periodKey}:{attempt}");
 
-    /// <summary>
-    /// A plan change's order id, scoped to the version being changed from.
-    /// </summary>
-    /// <remarks>
-    /// A plan change has no period key to scope by — it is not a renewal — but <c>Version</c> is
-    /// already a monotonically increasing number unique to this exact attempt, which is all the
-    /// "one recurring payment per order id, ever" rule needs to stay satisfied.
-    /// </remarks>
-    public static string PlanChangeOrderIdFor(string subscriptionId, int version) =>
-        $"{OrderIdPrefix}{subscriptionId}:planchange:{version}";
-
     public static string PlanChangeKeyFor(string subscriptionId, int version) =>
         DeterministicKey($"sub-planchange:{subscriptionId}:{version}");
 
     /// <summary>
-    /// The order a quantity increase is charged under, scoped by the claim it is settling.
+    /// The order a settlement is charged under, named for what it settles and scoped by the
+    /// reservation it settles.
     /// </summary>
     /// <remarks>
-    /// Deliberately not the version, unlike a plan change. A quantity increase writes its claim
-    /// before it spends anything, so the claim id is available and is the one identifier a
-    /// concurrent change cannot move — which is exactly what a retry needs to find the charge it
-    /// already raised instead of taking the money a second time.
+    /// Scoped by the reservation rather than the version. A settlement writes its reservation before
+    /// it spends anything, so that id is available and is the one identifier a concurrent change
+    /// cannot move — which is exactly what a retry needs to find the charge it already raised instead
+    /// of taking the money a second time.
+    /// <para>
+    /// The kind is in the id because invoice history reads it back: both kinds shared the
+    /// <c>quantity:</c> form, so a plan-change invoice classified itself as a renewal, and the
+    /// suffix it could not parse became the period key. The id is a label and a classifier, never the
+    /// dedupe: that is <see cref="SettlementChargeKeyFor"/>, which is deliberately left alone here so
+    /// a reservation taken before this change and replayed after it still finds its own attempt
+    /// rather than raising a second.
+    /// </para>
+    /// <para>
+    /// The segments are short because the whole id has to fit the payment module's 80-character
+    /// order-id limit, and a subscription id and a reservation id already spend 68 of it. Spelling
+    /// this "planchange" put it at 84 — which is how the existing "quantity" spelling turned out to
+    /// have been two characters over the limit all along, untested.
+    /// </para>
+    /// <para>
+    /// Rows charged before the kinds were told apart carry the old <c>quantity</c> spelling whichever
+    /// kind they were, so a historical plan-change invoice reads as a quantity change. Better than
+    /// reading as a renewal, and not worth rewriting settled financial records to improve. Both old
+    /// spellings are still read — see <see cref="LegacyPlanChangeSegment"/> — and neither is written.
+    /// </para>
     /// </remarks>
-    public static string SettlementOrderIdFor(string subscriptionId, string claimId) =>
-        $"{OrderIdPrefix}{subscriptionId}:quantity:{claimId}";
+    public static string SettlementOrderIdFor(
+        string subscriptionId,
+        SettlementReservationKind kind,
+        string reservationId) =>
+        $"{OrderIdPrefix}{subscriptionId}:{SettlementSegmentFor(kind)}:{reservationId}";
+
+    /// <summary>
+    /// The segment naming a settlement's kind, shared by the writer and the reader so they cannot
+    /// disagree about the spelling.
+    /// </summary>
+    public static string SettlementSegmentFor(SettlementReservationKind kind) =>
+        kind switch
+        {
+            SettlementReservationKind.PlanChange => PlanChangeSegment,
+            _ => QuantitySegment
+        };
+
+    public const string PlanChangeSegment = "pc";
+
+    public const string QuantitySegment = "qty";
+
+    public const string UsageSegment = "usage";
+
+    /// <summary>
+    /// Spellings written before the settlement kinds were distinguished and before the ids were
+    /// shortened to fit the order-id limit. Read forever, written never: the rows carrying them are
+    /// settled payments, and a financial record does not get rewritten to tidy up a string.
+    /// </summary>
+    public const string LegacyPlanChangeSegment = "planchange";
+
+    /// <summary>
+    /// The one both kinds shared. A row carrying it may be either, and is reported as a quantity
+    /// change because that is what the great majority of them are.
+    /// </summary>
+    public const string LegacySettlementSegment = "quantity";
 
     public static string SettlementChargeKeyFor(string subscriptionId, string claimId) =>
         DeterministicKey($"sub-quantity:{subscriptionId}:{claimId}");
@@ -133,7 +178,7 @@ public static class SubscriptionConstants
     /// satisfied by a second, duplicate charge for the same period.
     /// </summary>
     public static string UsageInvoiceOrderIdFor(string subscriptionId, string periodKey) =>
-        $"{OrderIdPrefix}{subscriptionId}:usage:{periodKey}";
+        $"{OrderIdPrefix}{subscriptionId}:{UsageSegment}:{periodKey}";
 
     /// <summary>
     /// The idempotency key one overage-charge attempt is raised under. Carries the attempt

--- a/server/Subscription.DomainService/Validators/CreateDiscountRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreateDiscountRequestValidator.cs
@@ -19,6 +19,7 @@ public sealed class CreateDiscountRequestValidator : AbstractValidator<CreateDis
         RuleFor(request => request.DurationPeriods).GreaterThan(0)
             .When(request => request.DurationPeriods.HasValue);
         RuleForEach(request => request.ApplicablePlanCodes).NotEmpty().MaximumLength(64);
+        RuleForEach(request => request.ApplicablePriceIds).NotEmpty().MaximumLength(64);
         RuleFor(request => request).Must(request =>
             request.Kind != DiscountKind.Percent || request.AmountMinor is null)
             .WithMessage("A percentage discount cannot also define a fixed amount.");

--- a/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
@@ -44,6 +44,19 @@ public sealed class CreatePriceRequestValidator : AbstractValidator<CreatePriceR
             .IsInEnum()
             .When(request => request.TaxMode.HasValue);
 
+        RuleFor(request => request.AutomaticDiscountBasisPoints!.Value)
+            .InclusiveBetween(0, 10_000)
+            .When(request => request.AutomaticDiscountBasisPoints.HasValue)
+            .WithErrorCode("subscription_price_discount_invalid");
+
+        // Unlike a tax mode, the combination is defaulted rather than required. Both answers are
+        // safe to guess wrong in only one direction, and BestDiscount is that direction: it can
+        // never give away more than the larger of the two reductions the author actually wrote.
+        RuleFor(request => request.QuantityDiscountCombination!.Value)
+            .IsInEnum()
+            .When(request => request.QuantityDiscountCombination.HasValue)
+            .WithErrorCode("subscription_price_discount_invalid");
+
         RuleFor(request => request)
             .Must(request => IsChargeable(currencyResolver, request))
             .WithName(nameof(CreatePriceRequest.CurrencyCode))

--- a/server/XUnitTest/Subscription/AutomaticPriceDiscountTests.cs
+++ b/server/XUnitTest/Subscription/AutomaticPriceDiscountTests.cs
@@ -1,0 +1,484 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using System.Text.Json;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// What a price's own automatic discount does to the money.
+/// </summary>
+/// <remarks>
+/// The case this exists for: one plan, a monthly price at full rate and a yearly price at 8% off,
+/// with no code involved. Everything here is about which reductions apply, in what order, and what
+/// happens when more than one of them wants the same charge.
+/// <para>
+/// The rates are 8% for the cadence and 5% for the volume throughout, because 8 + 5 = 13 is exactly
+/// the arithmetic the two combinations disagree about — additive gives 13%, compounding would give
+/// 12.6%, and "best" gives 8%. Three different answers to the same pair of numbers is the whole
+/// reason the choice is stored rather than assumed.
+/// </para>
+/// </remarks>
+public sealed class AutomaticPriceDiscountTests
+{
+    private static readonly DateTime Now = new(2026, 8, 25, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void A_price_with_an_automatic_discount_charges_below_its_configured_amount()
+    {
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            Subscribed(100_000, automaticBasisPoints: 800),
+            Now);
+
+        // The yearly price: CHF 1,000.00 authored, 8% off, nothing typed by the subscriber.
+        charge.GrossAmountMinor.Should().Be(100_000);
+        charge.BuiltInDiscountMinor.Should().Be(8_000);
+        charge.PromotionalDiscountMinor.Should().Be(0);
+        charge.AmountMinor.Should().Be(92_000);
+    }
+
+    [Fact]
+    public void Two_prices_under_one_plan_can_discount_differently()
+    {
+        // The requirement in one test. Same plan, same subscriber, two prices — and the monthly one
+        // must not inherit the yearly one's offer.
+        var monthly = SubscriptionAmountCalculator.PeriodAmountMinor(
+            Subscribed(10_000, automaticBasisPoints: null), Now);
+        var yearly = SubscriptionAmountCalculator.PeriodAmountMinor(
+            Subscribed(100_000, automaticBasisPoints: 800), Now);
+
+        monthly.AmountMinor.Should().Be(10_000);
+        monthly.BuiltInDiscountMinor.Should().Be(0);
+        yearly.AmountMinor.Should().Be(92_000);
+    }
+
+    [Fact]
+    public void Additive_adds_the_two_rates_and_applies_them_once()
+    {
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            SubscribedWithBand(
+                unitAmountMinor: 10_000,
+                quantity: 10,
+                bandBasisPoints: 500,
+                automaticBasisPoints: 800,
+                combination: AutomaticDiscountCombination.Additive),
+            Now);
+
+        // 100,000 gross, 13% off — exactly 13,000, not the 12,600 that applying 8% and then 5% of
+        // what is left would produce.
+        charge.GrossAmountMinor.Should().Be(100_000);
+        charge.BuiltInDiscountMinor.Should().Be(13_000);
+        charge.AmountMinor.Should().Be(87_000);
+    }
+
+    [Fact]
+    public void Best_discount_applies_only_the_larger_of_the_two()
+    {
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            SubscribedWithBand(
+                unitAmountMinor: 10_000,
+                quantity: 10,
+                bandBasisPoints: 500,
+                automaticBasisPoints: 800,
+                combination: AutomaticDiscountCombination.BestDiscount),
+            Now);
+
+        // 8% beats 5%, and the 5% is not also given.
+        charge.BuiltInDiscountMinor.Should().Be(8_000);
+        charge.AmountMinor.Should().Be(92_000);
+    }
+
+    [Fact]
+    public void Best_discount_lets_the_band_win_when_the_band_is_larger()
+    {
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            SubscribedWithBand(
+                unitAmountMinor: 10_000,
+                quantity: 10,
+                bandBasisPoints: 1_500,
+                automaticBasisPoints: 800,
+                combination: AutomaticDiscountCombination.BestDiscount),
+            Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(15_000);
+        charge.AmountMinor.Should().Be(85_000);
+    }
+
+    [Fact]
+    public void An_additive_pair_can_never_take_more_than_everything()
+    {
+        // Two generous rates summing past 100%. A charge must not arrive negative, and the cap is
+        // the only thing standing between a mis-authored pair and a refund by arithmetic.
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            SubscribedWithBand(
+                unitAmountMinor: 10_000,
+                quantity: 1,
+                bandBasisPoints: 6_000,
+                automaticBasisPoints: 6_000,
+                combination: AutomaticDiscountCombination.Additive),
+            Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(10_000);
+        charge.AmountMinor.Should().Be(0);
+    }
+
+    [Fact]
+    public void A_missing_combination_reads_as_best_discount()
+    {
+        // What a caller that has never heard of this field sends, and what every price stored before
+        // it existed carries. It has to be the conservative answer, not the generous one.
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            SubscribedWithBand(
+                unitAmountMinor: 10_000,
+                quantity: 10,
+                bandBasisPoints: 500,
+                automaticBasisPoints: 800,
+                combination: null),
+            Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(8_000, "the larger of the two, never their sum");
+    }
+
+    [Fact]
+    public void A_price_without_an_automatic_discount_is_banded_exactly_as_before()
+    {
+        // The case almost every stored price is in. Its arithmetic must be untouched to the minor
+        // unit — a band that produced 4,999 before must not start producing 5,000.
+        var band = QuantityDiscountCalculator.Resolve(
+            [new QuantityDiscountTier { MinimumQuantity = 1, DiscountBasisPoints = 500 }],
+            unitAmountMinor: 3_333,
+            quantity: 3);
+
+        var builtIn = BuiltInDiscountCalculator.Resolve(
+            9_999,
+            band,
+            automaticBasisPoints: null,
+            combination: null);
+
+        builtIn.DiscountAmountMinor.Should().Be(band.DiscountAmountMinor);
+        builtIn.SubtotalMinor.Should().Be(band.SubtotalMinor);
+        builtIn.EffectiveBasisPoints.Should().Be(500);
+    }
+
+    [Fact]
+    public void Nothing_is_taken_off_a_charge_of_nothing()
+    {
+        var builtIn = BuiltInDiscountCalculator.Resolve(
+            0,
+            new QuantityDiscountOutcome(null, 0, 0, 0, 0),
+            automaticBasisPoints: 800,
+            combination: AutomaticDiscountCombination.Additive);
+
+        builtIn.DiscountAmountMinor.Should().Be(0);
+        builtIn.SubtotalMinor.Should().Be(0);
+    }
+
+    [Fact]
+    public void A_promotion_larger_than_the_built_in_discount_replaces_it()
+    {
+        // The plan's own policy, unchanged by any of this: BestDiscount compares the code against
+        // whatever the price and band already produced.
+        var subscription = Subscribed(100_000, automaticBasisPoints: 800);
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "launch25",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_500
+        };
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(0, "only one of the two applies");
+        charge.PromotionalDiscountMinor.Should().Be(25_000);
+        charge.AmountMinor.Should().Be(75_000);
+        charge.DiscountApplied.Should().BeTrue("the code reduced the charge, so it is consumed");
+    }
+
+    [Fact]
+    public void A_promotion_smaller_than_the_built_in_discount_is_not_consumed()
+    {
+        var subscription = Subscribed(100_000, automaticBasisPoints: 800);
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "small",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 200,
+            DurationPeriods = 3
+        };
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(8_000);
+        charge.PromotionalDiscountMinor.Should().Be(0);
+        charge.AmountMinor.Should().Be(92_000);
+        charge.DiscountApplied.Should().BeFalse(
+            "three months of 2% off must not expire on periods where it reduced nothing");
+    }
+
+    [Fact]
+    public void Stack_applies_the_promotion_to_what_the_built_in_discount_left()
+    {
+        var subscription = Subscribed(100_000, automaticBasisPoints: 800);
+        subscription.Plan.QuantityDiscountCombinationPolicy =
+            QuantityDiscountCombinationPolicy.Stack;
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "extra10",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 1_000
+        };
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        // 8% off 100,000 is 92,000; 10% of that is 9,200.
+        charge.BuiltInDiscountMinor.Should().Be(8_000);
+        charge.PromotionalDiscountMinor.Should().Be(9_200);
+        charge.AmountMinor.Should().Be(82_800);
+    }
+
+    [Fact]
+    public void Quantity_only_suppresses_the_code_and_keeps_the_built_in_discount()
+    {
+        var subscription = Subscribed(100_000, automaticBasisPoints: 800);
+        subscription.Plan.QuantityDiscountCombinationPolicy =
+            QuantityDiscountCombinationPolicy.QuantityOnly;
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "ignored",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 5_000
+        };
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(8_000);
+        charge.PromotionalDiscountMinor.Should().Be(0);
+        charge.AmountMinor.Should().Be(92_000);
+    }
+
+    [Fact]
+    public void Tax_is_calculated_after_the_automatic_discount()
+    {
+        var subscription = Subscribed(100_000, automaticBasisPoints: 800);
+        subscription.Price.TaxRateBasisPoints = 770;
+        subscription.Price.TaxMode = TaxMode.Exclusive;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        // 7.7% of 92,000, not of 100,000. Taxing the gross would charge tax on money nobody paid.
+        charge.NetAmountMinor.Should().Be(92_000);
+        charge.TaxAmountMinor.Should().Be(7_084);
+        charge.AmountMinor.Should().Be(99_084);
+    }
+
+    [Fact]
+    public void An_inclusive_price_still_charges_its_amount_less_the_discount()
+    {
+        var subscription = Subscribed(100_000, automaticBasisPoints: 800);
+        subscription.Price.TaxRateBasisPoints = 770;
+        subscription.Price.TaxMode = TaxMode.Inclusive;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        // The configured amount is what a customer pays before the discount, so 8% off it is what
+        // they pay after — with the tax found inside the reduced figure, not the original.
+        charge.AmountMinor.Should().Be(92_000);
+        charge.TaxAmountMinor.Should().Be(6_578, "92,000 × 770 / 10,770");
+        charge.NetAmountMinor.Should().Be(85_422);
+    }
+
+    [Fact]
+    public void Credit_is_spent_last_and_does_not_change_what_was_discounted()
+    {
+        var subscription = Subscribed(100_000, automaticBasisPoints: 800);
+        subscription.CreditBalanceMinor = 20_000;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(8_000);
+        charge.CreditConsumedMinor.Should().Be(20_000);
+        charge.AmountMinor.Should().Be(72_000);
+    }
+
+    [Fact]
+    public void An_invoice_can_always_be_reconciled_from_its_parts()
+    {
+        // The property that matters more than any single figure: gross, less both reductions, is
+        // what was taxed; plus tax, less credit, is what was charged.
+        var subscription = SubscribedWithBand(
+            unitAmountMinor: 3_333,
+            quantity: 7,
+            bandBasisPoints: 500,
+            automaticBasisPoints: 800,
+            combination: AutomaticDiscountCombination.Additive);
+        subscription.Price.TaxRateBasisPoints = 770;
+        subscription.Price.TaxMode = TaxMode.Exclusive;
+        subscription.CreditBalanceMinor = 1_000;
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "stackable",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 1_000
+        };
+        subscription.Plan.QuantityDiscountCombinationPolicy =
+            QuantityDiscountCombinationPolicy.Stack;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        var discounted = charge.GrossAmountMinor
+            - charge.BuiltInDiscountMinor
+            - charge.PromotionalDiscountMinor;
+
+        discounted.Should().Be(charge.NetAmountMinor);
+        charge.AmountMinor.Should().Be(
+            charge.NetAmountMinor + charge.TaxAmountMinor - charge.CreditConsumedMinor);
+    }
+
+    [Fact]
+    public void A_renewal_prices_from_the_snapshot_rather_than_the_catalogue()
+    {
+        // The subscriber holds their own copy of the discount, so what the catalogue says now is
+        // irrelevant to what they are charged. That the copy is *taken* is asserted where the
+        // subscription is built — see SubscriptionCreationServiceTests; this is the half that
+        // matters to the money.
+        var sold = new PriceSnapshot
+        {
+            PriceId = "price-yearly",
+            UnitAmountMinor = 100_000,
+            AutomaticDiscountBasisPoints = 800,
+            QuantityDiscountCombination = AutomaticDiscountCombination.Additive,
+            PriceVersion = 3
+        };
+
+        var subscription = new SubscriptionDetail { Price = sold, Plan = new PlanSnapshot() };
+
+        SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now)
+            .AmountMinor.Should().Be(92_000);
+    }
+
+    [Fact]
+    public void A_plan_change_prices_the_target_price_with_the_targets_own_discount()
+    {
+        // Moving from the monthly price to the yearly one, halfway through the month. What matters
+        // here is only that the new side is discounted and the old side is not.
+        var subscription = new SubscriptionDetail
+        {
+            Plan = new PlanSnapshot(),
+            Price = new PriceSnapshot { UnitAmountMinor = 10_000 },
+            CurrentPeriodStartUtc = Now.AddDays(-15),
+            CurrentPeriodEndUtc = Now.AddDays(15)
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            subscription.Plan,
+            new PriceSnapshot
+            {
+                UnitAmountMinor = 100_000,
+                AutomaticDiscountBasisPoints = 800,
+                QuantityDiscountCombination = AutomaticDiscountCombination.BestDiscount
+            },
+            [],
+            Now,
+            Now.AddDays(-15),
+            Now.AddDays(350));
+
+        var undiscounted = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            subscription.Plan,
+            new PriceSnapshot { UnitAmountMinor = 100_000 },
+            [],
+            Now,
+            Now.AddDays(-15),
+            Now.AddDays(350));
+
+        outcome.ChargeMinor.Should().BeLessThan(undiscounted.ChargeMinor,
+            "the target price's own 8% has to reach the proration, not just the renewal");
+        outcome.ChargeMinor.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void The_request_accepts_the_combination_by_name()
+    {
+        var request = JsonSerializer.Deserialize<CreatePriceRequest>(
+            """{"automaticDiscountBasisPoints":800,"quantityDiscountCombination":"Additive"}""",
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        request!.AutomaticDiscountBasisPoints.Should().Be(800);
+        request.QuantityDiscountCombination.Should().Be(AutomaticDiscountCombination.Additive);
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData(0, null, null)]
+    [InlineData(800, null, "BestDiscount")]
+    [InlineData(800, AutomaticDiscountCombination.Additive, "Additive")]
+    public void A_combination_is_only_reported_where_there_is_a_discount_to_combine(
+        int? basisPoints,
+        AutomaticDiscountCombination? stored,
+        string? expected)
+    {
+        SubscriptionDiscountPresentation.Describe(basisPoints, stored).Should().Be(expected);
+    }
+
+    private static SubscriptionDetail Subscribed(
+        long unitAmountMinor,
+        int? automaticBasisPoints,
+        AutomaticDiscountCombination? combination = null) => new()
+    {
+        Plan = new PlanSnapshot(),
+        Price = new PriceSnapshot
+        {
+            PriceId = "price-1",
+            UnitAmountMinor = unitAmountMinor,
+            AutomaticDiscountBasisPoints = automaticBasisPoints,
+            QuantityDiscountCombination = combination
+        }
+    };
+
+    private static SubscriptionDetail SubscribedWithBand(
+        long unitAmountMinor,
+        long quantity,
+        int bandBasisPoints,
+        int? automaticBasisPoints,
+        AutomaticDiscountCombination? combination) => new()
+    {
+        Plan = new PlanSnapshot
+        {
+            QuantityItems =
+            [
+                new PlanQuantityItem
+                {
+                    ItemKey = "seats",
+                    QuantityDiscountTiers =
+                    [
+                        new QuantityDiscountTier
+                        {
+                            MinimumQuantity = 1,
+                            DiscountBasisPoints = bandBasisPoints
+                        }
+                    ]
+                }
+            ]
+        },
+        Price = new PriceSnapshot
+        {
+            PriceId = "price-1",
+            UnitAmountMinor = unitAmountMinor,
+            QuantityItemKey = "seats",
+            AutomaticDiscountBasisPoints = automaticBasisPoints,
+            QuantityDiscountCombination = combination
+        },
+        QuantityItems =
+        [
+            new SubscriptionQuantityItem
+            {
+                ItemKey = "seats",
+                Quantity = quantity,
+                UnitAmountMinor = unitAmountMinor
+            }
+        ]
+    };
+}

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
@@ -1,0 +1,194 @@
+using FluentAssertions;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Validators;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Authoring a discount, and the restrictions that would make one unredeemable.
+/// </summary>
+/// <remarks>
+/// The failure this is mostly about: a discount restricted to a plan or price that does not exist is
+/// accepted happily and then refuses every redemption with
+/// <c>subscription_discount_not_applicable</c> — an error that says nothing about the typo that
+/// caused it. The portal picks from a list and cannot make that mistake; a script, an API client, or
+/// an identifier copied from another environment can.
+/// </remarks>
+public sealed class DiscountCatalogueServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private Discount? _created;
+
+    public DiscountCatalogueServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Plan("plan-pro", "pro"), Plan("plan-team", "team")]);
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-pro-yearly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Price("price-pro-yearly", "plan-pro"));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-team-monthly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Price("price-team-monthly", "plan-team"));
+
+        _discounts
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<Discount>(), It.IsAny<CancellationToken>()))
+            .Callback<Discount, CancellationToken>((discount, _) => _created = discount)
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task An_unrestricted_discount_needs_no_catalogue_lookup()
+    {
+        // The ordinary case, and the one that must not pay for this check.
+        var result = await Service().CreateAsync(Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _catalogue.Verify(repository => repository.ListPlansAsync(
+            It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A_discount_restricted_to_real_plans_and_prices_is_accepted()
+    {
+        var request = Request();
+        request.ApplicablePlanCodes = ["pro"];
+        request.ApplicablePriceIds = ["price-pro-yearly"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.ApplicablePriceIds.Should().Equal("price-pro-yearly");
+    }
+
+    [Fact]
+    public async Task A_plan_code_that_does_not_exist_is_refused()
+    {
+        var request = Request();
+        request.ApplicablePlanCodes = ["por"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorMessage.Should().Contain("por", "the author has to be told which one is wrong");
+        _created.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_price_that_does_not_exist_is_refused()
+    {
+        var request = Request();
+        request.ApplicablePriceIds = ["price-typo"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+        _created.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_price_belonging_to_another_organizations_plan_reads_as_unknown()
+    {
+        // Not "forbidden": a refusal that distinguished the two would confirm that somebody else's
+        // price exists to anyone willing to guess identifiers.
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-elsewhere", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Price("price-elsewhere", "plan-not-visible"));
+
+        var request = Request();
+        request.ApplicablePriceIds = ["price-elsewhere"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+        result.ErrorMessage.Should().NotContain("plan-not-visible");
+    }
+
+    [Fact]
+    public async Task A_price_outside_the_named_plans_is_refused_as_unredeemable()
+    {
+        // Both restrictions narrow, so a price on an unlisted plan matches nothing. Accepted, this
+        // would be a discount that exists and can never be used.
+        var request = Request();
+        request.ApplicablePlanCodes = ["pro"];
+        request.ApplicablePriceIds = ["price-team-monthly"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+        result.ErrorMessage.Should().Contain("could never be redeemed");
+    }
+
+    [Fact]
+    public async Task A_price_named_without_any_plan_restriction_is_accepted()
+    {
+        // Price-only is a legitimate authoring choice: "8% off the yearly price, whatever plan it is
+        // on" needs no plan list.
+        var request = Request();
+        request.ApplicablePriceIds = ["price-team-monthly"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    private DiscountCatalogueService Service() => new(
+        _discounts.Object,
+        _catalogue.Object,
+        _contextResolver.Object,
+        new CreateDiscountRequestValidator());
+
+    private static CreateDiscountRequest Request() => new()
+    {
+        Code = "launch25",
+        DisplayName = "Launch offer",
+        Kind = DiscountKind.Percent,
+        PercentBasisPoints = 2_500
+    };
+
+    private static Plan Plan(string planId, string code) => new()
+    {
+        ItemId = planId,
+        TenantId = TenantId,
+        Code = code,
+        DisplayName = code,
+        Status = CatalogueStatus.Active
+    };
+
+    private static Price Price(string priceId, string planId) => new()
+    {
+        ItemId = priceId,
+        TenantId = TenantId,
+        PlanId = planId,
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 10_000,
+        Status = CatalogueStatus.Active
+    };
+}

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
@@ -24,6 +24,7 @@ public sealed class DiscountCatalogueServiceTests
 {
     private const string TenantId = "tenant-1";
     private const string OrganizationId = "org-1";
+    private const string CustomerOrganizationId = "org-customer";
 
     private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
     private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
@@ -60,6 +61,97 @@ public sealed class DiscountCatalogueServiceTests
                 It.IsAny<Discount>(), It.IsAny<CancellationToken>()))
             .Callback<Discount, CancellationToken>((discount, _) => _created = discount)
             .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task Authoring_for_another_organization_validates_against_that_organizations_catalogue()
+    {
+        // The console authoring a customer's discount. Resolved against the organization named in the
+        // request — validating against the console's own catalogue reported the customer's plans as
+        // unknown, on a discount that was then stored under the customer's scope anyway.
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                CustomerOrganizationId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(
+                    TenantId, CustomerOrganizationId, "actor-1", "user-1")));
+
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId, CustomerOrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Plan("plan-customer", "customer-only")]);
+
+        var request = Request();
+        request.OrganizationId = CustomerOrganizationId;
+        request.ApplicablePlanCodes = ["customer-only"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "the plan exists in the organization the discount is being authored for");
+        _created!.OrganizationId.Should().Be(CustomerOrganizationId);
+
+        // The exact argument matters: this is the whole bug.
+        _contextResolver.Verify(resolver => resolver.ResolveAsync(
+            It.IsAny<string>(), CustomerOrganizationId, It.IsAny<CancellationToken>()), Times.Once);
+        _contextResolver.Verify(resolver => resolver.ResolveAsync(
+            It.IsAny<string>(), null, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A_plan_from_another_organization_is_still_refused_when_authoring_for_it()
+    {
+        // The other half: resolving the requested organization must not become "validate against
+        // nothing". A code naming a plan that organization does not have is still unredeemable.
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(),
+                CustomerOrganizationId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(
+                    TenantId, CustomerOrganizationId, "actor-1", "user-1")));
+
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId, CustomerOrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Plan("plan-customer", "customer-only")]);
+
+        var request = Request();
+        request.OrganizationId = CustomerOrganizationId;
+        request.ApplicablePlanCodes = ["pro"];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+    }
+
+    [Fact]
+    public async Task A_caller_naming_an_organization_it_may_not_write_to_is_scoped_to_its_own()
+    {
+        // The resolver honours a named organization only for the console and answers with the
+        // caller's own otherwise. Storing the *requested* value would have let anybody write a
+        // discount into somebody else's catalogue scope.
+        var request = Request();
+        request.OrganizationId = "org-somebody-else";
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.OrganizationId.Should().Be(OrganizationId, "the resolver's answer, not the ask");
+    }
+
+    [Fact]
+    public async Task A_tenant_wide_discount_stays_tenant_wide()
+    {
+        // Null is a scope rather than an organization, and it has to survive resolution — which
+        // always answers with a concrete organization.
+        var result = await Service().CreateAsync(Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.OrganizationId.Should().BeNull();
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -563,6 +563,163 @@ public sealed class PlanCatalogueServiceTests
     }
 
     [Fact]
+    public async Task An_existing_price_can_be_given_an_automatic_discount()
+    {
+        var plan = StoredPlan();
+        StoredPriceFor(plan, version: 4);
+        _catalogue.Setup(repository => repository.TryUpdatePriceAutomaticDiscountAsync(
+            TenantId, "price-1", 4, 800, AutomaticDiscountCombination.Additive,
+            It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var result = await Service().UpdatePriceDiscountAsync(
+            "price-1",
+            new UpdatePriceDiscountRequest
+            {
+                AutomaticDiscountBasisPoints = 800,
+                QuantityDiscountCombination = AutomaticDiscountCombination.Additive
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _catalogue.Verify(repository => repository.TryUpdatePriceAutomaticDiscountAsync(
+            TenantId, "price-1", 4, 800, AutomaticDiscountCombination.Additive,
+            It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Clearing_an_automatic_discount_clears_its_combination_too()
+    {
+        // Zero means "no discount", and a price with no discount must not keep a stale answer to how
+        // that discount would have combined with a band.
+        var plan = StoredPlan();
+        StoredPriceFor(plan, version: 2);
+        _catalogue.Setup(repository => repository.TryUpdatePriceAutomaticDiscountAsync(
+            TenantId, "price-1", 2, null, null,
+            It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var result = await Service().UpdatePriceDiscountAsync(
+            "price-1",
+            new UpdatePriceDiscountRequest
+            {
+                AutomaticDiscountBasisPoints = 0,
+                QuantityDiscountCombination = AutomaticDiscountCombination.Additive
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _catalogue.Verify(repository => repository.TryUpdatePriceAutomaticDiscountAsync(
+            TenantId, "price-1", 2, null, null,
+            It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task A_discount_without_a_combination_is_stored_as_the_safe_one()
+    {
+        var plan = StoredPlan();
+        StoredPriceFor(plan, version: 1);
+        _catalogue.Setup(repository => repository.TryUpdatePriceAutomaticDiscountAsync(
+            TenantId, "price-1", 1, 800, AutomaticDiscountCombination.BestDiscount,
+            It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        var result = await Service().UpdatePriceDiscountAsync(
+            "price-1",
+            new UpdatePriceDiscountRequest { AutomaticDiscountBasisPoints = 800 },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(10_001)]
+    public async Task An_automatic_discount_outside_nought_to_a_hundred_percent_is_refused(
+        int basisPoints)
+    {
+        var result = await Service().UpdatePriceDiscountAsync(
+            "price-1",
+            new UpdatePriceDiscountRequest { AutomaticDiscountBasisPoints = basisPoints },
+            "corr-1",
+            CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_price_discount_invalid");
+    }
+
+    [Fact]
+    public async Task A_price_that_moved_while_being_saved_reports_a_conflict()
+    {
+        var plan = StoredPlan();
+        StoredPriceFor(plan, version: 7);
+        _catalogue.Setup(repository => repository.TryUpdatePriceAutomaticDiscountAsync(
+            TenantId, "price-1", 7, 800, It.IsAny<AutomaticDiscountCombination?>(),
+            It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await Service().UpdatePriceDiscountAsync(
+            "price-1",
+            new UpdatePriceDiscountRequest { AutomaticDiscountBasisPoints = 800 },
+            "corr-1",
+            CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be("subscription_price_discount_conflict");
+    }
+
+    [Fact]
+    public async Task A_new_price_can_be_authored_with_an_automatic_discount()
+    {
+        Price? stored = null;
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StoredPlan());
+        _catalogue
+            .Setup(repository => repository.TryCreatePriceAsync(
+                It.IsAny<Price>(), It.IsAny<CancellationToken>()))
+            .Callback<Price, CancellationToken>((price, _) => stored = price)
+            .ReturnsAsync(true);
+
+        var result = await Service().CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = "plan-1",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 100_000,
+                AutomaticDiscountBasisPoints = 800,
+                QuantityDiscountCombination = AutomaticDiscountCombination.Additive
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        stored!.AutomaticDiscountBasisPoints.Should().Be(800);
+        stored.QuantityDiscountCombination.Should().Be(AutomaticDiscountCombination.Additive);
+    }
+
+    /// <summary>
+    /// An active price on the plan, wired for the two lookups every price editor performs.
+    /// </summary>
+    private Price StoredPriceFor(Plan plan, int version)
+    {
+        var price = new Price
+        {
+            ItemId = "price-1",
+            TenantId = TenantId,
+            PlanId = plan.ItemId,
+            Status = CatalogueStatus.Active,
+            Version = version
+        };
+
+        _catalogue.Setup(repository => repository.GetPriceAsync(
+            TenantId, "price-1", It.IsAny<CancellationToken>())).ReturnsAsync(price);
+        _catalogue.Setup(repository => repository.GetPlanAsync(
+            TenantId, plan.ItemId, It.IsAny<CancellationToken>())).ReturnsAsync(plan);
+
+        return price;
+    }
+
+    [Fact]
     public async Task Another_organizations_plan_reports_as_missing()
     {
         _catalogue

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -528,6 +528,54 @@ public sealed class StripeInvoiceBillingGatewayTests
         return request;
     }
 
+    [Fact]
+    public async Task The_recorded_payment_carries_the_discount_breakdown()
+    {
+        PaymentDetail? recorded = null;
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .Callback((PaymentDetail payment, CancellationToken _) => recorded = payment)
+            .ReturnsAsync(true);
+
+        var request = Request();
+        request.GrossAmountMinor = 100_000;
+        request.BuiltInDiscountMinor = 8_000;
+        request.PromotionalDiscountMinor = 9_200;
+        request.AutomaticDiscountBasisPoints = 800;
+        request.QuantityDiscountBasisPoints = 500;
+        request.DiscountCombination = "Additive";
+
+        await Gateway().ChargeAsync(request, "idem-1", "corr-1", CancellationToken.None);
+
+        recorded!.SubscriptionGrossAmountMinor.Should().Be(100_000);
+        recorded.SubscriptionBuiltInDiscountMinor.Should().Be(8_000);
+        recorded.SubscriptionPromotionalDiscountMinor.Should().Be(9_200);
+        recorded.SubscriptionAutomaticDiscountBasisPoints.Should().Be(800);
+        recorded.SubscriptionQuantityDiscountBasisPoints.Should().Be(500);
+        recorded.SubscriptionDiscountCombination.Should().Be("Additive");
+    }
+
+    [Fact]
+    public async Task A_charge_with_no_breakdown_records_none_rather_than_zeroes()
+    {
+        // A settlement charge is the difference between two prorated periods and does not decompose
+        // into a gross and a reduction. Nulls say "not applicable"; zeroes would say "nothing came
+        // off", which is a different and false claim.
+        PaymentDetail? recorded = null;
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .Callback((PaymentDetail payment, CancellationToken _) => recorded = payment)
+            .ReturnsAsync(true);
+
+        await Gateway().ChargeAsync(Request(), "idem-1", "corr-1", CancellationToken.None);
+
+        recorded!.SubscriptionGrossAmountMinor.Should().BeNull();
+        recorded.SubscriptionBuiltInDiscountMinor.Should().BeNull();
+        recorded.SubscriptionPromotionalDiscountMinor.Should().BeNull();
+    }
+
     private static SubscriptionChargeRequest Request() => new()
     {
         TenantId = TenantId,

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -576,6 +576,51 @@ public sealed class StripeInvoiceBillingGatewayTests
         recorded.SubscriptionPromotionalDiscountMinor.Should().BeNull();
     }
 
+    [Fact]
+    public async Task A_settlement_charge_records_both_of_its_sides()
+    {
+        PaymentDetail? recorded = null;
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .Callback((PaymentDetail payment, CancellationToken _) => recorded = payment)
+            .ReturnsAsync(true);
+
+        var request = Request();
+        request.Settlement = new SubscriptionSettlementBreakdown
+        {
+            Outgoing = new SubscriptionSettlementSide
+            {
+                GrossAmountMinor = 1_000,
+                BuiltInDiscountMinor = 100,
+                TaxAmountMinor = 90,
+                PeriodTotalMinor = 990,
+                ProratedValueMinor = 495
+            },
+            Target = new SubscriptionSettlementSide
+            {
+                GrossAmountMinor = 2_000,
+                BuiltInDiscountMinor = 160,
+                TaxAmountMinor = 184,
+                PeriodTotalMinor = 2_024,
+                ProratedValueMinor = 1_012
+            },
+            CreditConsumedMinor = 0,
+            NetSettlementMinor = 517
+        };
+
+        await Gateway().ChargeAsync(request, "idem-1", "corr-1", CancellationToken.None);
+
+        recorded!.SubscriptionSettlement.Should().NotBeNull();
+        recorded.SubscriptionSettlement!.Outgoing.ProratedValueMinor.Should().Be(495);
+        recorded.SubscriptionSettlement.Target.ProratedValueMinor.Should().Be(1_012);
+        recorded.SubscriptionSettlement.NetSettlementMinor.Should().Be(517);
+
+        // The two are alternatives: a settlement is not a discounted price, so the flat fields stay
+        // empty rather than describing it badly.
+        recorded.SubscriptionGrossAmountMinor.Should().BeNull();
+    }
+
     private static SubscriptionChargeRequest Request() => new()
     {
         TenantId = TenantId,

--- a/server/XUnitTest/Subscription/SubscriptionConstantsTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionConstantsTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Utilities;
 
 namespace XUnitTest.Subscription;
@@ -18,6 +19,7 @@ public sealed class SubscriptionConstantsTests
 {
     private const string SubscriptionId = "8a7b6c5d-4e3f-2a1b-0c9d-8e7f6a5b4c3d";
     private const string PeriodKey = "M20260901T000000Z";
+    private const string ReservationId = "3f2e1d0c9b8a7f6e5d4c3b2a1908f7e6";
 
     public static TheoryData<string, string> EveryKey() => new()
     {
@@ -115,7 +117,23 @@ public sealed class SubscriptionConstantsTests
         SubscriptionConstants.UsageInvoiceOrderIdFor(SubscriptionId, PeriodKey)
             .Length.Should().BeLessThanOrEqualTo(80);
 
-        SubscriptionConstants.PlanChangeOrderIdFor(SubscriptionId, 3)
+        // Both settlement kinds, since the kind is now part of the id. This is the assertion that
+        // caught the segments being too long: a subscription id and a reservation id already spend 68
+        // of the 80 characters, so "planchange" did not fit — and the "quantity" spelling this
+        // replaced had been two over the limit, untested, all along.
+        SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId, SettlementReservationKind.PlanChange, ReservationId)
             .Length.Should().BeLessThanOrEqualTo(80);
+
+        SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId, SettlementReservationKind.QuantityIncrease, ReservationId)
+            .Length.Should().BeLessThanOrEqualTo(80);
+
+        // The two kinds must not share a segment: invoice history reads the kind back out of this
+        // string, and sharing one is what classified plan-change invoices as renewals.
+        SubscriptionConstants.SettlementSegmentFor(SettlementReservationKind.PlanChange)
+            .Should().NotBe(
+                SubscriptionConstants.SettlementSegmentFor(
+                    SettlementReservationKind.QuantityIncrease));
     }
 }

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -290,6 +290,34 @@ public sealed class SubscriptionCreationServiceTests
     }
 
     [Fact]
+    public async Task A_promotions_restrictions_are_snapshotted_with_its_terms()
+    {
+        // Copied so a later plan change can ask the same question the redemption did. Without this the
+        // restriction is enforced once and then forgotten, which is how a monthly-only code ends up
+        // discounting an annual price.
+        var request = NewRequest();
+        request.DiscountCode = "thisone";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "thisone", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ApplicablePlanCodes = ["professional"],
+                ApplicablePriceIds = ["price-1"],
+                Terms = new DiscountTerms
+                {
+                    Code = "thisone",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 800
+                }
+            });
+
+        await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        _created!.Discount!.ApplicablePlanCodes.Should().Equal("professional");
+        _created.Discount.ApplicablePriceIds.Should().Equal("price-1");
+    }
+
+    [Fact]
     public async Task The_prices_automatic_discount_is_snapshotted_onto_the_subscription()
     {
         // The copy is what makes a catalogue edit safe. Without it, clearing the discount tomorrow

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -185,6 +185,136 @@ public sealed class SubscriptionCreationServiceTests
     }
 
     [Fact]
+    public async Task A_promotion_restricted_to_another_price_is_refused()
+    {
+        // A code authored for the yearly price, typed against the monthly one. Refused rather than
+        // quietly applied, which is the whole reason a price restriction is worth having.
+        var request = NewRequest();
+        request.DiscountCode = "yearly8";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "yearly8", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ApplicablePriceIds = ["price-yearly"],
+                Terms = new DiscountTerms
+                {
+                    Code = "yearly8",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 800
+                }
+            });
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_not_applicable");
+        _created.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_promotion_restricted_by_plan_and_price_needs_both_to_match()
+    {
+        // Two restrictions narrow, they do not offer two ways to qualify. The right plan and the
+        // wrong price is still the wrong thing to discount.
+        var request = NewRequest();
+        request.DiscountCode = "both";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "both", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ApplicablePlanCodes = ["professional"],
+                ApplicablePriceIds = ["price-yearly"],
+                Terms = new DiscountTerms
+                {
+                    Code = "both",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 800
+                }
+            });
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_not_applicable");
+    }
+
+    [Fact]
+    public async Task A_promotion_naming_this_price_is_accepted()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "thisone";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "thisone", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ApplicablePlanCodes = ["professional"],
+                ApplicablePriceIds = ["price-1"],
+                Terms = new DiscountTerms
+                {
+                    Code = "thisone",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 800
+                }
+            });
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Discount!.Code.Should().Be("thisone");
+    }
+
+    [Fact]
+    public async Task A_discount_stored_before_price_restrictions_existed_stays_unrestricted()
+    {
+        // Every discount already in a tenant's catalogue is this shape: no price list at all. It has
+        // to keep applying to whatever it applied to yesterday.
+        var request = NewRequest();
+        request.DiscountCode = "legacy";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "legacy", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms
+                {
+                    Code = "legacy",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 1_000
+                }
+            });
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task The_prices_automatic_discount_is_snapshotted_onto_the_subscription()
+    {
+        // The copy is what makes a catalogue edit safe. Without it, clearing the discount tomorrow
+        // would raise the price of every subscription already sold on it.
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var price = NewPrice();
+                price.AutomaticDiscountBasisPoints = 800;
+                price.QuantityDiscountCombination = AutomaticDiscountCombination.Additive;
+
+                return price;
+            });
+
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.Price.AutomaticDiscountBasisPoints.Should().Be(800);
+        _created.Price.QuantityDiscountCombination
+            .Should().Be(AutomaticDiscountCombination.Additive);
+    }
+
+    [Fact]
     public async Task A_missing_quantity_takes_the_plans_default()
     {
         var request = NewRequest();

--- a/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryServiceTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Moq;
+using Payment.DomainService.Entities;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Services;
@@ -172,6 +173,88 @@ public sealed class SubscriptionInvoiceHistoryServiceTests
         result.IsSuccess.Should().BeFalse();
         result.ValidationErrors.Should().ContainKey("After");
         _invoices.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task A_settlement_invoice_reports_both_sides_and_its_derived_taxable_amounts()
+    {
+        // The promise this keeps: a plan-change charge is a subtraction between two prorated periods,
+        // and the invoice has to be able to show the subtraction rather than only its answer.
+        var settled = Invoice("payment-3", "sub:subscription-3:settle:res-1") with
+        {
+            Settlement = new SubscriptionSettlementBreakdown
+            {
+                Outgoing = new SubscriptionSettlementSide
+                {
+                    GrossAmountMinor = 1_000,
+                    BuiltInDiscountMinor = 100,
+                    PromotionalDiscountMinor = 50,
+                    TaxAmountMinor = 85,
+                    PeriodTotalMinor = 935,
+                    ProratedValueMinor = 467
+                },
+                Target = new SubscriptionSettlementSide
+                {
+                    GrossAmountMinor = 2_000,
+                    BuiltInDiscountMinor = 160,
+                    TaxAmountMinor = 184,
+                    PeriodTotalMinor = 2_024,
+                    ProratedValueMinor = 1_012
+                },
+                CreditConsumedMinor = 100,
+                NetSettlementMinor = 445
+            }
+        };
+
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                "tenant-1", "subscriber-1", It.IsAny<int>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionInvoiceHistoryPage([settled], false));
+
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest(), "corr-1", CancellationToken.None);
+
+        var invoice = result.Value!.Items[0];
+
+        invoice.Settlement.Should().NotBeNull();
+        invoice.Settlement!.Outgoing.DiscountedAmountMinor.Should().Be(
+            850, "1,000 less the 100 built in and the 50 promotional");
+        invoice.Settlement.Outgoing.ProratedValueMinor.Should().Be(467);
+        invoice.Settlement.Target.DiscountedAmountMinor.Should().Be(1_840);
+        invoice.Settlement.Target.PeriodTotalMinor.Should().Be(2_024);
+        invoice.Settlement.CreditConsumedMinor.Should().Be(100);
+        invoice.Settlement.NetSettlementMinor.Should().Be(445);
+
+        // The renewal-shaped fields stay absent: this charge has two sides, not one.
+        invoice.GrossAmountMinor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_renewal_invoice_reports_its_own_breakdown_and_no_settlement()
+    {
+        var renewal = Invoice("payment-4", "sub:subscription-4:2026-09") with
+        {
+            GrossAmountMinor = 10_000,
+            BuiltInDiscountMinor = 800,
+            PromotionalDiscountMinor = 0,
+            AutomaticDiscountBasisPoints = 800,
+            DiscountCombination = "Additive"
+        };
+
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                "tenant-1", "subscriber-1", It.IsAny<int>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionInvoiceHistoryPage([renewal], false));
+
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest(), "corr-1", CancellationToken.None);
+
+        var invoice = result.Value!.Items[0];
+
+        invoice.Settlement.Should().BeNull("a renewal is one priced period, not two");
+        invoice.GrossAmountMinor.Should().Be(10_000);
+        invoice.DiscountedAmountMinor.Should().Be(9_200);
+        invoice.QuantityDiscountCombination.Should().Be("Additive");
     }
 
     private SubscriptionInvoiceHistoryService Service() => new(

--- a/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionInvoiceHistoryServiceTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using Moq;
 using Payment.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Utilities;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Services;
@@ -180,7 +182,13 @@ public sealed class SubscriptionInvoiceHistoryServiceTests
     {
         // The promise this keeps: a plan-change charge is a subtraction between two prorated periods,
         // and the invoice has to be able to show the subtraction rather than only its answer.
-        var settled = Invoice("payment-3", "sub:subscription-3:settle:res-1") with
+        // Built by the same helper the charge uses, rather than hand-written: the previous fixture
+        // said "settle:", which nothing produces, so it proved the mapping worked for a shape that
+        // never reaches this code.
+        var settled = Invoice(
+            "payment-3",
+            SubscriptionConstants.SettlementOrderIdFor(
+                "subscription-3", SettlementReservationKind.PlanChange, "res-1")) with
         {
             Settlement = new SubscriptionSettlementBreakdown
             {
@@ -216,6 +224,8 @@ public sealed class SubscriptionInvoiceHistoryServiceTests
 
         var invoice = result.Value!.Items[0];
 
+        invoice.InvoiceType.Should().Be("PlanChange", "a settlement is not a renewal");
+        invoice.PeriodKey.Should().BeNull("a settlement is scoped by its reservation, not a period");
         invoice.Settlement.Should().NotBeNull();
         invoice.Settlement!.Outgoing.DiscountedAmountMinor.Should().Be(
             850, "1,000 less the 100 built in and the 50 promotional");
@@ -232,7 +242,9 @@ public sealed class SubscriptionInvoiceHistoryServiceTests
     [Fact]
     public async Task A_renewal_invoice_reports_its_own_breakdown_and_no_settlement()
     {
-        var renewal = Invoice("payment-4", "sub:subscription-4:2026-09") with
+        var renewal = Invoice(
+            "payment-4",
+            SubscriptionConstants.RenewalOrderIdFor("subscription-4", "2026-09")) with
         {
             GrossAmountMinor = 10_000,
             BuiltInDiscountMinor = 800,
@@ -251,10 +263,62 @@ public sealed class SubscriptionInvoiceHistoryServiceTests
 
         var invoice = result.Value!.Items[0];
 
+        invoice.InvoiceType.Should().Be("Renewal");
+        invoice.PeriodKey.Should().Be("2026-09");
         invoice.Settlement.Should().BeNull("a renewal is one priced period, not two");
         invoice.GrossAmountMinor.Should().Be(10_000);
         invoice.DiscountedAmountMinor.Should().Be(9_200);
         invoice.QuantityDiscountCombination.Should().Be("Additive");
+    }
+
+    [Fact]
+    public async Task Every_order_id_this_module_writes_classifies_itself()
+    {
+        // The defect this exists for: both settlement kinds shared the "quantity:" form, so a
+        // plan-change invoice reported itself as a renewal and handed the client the reservation id
+        // where a period key belongs. Built from the real helpers, because a hand-written fixture is
+        // exactly how that went unnoticed.
+        var expected = new (string OrderId, string Type, string? PeriodKey)[]
+        {
+            (SubscriptionConstants.RenewalOrderIdFor("sub-1", "M20260901T000000Z"),
+                "Renewal", "M20260901T000000Z"),
+            (SubscriptionConstants.UsageInvoiceOrderIdFor("sub-1", "M20260901T000000Z"),
+                "Usage", "M20260901T000000Z"),
+            (SubscriptionConstants.SettlementOrderIdFor(
+                    "sub-1", SettlementReservationKind.PlanChange, "res-1"),
+                "PlanChange", null),
+            (SubscriptionConstants.SettlementOrderIdFor(
+                    "sub-1", SettlementReservationKind.QuantityIncrease, "res-2"),
+                "QuantityChange", null),
+            (SubscriptionConstants.OrderIdFor("sub-1"), "Unknown", null),
+            ("not-ours-at-all", "Unknown", null),
+
+            // Settled rows written before the kinds were told apart and before the segments were
+            // shortened to fit the order-id limit. Still read, because they are somebody's invoices.
+            ($"sub:sub-1:{SubscriptionConstants.LegacySettlementSegment}:res-3",
+                "QuantityChange", null),
+            ($"sub:sub-1:{SubscriptionConstants.LegacyPlanChangeSegment}:7",
+                "PlanChange", null)
+        };
+
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                "tenant-1", "subscriber-1", It.IsAny<int>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionInvoiceHistoryPage(
+                expected.Select((row, index) => Invoice($"payment-{index}", row.OrderId)).ToList(),
+                false));
+
+        var result = await Service().ListAsync(
+            new GetSubscriptionInvoicesRequest(), "corr-1", CancellationToken.None);
+
+        for (var index = 0; index < expected.Length; index++)
+        {
+            var (orderId, type, periodKey) = expected[index];
+            var item = result.Value!.Items[index];
+
+            item.InvoiceType.Should().Be(type, $"of {orderId}");
+            item.PeriodKey.Should().Be(periodKey, $"of {orderId}");
+        }
     }
 
     private SubscriptionInvoiceHistoryService Service() => new(

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -225,6 +225,126 @@ public sealed class SubscriptionPlanChangeServiceTests
     }
 
     [Fact]
+    public async Task A_price_restricted_promotion_refuses_a_move_it_does_not_cover()
+    {
+        // The hole this closes: applicability was checked once, at redemption, and a plan change kept
+        // the discount without asking again — so a code sold as monthly-only went on reducing the
+        // annual price it was never offered for.
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "monthly8",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 800,
+            ApplicablePriceIds = ["price-monthly"]
+        };
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_not_applicable");
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        _subscriptions.Verify(repository => repository.TryChangePlanAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(),
+            It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
+            It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(),
+            It.IsAny<PendingUsagePeriod>(), It.IsAny<long>(), It.IsAny<string?>(),
+            It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A_plan_restricted_promotion_refuses_a_move_to_another_plan()
+    {
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "basiconly",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 800,
+            ApplicablePlanCodes = ["basic"]
+        };
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_not_applicable");
+    }
+
+    [Fact]
+    public async Task A_promotion_that_covers_the_target_moves_with_the_subscriber()
+    {
+        // The other half: a restriction naming where they are going must not block them.
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "premium8",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 800,
+            ApplicablePlanCodes = ["premium"],
+            ApplicablePriceIds = ["price-2"]
+        };
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_unrestricted_promotion_moves_with_the_subscriber()
+    {
+        // Every discount authored before either restriction existed is this shape. A plan change must
+        // not start refusing them.
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "anything",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 800
+        };
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_spent_promotion_does_not_block_a_move_it_no_longer_pays_for()
+    {
+        // Three months of "8% off", all three used. It reduces nothing now, so enforcing where it
+        // could once have been redeemed would be blocking a plan change over an offer that has ended.
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "monthly8",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 800,
+            DurationPeriods = 3,
+            ApplicablePriceIds = ["price-monthly"]
+        };
+        _subscription.DiscountPeriodsApplied = 3;
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_expired_promotion_does_not_block_a_move_either()
+    {
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "monthly8",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 800,
+            ExpiresAtUtc = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+            ApplicablePriceIds = ["price-monthly"]
+        };
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task A_change_snapshots_the_target_prices_automatic_discount()
     {
         // Moving onto the yearly price is how a subscriber gets its 8%. The snapshot is what makes it

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -345,6 +345,61 @@ public sealed class SubscriptionPlanChangeServiceTests
     }
 
     [Fact]
+    public async Task A_reserved_change_records_how_its_charge_was_arrived_at()
+    {
+        // Recorded on the reservation, which is what a replay repeats and what the payment record is
+        // built from. Recomputing it when the charge settles would price it at a different instant,
+        // and possibly against an edited catalogue — an explanation of a charge nobody was quoted.
+        var price = NewPrice(2_000);
+        price.AutomaticDiscountBasisPoints = 800;
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(price);
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _reserved.Should().NotBeNull();
+
+        var settlement = _reserved!.Settlement;
+        settlement.Should().NotBeNull();
+        settlement!.Outgoing.GrossAmountMinor.Should().Be(1_000);
+        settlement.Outgoing.BuiltInDiscountMinor.Should().Be(0);
+        settlement.Target.GrossAmountMinor.Should().Be(2_000);
+        settlement.Target.BuiltInDiscountMinor.Should().Be(160, "8% of the target price");
+        settlement.NetSettlementMinor.Should().Be(_reserved.ChargeAmountMinor);
+    }
+
+    [Fact]
+    public async Task The_settlement_charge_carries_the_reservations_breakdown()
+    {
+        // One hop further: the charge the gateway records has to be the reservation's own account of
+        // itself, not a fresh calculation.
+        SubscriptionChargeRequest? charged = null;
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionChargeRequest request, string _, string __, CancellationToken ___) =>
+                charged = request)
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+
+        await Service().ChangePlanAsync("sub-1", Request(), "corr-1", CancellationToken.None);
+
+        charged.Should().NotBeNull();
+        charged!.Settlement.Should().BeSameAs(_reserved!.Settlement);
+
+        // And none of the renewal-shaped fields, which would describe this charge as a discounted
+        // price rather than a difference between two of them.
+        charged.GrossAmountMinor.Should().Be(0);
+        charged.BuiltInDiscountMinor.Should().Be(0);
+    }
+
+    [Fact]
     public async Task A_change_snapshots_the_target_prices_automatic_discount()
     {
         // Moving onto the yearly price is how a subscriber gets its 8%. The snapshot is what makes it

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -225,6 +225,41 @@ public sealed class SubscriptionPlanChangeServiceTests
     }
 
     [Fact]
+    public async Task A_change_snapshots_the_target_prices_automatic_discount()
+    {
+        // Moving onto the yearly price is how a subscriber gets its 8%. The snapshot is what makes it
+        // theirs to keep: clearing the catalogue's discount afterwards must not raise their renewal.
+        var price = NewPrice(2_000);
+        price.AutomaticDiscountBasisPoints = 800;
+        price.QuantityDiscountCombination = AutomaticDiscountCombination.Additive;
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(price);
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _subscriptions.Verify(repository => repository.TryChangePlanAsync(
+            TenantId,
+            "sub-1",
+            It.IsAny<int>(),
+            It.IsAny<string?>(),
+            It.IsAny<PlanSnapshot>(),
+            It.Is<PriceSnapshot>(snapshot =>
+                snapshot.AutomaticDiscountBasisPoints == 800 &&
+                snapshot.QuantityDiscountCombination == AutomaticDiscountCombination.Additive),
+            It.IsAny<List<SubscriptionQuantityItem>>(),
+            It.IsAny<SubscriptionPlanSchedule>(),
+            It.IsAny<PendingUsagePeriod>(),
+            It.IsAny<long>(),
+            It.IsAny<string?>(),
+            It.IsAny<SubscriptionOutboxEvent>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Annual_to_monthly_rebuilds_the_fee_schedule_in_the_other_direction()
     {
         _subscription.Price.Interval = BillingInterval.Year;

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -373,6 +373,59 @@ public sealed class SubscriptionPlanChangeServiceTests
     }
 
     [Fact]
+    public async Task A_plan_change_charges_under_an_order_id_that_says_so()
+    {
+        // Both settlement kinds used to share the "quantity:" form, so invoice history classified a
+        // plan-change invoice as a renewal and handed the client a reservation id where a period key
+        // belongs. The id is what history reads, so this is where the fix has to hold.
+        SubscriptionChargeRequest? charged = null;
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionChargeRequest request, string _, string __, CancellationToken ___) =>
+                charged = request)
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+
+        await Service().ChangePlanAsync("sub-1", Request(), "corr-1", CancellationToken.None);
+
+        charged!.OrderId.Should().Be(SubscriptionConstants.SettlementOrderIdFor(
+            "sub-1", SettlementReservationKind.PlanChange, _reserved!.ReservationId));
+        // Named through the constants rather than spelled out, so shortening a segment cannot leave
+        // this test asserting something the code no longer writes.
+        charged.OrderId.Should().Contain(
+            $":{SubscriptionConstants.PlanChangeSegment}:");
+        charged.OrderId.Should().NotContain(
+            $":{SubscriptionConstants.QuantitySegment}:",
+            "this is not a quantity change, and history reads the kind out of this string");
+    }
+
+    [Fact]
+    public async Task The_charge_is_still_keyed_on_the_reservation_alone()
+    {
+        // The order id gained the kind; the *idempotency* key deliberately did not. A reservation
+        // taken before that change and replayed after it has to find its own attempt rather than
+        // raising a second charge, and the key is what finds it.
+        string? key = null;
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionChargeRequest _, string idempotencyKey, string __, CancellationToken ___) =>
+                key = idempotencyKey)
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+
+        await Service().ChangePlanAsync("sub-1", Request(), "corr-1", CancellationToken.None);
+
+        key.Should().Be(
+            SubscriptionConstants.SettlementChargeKeyFor("sub-1", _reserved!.ReservationId));
+    }
+
+    [Fact]
     public async Task The_settlement_charge_carries_the_reservations_breakdown()
     {
         // One hop further: the charge the gateway records has to be the reservation's own account of

--- a/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
@@ -215,6 +215,109 @@ public sealed class SubscriptionProrationCalculatorTests
         outcome.ChargeMinor.Should().Be(1_100, "the same answer as before modes existed");
     }
 
+    [Fact]
+    public void A_settlement_reports_both_sides_it_was_subtracted_from()
+    {
+        // The figure a subscriber queries is a remainder, and a remainder cannot explain itself. Both
+        // priced periods and both prorated values are reported so an invoice can show the subtraction
+        // rather than only its answer.
+        var subscription = NewSubscription(oldAmountMinor: 1_000);
+        subscription.Price.AutomaticDiscountBasisPoints = 1_000;
+        subscription.Price.TaxRateBasisPoints = 1_000;
+        subscription.Price.TaxMode = TaxMode.Exclusive;
+
+        var targetPrice = NewPrice(2_000);
+        targetPrice.AutomaticDiscountBasisPoints = 800;
+        targetPrice.TaxRateBasisPoints = 1_000;
+        targetPrice.TaxMode = TaxMode.Exclusive;
+
+        var halfway = PeriodStart.AddDays(15);
+        var outcome = Calculate(subscription, targetPrice, [], halfway);
+
+        var outgoing = outcome.Breakdown.Outgoing;
+        var target = outcome.Breakdown.Target;
+
+        // Outgoing: 1,000 less 10% is 900, plus 10% tax is 990 for the period.
+        outgoing.GrossAmountMinor.Should().Be(1_000);
+        outgoing.BuiltInDiscountMinor.Should().Be(100);
+        outgoing.PromotionalDiscountMinor.Should().Be(0);
+        outgoing.TaxAmountMinor.Should().Be(90);
+        outgoing.PeriodTotalMinor.Should().Be(990);
+
+        // Target: 2,000 less 8% is 1,840, plus 10% tax is 2,024.
+        target.GrossAmountMinor.Should().Be(2_000);
+        target.BuiltInDiscountMinor.Should().Be(160);
+        target.TaxAmountMinor.Should().Be(184);
+        target.PeriodTotalMinor.Should().Be(2_024);
+
+        // Each side's own rate reaches its own proration, and the charge is the difference between
+        // the two prorated values — not a percentage of anything.
+        outcome.ChargeMinor.Should().Be(
+            target.ProratedValueMinor - outgoing.ProratedValueMinor);
+        outcome.Breakdown.NetSettlementMinor.Should().Be(outcome.ChargeMinor);
+    }
+
+    [Fact]
+    public void A_settlement_reports_the_credit_it_actually_spent()
+    {
+        var subscription = NewSubscription(oldAmountMinor: 1_000, creditBalanceMinor: 300);
+        var targetPrice = NewPrice(2_000);
+
+        var outcome = Calculate(subscription, targetPrice, [], PeriodStart);
+
+        outcome.Breakdown.CreditConsumedMinor.Should().Be(300);
+        outcome.ChargeMinor.Should().Be(700, "1,000 of difference less the 300 banked");
+        outcome.Breakdown.NetSettlementMinor.Should().Be(700);
+    }
+
+    [Fact]
+    public void A_downgrade_spends_no_credit_and_says_so()
+    {
+        // The delta is negative: nothing is charged and the balance grows. Reporting the whole
+        // balance as "consumed" would describe money that was not spent.
+        var subscription = NewSubscription(oldAmountMinor: 2_000, creditBalanceMinor: 300);
+        var targetPrice = NewPrice(1_000);
+
+        var outcome = Calculate(subscription, targetPrice, [], PeriodStart.AddDays(15));
+
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.Breakdown.CreditConsumedMinor.Should().Be(0);
+        outcome.Breakdown.NetSettlementMinor.Should().BeNegative();
+        outcome.NewCreditBalanceMinor.Should().BeGreaterThan(300);
+    }
+
+    [Fact]
+    public void A_promotion_appears_on_the_side_it_reduced()
+    {
+        var subscription = NewSubscription(
+            oldAmountMinor: 1_000,
+            discount: new DiscountTerms
+            {
+                Code = "half",
+                Kind = DiscountKind.Percent,
+                PercentBasisPoints = 5_000
+            });
+        var targetPrice = NewPrice(2_000);
+
+        var outcome = Calculate(subscription, targetPrice, [], PeriodStart);
+
+        // The subscriber's own code applies to both sides — it belongs to them, not to a price.
+        outcome.Breakdown.Outgoing.PromotionalDiscountMinor.Should().Be(500);
+        outcome.Breakdown.Target.PromotionalDiscountMinor.Should().Be(1_000);
+    }
+
+    [Fact]
+    public void A_malformed_period_reports_no_breakdown_rather_than_zeroes()
+    {
+        // Nothing was prorated, so there are no two sides. Zeroes would claim both periods were free.
+        var subscription = NewSubscription(oldAmountMinor: 1_000);
+        subscription.CurrentPeriodEndUtc = subscription.CurrentPeriodStartUtc;
+
+        var outcome = Calculate(subscription, NewPrice(2_000), [], PeriodStart);
+
+        outcome.Breakdown.Should().Be(default(ProrationBreakdown));
+    }
+
     private static SubscriptionDetail NewSubscription(
         long oldAmountMinor,
         long creditBalanceMinor = 0,

--- a/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
@@ -270,7 +270,11 @@ public sealed class SubscriptionQuantityChangeServiceTests
         // after a concurrent change would build a different key and charge a second time.
         key.Should().Be(SubscriptionConstants.SettlementChargeKeyFor("sub-1", _reservation!.ReservationId));
         orderId.Should().Be(
-            SubscriptionConstants.SettlementOrderIdFor("sub-1", _reservation.ReservationId));
+            SubscriptionConstants.SettlementOrderIdFor(
+                "sub-1", SettlementReservationKind.QuantityIncrease, _reservation.ReservationId));
+        orderId.Should().Contain(
+            $":{SubscriptionConstants.QuantitySegment}:",
+            "invoice history reads the kind back out of the order id");
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
@@ -471,6 +471,71 @@ public sealed class SubscriptionRenewalServiceTests
         scheduler.VerifyNoOtherCalls();
     }
 
+    [Fact]
+    public async Task A_renewal_charge_carries_the_whole_discount_breakdown()
+    {
+        // Recorded so an invoice can explain itself later. One combined "something came off" cannot
+        // be turned back into which of the three reductions produced it, and that is the question
+        // somebody reading a months-old invoice actually has.
+        SubscriptionChargeRequest? charged = null;
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionChargeRequest request, string _, string __, CancellationToken ___) =>
+                charged = request)
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+
+        var subscription = NewSubscription(SubscriptionStatus.Active);
+        subscription.Price.UnitAmountMinor = 100_000;
+        subscription.Price.AutomaticDiscountBasisPoints = 800;
+        subscription.Price.QuantityDiscountCombination = AutomaticDiscountCombination.Additive;
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "extra10",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 1_000
+        };
+        subscription.Plan.QuantityDiscountCombinationPolicy =
+            QuantityDiscountCombinationPolicy.Stack;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        charged.Should().NotBeNull();
+        charged!.GrossAmountMinor.Should().Be(100_000);
+        charged.BuiltInDiscountMinor.Should().Be(8_000);
+        charged.PromotionalDiscountMinor.Should().Be(9_200, "10% of what the 8% left");
+        charged.AutomaticDiscountBasisPoints.Should().Be(800);
+        charged.DiscountCombination.Should().Be("Additive");
+        charged.AmountMinor.Should().Be(82_800);
+    }
+
+    [Fact]
+    public async Task An_undiscounted_renewal_still_states_its_gross()
+    {
+        // Gross is what tells a reader "nothing came off" apart from "this predates the breakdown".
+        SubscriptionChargeRequest? charged = null;
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionChargeRequest request, string _, string __, CancellationToken ___) =>
+                charged = request)
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+
+        await Service().RenewAsync(NewSubscription(SubscriptionStatus.Active), CancellationToken.None);
+
+        charged!.GrossAmountMinor.Should().Be(8_900);
+        charged.BuiltInDiscountMinor.Should().Be(0);
+        charged.PromotionalDiscountMinor.Should().Be(0);
+        charged.AutomaticDiscountBasisPoints.Should().BeNull();
+        charged.DiscountCombination.Should().BeNull();
+    }
+
     private static SubscriptionDetail NewSubscription(SubscriptionStatus status) => new()
     {
         ItemId = "sub-1",

--- a/server/XUnitTest/Subscription/SubscriptionSettlementReservationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSettlementReservationProcessorTests.cs
@@ -190,7 +190,9 @@ public sealed class SubscriptionSettlementReservationProcessorTests
                 It.Is<SubscriptionChargeRequest>(request =>
                     request.AmountMinor == 5_437 &&
                     request.OrderId == SubscriptionConstants.SettlementOrderIdFor(
-                        "sub-1", ReservationId)),
+                        "sub-1",
+                        SettlementReservationKind.QuantityIncrease,
+                        ReservationId)),
                 ChargeKey,
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -256,6 +256,52 @@ public sealed class SubscriptionUsageRatingProcessorTests
     }
 
     [Fact]
+    public async Task Overage_is_discounted_by_the_prices_automatic_discount_before_tax()
+    {
+        // Overage is a charge the price produces, so the price's own discount reaches it. Before tax,
+        // because tax is owed on what is actually charged.
+        var subscription = NewSubscription("sub-1");
+        subscription.Price.AutomaticDiscountBasisPoints = 800;
+        subscription.Price.TaxRateBasisPoints = 1_000;
+        subscription.Price.TaxMode = TaxMode.Exclusive;
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 700)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        // 2,000 of overage, 8% off is 160, leaving 1,840 to tax at 10%.
+        _createdInvoice!.Lines.Sum(line => line.AmountMinor).Should().Be(2_000,
+            "the lines say what was used; the discount is on the invoice, not inside a meter");
+        _createdInvoice.DiscountAmountMinor.Should().Be(160);
+        _createdInvoice.AutomaticDiscountBasisPoints.Should().Be(800);
+        _createdInvoice.NetAmountMinor.Should().Be(1_840);
+        _createdInvoice.TaxAmountMinor.Should().Be(184);
+        _createdInvoice.TotalAmountMinor.Should().Be(2_024);
+    }
+
+    [Fact]
+    public async Task Overage_on_a_price_without_an_automatic_discount_is_unchanged()
+    {
+        // Every metered plan that exists today is this shape, and its overage invoices must come out
+        // to the same figure they always did.
+        var subscription = NewSubscription("sub-1");
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 700)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        _createdInvoice!.TotalAmountMinor.Should().Be(2_000);
+        _createdInvoice.DiscountAmountMinor.Should().Be(0);
+        _createdInvoice.AutomaticDiscountBasisPoints.Should().BeNull();
+    }
+
+    [Fact]
     public async Task An_existing_invoice_is_not_recreated()
     {
         _due = [NewSubscription("sub-1")];

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -280,6 +280,10 @@ public sealed class SubscriptionUsageRatingProcessorTests
         _createdInvoice.NetAmountMinor.Should().Be(1_840);
         _createdInvoice.TaxAmountMinor.Should().Be(184);
         _createdInvoice.TotalAmountMinor.Should().Be(2_024);
+
+        // No band takes part in metered usage, so the invoice records the rate that applied and no
+        // combination — rather than naming one it never used.
+        _createdInvoice.AutomaticDiscountBasisPoints.Should().Be(800);
     }
 
     [Fact]


### PR DESCRIPTION
Adds an automatic percentage discount to every plan price, so a monthly and a yearly price under one plan can be discounted differently without a code.

## What this is

A price can now reduce itself:

```json
{ "automaticDiscountBasisPoints": 800, "quantityDiscountCombination": "Additive" }
```

Pro Monthly carries nothing, Pro Yearly carries 8%, and both stay prices on one plan rather than two products. It lives on the **price**, not the plan, because the offer is cadence-specific — and because a plan sold in two currencies has two prices that may not be discounted alike.

## Two combinations, because there are two questions

Three reductions can now land on one charge, and the interesting design decision is that they are not one negotiation:

- **`BuiltInDiscountCalculator`** settles the two the *merchant* authored — the price's own discount and the volume band the quantity selects — the way the **price** says. `BestDiscount` takes whichever reduces the charge by more money and only that one; `Additive` adds the rates and applies the sum once, so 8% + 5% is **13%**, not the 12.6% that applying one after the other gives. Capped at 100%, because no charge may arrive negative.
- The plan's existing **`QuantityDiscountCombinationPolicy`** then settles what a *redeemed code* adds to that result, exactly as it already settled band-versus-code. `QuantityOnly` now means "built-in discounts only" — the stored wire value is unchanged, so an existing plan means what it always did.

Collapsing the two would make "8% for paying yearly" negotiate with a coupon, which is not a question anybody authoring a catalogue is asking.

A promotion that loses is still not consumed, and that now includes losing to an automatic discount: three months of "2% off" are not spent on periods where the price's own 8% was larger.

## Order of operations

**gross → built-in discount → promotional code → tax → credit.** Tax after the discounts because tax is owed on what is actually charged; credit last because a credit pays a bill without changing what the bill was for. One calculator serves checkout, renewal, quantity preview, plan-change proration, simulation and usage overage, so no two paths can disagree about the same charge.

Discounts **truncate** to the minor unit — the direction that favours the subscriber, and the one the existing volume bands already took. A price with **no** automatic discount goes through the new calculator and comes out with its band's own arithmetic untouched to the minor unit, which is the state every stored price is in. There is no repricing of anything already sold.

## Snapshots, and what an edit can reach

Both fields are snapshotted at signup and at plan change, like the amount and the tax. `PUT /api/subscription-plans/prices/{priceId}/discount` sets or clears the discount for **future subscriptions and future moves onto the price**; nobody already on it is repriced in either direction. A plan change snapshots the *target* price's discount and prorates both sides at their own.

Metered overage is charged by the price the subscription was sold on, so the automatic discount reaches an overage invoice too, before its tax. A volume band does not — it prices units of a quantity item and a meter has none — and a promotional code still does not reach usage invoices at all. That asymmetry is deliberate and documented rather than incidental.

## Promotional codes gain price applicability

`applicablePriceIds` beside the existing `applicablePlanCodes`. The two lists **narrow** rather than offering two ways to qualify: with both set, both have to match, so a code aimed at the yearly price is refused on the monthly one with `subscription_discount_not_applicable`. Discounts stored before this carry no price list and stay unrestricted by price.

## What a caller can now see

Subscription responses, quantity previews and overage invoices report the automatic rate, the combination, the gross, the built-in reduction, the promotional reduction and the amount that was then taxed — reported rather than left to be reverse-engineered, since recovering a discount from a total means knowing which combination produced it. Signup writes one financial log line naming the price, the rates, the policies and the reductions, with identifiers hashed the way the rest of this module hashes them.

Provider invoice lines continue to show the discounted subtotal rather than a separate discount line: the lines have to add up to what was charged, and a gross line plus a reduction line is a different invoice shape than this module writes.

## UI

Each price card in the plan builder gains **Automatic discount (%)** and **Combine with quantity discount**, plus a preview that prices the *default quantity* through the band that quantity selects and then taxes what is left. The preview is the point — an author choosing between "use the better discount" and "add the percentages" cannot otherwise see that the two answers differ by real money, and finding out on a customer's first invoice is the expensive way to learn which one they picked. Existing prices get an editor beside the tax one, worded so it is clear it reaches future subscriptions only.

The discount catalogue replaces its comma-separated plan-code box with plan and price selectors, the price list filtered by the plans chosen, and each catalogue row states what it applies to in words rather than identifiers.

## Verification

- Server unit suite **2526 passing**. The 4 `SubscriptionSimulation*` permission-guard failures are pre-existing on `dev` and untouched.
- New: `AutomaticPriceDiscountTests` (24) covering both combinations, the 100% cap, the untouched no-discount path, all three promotion policies, tax ordering in both modes, credit last, and a reconciliation property — gross less both reductions is what was taxed, plus tax less credit is what was charged. Plus price applicability and snapshotting in the creation, plan-change, catalogue and usage-rating suites.
- Client: typecheck clean, production build succeeds, `app/cross-modules` **827 passing**. Six unrelated test files fail to transform an SVG asset — verified failing on `dev` too.

## Open question

Metered overage now carries the price's automatic discount. The spec said "usage charges where applicable" and the assumption that all charges associated with the price use its configuration, so this reads as intended — but it is the one place where a percentage authored for a recurring fee reaches a usage-rated line, and it is easy to reverse if that is not wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
