### PR TITLE
Calendar-aligned monthly billing with a prorated first period

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-alignment.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-alignment.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+import type { ReactNode } from "react";
+
+import type { PlanPrice } from "../../models/subscription-plan.model";
+import {
+  defaultSubscriptionPlanFormValues,
+  type CreateSubscriptionPlanFormValues,
+} from "../../schemas/subscription-plan.schema";
+import { PlanPriceFields } from "./plan-price-fields";
+
+const Harness = ({ children }: { children: ReactNode }) => {
+  const form = useForm<CreateSubscriptionPlanFormValues>({
+    defaultValues: defaultSubscriptionPlanFormValues,
+  });
+
+  return <FormProvider {...form}>{children}</FormProvider>;
+};
+
+const renderFields = () =>
+  render(
+    <Harness>
+      <PlanPriceFields />
+    </Harness>,
+  );
+
+describe("the billing cycle field", () => {
+  it("is offered for a monthly price, which is the default cadence", () => {
+    renderFields();
+
+    expect(screen.getByLabelText("Billing cycle for price 1")).toBeInTheDocument();
+  });
+
+  it("starts on the anniversary, so an author who ignores it changes nothing", () => {
+    renderFields();
+
+    expect(screen.getByLabelText("Billing cycle for price 1")).toHaveTextContent(
+      "Subscription anniversary",
+    );
+  });
+
+  /**
+   * Hidden rather than disabled. A greyed-out "renew on the 1st" invites the question of how to
+   * enable it, and the answer is to sell a different cadence.
+   */
+  it("disappears once the cadence can no longer carry it", async () => {
+    const user = userEvent.setup();
+    renderFields();
+
+    const howMany = screen.getByRole("spinbutton", { name: /how many/i });
+    await user.clear(howMany);
+    await user.type(howMany, "3");
+
+    expect(screen.queryByLabelText("Billing cycle for price 1")).not.toBeInTheDocument();
+  });
+
+  it("shows the worked example only once the calendar is actually chosen", async () => {
+    const user = userEvent.setup();
+    renderFields();
+
+    expect(screen.queryByTestId("billing-alignment-example-0")).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Billing cycle for price 1"));
+    await user.click(screen.getByRole("option", { name: /renew on the 1st/i }));
+
+    expect(screen.getByTestId("billing-alignment-example-0")).toHaveTextContent(
+      "A signup on August 25 pays 7/31 of this monthly price, then renews on September 1.",
+    );
+  });
+});
+
+describe("an existing price on the plan", () => {
+  const price = (overrides: Partial<PlanPrice> = {}): PlanPrice => ({
+    priceId: "price-1",
+    currencyCode: "EUR",
+    unitAmountMinor: 1_200,
+    interval: "Month",
+    intervalCount: 1,
+    quantityItemKey: null,
+    ...overrides,
+  });
+
+  it("says when a calendar-aligned one renews", () => {
+    render(
+      <Harness>
+        <PlanPriceFields
+          isEditing
+          existingPrices={[price({ billingAlignment: "CalendarMonth" })]}
+        />
+      </Harness>,
+    );
+
+    expect(screen.getByText(/every month, on the 1st/)).toBeInTheDocument();
+  });
+
+  it("says nothing extra about an anniversary one", () => {
+    render(
+      <Harness>
+        <PlanPriceFields isEditing existingPrices={[price()]} />
+      </Harness>,
+    );
+
+    expect(screen.getByText(/€12\.00 every month/)).toBeInTheDocument();
+    expect(screen.queryByText(/on the 1st/)).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -577,8 +577,10 @@ export const PlanPriceFields = ({
           <p className="mt-2 text-xs text-muted-foreground">
             Retiring stops a price being sold. Anyone already on it keeps their terms and their
             renewals — a subscription bills from what it was sold on, not from this list. Prices
-            keep immutable amount and cadence terms; only tax and automatic-discount metadata can be
-            edited, and only for future subscriptions and future moves onto the price.
+            keep immutable amount, cadence and billing-cycle terms; only tax and
+            automatic-discount metadata can be edited, and only for future subscriptions and future
+            moves onto the price. To move a plan onto a different billing cycle, add a new price and
+            retire this one.
           </p>
         </div>
       )}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui-kits/select/select";
 import {
+  BILLING_ALIGNMENT_OPTIONS,
   BILLING_INTERVAL_OPTIONS,
   SUBSCRIPTION_CURRENCY_OPTIONS,
 } from "../../constants/subscription.constants";
@@ -27,6 +28,10 @@ import {
   defaultSubscriptionPriceFormValues,
   FLAT_FEE,
 } from "../../schemas/subscription-price.schema";
+import {
+  CALENDAR_ALIGNMENT_EXAMPLE,
+  isCalendarEligible,
+} from "../../utilities/billing-alignment";
 import { formatPrice } from "../../utilities/subscription-format";
 import {
   AUTOMATIC_DISCOUNT_COMBINATION_OPTIONS,
@@ -418,6 +423,73 @@ const PriceDiscountFields = ({ index }: { index: number }) => {
 };
 
 /**
+ * When this price renews, for the one cadence that gets a choice.
+ *
+ * Hidden rather than disabled for every other cadence. A greyed-out "renew on the 1st" invites the
+ * question of how to enable it, and the answer — change the cadence you are selling — is not a
+ * setting on this control.
+ *
+ * Its own component because it watches two fields of this row; watching them in the list body
+ * would re-render every price card whenever either changed.
+ */
+const PriceBillingAlignmentField = ({ index }: { index: number }) => {
+  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const price = useWatch({ control, name: `prices.${index}` });
+
+  if (
+    !price ||
+    !isCalendarEligible({
+      interval: Number(price.interval),
+      intervalCount: Number(price.intervalCount),
+    })
+  ) {
+    return null;
+  }
+
+  return (
+    <FormField
+      control={control}
+      name={`prices.${index}.billingAlignment`}
+      render={({ field: inputField }) => (
+        <FormItem>
+          <FormLabel className="text-xs">Billing cycle</FormLabel>
+          <Select value={inputField.value} onValueChange={inputField.onChange}>
+            <FormControl>
+              <SelectTrigger aria-label={`Billing cycle for price ${index + 1}`}>
+                <SelectValue />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {BILLING_ALIGNMENT_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormDescription className="text-xs">
+            {
+              BILLING_ALIGNMENT_OPTIONS.find(
+                (option) => option.value === inputField.value,
+              )?.hint
+            }
+          </FormDescription>
+          {inputField.value === "CalendarMonth" && (
+            <p
+              className="text-xs text-muted-foreground"
+              data-testid={`billing-alignment-example-${index}`}
+            >
+              {CALENDAR_ALIGNMENT_EXAMPLE}
+            </p>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
+/**
  * The prices the plan will be sold on. A repeatable list rather than one price, because the
  * ordinary case is more than one — a monthly and an annual price are two prices on the same plan,
  * and so is the same plan sold in two currencies.
@@ -605,6 +677,8 @@ export const PlanPriceFields = ({
                 )}
               />
             </div>
+
+            <PriceBillingAlignmentField index={index} />
 
             <FormField
               control={control}

--- a/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
+++ b/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
@@ -13,6 +13,23 @@ export const BILLING_INTERVAL_OPTIONS = [
   { value: 3, label: "Year" },
 ] as const;
 
+/**
+ * The two answers to "when does this renew". Shown only for a price billed every single month,
+ * because that is the only cadence the server will align to a calendar.
+ */
+export const BILLING_ALIGNMENT_OPTIONS = [
+  {
+    value: "Anniversary",
+    label: "Subscription anniversary",
+    hint: "Renews on the day of the month they subscribed.",
+  },
+  {
+    value: "CalendarMonth",
+    label: "Calendar month — renew on the 1st",
+    hint: "The first period is prorated to the days remaining in the month.",
+  },
+] as const;
+
 export const METER_AGGREGATION_OPTIONS = [
   { value: 0, label: "Sum — add up every recorded amount" },
   { value: 1, label: "Max — the highest single recording" },

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -35,6 +35,14 @@ export const ENTITLEMENT_LIMIT_KIND_NAMES = ["Boolean", "Count", "Unlimited"] as
 
 export const BILLING_INTERVAL_NAMES = ["Day", "Week", "Month", "Year"] as const;
 
+/**
+ * Where a price puts its renewal boundary. Sent and returned as the name, never an index: a client
+ * that has to know `1` means the calendar is coupled to the server's storage format.
+ */
+export const BILLING_ALIGNMENT_NAMES = ["Anniversary", "CalendarMonth"] as const;
+
+export type BillingAlignmentName = (typeof BILLING_ALIGNMENT_NAMES)[number];
+
 export type BillingIntervalName = keyof typeof BILLING_INTERVAL;
 export type MeterAggregationName = keyof typeof METER_AGGREGATION;
 export type MeterResetPolicyName = keyof typeof METER_RESET_POLICY;
@@ -124,6 +132,12 @@ export interface PlanPrice {
   /** Response DTOs carry this as a string name (e.g. "Month"); requests send the numeric value. */
   interval: BillingIntervalName;
   intervalCount: number;
+  /**
+   * "Anniversary" renews on the day the subscriber signed up; "CalendarMonth" renews on the 1st
+   * after a prorated opening period. Absent on responses from a server that predates alignment,
+   * which only ever sold anniversary prices.
+   */
+  billingAlignment?: BillingAlignmentName;
   displayPriceNote?: string | null;
   quantityItemKey: string | null;
   /** Basis points — 770 is 7.7%. Absent when the price carries no tax. */
@@ -278,6 +292,8 @@ export interface CreateSubscriptionPriceRequest {
   unitAmountMinor: number;
   interval: number;
   intervalCount: number;
+  /** Omitted means "Anniversary". Only a monthly price billed once a month may be calendar-aligned. */
+  billingAlignment?: BillingAlignmentName;
   displayPriceNote?: string;
   quantityItemKey?: string;
   /** Basis points. Omitted for an untaxed price; the mode is required whenever this is positive. */

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { AUTOMATIC_DISCOUNT_COMBINATIONS } from "../utilities/subscription-discount";
+import { BILLING_ALIGNMENT_NAMES } from "../models/subscription-plan.model";
 import { TAX_MODES } from "../utilities/subscription-tax";
 
 /**
@@ -25,6 +26,15 @@ export const subscriptionPriceFieldsSchema = z.object({
   amount: z.coerce.number().min(0, "Enter an amount of zero or more."),
   interval: z.coerce.number().int().min(0).max(3),
   intervalCount: z.coerce.number().int().min(1).max(36),
+  /**
+   * Where renewals land. Defaulted rather than required, because "unstated" already means
+   * anniversary everywhere else — on the server, and on every price authored before this existed.
+   *
+   * Not validated against the cadence here. The field is only shown for a monthly price billed
+   * once a month, and submit sends it only for that cadence, so an author cannot produce the
+   * invalid combination through this form; the server refuses it regardless.
+   */
+  billingAlignment: z.enum(BILLING_ALIGNMENT_NAMES).default("Anniversary"),
   displayPriceNote: z.string().trim().max(200).optional().or(z.literal("")),
   quantityItemKey: z.string().min(1),
   /**
@@ -84,6 +94,9 @@ export const defaultSubscriptionPriceFormValues: CreateSubscriptionPriceFormValu
   amount: 0,
   interval: 2,
   intervalCount: 1,
+  // Anniversary by default, so an author who never opens this section sells the price they always
+  // would have.
+  billingAlignment: "Anniversary",
   displayPriceNote: "",
   quantityItemKey: FLAT_FEE,
   taxPercent: undefined,

--- a/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { isCalendarEligible } from "./billing-alignment";
+import { defaultSubscriptionPriceFormValues } from "../schemas/subscription-price.schema";
+import { createSubscriptionPriceSchema } from "../schemas/subscription-price.schema";
+
+describe("isCalendarEligible", () => {
+  it("accepts a price billed every single month", () => {
+    expect(isCalendarEligible({ interval: 2, intervalCount: 1 })).toBe(true);
+  });
+
+  it.each([
+    ["quarterly", 2, 3],
+    ["annually as twelve months", 2, 12],
+    ["daily", 0, 1],
+    ["fortnightly", 1, 2],
+    ["yearly", 3, 1],
+  ])("refuses %s, which has no single first to renew on", (_label, interval, intervalCount) => {
+    expect(isCalendarEligible({ interval, intervalCount })).toBe(false);
+  });
+});
+
+describe("the price schema's alignment field", () => {
+  it("defaults to the anniversary, so an author who ignores it changes nothing", () => {
+    expect(defaultSubscriptionPriceFormValues.billingAlignment).toBe("Anniversary");
+  });
+
+  it("reads an omitted alignment as the anniversary", () => {
+    const parsed = createSubscriptionPriceSchema.parse({
+      currencyCode: "chf",
+      amount: 89,
+      interval: 2,
+      intervalCount: 1,
+      quantityItemKey: "seat",
+    });
+
+    expect(parsed.billingAlignment).toBe("Anniversary");
+  });
+
+  it("keeps a calendar alignment the author chose", () => {
+    const parsed = createSubscriptionPriceSchema.parse({
+      currencyCode: "CHF",
+      amount: 89,
+      interval: 2,
+      intervalCount: 1,
+      quantityItemKey: "seat",
+      billingAlignment: "CalendarMonth",
+    });
+
+    expect(parsed.billingAlignment).toBe("CalendarMonth");
+  });
+
+  it("rejects an alignment it has never heard of", () => {
+    const result = createSubscriptionPriceSchema.safeParse({
+      currencyCode: "CHF",
+      amount: 89,
+      interval: 2,
+      intervalCount: 1,
+      quantityItemKey: "seat",
+      billingAlignment: "FinancialQuarter",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.ts
@@ -1,0 +1,27 @@
+import { BILLING_INTERVAL } from "../models/subscription-plan.model";
+
+/**
+ * Whether a price's cadence can be aligned to the calendar at all.
+ *
+ * Monthly, once a month, and nothing else — the same rule the server validates. A fortnight and a
+ * quarter both have boundaries that only sometimes land on a first, so there is no honest "the
+ * 1st" to offer an author for them.
+ *
+ * Takes the numeric interval the form holds rather than the name a response carries, because this
+ * decides what the plan builder shows while it is being filled in.
+ */
+export const isCalendarEligible = (price: {
+  interval: number;
+  intervalCount: number;
+}): boolean =>
+  price.interval === BILLING_INTERVAL.Month && price.intervalCount === 1;
+
+/**
+ * The worked example an author needs to believe the arithmetic.
+ *
+ * A percentage is not enough on its own: "prorated" describes a dozen different rules, and the one
+ * that matters here is that the days are calendar dates counted inclusively. Showing the fraction
+ * against a real date is the shortest way to say that.
+ */
+export const CALENDAR_ALIGNMENT_EXAMPLE =
+  "A signup on August 25 pays 7/31 of this monthly price, then renews on September 1.";

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -205,6 +205,10 @@ const planPriceToFormValues = (price: PlanPrice): CreateSubscriptionPriceFormVal
   amount: toMajorUnits(price.unitAmountMinor, price.currencyCode),
   interval: BILLING_INTERVAL[price.interval] ?? BILLING_INTERVAL.Month,
   intervalCount: price.intervalCount,
+  // Absent means anniversary, which is both the server's default and what every price authored
+  // before alignment existed was sold on. Reading it as anything else would silently re-anchor a
+  // duplicated price onto a calendar its original never used.
+  billingAlignment: price.billingAlignment ?? "Anniversary",
   displayPriceNote: price.displayPriceNote ?? "",
   quantityItemKey: price.quantityItemKey ?? FLAT_FEE,
   taxPercent: price.taxRateBasisPoints

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-alignment.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-alignment.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  CreateSubscriptionPriceRequest,
+  SubscriptionPlan,
+} from "../models/subscription-plan.model";
+import type { CreateSubscriptionPriceFormValues } from "../schemas/subscription-price.schema";
+import { defaultSubscriptionPriceFormValues } from "../schemas/subscription-price.schema";
+import { submitPlanWithPrices } from "./submit-plan-with-prices";
+
+const plan = { planId: "plan-1", organizationId: null } as unknown as SubscriptionPlan;
+
+const submit = async (...prices: Partial<CreateSubscriptionPriceFormValues>[]) => {
+  const createPrice = vi.fn<(request: CreateSubscriptionPriceRequest) => Promise<SubscriptionPlan>>(
+    () => Promise.resolve(plan),
+  );
+
+  await submitPlanWithPrices({
+    planRequest: {},
+    prices: prices.map((price) => ({
+      ...defaultSubscriptionPriceFormValues,
+      quantityItemKey: "seat",
+      amount: 89,
+      ...price,
+    })),
+    createPlan: () => Promise.resolve(plan),
+    createPrice,
+  });
+
+  return createPrice.mock.calls.map(([request]) => request);
+};
+
+describe("submitting a plan's prices", () => {
+  it("sends the calendar alignment for a monthly price", async () => {
+    const [request] = await submit({
+      interval: 2,
+      intervalCount: 1,
+      billingAlignment: "CalendarMonth",
+    });
+
+    expect(request.billingAlignment).toBe("CalendarMonth");
+  });
+
+  /**
+   * The combination the server refuses outright, and the one a form can drift into: an author
+   * picks the calendar on a monthly price and then changes the cadence to quarterly. The field
+   * stops being shown, but the value it held is still in the form.
+   */
+  it("drops a calendar alignment the cadence can no longer carry", async () => {
+    const [request] = await submit({
+      interval: 2,
+      intervalCount: 3,
+      billingAlignment: "CalendarMonth",
+    });
+
+    expect(request.billingAlignment).toBeUndefined();
+    expect(request.intervalCount).toBe(3);
+  });
+
+  it("sends nothing for a yearly price", async () => {
+    const [request] = await submit({
+      interval: 3,
+      intervalCount: 1,
+      billingAlignment: "CalendarMonth",
+    });
+
+    expect(request.billingAlignment).toBeUndefined();
+  });
+
+  it("sends the anniversary explicitly when that is what was chosen", async () => {
+    const [request] = await submit({
+      interval: 2,
+      intervalCount: 1,
+      billingAlignment: "Anniversary",
+    });
+
+    expect(request.billingAlignment).toBe("Anniversary");
+  });
+
+  it("carries each price's own alignment when a plan sells several", async () => {
+    const requests = await submit(
+      { interval: 2, intervalCount: 1, billingAlignment: "CalendarMonth" },
+      { interval: 3, intervalCount: 1, billingAlignment: "Anniversary" },
+    );
+
+    expect(requests.map((request) => request.billingAlignment)).toEqual([
+      "CalendarMonth",
+      undefined,
+    ]);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
@@ -4,6 +4,7 @@ import type {
 } from "../models/subscription-plan.model";
 import type { CreateSubscriptionPriceFormValues } from "../schemas/subscription-price.schema";
 import { FLAT_FEE } from "../schemas/subscription-price.schema";
+import { isCalendarEligible } from "./billing-alignment";
 import { toMinorUnits } from "./subscription-format";
 import { toBasisPoints } from "./subscription-tax";
 
@@ -50,6 +51,10 @@ export const submitPlanWithPrices = async <TPlanRequest,>({
         unitAmountMinor: toMinorUnits(price.amount, price.currencyCode),
         interval: price.interval,
           intervalCount: price.intervalCount,
+          // Only for the cadence that can carry it. Sending "CalendarMonth" alongside a quarterly
+          // cadence is the one combination the server refuses outright, and the form can drift
+          // into it by an author choosing the calendar and then changing the interval.
+          billingAlignment: isCalendarEligible(price) ? price.billingAlignment : undefined,
           displayPriceNote: price.displayPriceNote?.trim() || undefined,
         quantityItemKey:
           price.quantityItemKey === FLAT_FEE ? undefined : price.quantityItemKey,

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-format.ts
@@ -42,18 +42,31 @@ export const formatInterval = (interval: string, intervalCount: number): string 
   return intervalCount === 1 ? `every ${unit}` : `every ${intervalCount} ${unit}s`;
 };
 
+/**
+ * How a calendar-aligned price renews, in the words an author reads back.
+ *
+ * Only ever added for the calendar, never for the anniversary. Anniversary is what "every month"
+ * already means, and spelling it out on every price would make the ordinary case look like a
+ * setting somebody had chosen.
+ */
+const formatAlignment = (billingAlignment?: string | null): string =>
+  billingAlignment === "CalendarMonth" ? ", on the 1st" : "";
+
 export const formatPrice = (price: {
   currencyCode: string;
   unitAmountMinor: number;
   interval: string;
   intervalCount: number;
   quantityItemKey: string | null;
+  billingAlignment?: string | null;
   taxRateBasisPoints?: number | null;
   taxMode?: string | null;
   automaticDiscountBasisPoints?: number | null;
 }): string => {
   const amount = formatMoney(price.unitAmountMinor, price.currencyCode);
-  const cadence = formatInterval(price.interval, price.intervalCount);
+  const cadence =
+    formatInterval(price.interval, price.intervalCount) +
+    formatAlignment(price.billingAlignment);
   const base = price.quantityItemKey
     ? `${amount} per ${price.quantityItemKey}, ${cadence}`
     : `${amount} ${cadence}`;

--- a/server/Subscription.DomainService/Entities/Price.cs
+++ b/server/Subscription.DomainService/Entities/Price.cs
@@ -32,6 +32,17 @@ public sealed class Price
 
     public int IntervalCount { get; set; } = 1;
 
+    /// <summary>
+    /// Where this price's renewal boundary falls: the subscriber's anniversary, or the first of
+    /// the calendar month.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Enums.BillingAlignment.Anniversary"/>, which is both the enum's zero
+    /// and how every price authored before alignment existed was sold — so an existing document
+    /// deserializes to exactly the behaviour it already had.
+    /// </remarks>
+    public BillingAlignment BillingAlignment { get; set; } = BillingAlignment.Anniversary;
+
     public string? DisplayPriceNote { get; set; }
 
     /// <summary>

--- a/server/Subscription.DomainService/Entities/PriceSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PriceSnapshot.cs
@@ -23,6 +23,17 @@ public sealed class PriceSnapshot
 
     public int IntervalCount { get; set; } = 1;
 
+    /// <summary>
+    /// Where this price's renewal boundary falls: the subscriber's anniversary, or the first of
+    /// the calendar month.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Enums.BillingAlignment.Anniversary"/>, which is both the enum's zero
+    /// and how every price authored before alignment existed was sold — so an existing document
+    /// deserializes to exactly the behaviour it already had.
+    /// </remarks>
+    public BillingAlignment BillingAlignment { get; set; } = BillingAlignment.Anniversary;
+
     public string? DisplayPriceNote { get; set; }
 
     public string? QuantityItemKey { get; set; }

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -85,6 +85,18 @@ public sealed class SubscriptionDetail
     /// <summary>Whether that first charge covered part of a month rather than all of one.</summary>
     public bool InitialChargeProrated { get; set; }
 
+    /// <summary>
+    /// Whether a promotional discount actually reduced that frozen first charge.
+    /// </summary>
+    /// <remarks>
+    /// Frozen with the amount, and for the same reason. Whether a discount applies depends on the
+    /// clock — a limited promotion expires — so asking the question again at activation can give a
+    /// different answer than the charge already taken. A first charge that was discounted and then
+    /// activated after the promotion lapsed would otherwise consume no period, and the subscriber
+    /// would get one more discounted renewal than they were sold.
+    /// </remarks>
+    public bool InitialChargeDiscountApplied { get; set; }
+
     /// <summary>Calendar dates the first period covered — the 7 of "7/31". Null when not prorated.</summary>
     public int? ProrationDays { get; set; }
 

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -66,6 +66,32 @@ public sealed class SubscriptionDetail
     public int DiscountPeriodsApplied { get; set; }
 
     /// <summary>
+    /// What the first charge was fixed at when checkout was created, if it was ever calculated.
+    /// </summary>
+    /// <remarks>
+    /// Frozen rather than derived, because the alternative is a price that moves while the
+    /// customer is looking at it. A calendar-aligned first period is a fraction of a month, and
+    /// recalculating it when a customer returns to a checkout the next morning would quote them
+    /// one day less than the page they left open says — the same charge has to survive a delayed
+    /// payment, a resumed checkout and a recovery sweep.
+    /// <para>
+    /// Null on subscriptions created before this existed, and on any path that never priced a
+    /// first period. Kept after activation for tracing: "why was this customer charged 32.74"
+    /// has no other answer once the period it covered has closed.
+    /// </para>
+    /// </remarks>
+    public long? InitialChargeAmountMinor { get; set; }
+
+    /// <summary>Whether that first charge covered part of a month rather than all of one.</summary>
+    public bool InitialChargeProrated { get; set; }
+
+    /// <summary>Calendar dates the first period covered — the 7 of "7/31". Null when not prorated.</summary>
+    public int? ProrationDays { get; set; }
+
+    /// <summary>Dates in the month it was a fraction of — the 31 of "7/31". Null when not prorated.</summary>
+    public int? ProrationTotalDays { get; set; }
+
+    /// <summary>
     /// Banked value from a downgrade's unused time, in this subscription's own currency.
     /// Consumed automatically by future renewals before anything is charged — never paid out.
     /// </summary>

--- a/server/Subscription.DomainService/Enums/BillingAlignment.cs
+++ b/server/Subscription.DomainService/Enums/BillingAlignment.cs
@@ -1,0 +1,32 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Where a recurring price puts its renewal boundary.
+/// </summary>
+/// <remarks>
+/// A cadence says how often; this says when. The two are independent — "every month" is the same
+/// cadence whether it renews on the day the subscriber signed up or on the first of the month —
+/// which is why this is its own concept rather than another <see cref="BillingInterval"/> member.
+/// </remarks>
+public enum BillingAlignment
+{
+    /// <summary>
+    /// Renews on the anniversary of the signup. An August 25 signup renews September 25.
+    /// </summary>
+    /// <remarks>
+    /// Zero, and therefore what every price and subscription authored before alignment existed
+    /// deserializes to. That is deliberate: it is the behaviour they were sold on.
+    /// </remarks>
+    Anniversary = 0,
+
+    /// <summary>
+    /// Renews at local midnight on the first of the month, with a prorated first period covering
+    /// the days from signup to that boundary.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful for a price billed every single month. A cadence of three months has no
+    /// "the first" to align to that is not also a choice of which month, and the plan builder
+    /// refuses the combination rather than inventing one.
+    /// </remarks>
+    CalendarMonth = 1
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -298,6 +298,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             {
                 ActivatedAtUtc = _time.GetUtcNow().UtcDateTime,
                 InitialPaymentDetailId = payment.ItemId,
+                DiscountPeriodsApplied = StubConsumedDiscountPeriod(subscription) ? 1 : null,
                 Event = _events.Create(
                     subscription,
                     eventType,
@@ -324,6 +325,29 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             link.ItemId,
             SubscriptionPaymentLinkState.Applied,
             cancellationToken);
+    }
+
+    /// <summary>
+    /// Whether this activation just paid for a prorated stub that a limited discount reduced.
+    /// </summary>
+    /// <remarks>
+    /// A stub is a period the subscriber was charged for, so a discount that reduced it has been
+    /// used — three months of "20% off" that skipped the opening stub would run to four bills.
+    /// <para>
+    /// Deliberately only a *stub*. An anniversary first period has never counted here, and making
+    /// it start to would shorten every existing plan's discount by one period for reasons that
+    /// have nothing to do with calendar billing.
+    /// </para>
+    /// </remarks>
+    private bool StubConsumedDiscountPeriod(SubscriptionDetail subscription)
+    {
+        var fraction = CalendarBillingAlignment.FrozenFraction(subscription);
+
+        return fraction.IsPartial &&
+               SubscriptionAmountCalculator.FirstPeriodCharge(
+                   subscription,
+                   fraction,
+                   _time.GetUtcNow().UtcDateTime).DiscountApplied;
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -299,6 +299,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                 ActivatedAtUtc = _time.GetUtcNow().UtcDateTime,
                 InitialPaymentDetailId = payment.ItemId,
                 DiscountPeriodsApplied = StubConsumedDiscountPeriod(subscription) ? 1 : null,
+
                 Event = _events.Create(
                     subscription,
                     eventType,
@@ -328,27 +329,21 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     }
 
     /// <summary>
-    /// Whether this activation just paid for a prorated stub that a limited discount reduced.
+    /// Whether this activation just paid for a prorated stub that a promotion reduced.
     /// </summary>
     /// <remarks>
-    /// A stub is a period the subscriber was charged for, so a discount that reduced it has been
-    /// used — three months of "20% off" that skipped the opening stub would run to four bills.
+    /// Read from what checkout froze, never recalculated. Whether a discount applies depends on
+    /// the clock, and activation can happen long after the charge was raised: a limited promotion
+    /// that lapsed in between would look inactive here while the money already taken was reduced
+    /// by it, and the subscriber would get one more discounted renewal than they paid for.
     /// <para>
     /// Deliberately only a *stub*. An anniversary first period has never counted here, and making
     /// it start to would shorten every existing plan's discount by one period for reasons that
     /// have nothing to do with calendar billing.
     /// </para>
     /// </remarks>
-    private bool StubConsumedDiscountPeriod(SubscriptionDetail subscription)
-    {
-        var fraction = CalendarBillingAlignment.FrozenFraction(subscription);
-
-        return fraction.IsPartial &&
-               SubscriptionAmountCalculator.FirstPeriodCharge(
-                   subscription,
-                   fraction,
-                   _time.GetUtcNow().UtcDateTime).DiscountApplied;
-    }
+    private static bool StubConsumedDiscountPeriod(SubscriptionDetail subscription) =>
+        subscription.InitialChargeProrated && subscription.InitialChargeDiscountApplied;
 
     /// <summary>
     /// Records the provider's customer from the card the charge saved.

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -245,11 +245,24 @@ The gross is scaled once, at the front, and everything downstream applies to a p
 
 1. Gross from the price and its quantities.
 2. **Prorate by covered calendar days**, rounded to the nearest minor unit, halves away from zero.
-3. Volume band and promotional discount, combined by the plan's policy. A *fixed* discount is
-   prorated by the same day fraction; a percentage needs no scaling, since it is already a
-   percentage of a scaled amount.
-4. Tax, on the discounted amount, at the price's own rate and mode.
-5. Banked credit, last of all — it pays the bill rather than changing what the bill was for.
+3. Built-in reductions — the price's automatic discount and the volume band the quantity selects —
+   combined by the price's `QuantityDiscountCombination`.
+4. Promotional code, settled against the built-in reduction by the plan's
+   `QuantityDiscountCombinationPolicy`. A *fixed* code is prorated by the same day fraction; a
+   percentage needs no scaling, since it is already a percentage of a scaled amount.
+5. Tax, on the discounted amount, at the price's own rate and mode.
+6. Banked credit, last of all — it pays the bill rather than changing what the bill was for.
+
+Steps 3 and 4 are where proration has to happen *first* rather than last. A discount worked out
+against a whole month and then subtracted from a fraction of one is not a smaller discount, it is a
+larger one — 8% of a full month against a seven-day stub would take a third of the stub.
+
+One subtlety inside step 3: `BuiltInDiscountCalculator` uses a volume band's resolved *money*
+verbatim when the band wins, deliberately, so plans that had bands before automatic discounts
+existed price them to the same minor unit. That figure is a whole month's, so a prorated period
+re-expresses the band's *rate* against the prorated gross before handing it over. A whole period
+passes the band through untouched, which is every anniversary subscription and every renewal after
+an opening stub.
 
 A fixed discount left whole would take a full month's reduction off a quarter of a month's charge,
 and a large enough one would make the stub free.

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -206,11 +206,23 @@ Two consequences worth stating:
 
 ### The first charge is frozen at checkout creation
 
-`InitialChargeAmountMinor`, `InitialChargeProrated`, `ProrationDays` and `ProrationTotalDays` are
-written when the subscription is built and are never recalculated. A checkout paid the following
-morning, resumed next week, or recovered by the activation sweep settles the figure the customer
-was quoted — a stub priced by the day would otherwise shrink underneath somebody who left the page
-open overnight.
+`InitialChargeAmountMinor`, `InitialChargeProrated`, `InitialChargeDiscountApplied`,
+`ProrationDays` and `ProrationTotalDays` are written when the subscription is built and are never
+recalculated. A checkout paid the following morning, resumed next week, or recovered by the
+activation sweep settles the figure the customer was quoted — a stub priced by the day would
+otherwise shrink underneath somebody who left the page open overnight.
+
+`InitialChargeDiscountApplied` is frozen for the same reason the amount is, and it is the field
+activation reads to decide whether the stub spent a discount period. Whether a promotion applies
+depends on the clock, so a promotion that lapsed between the charge being raised and the webhook
+arriving would otherwise look inactive at activation while the money already taken was reduced by
+it — and the subscriber would get one more discounted renewal than they paid for. **Activation
+never reprices the first charge.**
+
+A **card-free trial is the exception**: it charges nothing at signup, and what its first paid
+period will cost depends on when the trial ends. All of these fields are therefore left unset at
+signup and written atomically when that first paid period is actually created — filling them in
+from the signup date would record a fraction the eventual charge contradicts.
 
 They are exposed on the subscription response, and kept after activation for tracing:
 
@@ -257,9 +269,12 @@ an allowance is capacity for a period, not money to be prorated.
 ### Trials
 
 - A **payment-free trial** ending mid-month charges a stub from the local trial-end date to the
-  next first. The fraction is anchored on the trial's own end date rather than on the clock, so a
-  worker picking the conversion up the following morning still charges for the days the subscriber
-  was entitled to.
+  next first. The period charged is the one the **trial ended in**, resolved from `Trial.EndsAtUtc`
+  and never from the sweep's own clock. A conversion discovered after the next month boundary — a
+  trial ending 20 August that nothing picked up until 2 September — therefore still bills the
+  12/31 August stub it owes, keys it to August, advances to 1 September and leaves the
+  subscription due again, so the next pass raises September as its own separate charge. Anchoring
+  on the clock instead would silently write off the days in between.
 - A trial ending **on the first** starts with a full month.
 - A **payment-required trial** is charged up front at checkout, so its first fee uses the calendar
   stub exactly as an ordinary signup does.
@@ -274,6 +289,11 @@ later renewal. Two different prorations meet, and deliberately are not the same 
 - What they are buying is a calendar stub, so it is priced **by calendar dates** — the same 7/31 a
   fresh signup that day would pay.
 
+This holds for a whole target month as much as for a stub. A change landing on the first is priced
+`30/30` rather than "no fraction given", because the latter means "scale by elapsed clock time",
+and that would charge a subscriber who moved at noon less than one who signed up fresh at noon for
+the identical month. Calendar dates decide; the time of day is not one of them.
+
 A positive difference is charged immediately; a negative one is banked as credit. The target
 schedule is installed atomically with the settled plan change, and the outgoing usage period is
 closed and rated through the existing safe plan-change flow rather than being reset or discarded.
@@ -285,8 +305,12 @@ key on the frozen period boundary, so a failed renewal and its retry land on the
 raise no second charge. The first-period checkout still produces no Stripe invoice — invoice
 history begins at the first renewal.
 
-Editing a price's alignment affects future subscriptions and future plan changes only. Existing
-subscriptions bill from their own snapshot and are never migrated automatically.
+**Alignment is chosen when a price is created and cannot be changed afterwards.** Prices are
+otherwise immutable in their commercial terms, and tax metadata is the one existing exception; an
+alignment editor would need the same CAS-protected, future-snapshots-only treatment and does not
+exist yet. To move a plan onto calendar billing, add a new price and retire the old one — existing
+subscribers keep the terms they were sold on either way, since a subscription bills from its own
+snapshot and is never migrated automatically.
 
 ## Two schedules
 

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -167,6 +167,127 @@ Two rules inside it are worth knowing:
 > without it every IANA identifier fails — in production only, since developer machines have a
 > system time zone database. Both Dockerfiles install it.
 
+## Calendar-aligned billing
+
+A monthly price can renew on the subscriber's anniversary — an August 25 signup renews
+September 25 — or on the first of the calendar month. The choice is `billingAlignment` on the
+price, snapshotted onto every subscription sold on it:
+
+```json
+{ "interval": "Month", "intervalCount": 1, "billingAlignment": "CalendarMonth" }
+```
+
+`Anniversary` is the default and the enum's zero, so every price and subscription written before
+alignment existed deserializes to exactly the behaviour it was sold on.
+
+**Only `Month` with an `intervalCount` of 1 may be calendar-aligned.** A quarterly price has no
+single "first" to renew on that is not also a choice of which month, so the combination is refused
+at authoring time as `subscription_billing_alignment_invalid` rather than guessed at on an invoice.
+
+### The opening period is a stub
+
+The recurring schedule needs nothing new: a calendar-aligned `BillingSchedule` is an ordinary
+monthly one anchored on the first at local midnight, and `BillingPeriodCalculator` derives every
+later boundary from it as it always has. Only the first period is special, because it starts
+mid-month.
+
+A signup on August 25 gets `[August 25, September 1)` and pays **7/31** of the monthly amount —
+the 25th through the 31st is seven calendar dates, counted inclusively, over the 31 the month
+actually has. February uses 28 or 29 as appropriate.
+
+Two consequences worth stating:
+
+- **The time of day never enters into it.** Everyone who signs up on the 25th buys the same seven
+  dates and pays the same fraction. Anything else would have a 23:59 signup paying for a day it
+  had a minute of.
+- **The subscriber's calendar decides, not the server's.** 31 August 23:00 UTC is already
+  1 September in Zurich, and a Zurich subscriber signing up then gets a whole month rather than a
+  one-day stub. A signup on the local first is a full period and is *not* reported as prorated.
+
+### The first charge is frozen at checkout creation
+
+`InitialChargeAmountMinor`, `InitialChargeProrated`, `ProrationDays` and `ProrationTotalDays` are
+written when the subscription is built and are never recalculated. A checkout paid the following
+morning, resumed next week, or recovered by the activation sweep settles the figure the customer
+was quoted — a stub priced by the day would otherwise shrink underneath somebody who left the page
+open overnight.
+
+They are exposed on the subscription response, and kept after activation for tracing:
+
+```json
+{
+  "billingAlignment": "CalendarMonth",
+  "initialChargeAmountMinor": 3274,
+  "initialChargeProrated": true,
+  "prorationDays": 7,
+  "prorationTotalDays": 31
+}
+```
+
+`recurringAmountMinor` is unaffected throughout — it is what the next *full* month costs, which is
+a different question from what the opening stub cost.
+
+### What the fraction applies to, and in what order
+
+The gross is scaled once, at the front, and everything downstream applies to a prorated gross:
+
+1. Gross from the price and its quantities.
+2. **Prorate by covered calendar days**, rounded to the nearest minor unit, halves away from zero.
+3. Volume band and promotional discount, combined by the plan's policy. A *fixed* discount is
+   prorated by the same day fraction; a percentage needs no scaling, since it is already a
+   percentage of a scaled amount.
+4. Tax, on the discounted amount, at the price's own rate and mode.
+5. Banked credit, last of all — it pays the bill rather than changing what the bill was for.
+
+A fixed discount left whole would take a full month's reduction off a quarter of a month's charge,
+and a large enough one would make the stub free.
+
+A successfully paid stub **counts as one period** against a limited-duration promotional discount:
+it is a period the subscriber was charged for, and three months of "20% off" that skipped the stub
+would run to four bills. This applies to stubs only — an anniversary first period has never counted
+here, and changing that would shorten every existing plan's discount for reasons unrelated to
+calendar billing.
+
+### Metering is left alone
+
+The usage schedule is never realigned. Metering keeps the plan's own independent cadence, the
+allowance stays whole for the stub, and nothing is reset or forcibly rolled over on the first —
+an allowance is capacity for a period, not money to be prorated.
+
+### Trials
+
+- A **payment-free trial** ending mid-month charges a stub from the local trial-end date to the
+  next first. The fraction is anchored on the trial's own end date rather than on the clock, so a
+  worker picking the conversion up the following morning still charges for the days the subscriber
+  was entitled to.
+- A trial ending **on the first** starts with a full month.
+- A **payment-required trial** is charged up front at checkout, so its first fee uses the calendar
+  stub exactly as an ordinary signup does.
+
+### Plan changes
+
+Moving onto a calendar-aligned price installs that price's boundaries there and then, not at some
+later renewal. Two different prorations meet, and deliberately are not the same kind:
+
+- What the subscriber has left on the plan they are leaving is time they paid for, so it is
+  credited **by elapsed time**, through the existing proration and credit logic.
+- What they are buying is a calendar stub, so it is priced **by calendar dates** — the same 7/31 a
+  fresh signup that day would pay.
+
+A positive difference is charged immediately; a negative one is banked as credit. The target
+schedule is installed atomically with the settled plan change, and the outgoing usage period is
+closed and rated through the existing safe plan-change flow rather than being reset or discarded.
+
+### What is unchanged
+
+Cancellation, dunning, renewal recovery, idempotency and pending-checkout recovery all continue to
+key on the frozen period boundary, so a failed renewal and its retry land on the same period and
+raise no second charge. The first-period checkout still produces no Stripe invoice — invoice
+history begins at the first renewal.
+
+Editing a price's alignment affects future subscriptions and future plan changes only. Existing
+subscriptions bill from their own snapshot and are never migrated automatically.
+
 ## Two schedules
 
 A subscription has a fee cadence and a usage cadence, and they are independent. The fee follows

--- a/server/Subscription.DomainService/Repositories/SubscriptionPlanSchedule.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionPlanSchedule.cs
@@ -1,7 +1,13 @@
 using Subscription.DomainService.Entities;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Repositories;
 
+/// <param name="FeePeriodFraction">
+/// How much of a month <see cref="CurrentPeriodStartUtc"/> to <see cref="CurrentPeriodEndUtc"/>
+/// actually is, when the target price bills on calendar boundaries and this period is a stub.
+/// Default — a whole period — for every anniversary schedule.
+/// </param>
 public sealed record SubscriptionPlanSchedule(
     BillingSchedule FeeSchedule,
     DateTime CurrentPeriodStartUtc,
@@ -10,4 +16,5 @@ public sealed record SubscriptionPlanSchedule(
     BillingSchedule UsageSchedule,
     DateTime CurrentUsagePeriodStartUtc,
     DateTime CurrentUsagePeriodEndUtc,
-    DateTime NextUsageBillingAtUtc);
+    DateTime NextUsageBillingAtUtc,
+    BillingDayFraction FeePeriodFraction = default);

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -807,6 +807,37 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
                 discountPeriodsApplied);
         }
 
+        if (transition.InitialChargeAmountMinor is { } initialChargeAmountMinor)
+        {
+            update = update.Set(
+                subscription => subscription.InitialChargeAmountMinor,
+                initialChargeAmountMinor);
+        }
+
+        if (transition.InitialChargeProrated is { } initialChargeProrated)
+        {
+            update = update.Set(
+                subscription => subscription.InitialChargeProrated,
+                initialChargeProrated);
+        }
+
+        if (transition.InitialChargeDiscountApplied is { } initialChargeDiscountApplied)
+        {
+            update = update.Set(
+                subscription => subscription.InitialChargeDiscountApplied,
+                initialChargeDiscountApplied);
+        }
+
+        // Written as a pair, and only alongside a prorated first charge — the fraction is
+        // meaningless without both halves of it.
+        if (transition.ProrationDays is { } prorationDays &&
+            transition.ProrationTotalDays is { } prorationTotalDays)
+        {
+            update = update
+                .Set(subscription => subscription.ProrationDays, prorationDays)
+                .Set(subscription => subscription.ProrationTotalDays, prorationTotalDays);
+        }
+
         if (transition.CreditBalanceMinor is { } creditBalanceMinor)
         {
             update = update.Set(

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -49,6 +49,24 @@ public sealed record SubscriptionTransition(
 
     public int? DiscountPeriodsApplied { get; init; }
 
+    /// <summary>
+    /// What the first paid period cost, written when that period is actually created.
+    /// </summary>
+    /// <remarks>
+    /// Set by a card-free trial converting to paid, which is the one path where the opening charge
+    /// is not known at signup: what it costs depends on when the trial ends. Every other path
+    /// freezes these at checkout creation and never writes them again.
+    /// </remarks>
+    public long? InitialChargeAmountMinor { get; init; }
+
+    public bool? InitialChargeProrated { get; init; }
+
+    public bool? InitialChargeDiscountApplied { get; init; }
+
+    public int? ProrationDays { get; init; }
+
+    public int? ProrationTotalDays { get; init; }
+
     public long? CreditBalanceMinor { get; init; }
 
     public DateTime? CurrentUsagePeriodStartUtc { get; init; }

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -26,6 +26,17 @@ public sealed class CreatePriceRequest
     /// <summary>Paired with the interval, so three months is a quarter and no enum grows.</summary>
     public int IntervalCount { get; set; } = 1;
 
+    /// <summary>
+    /// Where renewals land: on the subscriber's anniversary, or on the first of the month with a
+    /// prorated opening period.
+    /// </summary>
+    /// <remarks>
+    /// Only <c>Month</c> with an interval count of one may be calendar-aligned; anything else is
+    /// refused as <c>subscription_billing_alignment_invalid</c>. Omitted means anniversary, so a
+    /// caller that has never heard of alignment authors exactly the price it always did.
+    /// </remarks>
+    public BillingAlignment BillingAlignment { get; set; } = BillingAlignment.Anniversary;
+
     public string? DisplayPriceNote { get; set; }
 
     /// <summary>Which quantity item this multiplies. Null is a flat fee.</summary>

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -180,6 +180,12 @@ public sealed class PlanPriceResponse
 
     public int IntervalCount { get; init; }
 
+    /// <summary>
+    /// "Anniversary" or "CalendarMonth", as its name. Always present — a client showing a price
+    /// cannot say when it renews without it, and every price has an answer.
+    /// </summary>
+    public string BillingAlignment { get; init; } = string.Empty;
+
     public string? DisplayPriceNote { get; init; }
 
     public string? QuantityItemKey { get; init; }

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -105,6 +105,37 @@ public sealed class SubscriptionResponse
 
 
     /// <summary>
+    /// "Anniversary" or "CalendarMonth" — where this subscription's renewals land.
+    /// </summary>
+    /// <remarks>
+    /// From the subscription's own snapshot, not the catalogue. Re-authoring the price a
+    /// subscriber was sold on does not move their renewal date, so the catalogue is the wrong
+    /// place to read this from.
+    /// </remarks>
+    public string BillingAlignment { get; init; } = string.Empty;
+
+    /// <summary>
+    /// What the first charge was fixed at. Null when nothing was ever charged for a first period
+    /// — a card-free trial, or a subscription created before this was recorded.
+    /// </summary>
+    /// <remarks>
+    /// Populated while a checkout is pending, which is when a client actually needs it, and kept
+    /// afterwards so support can still answer "why this number" once the period has closed.
+    /// <see cref="RecurringAmountMinor"/> is unaffected throughout: it is what the next full
+    /// month costs, which is a different question from what the opening stub cost.
+    /// </remarks>
+    public long? InitialChargeAmountMinor { get; init; }
+
+    /// <summary>Whether that first charge covered part of a month rather than all of one.</summary>
+    public bool InitialChargeProrated { get; init; }
+
+    /// <summary>Calendar dates the first period covered — the 7 of "7/31".</summary>
+    public int? ProrationDays { get; init; }
+
+    /// <summary>Dates in the month it was a fraction of — the 31 of "7/31".</summary>
+    public int? ProrationTotalDays { get; init; }
+
+    /// <summary>
     /// Where to send the customer to pay. Present only while the first charge is outstanding.
     /// </summary>
     public string? CheckoutUrl { get; init; }

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -253,6 +253,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             UnitAmountMinor = request.UnitAmountMinor,
             Interval = request.Interval,
             IntervalCount = request.IntervalCount,
+            BillingAlignment = request.BillingAlignment,
             DisplayPriceNote = request.DisplayPriceNote,
             QuantityItemKey = request.QuantityItemKey,
             TaxRateBasisPoints = request.TaxRateBasisPoints,

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -109,6 +109,7 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     UnitAmountMinor = price.UnitAmountMinor,
                     Interval = price.Interval.ToString(),
                     IntervalCount = price.IntervalCount,
+                    BillingAlignment = price.BillingAlignment.ToString(),
                     DisplayPriceNote = price.DisplayPriceNote,
                     QuantityItemKey = price.QuantityItemKey,
                     TaxRateBasisPoints = price.TaxRateBasisPoints,

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -1,5 +1,6 @@
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
 
@@ -14,7 +15,41 @@ namespace Subscription.DomainService.Services;
 public static class SubscriptionAmountCalculator
 {
     /// <summary>Kept for the first charge, where no prior period and no discount history exist yet.</summary>
-    public static long PeriodAmountMinor(SubscriptionDetail subscription)
+    public static long PeriodAmountMinor(SubscriptionDetail subscription) =>
+        FirstPeriodAmountMinor(subscription, default, DateTime.UtcNow);
+
+    /// <summary>
+    /// What the opening period costs, when that period may be a fraction of a month.
+    /// </summary>
+    /// <remarks>
+    /// The same path as a renewal, with one extra step at the front: the gross is scaled to the
+    /// dates actually covered before anything else touches it. Everything downstream — the volume
+    /// band, the promotional code, the tax — then applies to a prorated gross, which is what makes
+    /// the fraction a property of the *period* rather than a discount competing with the others.
+    /// <para>
+    /// A whole <paramref name="fraction"/> — the default — reproduces the previous arithmetic
+    /// exactly, so an anniversary signup is priced by the identical integer operations it always
+    /// was.
+    /// </para>
+    /// </remarks>
+    public static long FirstPeriodAmountMinor(
+        SubscriptionDetail subscription,
+        BillingDayFraction fraction,
+        DateTime nowUtc) =>
+        FirstPeriodCharge(subscription, fraction, nowUtc).AmountMinor;
+
+    /// <summary>
+    /// The opening period's charge in full, including whether a promotion reduced it.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="FirstPeriodAmountMinor"/> because activation needs the flag and
+    /// checkout needs the number, and re-deriving one from the other would be two answers to the
+    /// same question.
+    /// </remarks>
+    public static PeriodCharge FirstPeriodCharge(
+        SubscriptionDetail subscription,
+        BillingDayFraction fraction,
+        DateTime nowUtc)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -24,12 +59,20 @@ public static class SubscriptionAmountCalculator
             subscription.Price,
             subscription.QuantityItems,
             0,
-            DateTime.UtcNow).AmountMinor;
+            nowUtc,
+            fraction);
 
-        return TaxBreakdownFor(
-            discounted,
+        var breakdown = TaxBreakdownFor(
+            discounted.AmountMinor,
             subscription.Price.TaxRateBasisPoints,
-            subscription.Price.TaxMode).TotalAmountMinor;
+            subscription.Price.TaxMode);
+
+        return discounted with
+        {
+            AmountMinor = breakdown.TotalAmountMinor,
+            NetAmountMinor = breakdown.NetAmountMinor,
+            TaxAmountMinor = breakdown.TaxAmountMinor
+        };
     }
 
     /// <summary>
@@ -41,7 +84,10 @@ public static class SubscriptionAmountCalculator
     /// total, never below zero. A credit offsets what the subscriber owes including tax; it does not
     /// shrink the taxable base, which is why it is applied last.
     /// </summary>
-    public static PeriodCharge PeriodAmountMinor(SubscriptionDetail subscription, DateTime nowUtc)
+    public static PeriodCharge PeriodAmountMinor(
+        SubscriptionDetail subscription,
+        DateTime nowUtc,
+        BillingDayFraction fraction = default)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -51,7 +97,8 @@ public static class SubscriptionAmountCalculator
             subscription.Price,
             subscription.QuantityItems,
             subscription.DiscountPeriodsApplied,
-            nowUtc);
+            nowUtc,
+            fraction);
 
         var breakdown = TaxBreakdownFor(
             discounted.AmountMinor,
@@ -101,15 +148,22 @@ public static class SubscriptionAmountCalculator
         PriceSnapshot price,
         IReadOnlyList<SubscriptionQuantityItem> quantityItems,
         int periodsApplied,
-        DateTime nowUtc)
+        DateTime nowUtc,
+        BillingDayFraction fraction = default)
     {
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(price);
 
-        var gross = GrossAmountMinor(price, quantityItems);
+        // Scaled once, at the front, so every reduction below — the price's own automatic discount,
+        // the volume band, the promotional code, and the tax after them — reduces what this period
+        // actually costs rather than a month the subscriber is not buying.
+        var gross = fraction.Apply(GrossAmountMinor(price, quantityItems));
         var builtIn = BuiltInDiscountCalculator.Resolve(
             gross,
-            QuantityDiscountCalculator.ResolveFrom(plan, price, quantityItems),
+            ProrateBand(
+                QuantityDiscountCalculator.ResolveFrom(plan, price, quantityItems),
+                gross,
+                fraction),
             price.AutomaticDiscountBasisPoints,
             price.QuantityDiscountCombination);
 
@@ -124,7 +178,7 @@ public static class SubscriptionAmountCalculator
             case QuantityDiscountCombinationPolicy.Stack:
             {
                 var stacked = ApplyDiscount(
-                    builtIn.SubtotalMinor, discount, periodsApplied, nowUtc);
+                    builtIn.SubtotalMinor, discount, periodsApplied, nowUtc, fraction);
 
                 return stacked with
                 {
@@ -136,7 +190,7 @@ public static class SubscriptionAmountCalculator
 
             default:
             {
-                var promotional = ApplyDiscount(gross, discount, periodsApplied, nowUtc);
+                var promotional = ApplyDiscount(gross, discount, periodsApplied, nowUtc, fraction);
                 var promotionalDiscount = gross - promotional.AmountMinor;
 
                 // Ties go to the promotion, so a built-in reduction worth the same as a code does
@@ -151,6 +205,42 @@ public static class SubscriptionAmountCalculator
                     };
             }
         }
+    }
+
+    /// <summary>
+    /// A volume band re-expressed against a prorated gross.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BuiltInDiscountCalculator"/> uses a band's resolved <em>money</em> verbatim when
+    /// the band wins, deliberately, so a plan that priced its bands one way before automatic
+    /// discounts existed keeps doing so to the minor unit. That figure is a whole month's, though —
+    /// handing it to a stub period would take a full month's volume discount off a fraction of a
+    /// month's charge, and a large enough band would make the stub free.
+    /// <para>
+    /// So the band's <em>rate</em> is re-applied to the prorated gross, truncated exactly as
+    /// <see cref="QuantityDiscountCalculator"/> and <see cref="BuiltInDiscountCalculator"/> both
+    /// truncate. A whole period returns the band untouched, which is every anniversary
+    /// subscription and every renewal after an opening stub.
+    /// </para>
+    /// </remarks>
+    private static QuantityDiscountOutcome ProrateBand(
+        QuantityDiscountOutcome band,
+        long proratedGrossMinor,
+        BillingDayFraction fraction)
+    {
+        if (!fraction.IsPartial || band.DiscountBasisPoints <= 0)
+        {
+            return band;
+        }
+
+        var discount = proratedGrossMinor * band.DiscountBasisPoints / 10_000;
+
+        return band with
+        {
+            GrossAmountMinor = proratedGrossMinor,
+            DiscountAmountMinor = discount,
+            SubtotalMinor = Math.Max(0, proratedGrossMinor - discount)
+        };
     }
 
     /// <summary>
@@ -197,7 +287,8 @@ public static class SubscriptionAmountCalculator
         long amountMinor,
         DiscountTerms? discount,
         int periodsApplied,
-        DateTime nowUtc)
+        DateTime nowUtc,
+        BillingDayFraction fraction = default)
     {
         if (discount is null ||
             amountMinor <= 0 ||
@@ -210,8 +301,12 @@ public static class SubscriptionAmountCalculator
         {
             DiscountKind.Percent when discount.PercentBasisPoints is { } basisPoints =>
                 amountMinor - (amountMinor * basisPoints / 10_000),
+            // A percentage needs no scaling — it is already a percentage of an amount that was
+            // scaled. A fixed sum does: "10 off" against a week of a month would otherwise take a
+            // whole month's discount off a quarter of a month's charge, and a large enough one
+            // would make a stub period free.
             DiscountKind.FixedAmount when discount.AmountMinor is { } off =>
-                amountMinor - off,
+                amountMinor - fraction.Apply(off),
             _ => amountMinor
         };
 

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -105,7 +105,12 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         }
 
         var subscription = created.Value!;
-        var amountMinor = SubscriptionAmountCalculator.PeriodAmountMinor(subscription);
+
+        // The figure fixed when the subscription was built, so the charge raised here is the one
+        // the customer was quoted. Falls back for the paths that never priced a first period —
+        // a card-free trial, and any subscription written before the amount was frozen.
+        var amountMinor = subscription.InitialChargeAmountMinor
+            ?? SubscriptionAmountCalculator.PeriodAmountMinor(subscription);
 
         return RequiresPayment(subscription, amountMinor)
             ? await ChargeAsync(subscription, amountMinor, correlationId, cancellationToken)

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -93,12 +93,25 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         var now = _time.GetUtcNow().UtcDateTime;
 
-        if (!BillingPeriodCalculator.TryCreateSchedule(
+        // A calendar-aligned price anchors on the first of the month rather than on this instant;
+        // every later boundary then derives from that anchor exactly as an anniversary one does.
+        // The usage schedule is never realigned — metering keeps the plan's own independent
+        // cadence, which is the whole reason it is a separate schedule.
+        var calendarAligned = CalendarBillingAlignment.IsCalendarAligned(
+            price.BillingAlignment,
+            price.Interval,
+            price.IntervalCount);
+
+        var feeScheduleBuilt = calendarAligned
+            ? CalendarBillingAlignment.TryCreateSchedule(now, request.TimeZoneId, out var feeSchedule)
+            : BillingPeriodCalculator.TryCreateSchedule(
                 price.Interval,
                 price.IntervalCount,
                 now,
                 request.TimeZoneId,
-                out var feeSchedule) ||
+                out feeSchedule);
+
+        if (!feeScheduleBuilt ||
             !BillingPeriodCalculator.TryCreateSchedule(
                 plan.UsageInterval,
                 plan.UsageIntervalCount,
@@ -136,7 +149,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             now,
             correlationId);
 
-        if (!ApplyPeriods(subscription, now))
+        if (!ApplyPeriods(subscription, now, calendarAligned))
         {
             return Failure(
                 PaymentFailureKind.Validation,
@@ -387,7 +400,10 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                     .ToList()
             };
 
-    private static bool ApplyPeriods(SubscriptionDetail subscription, DateTime now)
+    private static bool ApplyPeriods(
+        SubscriptionDetail subscription,
+        DateTime now,
+        bool calendarAligned)
     {
         if (!BillingPeriodCalculator.TryGetPeriod(
                 subscription.FeeSchedule,
@@ -400,6 +416,45 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         {
             return false;
         }
+
+        var fraction = default(BillingDayFraction);
+
+        if (calendarAligned)
+        {
+            if (!CalendarBillingAlignment.TryResolveFirstPeriod(
+                    now,
+                    subscription.FeeSchedule.TimeZoneId,
+                    out var first))
+            {
+                return false;
+            }
+
+            // The stub, not the whole month the schedule derives. A subscriber joining on the 25th
+            // is entitled from the 25th and pays from the 25th; the derived period starting on the
+            // 1st is a month they were not here for.
+            feePeriod = feePeriod with
+            {
+                StartUtc = first.StartUtc,
+                EndUtc = first.EndUtc
+            };
+
+            fraction = BillingDayFraction.Of(first);
+            subscription.InitialChargeProrated = first.IsProrated;
+            subscription.ProrationDays = first.IsProrated ? first.CoveredDays : null;
+            subscription.ProrationTotalDays = first.IsProrated ? first.TotalDays : null;
+        }
+
+        // Fixed here, while the terms are the ones the customer is being quoted. A checkout that is
+        // paid tomorrow, resumed next week, or recovered by a sweep settles this figure and not a
+        // freshly derived one — a stub priced by the day would otherwise shrink underneath a
+        // customer who left the page open overnight.
+        //
+        // A card-free trial is the exception: it charges nothing now, and what its first paid
+        // period costs depends on when the trial ends, so it is priced at that boundary instead.
+        subscription.InitialChargeAmountMinor =
+            subscription.Trial is { RequiresPaymentMethod: false }
+                ? null
+                : SubscriptionAmountCalculator.FirstPeriodAmountMinor(subscription, fraction, now);
 
         subscription.CurrentPeriodStartUtc = feePeriod.StartUtc;
         subscription.CurrentPeriodEndUtc = feePeriod.EndUtc;

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -439,22 +439,27 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             };
 
             fraction = BillingDayFraction.Of(first);
-            subscription.InitialChargeProrated = first.IsProrated;
-            subscription.ProrationDays = first.IsProrated ? first.CoveredDays : null;
-            subscription.ProrationTotalDays = first.IsProrated ? first.TotalDays : null;
         }
 
-        // Fixed here, while the terms are the ones the customer is being quoted. A checkout that is
-        // paid tomorrow, resumed next week, or recovered by a sweep settles this figure and not a
-        // freshly derived one — a stub priced by the day would otherwise shrink underneath a
-        // customer who left the page open overnight.
+        // A card-free trial charges nothing now, and what its first paid period will cost depends
+        // on when the trial ends — a date that is not this one. Every initial-charge field is left
+        // unset rather than filled in from today, because a stored 26/31 that the eventual charge
+        // contradicts is worse than an absent one: it reads as a charge that was made.
         //
-        // A card-free trial is the exception: it charges nothing now, and what its first paid
-        // period costs depends on when the trial ends, so it is priced at that boundary instead.
-        subscription.InitialChargeAmountMinor =
-            subscription.Trial is { RequiresPaymentMethod: false }
-                ? null
-                : SubscriptionAmountCalculator.FirstPeriodAmountMinor(subscription, fraction, now);
+        // Everything else freezes here, while the terms are the ones the customer is being quoted.
+        // A checkout paid tomorrow, resumed next week, or recovered by a sweep settles these
+        // figures and not freshly derived ones — a stub priced by the day would otherwise shrink
+        // underneath a customer who left the page open overnight.
+        if (subscription.Trial is not { RequiresPaymentMethod: false })
+        {
+            var charge = SubscriptionAmountCalculator.FirstPeriodCharge(subscription, fraction, now);
+
+            subscription.InitialChargeAmountMinor = charge.AmountMinor;
+            subscription.InitialChargeDiscountApplied = charge.DiscountApplied;
+            subscription.InitialChargeProrated = fraction.IsPartial;
+            subscription.ProrationDays = fraction.IsPartial ? fraction.CoveredDays : null;
+            subscription.ProrationTotalDays = fraction.IsPartial ? fraction.TotalDays : null;
+        }
 
         subscription.CurrentPeriodStartUtc = feePeriod.StartUtc;
         subscription.CurrentPeriodEndUtc = feePeriod.EndUtc;

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -267,7 +267,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             quantities,
             now,
             newSchedule.CurrentPeriodStartUtc,
-            newSchedule.CurrentPeriodEndUtc);
+            newSchedule.CurrentPeriodEndUtc,
+            newSchedule.FeePeriodFraction);
 
         if (outcome.ChargeMinor <= 0)
         {
@@ -552,8 +553,17 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         schedule = null!;
         var timeZoneId = subscription.FeeSchedule.TimeZoneId;
 
-        if (!BillingPeriodCalculator.TryCreateSchedule(
-                targetPrice.Interval, targetPrice.IntervalCount, now, timeZoneId, out var fee) ||
+        // Moving onto a calendar-aligned price installs that price's own boundaries, exactly as
+        // subscribing to it would. The subscriber is not left on their old anniversary until some
+        // later renewal notices — the schedule they move onto is the one they were shown.
+        var calendarAligned = CalendarBillingAlignment.IsCalendarAligned(targetPrice);
+
+        var feeBuilt = calendarAligned
+            ? CalendarBillingAlignment.TryCreateSchedule(now, timeZoneId, out var fee)
+            : BillingPeriodCalculator.TryCreateSchedule(
+                targetPrice.Interval, targetPrice.IntervalCount, now, timeZoneId, out fee);
+
+        if (!feeBuilt ||
             !BillingPeriodCalculator.TryGetPeriod(fee, now, out var feePeriod) ||
             !BillingPeriodCalculator.TryCreateSchedule(
                 targetPlan.UsageInterval, targetPlan.UsageIntervalCount, now, timeZoneId, out var usage) ||
@@ -562,15 +572,32 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             return false;
         }
 
+        var fraction = default(BillingDayFraction);
+        var feeStartUtc = feePeriod.StartUtc;
+        var feeEndUtc = feePeriod.EndUtc;
+
+        if (calendarAligned)
+        {
+            if (!CalendarBillingAlignment.TryResolveFirstPeriod(now, timeZoneId, out var first))
+            {
+                return false;
+            }
+
+            feeStartUtc = first.StartUtc;
+            feeEndUtc = first.EndUtc;
+            fraction = BillingDayFraction.Of(first);
+        }
+
         schedule = new SubscriptionPlanSchedule(
             fee,
-            feePeriod.StartUtc,
-            feePeriod.EndUtc,
-            feePeriod.EndUtc,
+            feeStartUtc,
+            feeEndUtc,
+            feeEndUtc,
             usage,
             usagePeriod.StartUtc,
             usagePeriod.EndUtc,
-            usagePeriod.EndUtc);
+            usagePeriod.EndUtc,
+            fraction);
         return true;
     }
 

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -1,4 +1,5 @@
 using Subscription.DomainService.Entities;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
 
@@ -30,7 +31,8 @@ public static class SubscriptionProrationCalculator
         IReadOnlyList<SubscriptionQuantityItem> targetQuantityItems,
         DateTime nowUtc,
         DateTime targetPeriodStartUtc,
-        DateTime targetPeriodEndUtc)
+        DateTime targetPeriodEndUtc,
+        BillingDayFraction targetFraction = default)
     {
         ArgumentNullException.ThrowIfNull(subscription);
         ArgumentNullException.ThrowIfNull(targetPlan);
@@ -61,13 +63,17 @@ public static class SubscriptionProrationCalculator
             subscription.DiscountPeriodsApplied,
             nowUtc);
 
+        // The target's own fraction, where it has one. A move onto a calendar-aligned price buys
+        // the days from here to the first of next month, and those are counted as calendar dates
+        // rather than as elapsed time — the same 7/31 a fresh signup on the same day would pay.
         var newDiscounted = SubscriptionAmountCalculator.DiscountedAmountMinor(
             targetPlan,
             subscription.Discount,
             targetPrice,
             targetQuantityItems,
             subscription.DiscountPeriodsApplied,
-            nowUtc);
+            nowUtc,
+            targetFraction);
 
         // Each side settled at its own price's rate *and* mode, before the two are netted against
         // each other. A plan change can move a subscriber from a tax-exclusive price to an inclusive
@@ -88,9 +94,14 @@ public static class SubscriptionProrationCalculator
             (targetPeriodEndUtc - nowUtc).Ticks,
             0,
             Math.Max(0, targetTotalTicks));
-        var newRemainingCost = targetTotalTicks <= 0
-            ? 0
-            : Prorate(newTaxInclusive, targetRemainingTicks, targetTotalTicks);
+
+        // A day-counted target is already exactly the period being bought — it runs from now to
+        // the next boundary — so scaling it again by the time left in it would prorate it twice.
+        var newRemainingCost = targetFraction.IsPartial
+            ? newTaxInclusive
+            : targetTotalTicks <= 0
+                ? 0
+                : Prorate(newTaxInclusive, targetRemainingTicks, targetTotalTicks);
 
         var rawDelta = newRemainingCost - oldRemainingValue;
         var netAfterCredit = rawDelta - subscription.CreditBalanceMinor;

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -97,7 +97,11 @@ public static class SubscriptionProrationCalculator
 
         // A day-counted target is already exactly the period being bought — it runs from now to
         // the next boundary — so scaling it again by the time left in it would prorate it twice.
-        var newRemainingCost = targetFraction.IsPartial
+        //
+        // Every calendar-priced target, not only the partial ones. A change landing on the first
+        // buys a whole month, and letting the clock scale it would charge a subscriber who moved
+        // at noon less than one who signed up fresh at noon for the identical month.
+        var newRemainingCost = targetFraction.IsCalendarPriced
             ? newTaxInclusive
             : targetTotalTicks <= 0
                 ? 0

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -131,7 +131,19 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             subscription.QuantityItems = pendingQuantities;
         }
 
-        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, now);
+        // A card-free trial that ends mid-month buys the rest of that month, not all of it. This
+        // is the only renewal that can be charging for a partial period: every later one runs on a
+        // boundary, where the period it opens is whole by construction.
+        var fraction = TrialConversionFraction(subscription, period, out var stub)
+            ? BillingDayFraction.Of(stub)
+            : default;
+
+        if (fraction.IsPartial)
+        {
+            period = period with { StartUtc = stub.StartUtc, EndUtc = stub.EndUtc };
+        }
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, now, fraction);
 
         var outcome = charge.AmountMinor <= 0
             ? SubscriptionOperationResult<string>.Success(string.Empty, subscription.CorrelationId)
@@ -250,6 +262,37 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         pending.EffectiveAtUtc <= subscription.CurrentPeriodEndUtc
             ? pending.RequestedQuantities
             : null;
+
+    /// <summary>
+    /// Whether this renewal is a calendar-aligned trial converting part-way through a month, and
+    /// if so which stub it should charge for.
+    /// </summary>
+    /// <remarks>
+    /// Anchored on the trial's own end date, not on the clock. A worker that picks the renewal up
+    /// the following morning must still charge for the days the subscriber was actually entitled
+    /// to — pricing from "now" would quietly shorten the period by however late the sweep ran.
+    /// <para>
+    /// A trial that ended before the period now opening is not a stub at all. That is a renewal
+    /// running very late, and the month it opens is a whole one.
+    /// </para>
+    /// </remarks>
+    private static bool TrialConversionFraction(
+        SubscriptionDetail subscription,
+        BillingPeriod period,
+        out CalendarFirstPeriod stub)
+    {
+        stub = default;
+
+        return subscription.Status == SubscriptionStatus.Trialing &&
+               CalendarBillingAlignment.IsCalendarAligned(subscription.Price) &&
+               subscription.Trial is { RequiresPaymentMethod: false, EndsAtUtc: var endsAtUtc } &&
+               endsAtUtc >= period.StartUtc &&
+               endsAtUtc < period.EndUtc &&
+               CalendarBillingAlignment.TryResolveFirstPeriod(
+                   endsAtUtc,
+                   subscription.FeeSchedule.TimeZoneId,
+                   out stub);
+    }
 
     private async Task ApplySuccessAsync(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -156,7 +156,17 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             period = period with { StartUtc = stub.StartUtc, EndUtc = stub.EndUtc };
         }
 
-        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, now, fraction);
+        // Priced at the instant the period being charged *began*, not the instant this sweep runs.
+        // Whether a promotion is still live depends on the clock, so pricing a conversion from
+        // "now" would charge a subscriber who was mid-promotion when their trial ended the
+        // undiscounted amount purely because a worker was held up — and would make the same
+        // contractual period cost two different figures depending on sweep latency. Only the
+        // conversion moves it; an ordinary renewal begins at the boundary it is running on.
+        var pricingInstantUtc = converting ? trialEndUtc : now;
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
+            subscription,
+            pricingInstantUtc,
+            fraction);
 
         var outcome = charge.AmountMinor <= 0
             ? SubscriptionOperationResult<string>.Success(string.Empty, subscription.CorrelationId)
@@ -290,6 +300,14 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
     /// immediately. A conversion discovered a fortnight late therefore bills the stub it owes and
     /// then the whole months since, one boundary at a time, each under its own period key.
     /// </para>
+    /// <para>
+    /// Deliberately <em>not</em> keyed on <see cref="SubscriptionStatus.Trialing"/>. The first
+    /// attempt at a conversion can decline, which moves the subscription to
+    /// <see cref="SubscriptionStatus.PastDue"/> — and a dunning retry that no longer recognised
+    /// the conversion would abandon the unpaid stub and bill whatever month the clock had reached
+    /// by then. What actually ends a conversion is its first paid period being recorded, so that
+    /// is what this asks about.
+    /// </para>
     /// </remarks>
     private static bool TryResolveTrialConversion(
         SubscriptionDetail subscription,
@@ -300,7 +318,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         trialEndUtc = default;
         stub = default;
 
-        if (subscription.Status != SubscriptionStatus.Trialing ||
+        if (subscription.InitialChargeAmountMinor is not null ||
             !CalendarBillingAlignment.IsCalendarAligned(subscription.Price) ||
             subscription.Trial is not { RequiresPaymentMethod: false, EndsAtUtc: var endsAtUtc } ||
             endsAtUtc > nowUtc)

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -99,7 +99,17 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             return;
         }
 
-        if (!BillingPeriodCalculator.TryGetPeriod(subscription.FeeSchedule, now, out var period))
+        // Which instant the period being charged belongs to. Normally now — but a card-free trial
+        // converting is charged for the period its *trial ended* in, however late this sweep runs.
+        // Anchoring on the clock instead would skip the days between the trial's end and today,
+        // and those are days the subscriber was entitled to and nobody billed.
+        var converting = TryResolveTrialConversion(subscription, now, out var trialEndUtc, out var stub);
+        var periodAnchorUtc = converting ? trialEndUtc : now;
+
+        if (!BillingPeriodCalculator.TryGetPeriod(
+                subscription.FeeSchedule,
+                periodAnchorUtc,
+                out var period))
         {
             // A schedule that resolved at creation and stopped resolving is a configuration
             // problem, not a billing outcome — leave the subscription as it is and let the next
@@ -134,11 +144,14 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         // A card-free trial that ends mid-month buys the rest of that month, not all of it. This
         // is the only renewal that can be charging for a partial period: every later one runs on a
         // boundary, where the period it opens is whole by construction.
-        var fraction = TrialConversionFraction(subscription, period, out var stub)
-            ? BillingDayFraction.Of(stub)
-            : default;
+        //
+        // The period *key* is deliberately left as the calendar month's, which is what the order id
+        // and idempotency key above were built from. A late sweep charging August must key on
+        // August, so that when it then advances to 1 September the next pass raises a genuinely
+        // different charge rather than colliding with this one.
+        var fraction = converting ? BillingDayFraction.Of(stub) : default;
 
-        if (fraction.IsPartial)
+        if (converting)
         {
             period = period with { StartUtc = stub.StartUtc, EndUtc = stub.EndUtc };
         }
@@ -201,8 +214,8 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             await ApplySuccessAsync(
                 subscription,
                 period,
-                charge.DiscountApplied,
-                charge.CreditConsumedMinor,
+                charge,
+                converting ? fraction : null,
                 outcome.Value,
                 attemptNumber,
                 pendingQuantities,
@@ -264,41 +277,55 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             : null;
 
     /// <summary>
-    /// Whether this renewal is a calendar-aligned trial converting part-way through a month, and
-    /// if so which stub it should charge for.
+    /// Whether this renewal is a calendar-aligned card-free trial converting to paid, and if so
+    /// which period it should charge for.
     /// </summary>
     /// <remarks>
-    /// Anchored on the trial's own end date, not on the clock. A worker that picks the renewal up
-    /// the following morning must still charge for the days the subscriber was actually entitled
-    /// to — pricing from "now" would quietly shorten the period by however late the sweep ran.
+    /// Anchored on the trial's own end date and nothing else. A sweep that runs the next morning,
+    /// or a fortnight later after an outage, must still charge for the period the subscriber was
+    /// entitled to from — pricing from "now" would shorten it by however late the sweep ran, and
+    /// once the clock has crossed a month boundary it would skip those days entirely.
     /// <para>
-    /// A trial that ended before the period now opening is not a stub at all. That is a renewal
-    /// running very late, and the month it opens is a whole one.
+    /// The caller charges that period, advances to its end, and leaves the subscription due again
+    /// immediately. A conversion discovered a fortnight late therefore bills the stub it owes and
+    /// then the whole months since, one boundary at a time, each under its own period key.
     /// </para>
     /// </remarks>
-    private static bool TrialConversionFraction(
+    private static bool TryResolveTrialConversion(
         SubscriptionDetail subscription,
-        BillingPeriod period,
+        DateTime nowUtc,
+        out DateTime trialEndUtc,
         out CalendarFirstPeriod stub)
     {
+        trialEndUtc = default;
         stub = default;
 
-        return subscription.Status == SubscriptionStatus.Trialing &&
-               CalendarBillingAlignment.IsCalendarAligned(subscription.Price) &&
-               subscription.Trial is { RequiresPaymentMethod: false, EndsAtUtc: var endsAtUtc } &&
-               endsAtUtc >= period.StartUtc &&
-               endsAtUtc < period.EndUtc &&
-               CalendarBillingAlignment.TryResolveFirstPeriod(
-                   endsAtUtc,
-                   subscription.FeeSchedule.TimeZoneId,
-                   out stub);
+        if (subscription.Status != SubscriptionStatus.Trialing ||
+            !CalendarBillingAlignment.IsCalendarAligned(subscription.Price) ||
+            subscription.Trial is not { RequiresPaymentMethod: false, EndsAtUtc: var endsAtUtc } ||
+            endsAtUtc > nowUtc)
+        {
+            return false;
+        }
+
+        trialEndUtc = endsAtUtc;
+
+        return CalendarBillingAlignment.TryResolveFirstPeriod(
+            endsAtUtc,
+            subscription.FeeSchedule.TimeZoneId,
+            out stub);
     }
 
+    /// <param name="firstPaidFraction">
+    /// The day fraction this charge covered, when it was a card-free trial's first paid period and
+    /// therefore the moment those tracing fields become knowable. Null on every ordinary renewal,
+    /// which must never overwrite what the original checkout froze.
+    /// </param>
     private async Task ApplySuccessAsync(
         SubscriptionDetail subscription,
         BillingPeriod period,
-        bool discountApplied,
-        long creditConsumedMinor,
+        PeriodCharge charge,
+        BillingDayFraction? firstPaidFraction,
         string? paymentDetailId,
         int attemptNumber,
         List<SubscriptionQuantityItem>? appliedQuantities,
@@ -325,8 +352,20 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 QuantityItems = appliedQuantities,
                 ClearPendingQuantityChange = appliedQuantities is not null,
                 DiscountPeriodsApplied = subscription.DiscountPeriodsApplied +
-                    (discountApplied ? 1 : 0),
-                CreditBalanceMinor = subscription.CreditBalanceMinor - creditConsumedMinor,
+                    (charge.DiscountApplied ? 1 : 0),
+                // Written in the same transition that opens the period they describe, so a trial
+                // that converted can always account for what its first paid charge was.
+                InitialChargeAmountMinor = firstPaidFraction is null ? null : charge.AmountMinor,
+                InitialChargeProrated = firstPaidFraction?.IsPartial,
+                InitialChargeDiscountApplied =
+                    firstPaidFraction is null ? null : charge.DiscountApplied,
+                ProrationDays = firstPaidFraction is { IsPartial: true } paid
+                    ? paid.CoveredDays
+                    : null,
+                ProrationTotalDays = firstPaidFraction is { IsPartial: true } paidTotal
+                    ? paidTotal.TotalDays
+                    : null,
+                CreditBalanceMinor = subscription.CreditBalanceMinor - charge.CreditConsumedMinor,
                 LastRenewalPaymentDetailId = string.IsNullOrEmpty(paymentDetailId)
                     ? null
                     : paymentDetailId,

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -69,6 +69,11 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             DiscountedAmountMinor = recurring.GrossAmountMinor
                 - recurring.BuiltInDiscountMinor
                 - recurring.PromotionalDiscountMinor,
+            BillingAlignment = subscription.Price.BillingAlignment.ToString(),
+            InitialChargeAmountMinor = subscription.InitialChargeAmountMinor,
+            InitialChargeProrated = subscription.InitialChargeProrated,
+            ProrationDays = subscription.ProrationDays,
+            ProrationTotalDays = subscription.ProrationTotalDays,
             CheckoutUrl = checkoutUrl,
             Version = subscription.Version
         };

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -96,6 +96,9 @@ internal static class SubscriptionSnapshotBuilder
             UnitAmountMinor = price.UnitAmountMinor,
             Interval = price.Interval,
             IntervalCount = price.IntervalCount,
+            // Snapshotted with the cadence it qualifies, for the same reason the cadence is:
+            // re-authoring the catalogue must not move an existing subscriber's renewal date.
+            BillingAlignment = price.BillingAlignment,
             DisplayPriceNote = price.DisplayPriceNote,
             QuantityItemKey = price.QuantityItemKey,
             TaxRateBasisPoints = price.TaxRateBasisPoints,

--- a/server/Subscription.DomainService/Utilities/CalendarBillingAlignment.cs
+++ b/server/Subscription.DomainService/Utilities/CalendarBillingAlignment.cs
@@ -198,18 +198,35 @@ public static class CalendarBillingAlignment
 /// <param name="TotalDays">The 31 of "7/31". Zero or less means the period is whole.</param>
 public readonly record struct BillingDayFraction(int CoveredDays, int TotalDays)
 {
+    /// <summary>
+    /// Whether this period is priced by counting calendar dates at all.
+    /// </summary>
+    /// <remarks>
+    /// True for a whole calendar month as much as for a stub — 31/31 is still a calendar-day
+    /// price, and the caller has to be able to tell it apart from "no fraction given". Without
+    /// that distinction a plan change landing exactly on the first falls back to pricing by
+    /// elapsed clock time, and pays slightly less than the full month a fresh signup that
+    /// afternoon would pay.
+    /// </remarks>
+    public bool IsCalendarPriced => TotalDays > 0 && CoveredDays >= 0;
+
     /// <summary>Whether this actually scales anything down.</summary>
-    public bool IsPartial => TotalDays > 0 && CoveredDays < TotalDays && CoveredDays >= 0;
+    public bool IsPartial => IsCalendarPriced && CoveredDays < TotalDays;
 
     /// <summary>Scales an amount by this fraction, or returns it untouched when whole.</summary>
     public long Apply(long amountMinor) =>
         CalendarBillingAlignment.Prorate(amountMinor, CoveredDays, TotalDays);
 
-    /// <summary>The fraction a resolved first period represents.</summary>
+    /// <summary>
+    /// The fraction a resolved first period represents.
+    /// </summary>
+    /// <remarks>
+    /// Always the real day count, including for a whole month. A period that happens to be whole
+    /// is still one this module priced by dates, and saying so is what keeps the time of day out
+    /// of the answer.
+    /// </remarks>
     public static BillingDayFraction Of(CalendarFirstPeriod period) =>
-        period.IsProrated
-            ? new BillingDayFraction(period.CoveredDays, period.TotalDays)
-            : default;
+        new(period.CoveredDays, period.TotalDays);
 }
 
 /// <summary>

--- a/server/Subscription.DomainService/Utilities/CalendarBillingAlignment.cs
+++ b/server/Subscription.DomainService/Utilities/CalendarBillingAlignment.cs
@@ -1,0 +1,228 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// The calendar-month rules: which prices may use them, where the boundaries fall, and what
+/// fraction of a month a first period covers.
+/// </summary>
+/// <remarks>
+/// Pure and static, like <see cref="BillingPeriodCalculator"/> — every instant is a parameter, so
+/// a February boundary is as testable as an August one.
+/// <para>
+/// The recurring cadence itself needs nothing new. A calendar-aligned schedule is an ordinary
+/// monthly <see cref="BillingSchedule"/> whose anchor happens to be the first of a month at local
+/// midnight, so <see cref="BillingPeriodCalculator"/> derives every later boundary exactly as it
+/// always has. Only the <em>first</em> period is special, and only because it starts mid-month.
+/// </para>
+/// </remarks>
+public static class CalendarBillingAlignment
+{
+    /// <summary>
+    /// Whether a cadence can be aligned to the calendar at all.
+    /// </summary>
+    /// <remarks>
+    /// Monthly, once a month, and nothing else. A fortnight and a quarter both have boundaries
+    /// that only sometimes land on a first, so aligning them would mean silently changing the
+    /// cadence the author chose — the request is refused instead.
+    /// </remarks>
+    public static bool Supports(BillingInterval interval, int intervalCount) =>
+        interval == BillingInterval.Month && intervalCount == 1;
+
+    /// <summary>Whether this alignment is valid for this cadence.</summary>
+    public static bool IsValid(
+        BillingAlignment alignment,
+        BillingInterval interval,
+        int intervalCount) =>
+        alignment != BillingAlignment.CalendarMonth || Supports(interval, intervalCount);
+
+    /// <summary>Whether this alignment and cadence together mean calendar boundaries.</summary>
+    public static bool IsCalendarAligned(
+        BillingAlignment alignment,
+        BillingInterval interval,
+        int intervalCount) =>
+        alignment == BillingAlignment.CalendarMonth && Supports(interval, intervalCount);
+
+    /// <summary>Whether a snapshotted price actually bills on calendar boundaries.</summary>
+    /// <remarks>
+    /// Re-checks the cadence rather than trusting the stored alignment alone. A snapshot is only
+    /// as good as what was validated when it was taken, and a subscription whose alignment and
+    /// cadence disagree must bill the way its cadence says — never half-way between the two.
+    /// </remarks>
+    public static bool IsCalendarAligned(PriceSnapshot? price) =>
+        price is not null &&
+        IsCalendarAligned(price.BillingAlignment, price.Interval, price.IntervalCount);
+
+    /// <summary>
+    /// Builds the recurring schedule a calendar-aligned price renews on: local midnight, on the
+    /// first, every month.
+    /// </summary>
+    /// <remarks>
+    /// Anchored on the first of the month <paramref name="anchorInstantUtc"/> falls in — not the
+    /// next one. The anchor only has to be *a* boundary for the derivation to be right, and using
+    /// the current month keeps the first period's index at zero, where a reader expects it.
+    /// </remarks>
+    public static bool TryCreateSchedule(
+        DateTime anchorInstantUtc,
+        string timeZoneId,
+        out BillingSchedule schedule)
+    {
+        schedule = new BillingSchedule();
+
+        if (!BillingLocalTime.TryFindTimeZone(timeZoneId, out var timeZone))
+        {
+            return false;
+        }
+
+        var local = BillingLocalTime.ToLocal(anchorInstantUtc, timeZone);
+        var firstOfMonthLocal = new DateTime(local.Year, local.Month, 1);
+
+        return BillingPeriodCalculator.TryCreateSchedule(
+            BillingInterval.Month,
+            1,
+            BillingLocalTime.ToUtc(firstOfMonthLocal, timeZone),
+            timeZoneId,
+            out schedule);
+    }
+
+    /// <summary>
+    /// The first period a calendar-aligned subscription gets, and what fraction of a month it is.
+    /// </summary>
+    /// <remarks>
+    /// A signup on the local first is not a special case that happens to come to a whole month —
+    /// it *is* a whole month, and is reported as unprorated so nothing downstream describes it as
+    /// a partial period. Every other signup gets a stub running from the signup instant to the
+    /// next local first.
+    /// </remarks>
+    public static bool TryResolveFirstPeriod(
+        DateTime nowUtc,
+        string timeZoneId,
+        out CalendarFirstPeriod period)
+    {
+        period = default;
+
+        if (!BillingLocalTime.TryFindTimeZone(timeZoneId, out var timeZone))
+        {
+            return false;
+        }
+
+        var local = BillingLocalTime.ToLocal(nowUtc, timeZone);
+        var daysInMonth = DateTime.DaysInMonth(local.Year, local.Month);
+        var firstOfThisMonthLocal = new DateTime(local.Year, local.Month, 1);
+        var nextFirstLocal = firstOfThisMonthLocal.AddMonths(1);
+        var nextFirstUtc = BillingLocalTime.ToUtc(nextFirstLocal, timeZone);
+
+        if (local.Day == 1)
+        {
+            period = new CalendarFirstPeriod(
+                BillingLocalTime.ToUtc(firstOfThisMonthLocal, timeZone),
+                nextFirstUtc,
+                daysInMonth,
+                daysInMonth,
+                IsProrated: false);
+
+            return true;
+        }
+
+        // Calendar dates, inclusive of the signup date itself: a subscriber signing up on the 25th
+        // of a 31-day month has the 25th through the 31st, which is seven dates and not six. The
+        // time of day never enters into it — everyone who signs up on the 25th buys the same seven
+        // dates and pays the same fraction.
+        var coveredDays = daysInMonth - local.Day + 1;
+
+        period = new CalendarFirstPeriod(
+            DateTime.SpecifyKind(nowUtc, DateTimeKind.Utc),
+            nextFirstUtc,
+            coveredDays,
+            daysInMonth,
+            IsProrated: true);
+
+        return true;
+    }
+
+    /// <summary>
+    /// The fraction frozen onto a subscription when its first period was priced.
+    /// </summary>
+    /// <remarks>
+    /// Read back rather than recalculated, so anything settling that first charge later — an
+    /// activation, a recovery sweep — describes the period the customer actually bought and not
+    /// the one today's date would produce.
+    /// </remarks>
+    public static BillingDayFraction FrozenFraction(SubscriptionDetail subscription)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        return subscription is
+            { InitialChargeProrated: true, ProrationDays: { } covered, ProrationTotalDays: { } total }
+            ? new BillingDayFraction(covered, total)
+            : default;
+    }
+
+    /// <summary>
+    /// Scales an amount by a period's day fraction, rounded to the nearest minor unit with halves
+    /// away from zero.
+    /// </summary>
+    /// <remarks>
+    /// Exact integer arithmetic widened to <see cref="Int128"/> for the multiplication, matching
+    /// <see cref="SubscriptionAmountCalculator"/>'s tax split — this module's money never touches a
+    /// floating-point ratio, and a day fraction is no reason to start.
+    /// </remarks>
+    public static long Prorate(long amountMinor, int coveredDays, int totalDays)
+    {
+        if (totalDays <= 0 || coveredDays >= totalDays)
+        {
+            return amountMinor;
+        }
+
+        if (coveredDays <= 0 || amountMinor == 0)
+        {
+            return 0;
+        }
+
+        var scaled = ((Int128)Math.Abs(amountMinor) * coveredDays + (totalDays / 2)) / totalDays;
+
+        return amountMinor < 0 ? -(long)scaled : (long)scaled;
+    }
+}
+
+/// <summary>
+/// How much of a whole period a charge covers, as calendar dates.
+/// </summary>
+/// <remarks>
+/// <c>default</c> is a whole period — <see cref="TotalDays"/> of zero means "nothing to scale by"
+/// — so every existing call site that does not know about proration keeps charging full periods
+/// without naming a fraction it does not have.
+/// </remarks>
+/// <param name="CoveredDays">The 7 of "7/31".</param>
+/// <param name="TotalDays">The 31 of "7/31". Zero or less means the period is whole.</param>
+public readonly record struct BillingDayFraction(int CoveredDays, int TotalDays)
+{
+    /// <summary>Whether this actually scales anything down.</summary>
+    public bool IsPartial => TotalDays > 0 && CoveredDays < TotalDays && CoveredDays >= 0;
+
+    /// <summary>Scales an amount by this fraction, or returns it untouched when whole.</summary>
+    public long Apply(long amountMinor) =>
+        CalendarBillingAlignment.Prorate(amountMinor, CoveredDays, TotalDays);
+
+    /// <summary>The fraction a resolved first period represents.</summary>
+    public static BillingDayFraction Of(CalendarFirstPeriod period) =>
+        period.IsProrated
+            ? new BillingDayFraction(period.CoveredDays, period.TotalDays)
+            : default;
+}
+
+/// <summary>
+/// A calendar-aligned subscription's opening period.
+/// </summary>
+/// <param name="CoveredDays">Calendar dates this period actually covers — the 7 of "7/31".</param>
+/// <param name="TotalDays">Dates in the month it is a fraction of — the 31 of "7/31".</param>
+/// <param name="IsProrated">
+/// False when the period is a whole month, so a full first period is never reported as a stub.
+/// </param>
+public readonly record struct CalendarFirstPeriod(
+    DateTime StartUtc,
+    DateTime EndUtc,
+    int CoveredDays,
+    int TotalDays,
+    bool IsProrated);

--- a/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
@@ -1,6 +1,7 @@
 using FluentValidation;
 using Payment.DomainService.Services;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Validators;
 
@@ -56,6 +57,20 @@ public sealed class CreatePriceRequestValidator : AbstractValidator<CreatePriceR
             .IsInEnum()
             .When(request => request.QuantityDiscountCombination.HasValue)
             .WithErrorCode("subscription_price_discount_invalid");
+        RuleFor(request => request.BillingAlignment).IsInEnum();
+
+        // Refused here rather than clamped, because there is no honest way to clamp it: aligning a
+        // quarterly price to "the first" would have to pick which first, and whichever it picked
+        // would be a cadence the author did not choose.
+        RuleFor(request => request)
+            .Must(request => CalendarBillingAlignment.IsValid(
+                request.BillingAlignment,
+                request.Interval,
+                request.IntervalCount))
+            .WithName(nameof(CreatePriceRequest.BillingAlignment))
+            .WithMessage(
+                "Calendar-month billing is only available for a price billed every single month.")
+            .WithErrorCode("subscription_billing_alignment_invalid");
 
         RuleFor(request => request)
             .Must(request => IsChargeable(currencyResolver, request))

--- a/server/XUnitTest/Subscription/CalendarAlignedAutomaticDiscountTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedAutomaticDiscountTests.cs
@@ -1,0 +1,318 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Calendar stubs meeting the reductions a subscriber gets without asking for them.
+/// </summary>
+/// <remarks>
+/// The ordering is the whole subject: full gross, then the calendar-day fraction, then the
+/// built-in reductions, then a promotional code, then tax, then credit. Proration is a property of
+/// the <em>period</em>, so it happens before anything that reduces the price — a discount applied
+/// to a whole month and then subtracted from a fraction of one is not a smaller discount, it is a
+/// larger one.
+/// <para>
+/// Every figure below is against a seven-of-thirty-one-dates stub, so the same arithmetic a
+/// 25 August signup would be charged.
+/// </para>
+/// </remarks>
+public sealed class CalendarAlignedAutomaticDiscountTests
+{
+    private static readonly BillingDayFraction SevenOfThirtyOne = new(7, 31);
+    private static readonly DateTime Now = new(2026, 8, 25, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void An_automatic_discount_comes_off_the_prorated_gross()
+    {
+        // 7/31 of 8900 is 2010; 8% of that is 160.8, truncated to 160.
+        Charge(FlatPrice(automaticBasisPoints: 800)).Should().Be(1_850);
+    }
+
+    /// <summary>
+    /// The regression the ordering exists to prevent. 8% of a whole month is 712 — subtracting that
+    /// from a 2010 stub would hand the subscriber a third of the stub as a discount.
+    /// </summary>
+    [Fact]
+    public void An_automatic_discount_is_never_a_whole_months_worth_off_a_stub()
+    {
+        var stub = Charge(FlatPrice(automaticBasisPoints: 800));
+        var wholeMonth = Charge(
+            FlatPrice(automaticBasisPoints: 800),
+            fraction: new BillingDayFraction(0, 0));
+
+        stub.Should().Be(1_850);
+        wholeMonth.Should().Be(8_188, "8% of 8900 is 712");
+        (wholeMonth - stub).Should().BeGreaterThan(8_900 - 2_010 - 712,
+            "the stub's discount must be a fraction of the month's, not the whole of it");
+    }
+
+    /// <summary>
+    /// A volume band's resolved money is a whole month's, and is used verbatim when the band wins.
+    /// It has to be re-expressed against the prorated gross or the same leak appears through the
+    /// band instead of the automatic rate.
+    /// </summary>
+    [Fact]
+    public void A_winning_volume_band_is_re_expressed_against_the_prorated_gross()
+    {
+        // 12 seats at 8900 is 106800 for a month; 7/31 of that is 24116. A 15% band on the stub is
+        // 3617, not the 16020 that 15% of the whole month would be.
+        Charge(SeatPrice(automaticBasisPoints: null), Plan(bandBasisPoints: 1_500), Seats(12))
+            .Should().Be(20_499);
+    }
+
+    [Fact]
+    public void Best_discount_takes_whichever_of_the_two_is_larger_on_the_stub()
+    {
+        // Automatic 8% of 24116 is 1929; the 5% band is 1205. The automatic rate wins.
+        Charge(
+                SeatPrice(automaticBasisPoints: 800, AutomaticDiscountCombination.BestDiscount),
+                Plan(bandBasisPoints: 500),
+                Seats(12))
+            .Should().Be(22_187);
+
+        // Turn the band up past it and the band wins instead, still on the prorated gross.
+        Charge(
+                SeatPrice(automaticBasisPoints: 800, AutomaticDiscountCombination.BestDiscount),
+                Plan(bandBasisPoints: 1_500),
+                Seats(12))
+            .Should().Be(20_499);
+    }
+
+    [Fact]
+    public void Additive_combines_the_two_rates_and_applies_them_once_to_the_stub()
+    {
+        // 8% + 5% is one 13% rate: 13% of 24116 is 3135.08, truncated to 3135.
+        Charge(
+                SeatPrice(automaticBasisPoints: 800, AutomaticDiscountCombination.Additive),
+                Plan(bandBasisPoints: 500),
+                Seats(12))
+            .Should().Be(20_981);
+    }
+
+    /// <summary>
+    /// A code the subscriber typed is settled against the built-in reduction by the plan's policy,
+    /// after both have been expressed against the stub.
+    /// </summary>
+    [Fact]
+    public void A_promotional_code_is_compared_against_the_built_in_reduction_on_the_stub()
+    {
+        var plan = Plan(bandBasisPoints: 0);
+        var price = FlatPrice(automaticBasisPoints: 800);
+
+        // 20% of the 2010 stub is 402, which beats the automatic 160.
+        var charge = ChargeDetail(price, plan, [], Percent(2_000));
+
+        charge.AmountMinor.Should().Be(1_608);
+        charge.DiscountApplied.Should().BeTrue("the code reduced the charge, so it is being used");
+    }
+
+    [Fact]
+    public void A_promotional_code_that_loses_to_the_automatic_rate_is_not_consumed()
+    {
+        // 1% of the stub is 20, against the automatic 160.
+        var charge = ChargeDetail(
+            FlatPrice(automaticBasisPoints: 800), Plan(bandBasisPoints: 0), [], Percent(100));
+
+        charge.AmountMinor.Should().Be(1_850);
+        charge.DiscountApplied.Should().BeFalse(
+            "spending a month of a limited code on a period it did not reduce would expire it " +
+            "without the subscriber ever seeing it");
+    }
+
+    [Fact]
+    public void Stacking_applies_the_code_to_what_the_automatic_rate_left()
+    {
+        var plan = Plan(bandBasisPoints: 0);
+        plan.QuantityDiscountCombinationPolicy = QuantityDiscountCombinationPolicy.Stack;
+
+        // The automatic 8% leaves 1850; 20% of that is 370.
+        ChargeDetail(FlatPrice(automaticBasisPoints: 800), plan, [], Percent(2_000))
+            .AmountMinor.Should().Be(1_480);
+    }
+
+    /// <summary>
+    /// A fixed sum is the one discount that has to shrink with the period, because it is not
+    /// already a proportion of something that shrank.
+    /// </summary>
+    [Fact]
+    public void A_fixed_code_is_prorated_while_the_automatic_rate_is_not()
+    {
+        var plan = Plan(bandBasisPoints: 0);
+        plan.QuantityDiscountCombinationPolicy = QuantityDiscountCombinationPolicy.Stack;
+
+        var fixedOff = new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.FixedAmount,
+            AmountMinor = 1_000
+        };
+
+        // The automatic 8% leaves 1850, and 7/31 of the 1000 fixed discount is 226.
+        ChargeDetail(FlatPrice(automaticBasisPoints: 800), plan, [], fixedOff)
+            .AmountMinor.Should().Be(1_624);
+    }
+
+    [Fact]
+    public void Tax_is_charged_on_the_stub_after_every_discount()
+    {
+        var price = FlatPrice(automaticBasisPoints: 800);
+        price.TaxRateBasisPoints = 770;
+        price.TaxMode = TaxMode.Exclusive;
+
+        // 7.7% of the discounted 1850 is 142.45, rounded to 142.
+        Charge(price).Should().Be(1_992);
+    }
+
+    /// <summary>
+    /// A plan change onto a calendar-aligned price that carries an automatic discount: the target
+    /// stub is priced by calendar dates with the discount already in it, and netted against the
+    /// unused time on the plan being left.
+    /// </summary>
+    [Fact]
+    public void A_plan_change_onto_a_discounted_calendar_price_nets_the_discounted_stub()
+    {
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = "sub-1",
+            CurrencyCode = "CHF",
+            Plan = Plan(bandBasisPoints: 0),
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 8_900,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1
+            },
+            // 16 of 31 days unused on 25 August.
+            CurrentPeriodStartUtc = new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc),
+            CurrentPeriodEndUtc = new DateTime(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var target = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 40_000,
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            AutomaticDiscountBasisPoints = 800
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            Plan(bandBasisPoints: 0),
+            target,
+            [],
+            Now,
+            Now,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            SevenOfThirtyOne);
+
+        // The stub is 7/31 of 40000 = 9032, less the automatic 8% of that (722) = 8310. The
+        // outgoing side gives back 8900 x 16/31 = 4593.
+        outcome.ChargeMinor.Should().Be(3_717);
+        outcome.NewCreditBalanceMinor.Should().Be(0);
+    }
+
+    private static long Charge(
+        PriceSnapshot price,
+        PlanSnapshot? plan = null,
+        List<SubscriptionQuantityItem>? quantities = null,
+        BillingDayFraction? fraction = null) =>
+        ChargeDetail(price, plan, quantities, null, fraction).AmountMinor;
+
+    private static PeriodCharge ChargeDetail(
+        PriceSnapshot price,
+        PlanSnapshot? plan = null,
+        List<SubscriptionQuantityItem>? quantities = null,
+        DiscountTerms? discount = null,
+        BillingDayFraction? fraction = null)
+    {
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = "sub-1",
+            CurrencyCode = "CHF",
+            Plan = plan ?? Plan(bandBasisPoints: 0),
+            Price = price,
+            QuantityItems = quantities ?? [],
+            Discount = discount
+        };
+
+        return SubscriptionAmountCalculator.FirstPeriodCharge(
+            subscription,
+            fraction ?? SevenOfThirtyOne,
+            Now);
+    }
+
+    private static DiscountTerms Percent(int basisPoints) => new()
+    {
+        Code = "welcome",
+        Kind = DiscountKind.Percent,
+        PercentBasisPoints = basisPoints
+    };
+
+    private static List<SubscriptionQuantityItem> Seats(long quantity) =>
+    [
+        new SubscriptionQuantityItem
+        {
+            ItemKey = "seat",
+            UnitLabel = "seat",
+            Quantity = quantity,
+            UnitAmountMinor = 8_900
+        }
+    ];
+
+    private static PriceSnapshot FlatPrice(
+        int? automaticBasisPoints,
+        AutomaticDiscountCombination? combination = null) => new()
+    {
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 8_900,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        AutomaticDiscountBasisPoints = automaticBasisPoints,
+        QuantityDiscountCombination = combination
+    };
+
+    private static PriceSnapshot SeatPrice(
+        int? automaticBasisPoints,
+        AutomaticDiscountCombination? combination = null)
+    {
+        var price = FlatPrice(automaticBasisPoints, combination);
+        price.QuantityItemKey = "seat";
+
+        return price;
+    }
+
+    private static PlanSnapshot Plan(int bandBasisPoints) => new()
+    {
+        Code = "professional",
+        DisplayName = "Professional",
+        QuantityItems =
+        [
+            new PlanQuantityItem
+            {
+                ItemKey = "seat",
+                UnitLabel = "seat",
+                MinQuantity = 1,
+                DefaultQuantity = 1,
+                QuantityDiscountTiers = bandBasisPoints <= 0
+                    ? []
+                    :
+                    [
+                        new QuantityDiscountTier
+                        {
+                            MinimumQuantity = 1,
+                            MaximumQuantity = null,
+                            DiscountBasisPoints = bandBasisPoints
+                        }
+                    ]
+            }
+        ]
+    };
+}

--- a/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Moving onto a calendar-aligned price part-way through a period.
+/// </summary>
+/// <remarks>
+/// Two different prorations meet here, and they are deliberately not the same kind. What the
+/// subscriber has left on the plan they are leaving is time they paid for, so it is credited by
+/// elapsed time. What they are buying is a calendar stub, so it is priced by calendar dates — the
+/// same 7/31 a fresh signup on the same day would pay. Netting one against the other is what makes
+/// the change cost what the difference is worth.
+/// </remarks>
+public sealed class CalendarAlignedPlanChangeTests
+{
+    /// <summary>25 August, part-way through a 10th-to-10th anniversary period.</summary>
+    private static readonly DateTime Now = new(2026, 8, 25, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void A_downgrade_onto_a_calendar_price_banks_the_difference_as_credit()
+    {
+        var outcome = Calculate(targetUnitAmountMinor: 12_000);
+
+        // Leaving: 16 of the 31 days from 10 August are unused, so 8900 x 16/31 = 4593.
+        // Arriving: 25 August to 1 September is 7 of 31 dates, so 12000 x 7/31 = 2710.
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.NewCreditBalanceMinor.Should().Be(1_883, "4593 unused against a 2710 stub");
+    }
+
+    [Fact]
+    public void An_upgrade_onto_a_calendar_price_charges_only_the_difference_now()
+    {
+        var outcome = Calculate(targetUnitAmountMinor: 40_000);
+
+        // 40000 x 7/31 = 9032 for the stub, less the 4593 of unused time being given back.
+        outcome.ChargeMinor.Should().Be(4_439);
+        outcome.NewCreditBalanceMinor.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The stub must be priced once. It already runs from now to the next boundary, so scaling it
+    /// again by the time left in it would charge a fraction of a fraction.
+    /// </summary>
+    [Fact]
+    public void The_target_stub_is_not_prorated_twice()
+    {
+        var byCalendarDays = Calculate(targetUnitAmountMinor: 40_000);
+        var withoutAFraction = Calculate(
+            targetUnitAmountMinor: 40_000,
+            fraction: new BillingDayFraction(0, 0));
+
+        // Without a fraction the same target period is scaled by elapsed ticks instead, and the
+        // whole month is charged because the period starts now. The two must not agree, or this
+        // test is not exercising the calendar path at all.
+        byCalendarDays.ChargeMinor.Should().NotBe(withoutAFraction.ChargeMinor);
+        byCalendarDays.ChargeMinor.Should().BeLessThan(withoutAFraction.ChargeMinor,
+            "seven dates of a month cost less than the month");
+    }
+
+    [Fact]
+    public void A_fixed_discount_shrinks_with_the_target_stub()
+    {
+        var subscription = Subscription();
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.FixedAmount,
+            AmountMinor = 1_000
+        };
+
+        var outcome = Calculate(targetUnitAmountMinor: 40_000, subscription: subscription);
+
+        // The stub's gross is 9032; 7/31 of the 1000 discount is 226, leaving 8806. The outgoing
+        // side is discounted by the whole 1000 because it is a whole period: (8900 - 1000) x 16/31
+        // = 4077. 8806 - 4077 = 4729.
+        outcome.ChargeMinor.Should().Be(4_729);
+    }
+
+    private static ProrationOutcome Calculate(
+        long targetUnitAmountMinor,
+        BillingDayFraction? fraction = null,
+        SubscriptionDetail? subscription = null) =>
+        SubscriptionProrationCalculator.Calculate(
+            subscription ?? Subscription(),
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = targetUnitAmountMinor,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            [],
+            Now,
+            Now,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            fraction ?? new BillingDayFraction(7, 31));
+
+    private static SubscriptionDetail Subscription() => new()
+    {
+        ItemId = "sub-1",
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+        Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 8_900,
+            Interval = BillingInterval.Month,
+            IntervalCount = 1
+        },
+        // A 31-day anniversary period, 16 days of which are still unused on 25 August.
+        CurrentPeriodStartUtc = new DateTime(2026, 8, 10, 0, 0, 0, DateTimeKind.Utc),
+        CurrentPeriodEndUtc = new DateTime(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc)
+    };
+}

--- a/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
@@ -62,6 +62,48 @@ public sealed class CalendarAlignedPlanChangeTests
             "seven dates of a month cost less than the month");
     }
 
+    /// <summary>
+    /// A change landing on the first buys a whole month, and must pay for a whole month.
+    /// </summary>
+    /// <remarks>
+    /// The fraction is 30/30 rather than absent, which is the distinction that matters: absent
+    /// means "price this by the clock", and the clock would charge a subscriber who moved at noon
+    /// less than one who signed up fresh at noon for the identical month. Calendar dates decide,
+    /// and the time of day is not one of them.
+    /// </remarks>
+    [Theory]
+    // Midnight on the first, and midday on the first. The target month is the same month.
+    [InlineData(0)]
+    [InlineData(12)]
+    public void A_change_on_the_local_first_pays_for_the_whole_target_month(int hourOfDay)
+    {
+        // An outgoing period that ends exactly on the boundary, so nothing is credited back and
+        // the charge is the target's own price and nothing else.
+        var subscription = Subscription();
+        subscription.CurrentPeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+        subscription.CurrentPeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 40_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            [],
+            new DateTime(2026, 9, 1, hourOfDay, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+            new BillingDayFraction(30, 30));
+
+        outcome.ChargeMinor.Should().Be(40_000,
+            "half a day having elapsed does not make it eleven-twelfths of a month");
+    }
+
     [Fact]
     public void A_fixed_discount_shrinks_with_the_target_stub()
     {

--- a/server/XUnitTest/Subscription/CalendarAlignedPriceValidationTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPriceValidationTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Moq;
+using Payment.DomainService.Services;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Validators;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Which cadences may be sold on the calendar, refused where an author can still fix it.
+/// </summary>
+/// <remarks>
+/// Authoring time is the only place this question has an answer somebody can give. By the time a
+/// quarterly price aligned to "the first" reaches a renewal, the choice of which first is a guess,
+/// and every guess is a cadence the author did not sell.
+/// </remarks>
+public sealed class CalendarAlignedPriceValidationTests
+{
+    private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
+
+    public CalendarAlignedPriceValidationTests() =>
+        _currency
+            .Setup(resolver => resolver.TryConvertBack(
+                It.IsAny<long>(), It.IsAny<string>(), out It.Ref<decimal>.IsAny))
+            .Returns(true);
+
+    [Fact]
+    public void A_monthly_price_may_be_aligned_to_the_calendar()
+    {
+        var result = Validate(BillingAlignment.CalendarMonth, BillingInterval.Month, 1);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(BillingInterval.Month, 3)]
+    [InlineData(BillingInterval.Month, 12)]
+    [InlineData(BillingInterval.Day, 1)]
+    [InlineData(BillingInterval.Week, 2)]
+    [InlineData(BillingInterval.Year, 1)]
+    public void Every_other_cadence_is_refused_by_error_code(
+        BillingInterval interval,
+        int intervalCount)
+    {
+        var result = Validate(BillingAlignment.CalendarMonth, interval, intervalCount);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_billing_alignment_invalid");
+    }
+
+    [Theory]
+    [InlineData(BillingInterval.Month, 3)]
+    [InlineData(BillingInterval.Day, 1)]
+    [InlineData(BillingInterval.Year, 1)]
+    public void An_anniversary_price_is_never_refused_for_its_alignment(
+        BillingInterval interval,
+        int intervalCount)
+    {
+        var result = Validate(BillingAlignment.Anniversary, interval, intervalCount);
+
+        result.IsValid.Should().BeTrue(
+            "anniversary is the default, so refusing it here would refuse every existing price");
+    }
+
+    /// <summary>
+    /// The absent field has to mean anniversary, or every caller that predates alignment starts
+    /// failing validation for a question it was never asked.
+    /// </summary>
+    [Fact]
+    public void A_request_that_never_mentions_alignment_is_an_anniversary_price()
+    {
+        var request = new CreatePriceRequest
+        {
+            PlanId = "plan-1",
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 8900,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1
+        };
+
+        request.BillingAlignment.Should().Be(BillingAlignment.Anniversary);
+        new CreatePriceRequestValidator(_currency.Object).Validate(request)
+            .IsValid.Should().BeTrue();
+    }
+
+    private FluentValidation.Results.ValidationResult Validate(
+        BillingAlignment alignment,
+        BillingInterval interval,
+        int intervalCount) =>
+        new CreatePriceRequestValidator(_currency.Object).Validate(new CreatePriceRequest
+        {
+            PlanId = "plan-1",
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 8900,
+            Interval = interval,
+            IntervalCount = intervalCount,
+            BillingAlignment = alignment
+        });
+}

--- a/server/XUnitTest/Subscription/CalendarAlignedRenewalTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedRenewalTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Payment.DomainService.Enums;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
@@ -39,6 +40,9 @@ public sealed class CalendarAlignedRenewalTests
     private SubscriptionChargeRequest? _charge;
     private string? _idempotencyKey;
 
+    /// <summary>Set to make the next charge decline, so a dunning retry can be exercised.</summary>
+    private bool _declineCharge;
+
     public CalendarAlignedRenewalTests()
     {
         _billingAccounts
@@ -71,7 +75,13 @@ public sealed class CalendarAlignedRenewalTests
                     _charge = request;
                     _idempotencyKey = key;
                 })
-            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+            .ReturnsAsync(() => _declineCharge
+                ? SubscriptionOperationResult<string>.Failure(
+                    PaymentFailureKind.ProviderRejected,
+                    "card_declined",
+                    "The card was declined.",
+                    "corr-1")
+                : SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
     }
 
     [Fact]
@@ -96,23 +106,137 @@ public sealed class CalendarAlignedRenewalTests
     }
 
     /// <summary>
-    /// A failed renewal and its retry have to land on the same boundary, or dunning bills the same
-    /// month twice under two different keys.
+    /// A declined renewal and its dunning retry have to be attempts at the same period, or the
+    /// same month gets billed twice.
+    /// </summary>
+    /// <remarks>
+    /// The attempt number is deliberately part of the idempotency key, so the two differ there.
+    /// What must not move is the period they are both attempts at, which the order id carries.
+    /// </remarks>
+    [Fact]
+    public async Task A_retry_after_a_real_decline_charges_the_same_period()
+    {
+        var subscription = CalendarSubscription(SubscriptionStatus.Active);
+
+        _declineCharge = true;
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.PastDue);
+        var declinedAmount = _charge!.AmountMinor;
+        var declinedOrderId = _charge.OrderId;
+
+        // Dunning picks it up again, in the state the decline left it in.
+        subscription.Status = SubscriptionStatus.PastDue;
+        subscription.DunningAttemptCount = 1;
+        _declineCharge = false;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(declinedAmount);
+        _charge.OrderId.Should().Be(declinedOrderId,
+            "both are attempts at the same period, so they settle the same order");
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+    }
+
+    /// <summary>
+    /// The conversion equivalent, and the one that loses the stub if recognition is keyed on
+    /// status: a declined conversion is no longer <c>Trialing</c> when dunning retries it.
     /// </summary>
     [Fact]
-    public async Task A_retry_after_a_decline_charges_the_same_period_under_the_same_key()
+    public async Task A_declined_conversion_still_retries_the_stub_it_owes()
     {
-        var first = CalendarSubscription(SubscriptionStatus.Active);
-        await Service().RenewAsync(first, CancellationToken.None);
-        var firstKey = _idempotencyKey;
+        _time.Advance(
+            new DateTimeOffset(2026, 9, 2, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
 
-        // The same attempt, replayed after the charge was raised but before it was recorded.
-        var retry = CalendarSubscription(SubscriptionStatus.Active);
-        await Service().RenewAsync(retry, CancellationToken.None);
+        var subscription = ConvertingTrial();
 
-        _idempotencyKey.Should().Be(firstKey,
-            "the key is derived from the period, which a retry does not move");
-        _charge!.AmountMinor.Should().Be(8_900);
+        _declineCharge = true;
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(3_445);
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.PastDue);
+
+        // Dunning retries it, and the subscription is no longer Trialing.
+        subscription.Status = SubscriptionStatus.PastDue;
+        subscription.DunningAttemptCount = 1;
+        _declineCharge = false;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(3_445,
+            "the unpaid August stub is still what is owed, not whatever month the clock reached");
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _transition.InitialChargeAmountMinor.Should().Be(3_445);
+        _transition.ProrationDays.Should().Be(12);
+        _transition.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2026, 9, 1),
+            "September is still due, and is charged separately once the stub is paid");
+    }
+
+    /// <summary>
+    /// Once the stub is paid the conversion is over, whatever the status happens to be.
+    /// </summary>
+    [Fact]
+    public async Task A_paid_conversion_is_not_retried_as_one()
+    {
+        _time.Advance(
+            new DateTimeOffset(2026, 9, 2, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        var subscription = ConvertingTrial();
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        // The subscription as the conversion left it: first charge recorded, September due.
+        subscription.Status = SubscriptionStatus.Active;
+        subscription.InitialChargeAmountMinor = _transition!.InitialChargeAmountMinor;
+        subscription.CurrentPeriodStartUtc = _transition.CurrentPeriodStartUtc!.Value;
+        subscription.CurrentPeriodEndUtc = _transition.CurrentPeriodEndUtc!.Value;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(8_900, "September, in full");
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+    }
+
+    /// <summary>
+    /// A promotion that was live when the trial ended must price the period it covered, however
+    /// late the sweep runs — otherwise the same contractual period costs two different amounts
+    /// depending on worker latency.
+    /// </summary>
+    [Fact]
+    public async Task A_conversion_is_priced_at_the_trial_end_not_the_sweep_clock()
+    {
+        _time.Advance(
+            new DateTimeOffset(2026, 9, 2, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        var subscription = ConvertingTrial();
+        subscription.Discount = new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_000,
+            // Live when the trial ended on 20 August; lapsed by the time this sweep ran.
+            ExpiresAtUtc = new DateTime(2026, 8, 25, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        // 20% off the 3445 stub is 2756, not the undiscounted 3445.
+        _charge!.AmountMinor.Should().Be(2_756);
+        _transition!.InitialChargeDiscountApplied.Should().BeTrue();
+        _transition.DiscountPeriodsApplied.Should().Be(1);
+    }
+
+    /// <summary>A trial ending 20 August, converting a fortnight after it should have.</summary>
+    private static SubscriptionDetail ConvertingTrial()
+    {
+        var subscription = CalendarSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc),
+            RequiresPaymentMethod = false
+        };
+
+        return subscription;
     }
 
     /// <summary>
@@ -232,9 +356,12 @@ public sealed class CalendarAlignedRenewalTests
         await Service().RenewAsync(subscription, CancellationToken.None);
         var stubKey = _idempotencyKey;
 
-        // The subscription as the conversion left it: active, and due for September.
+        // The subscription as the conversion left it: active, its first charge recorded, and due
+        // for September. The recorded first charge is what ends the conversion — not the status,
+        // which a decline would have moved to PastDue instead.
         subscription.Status = SubscriptionStatus.Active;
-        subscription.CurrentPeriodStartUtc = _transition!.CurrentPeriodStartUtc!.Value;
+        subscription.InitialChargeAmountMinor = _transition!.InitialChargeAmountMinor;
+        subscription.CurrentPeriodStartUtc = _transition.CurrentPeriodStartUtc!.Value;
         subscription.CurrentPeriodEndUtc = _transition.CurrentPeriodEndUtc!.Value;
 
         await Service().RenewAsync(subscription, CancellationToken.None);

--- a/server/XUnitTest/Subscription/CalendarAlignedRenewalTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedRenewalTests.cs
@@ -1,0 +1,251 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// What a calendar-aligned subscription is charged once it is past its opening stub.
+/// </summary>
+/// <remarks>
+/// The stub is a property of the first period, not of the subscription. Every renewal after it
+/// runs on a boundary and buys a whole month — with the single exception of a card-free trial,
+/// which does its own first-period arithmetic at the moment it converts.
+/// </remarks>
+public sealed class CalendarAlignedRenewalTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+
+    /// <summary>1 September 2026, 00:00 Zurich — the renewal boundary itself.</summary>
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 31, 22, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionTransition? _transition;
+    private SubscriptionChargeRequest? _charge;
+    private string? _idempotencyKey;
+
+    public CalendarAlignedRenewalTests()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                ProviderName = "STRIPE",
+                DefaultPaymentMethodId = "pm-1"
+            });
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionChargeRequest, string, string, CancellationToken>(
+                (request, key, _, _) =>
+                {
+                    _charge = request;
+                    _idempotencyKey = key;
+                })
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+    }
+
+    [Fact]
+    public async Task The_first_renewal_after_a_stub_charges_a_whole_month()
+    {
+        var subscription = CalendarSubscription(SubscriptionStatus.Active);
+
+        // The stub it is closing: 25 August to 1 September.
+        subscription.CurrentPeriodStartUtc = new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc);
+        subscription.CurrentPeriodEndUtc = LocalMidnight(2026, 9, 1);
+        subscription.InitialChargeProrated = true;
+        subscription.ProrationDays = 7;
+        subscription.ProrationTotalDays = 31;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(8_900,
+            "the fraction belonged to the opening period, not to the subscription");
+        _transition!.CurrentPeriodStartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _transition.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+        _transition.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2026, 10, 1));
+    }
+
+    /// <summary>
+    /// A failed renewal and its retry have to land on the same boundary, or dunning bills the same
+    /// month twice under two different keys.
+    /// </summary>
+    [Fact]
+    public async Task A_retry_after_a_decline_charges_the_same_period_under_the_same_key()
+    {
+        var first = CalendarSubscription(SubscriptionStatus.Active);
+        await Service().RenewAsync(first, CancellationToken.None);
+        var firstKey = _idempotencyKey;
+
+        // The same attempt, replayed after the charge was raised but before it was recorded.
+        var retry = CalendarSubscription(SubscriptionStatus.Active);
+        await Service().RenewAsync(retry, CancellationToken.None);
+
+        _idempotencyKey.Should().Be(firstKey,
+            "the key is derived from the period, which a retry does not move");
+        _charge!.AmountMinor.Should().Be(8_900);
+    }
+
+    /// <summary>
+    /// The trial case: nothing was charged at signup, so the first paid period runs from the day
+    /// the trial ends to the next first, and is priced by those dates.
+    /// </summary>
+    [Fact]
+    public async Task A_card_free_trial_ending_mid_month_charges_a_stub_to_the_next_first()
+    {
+        _time.Advance(
+            new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        var subscription = CalendarSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc),
+            RequiresPaymentMethod = false
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        // 20 August through 31 August is 12 dates of 31: 8900 * 12 / 31 is 3445.16, so 3445.
+        _charge!.AmountMinor.Should().Be(3_445);
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+    }
+
+    [Fact]
+    public async Task A_card_free_trial_ending_on_the_first_starts_with_a_whole_month()
+    {
+        var subscription = CalendarSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = LocalMidnight(2026, 9, 1),
+            RequiresPaymentMethod = false
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(8_900, "the trial ended exactly on a boundary");
+    }
+
+    /// <summary>
+    /// A worker that picks the conversion up late must still charge for the days the subscriber
+    /// was entitled to — pricing from the clock would shorten the period by however late it ran.
+    /// </summary>
+    [Fact]
+    public async Task A_late_trial_conversion_is_still_priced_from_the_trial_end_date()
+    {
+        _time.Advance(
+            new DateTimeOffset(2026, 8, 23, 3, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        var subscription = CalendarSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc),
+            RequiresPaymentMethod = false
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(3_445,
+            "the subscriber was entitled from the 20th whatever day the sweep ran");
+    }
+
+    [Fact]
+    public async Task An_anniversary_renewal_is_untouched_by_any_of_this()
+    {
+        var subscription = CalendarSubscription(SubscriptionStatus.Active);
+        subscription.Price.BillingAlignment = BillingAlignment.Anniversary;
+        subscription.FeeSchedule.AnchorDayOfMonth = 25;
+        subscription.FeeSchedule.AnchorInstantUtc =
+            new DateTime(2026, 7, 25, 9, 30, 0, DateTimeKind.Utc);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(8_900);
+
+        // Still the 25th in the subscriber's own calendar, which is the day they bought on.
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 25));
+    }
+
+    private SubscriptionRenewalService Service() => new(
+        _subscriptions.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new OptionsStub(),
+        NullLogger<SubscriptionRenewalService>.Instance,
+        _time);
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(
+            new DateTime(year, month, day, 0, 0, 0),
+            TimeZoneInfo.FindSystemTimeZoneById(Zurich));
+
+    private static SubscriptionDetail CalendarSubscription(SubscriptionStatus status) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = status,
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+        Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 8_900,
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth
+        },
+        FeeSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = LocalMidnight(2026, 8, 1),
+            TimeZoneId = Zurich,
+            AnchorDayOfMonth = 1,
+            AnchorMinutesFromMidnight = 0
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new() { DunningMaxAttempts = 4 };
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/CalendarAlignedRenewalTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedRenewalTests.cs
@@ -180,6 +180,111 @@ public sealed class CalendarAlignedRenewalTests
             "the subscriber was entitled from the 20th whatever day the sweep ran");
     }
 
+    /// <summary>
+    /// The one that loses money if it is wrong. A sweep held up past the next month boundary must
+    /// still bill the stub it owes rather than starting from today and writing off the days in
+    /// between.
+    /// </summary>
+    [Fact]
+    public async Task A_conversion_discovered_after_the_month_boundary_still_bills_the_stub_it_owes()
+    {
+        // The trial ended 20 August. Nothing ran until 2 September.
+        _time.Advance(
+            new DateTimeOffset(2026, 9, 2, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        var subscription = CalendarSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc),
+            RequiresPaymentMethod = false
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(3_445,
+            "20 to 31 August is 12 of 31 dates, and nobody has billed them");
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+
+        // Left due again immediately, so the next pass raises September as its own charge rather
+        // than this one silently swallowing it.
+        _transition.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _transition.NextFeeBillingAtUtc.Should().BeBefore(_time.GetUtcNow().UtcDateTime);
+    }
+
+    /// <summary>
+    /// And the charge that follows it must be a different one, not a replay of the stub.
+    /// </summary>
+    [Fact]
+    public async Task The_month_after_a_late_conversion_is_charged_separately()
+    {
+        _time.Advance(
+            new DateTimeOffset(2026, 9, 2, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        var subscription = CalendarSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc),
+            RequiresPaymentMethod = false
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+        var stubKey = _idempotencyKey;
+
+        // The subscription as the conversion left it: active, and due for September.
+        subscription.Status = SubscriptionStatus.Active;
+        subscription.CurrentPeriodStartUtc = _transition!.CurrentPeriodStartUtc!.Value;
+        subscription.CurrentPeriodEndUtc = _transition.CurrentPeriodEndUtc!.Value;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(8_900, "September is a whole month");
+        _idempotencyKey.Should().NotBe(stubKey,
+            "August and September are different periods and must not collide on one key");
+        _transition.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+    }
+
+    /// <summary>
+    /// A trial's first paid period is the one case where the opening charge is not knowable at
+    /// signup, so it is recorded when it finally happens.
+    /// </summary>
+    [Fact]
+    public async Task A_conversion_records_what_the_first_paid_period_actually_cost()
+    {
+        _time.Advance(
+            new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        var subscription = CalendarSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc),
+            RequiresPaymentMethod = false
+        };
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.InitialChargeAmountMinor.Should().Be(3_445);
+        _transition.InitialChargeProrated.Should().BeTrue();
+        _transition.ProrationDays.Should().Be(12);
+        _transition.ProrationTotalDays.Should().Be(31,
+            "the fraction describes the month the trial ended in, not the one it started in");
+    }
+
+    [Fact]
+    public async Task An_ordinary_renewal_never_rewrites_what_the_first_charge_was()
+    {
+        var subscription = CalendarSubscription(SubscriptionStatus.Active);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.InitialChargeAmountMinor.Should().BeNull();
+        _transition.InitialChargeProrated.Should().BeNull();
+        _transition.ProrationDays.Should().BeNull(
+            "a renewal months later must not overwrite what the original checkout froze");
+    }
+
     [Fact]
     public async Task An_anniversary_renewal_is_untouched_by_any_of_this()
     {

--- a/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
@@ -264,6 +264,75 @@ public sealed class CalendarAlignedSubscriptionTests
             "an allowance is capacity for a period, not money to be prorated");
     }
 
+    /// <summary>
+    /// A card-free trial charges nothing at signup, and what its first paid period will cost
+    /// depends on a date that has not arrived. Recording today's fraction would describe a charge
+    /// nobody made — and describe it wrongly, since the trial ends in a different part of the month.
+    /// </summary>
+    [Fact]
+    public async Task A_payment_free_trial_records_no_first_charge_at_signup()
+    {
+        _time.Advance(new DateTimeOffset(2026, 8, 6, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        await Subscribe();
+
+        _created!.InitialChargeAmountMinor.Should().BeNull();
+        _created.InitialChargeProrated.Should().BeFalse();
+        _created.InitialChargeDiscountApplied.Should().BeFalse();
+        _created.ProrationDays.Should().BeNull(
+            "a 6 August signup would say 26/31 while the trial ends on the 20th and pays 12/31");
+        _created.ProrationTotalDays.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A trial that takes a card is charged up front, so its first period is priced now like any
+    /// other signup.
+    /// </summary>
+    [Fact]
+    public async Task A_payment_required_trial_still_freezes_its_first_charge()
+    {
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = true;
+
+        await Subscribe();
+
+        _created!.InitialChargeAmountMinor.Should().Be(2010);
+        _created.ProrationDays.Should().Be(7);
+    }
+
+    /// <summary>
+    /// Whether a promotion reduced the first charge is frozen with the amount, because the answer
+    /// depends on the clock and activation can happen long after the money moved.
+    /// </summary>
+    [Fact]
+    public async Task Whether_a_discount_reduced_the_first_charge_is_frozen_with_it()
+    {
+        GivenDiscount(new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_000,
+            DurationPeriods = 3,
+            ExpiresAtUtc = _time.GetUtcNow().UtcDateTime.AddHours(2)
+        });
+
+        await Subscribe(discountCode: "welcome");
+
+        _created!.InitialChargeAmountMinor.Should().Be(1608);
+        _created.InitialChargeDiscountApplied.Should().BeTrue(
+            "the promotion was live when the charge was raised, whenever it is finally settled");
+    }
+
+    [Fact]
+    public async Task An_undiscounted_first_charge_says_so()
+    {
+        await Subscribe();
+
+        _created!.InitialChargeDiscountApplied.Should().BeFalse();
+    }
+
     [Fact]
     public async Task An_anniversary_price_is_completely_unaffected()
     {

--- a/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
@@ -1,0 +1,397 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Subscribing to a calendar-aligned price: what the opening period is, what it costs, and what
+/// the subscription is left pointing at afterwards.
+/// </summary>
+/// <remarks>
+/// Driven through the creation service rather than the calculator, because the interesting part is
+/// the agreement between three things that are decided separately — the stub the subscriber is
+/// entitled to, the fraction they are charged for, and the schedule their renewals derive from.
+/// Any two of those can be right while the third quietly disagrees.
+/// </remarks>
+public sealed class CalendarAlignedSubscriptionTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+
+    /// <summary>25 August 2026, 09:30 UTC — 11:30 in Zurich, so the 25th either way.</summary>
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 25, 9, 30, 0, TimeSpan.Zero));
+
+    private Price _price = CalendarPrice();
+    private Plan _plan = NewPlan();
+    private SubscriptionDetail? _created;
+
+    public CalendarAlignedSubscriptionTests()
+    {
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "professional", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _plan);
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _price);
+
+        _accounts
+            .Setup(repository => repository.GetOrCreateAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionDetail, CancellationToken>((subscription, _) => _created = subscription)
+            .ReturnsAsync(true);
+    }
+
+    /// <summary>
+    /// The headline case, and the one every other rule is a variation of.
+    /// </summary>
+    [Fact]
+    public async Task An_august_25_signup_pays_seven_thirty_firsts_and_renews_on_september_1()
+    {
+        await Subscribe();
+
+        _created!.CurrentPeriodStartUtc.Should().Be(
+            new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc),
+            "entitlement starts when they subscribed, not on the first of the month");
+        _created.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _created.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2026, 9, 1));
+
+        _created.InitialChargeProrated.Should().BeTrue();
+        _created.ProrationDays.Should().Be(7);
+        _created.ProrationTotalDays.Should().Be(31);
+
+        // 8900 * 7 / 31 is 2009.68, to the nearest minor unit 2010.
+        _created.InitialChargeAmountMinor.Should().Be(2010);
+    }
+
+    [Fact]
+    public async Task The_renewal_schedule_runs_first_to_first_from_there_on()
+    {
+        await Subscribe();
+
+        var schedule = _created!.FeeSchedule;
+        schedule.AnchorDayOfMonth.Should().Be(1);
+        schedule.AnchorMinutesFromMidnight.Should().Be(0);
+
+        // September, then a short month, then a leap February: all first to first.
+        PeriodAt(schedule, new DateTime(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc))
+            .Should().Be((LocalMidnight(2026, 9, 1), LocalMidnight(2026, 10, 1)));
+        PeriodAt(schedule, new DateTime(2027, 2, 10, 0, 0, 0, DateTimeKind.Utc))
+            .Should().Be((LocalMidnight(2027, 2, 1), LocalMidnight(2027, 3, 1)));
+        PeriodAt(schedule, new DateTime(2028, 2, 10, 0, 0, 0, DateTimeKind.Utc))
+            .Should().Be((LocalMidnight(2028, 2, 1), LocalMidnight(2028, 3, 1)));
+    }
+
+    /// <summary>
+    /// The full month after the stub is charged at the full amount — the fraction belongs to the
+    /// opening period alone and must not follow the subscription around.
+    /// </summary>
+    [Fact]
+    public async Task The_renewal_after_the_stub_charges_a_whole_month()
+    {
+        await Subscribe();
+
+        var renewal = SubscriptionAmountCalculator.PeriodAmountMinor(
+            _created!,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        renewal.AmountMinor.Should().Be(8900);
+        renewal.AmountMinor.Should().BeGreaterThan(_created!.InitialChargeAmountMinor!.Value);
+    }
+
+    [Theory]
+    // February, in a common year and a leap year.
+    [InlineData(2026, 2, 10, 19, 28, 6039)]
+    [InlineData(2028, 2, 10, 20, 29, 6138)]
+    // A 30-day month.
+    [InlineData(2026, 4, 15, 16, 30, 4747)]
+    public async Task A_short_month_is_split_by_the_days_it_actually_has(
+        int year,
+        int month,
+        int day,
+        int expectedDays,
+        int expectedTotalDays,
+        long expectedAmountMinor)
+    {
+        _time.Advance(new DateTimeOffset(year, month, day, 12, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        await Subscribe();
+
+        _created!.ProrationDays.Should().Be(expectedDays);
+        _created.ProrationTotalDays.Should().Be(expectedTotalDays);
+        _created.InitialChargeAmountMinor.Should().Be(expectedAmountMinor);
+    }
+
+    [Fact]
+    public async Task A_signup_on_the_first_gets_a_whole_month_and_is_not_marked_prorated()
+    {
+        _time.Advance(new DateTimeOffset(2026, 9, 1, 8, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        await Subscribe();
+
+        _created!.InitialChargeProrated.Should().BeFalse();
+        _created.ProrationDays.Should().BeNull();
+        _created.ProrationTotalDays.Should().BeNull();
+        _created.InitialChargeAmountMinor.Should().Be(8900, "they are buying a whole month");
+        _created.CurrentPeriodStartUtc.Should().Be(LocalMidnight(2026, 9, 1),
+            "a full period starts on the boundary, not at the instant they happened to click");
+        _created.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+    }
+
+    /// <summary>
+    /// The guarantee that makes a quoted price safe to leave on screen: what the customer was
+    /// shown is what settles, however long they take to pay it.
+    /// </summary>
+    [Fact]
+    public async Task The_first_charge_is_frozen_when_the_checkout_is_created()
+    {
+        await Subscribe();
+
+        var quoted = _created!.InitialChargeAmountMinor;
+
+        // They come back the following morning and pay. Nothing about the subscription changed,
+        // but the calendar did.
+        _time.Advance(TimeSpan.FromDays(1));
+
+        _created.InitialChargeAmountMinor.Should().Be(quoted);
+        _created.ProrationDays.Should().Be(7,
+            "the frozen fraction describes the period they bought, not the one today would sell");
+        CalendarBillingAlignment.FrozenFraction(_created).Apply(8900).Should().Be(2010);
+    }
+
+    [Fact]
+    public async Task Quantity_pricing_is_prorated_after_the_units_are_multiplied()
+    {
+        _price.QuantityItemKey = "seat";
+
+        await Subscribe(quantity: 12);
+
+        // 8900 * 12 = 106800 for a whole month; 106800 * 7 / 31 is 24116.13, so 24116.
+        _created!.InitialChargeAmountMinor.Should().Be(24116);
+    }
+
+    [Fact]
+    public async Task Tax_is_charged_on_the_prorated_amount_not_the_whole_month()
+    {
+        _price.TaxRateBasisPoints = 770;
+        _price.TaxMode = TaxMode.Exclusive;
+
+        await Subscribe();
+
+        // 7/31 of 8900 is 2010; 7.7% of that is 154.77, so 155 of tax on top.
+        _created!.InitialChargeAmountMinor.Should().Be(2165);
+    }
+
+    /// <summary>
+    /// A fixed discount has to shrink with the period. Left whole, "50 off" against a seven-day
+    /// stub would take more than a quarter of the month's list price off a quarter of a month.
+    /// </summary>
+    [Fact]
+    public async Task A_fixed_discount_is_prorated_by_the_same_day_fraction()
+    {
+        GivenDiscount(new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.FixedAmount,
+            AmountMinor = 1000
+        });
+
+        await Subscribe(discountCode: "welcome");
+
+        // 7/31 of 8900 is 2010, and 7/31 of the 1000 discount is 226. 2010 - 226 = 1784.
+        _created!.InitialChargeAmountMinor.Should().Be(1784);
+    }
+
+    [Fact]
+    public async Task A_percentage_discount_applies_to_the_prorated_gross()
+    {
+        GivenDiscount(new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_000
+        });
+
+        await Subscribe(discountCode: "welcome");
+
+        // 20% off the prorated 2010 is 1608.
+        _created!.InitialChargeAmountMinor.Should().Be(1608);
+    }
+
+    /// <summary>
+    /// Metering keeps its own cadence. A subscriber who joins on the 25th gets the plan's whole
+    /// allowance for the days they are there, and their usage window is not dragged onto the first.
+    /// </summary>
+    [Fact]
+    public async Task The_usage_schedule_is_left_on_its_own_cadence_and_the_allowance_stays_whole()
+    {
+        await Subscribe();
+
+        _created!.UsageSchedule.AnchorDayOfMonth.Should().Be(25,
+            "usage is metered on the plan's independent schedule, not on the fee's boundary");
+
+        // The two windows open together — both start when the subscription does — but they close
+        // a week apart, which is the whole point: the fee stub ends on the first while the meter
+        // runs its full month.
+        _created.CurrentUsagePeriodEndUtc.Should().Be(
+            BillingLocalTime.ToUtc(new DateTime(2026, 9, 25, 11, 30, 0), Zone()));
+        _created.CurrentUsagePeriodEndUtc.Should().NotBe(_created.CurrentPeriodEndUtc,
+            "the meter must not be dragged onto the fee's calendar boundary");
+        _created.Plan.Meters[0].IncludedQuantity.Should().Be(500,
+            "an allowance is capacity for a period, not money to be prorated");
+    }
+
+    [Fact]
+    public async Task An_anniversary_price_is_completely_unaffected()
+    {
+        _price = AnniversaryPrice();
+
+        await Subscribe();
+
+        _created!.InitialChargeProrated.Should().BeFalse();
+        _created.ProrationDays.Should().BeNull();
+        _created.InitialChargeAmountMinor.Should().Be(8900);
+        _created.FeeSchedule.AnchorDayOfMonth.Should().Be(25,
+            "an anniversary subscription still renews on the day it was bought");
+        _created.CurrentPeriodEndUtc.Should().Be(
+            BillingLocalTime.ToUtc(new DateTime(2026, 9, 25, 11, 30, 0), Zone()),
+            "25 August renews 25 September");
+    }
+
+    [Fact]
+    public async Task A_calendar_alignment_on_a_cadence_that_cannot_carry_one_is_ignored_at_signup()
+    {
+        // A quarterly price whose stored alignment says calendar — only reachable if it was
+        // written by something that bypassed validation, and it must still bill quarterly.
+        _price.IntervalCount = 3;
+
+        await Subscribe();
+
+        _created!.InitialChargeProrated.Should().BeFalse();
+        _created.FeeSchedule.IntervalCount.Should().Be(3);
+        _created.FeeSchedule.AnchorDayOfMonth.Should().Be(25);
+    }
+
+    private async Task Subscribe(long quantity = 1, string? discountCode = null)
+    {
+        var request = new CreateSubscriptionRequest
+        {
+            PlanCode = "professional",
+            PriceId = "price-1",
+            TimeZoneId = Zurich,
+            DiscountCode = discountCode,
+            Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = quantity }]
+        };
+
+        var result = await Service().CreateAsync(
+            request,
+            new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1"),
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorCode ?? "creation should succeed");
+    }
+
+    private void GivenDiscount(DiscountTerms terms) =>
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, terms.Code, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                TenantId = TenantId,
+                Code = terms.Code,
+                CurrencyCode = "CHF",
+                Terms = terms
+            });
+
+    private SubscriptionCreationService Service() => new(
+        _catalogue.Object,
+        _subscriptions.Object,
+        _discounts.Object,
+        _accounts.Object,
+        new CreateSubscriptionRequestValidator(),
+        NullLogger<SubscriptionCreationService>.Instance,
+        _time);
+
+    private static (DateTime StartUtc, DateTime EndUtc) PeriodAt(
+        BillingSchedule schedule,
+        DateTime instantUtc)
+    {
+        BillingPeriodCalculator.TryGetPeriod(schedule, instantUtc, out var period)
+            .Should().BeTrue();
+
+        return (period.StartUtc, period.EndUtc);
+    }
+
+    private static TimeZoneInfo Zone() => TimeZoneInfo.FindSystemTimeZoneById(Zurich);
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(new DateTime(year, month, day, 0, 0, 0), Zone());
+
+    private static Price CalendarPrice() => new()
+    {
+        ItemId = "price-1",
+        TenantId = TenantId,
+        PlanId = "plan-1",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 8900,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        Status = CatalogueStatus.Active
+    };
+
+    private static Price AnniversaryPrice()
+    {
+        var price = CalendarPrice();
+        price.BillingAlignment = BillingAlignment.Anniversary;
+
+        return price;
+    }
+
+    private static Plan NewPlan() => new()
+    {
+        ItemId = "plan-1",
+        TenantId = TenantId,
+        Code = "professional",
+        DisplayName = "Professional",
+        Status = CatalogueStatus.Active,
+        Version = 3,
+        QuantityItems =
+        [
+            new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat", DefaultQuantity = 1 }
+        ],
+        Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                UnitLabel = "screening",
+                IncludedQuantity = 500
+            }
+        ]
+    };
+}

--- a/server/XUnitTest/Subscription/CalendarBillingAlignmentTests.cs
+++ b/server/XUnitTest/Subscription/CalendarBillingAlignmentTests.cs
@@ -1,0 +1,235 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The calendar rules themselves: which cadences may use them, where the stub falls, and what
+/// fraction of a month it is.
+/// </summary>
+/// <remarks>
+/// Every number here is one a customer can check against their own calendar, which is the point
+/// of counting dates rather than elapsed time. A month is not 30 days, and a subscriber who joins
+/// on the 25th of August has bought seven dates whether they signed up at breakfast or at
+/// midnight.
+/// </remarks>
+public sealed class CalendarBillingAlignmentTests
+{
+    private const string Zurich = "Europe/Zurich";
+
+    [Theory]
+    [InlineData(BillingInterval.Month, 1, true)]
+    [InlineData(BillingInterval.Month, 3, false)]
+    [InlineData(BillingInterval.Month, 12, false)]
+    [InlineData(BillingInterval.Day, 1, false)]
+    [InlineData(BillingInterval.Week, 1, false)]
+    [InlineData(BillingInterval.Year, 1, false)]
+    public void Only_a_single_month_cadence_can_be_aligned_to_the_calendar(
+        BillingInterval interval,
+        int intervalCount,
+        bool supported)
+    {
+        CalendarBillingAlignment.Supports(interval, intervalCount).Should().Be(supported);
+
+        CalendarBillingAlignment
+            .IsValid(BillingAlignment.CalendarMonth, interval, intervalCount)
+            .Should().Be(supported);
+
+        CalendarBillingAlignment
+            .IsValid(BillingAlignment.Anniversary, interval, intervalCount)
+            .Should().BeTrue("an anniversary price has no cadence it cannot describe");
+    }
+
+    [Fact]
+    public void A_signup_on_the_25th_of_a_31_day_month_buys_seven_dates()
+    {
+        Resolve(new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc), out var period);
+
+        period.IsProrated.Should().BeTrue();
+        period.CoveredDays.Should().Be(7, "the 25th through the 31st is seven dates, not six");
+        period.TotalDays.Should().Be(31);
+        period.EndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+    }
+
+    /// <summary>
+    /// The one that makes the fraction defensible: two customers who joined on the same date pay
+    /// the same, whatever the clock said. Anything else would mean a 23:59 signup buying a day it
+    /// had a minute of.
+    /// </summary>
+    [Fact]
+    public void The_time_of_day_never_changes_the_fraction()
+    {
+        // 24 August 22:05 UTC is already the 25th in Zurich, and 25 August 21:59 UTC still is.
+        Resolve(new DateTime(2026, 8, 24, 22, 5, 0, DateTimeKind.Utc), out var justAfterMidnight);
+        Resolve(new DateTime(2026, 8, 25, 21, 59, 0, DateTimeKind.Utc), out var lateEvening);
+
+        justAfterMidnight.CoveredDays.Should().Be(7);
+        lateEvening.CoveredDays.Should().Be(7);
+        justAfterMidnight.EndUtc.Should().Be(lateEvening.EndUtc);
+    }
+
+    [Theory]
+    [InlineData(2026, 2, 10, 19, 28)]
+    [InlineData(2028, 2, 10, 20, 29)]
+    [InlineData(2026, 4, 15, 16, 30)]
+    public void The_denominator_is_the_length_of_the_month_actually_being_split(
+        int year,
+        int month,
+        int day,
+        int expectedCoveredDays,
+        int expectedTotalDays)
+    {
+        Resolve(new DateTime(year, month, day, 12, 0, 0, DateTimeKind.Utc), out var period);
+
+        period.CoveredDays.Should().Be(expectedCoveredDays);
+        period.TotalDays.Should().Be(expectedTotalDays);
+    }
+
+    [Fact]
+    public void A_signup_on_the_local_first_is_a_whole_month_and_is_not_called_prorated()
+    {
+        Resolve(new DateTime(2026, 9, 1, 6, 0, 0, DateTimeKind.Utc), out var period);
+
+        period.IsProrated.Should().BeFalse(
+            "a full first period described as a stub would have every client showing a " +
+            "proration that did not happen");
+        period.CoveredDays.Should().Be(30);
+        period.TotalDays.Should().Be(30);
+        period.StartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        period.EndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+        BillingDayFraction.Of(period).IsPartial.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Zurich runs an hour or two ahead of UTC, so late-evening UTC instants are already tomorrow
+    /// there. The subscriber's own calendar decides, not the server's.
+    /// </summary>
+    [Fact]
+    public void The_local_calendar_decides_the_date_not_utc()
+    {
+        // 31 August 23:00 UTC is 1 September 01:00 in Zurich: a whole month, not a one-day stub.
+        Resolve(new DateTime(2026, 8, 31, 23, 0, 0, DateTimeKind.Utc), out var period);
+
+        period.IsProrated.Should().BeFalse();
+        period.TotalDays.Should().Be(30, "it is already September there");
+    }
+
+    [Fact]
+    public void A_boundary_across_a_daylight_saving_change_is_still_a_whole_calendar_month()
+    {
+        // Zurich springs forward on 29 March 2026 and back on 25 October 2026.
+        Resolve(new DateTime(2026, 3, 20, 12, 0, 0, DateTimeKind.Utc), out var march);
+        Resolve(new DateTime(2026, 10, 20, 12, 0, 0, DateTimeKind.Utc), out var october);
+
+        march.CoveredDays.Should().Be(12);
+        march.TotalDays.Should().Be(31, "March has 31 dates however many hours they add up to");
+        march.EndUtc.Should().Be(LocalMidnight(2026, 4, 1));
+
+        october.CoveredDays.Should().Be(12);
+        october.TotalDays.Should().Be(31);
+        october.EndUtc.Should().Be(LocalMidnight(2026, 11, 1));
+    }
+
+    [Fact]
+    public void The_recurring_schedule_lands_on_the_first_at_local_midnight()
+    {
+        CalendarBillingAlignment
+            .TryCreateSchedule(
+                new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc), Zurich, out var schedule)
+            .Should().BeTrue();
+
+        schedule.AnchorDayOfMonth.Should().Be(1);
+        schedule.AnchorMinutesFromMidnight.Should().Be(0);
+        schedule.Interval.Should().Be(BillingInterval.Month);
+        schedule.IntervalCount.Should().Be(1);
+
+        // Derived, not remembered: every later boundary falls out of the same anchor.
+        BillingPeriodCalculator
+            .TryGetPeriod(
+                schedule, new DateTime(2026, 9, 15, 0, 0, 0, DateTimeKind.Utc), out var september)
+            .Should().BeTrue();
+
+        september.StartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        september.EndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+
+        BillingPeriodCalculator
+            .TryGetPeriod(
+                schedule, new DateTime(2027, 2, 15, 0, 0, 0, DateTimeKind.Utc), out var february)
+            .Should().BeTrue();
+
+        february.StartUtc.Should().Be(LocalMidnight(2027, 2, 1));
+        february.EndUtc.Should().Be(LocalMidnight(2027, 3, 1),
+            "a short month still runs first to first");
+    }
+
+    [Fact]
+    public void An_unknown_time_zone_fails_closed_rather_than_throwing()
+    {
+        CalendarBillingAlignment
+            .TryCreateSchedule(DateTime.UtcNow, "Mars/Olympus_Mons", out _)
+            .Should().BeFalse();
+
+        CalendarBillingAlignment
+            .TryResolveFirstPeriod(DateTime.UtcNow, "Mars/Olympus_Mons", out _)
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    // 7/31 of 10000 is 2258.06, and the nearest minor unit is 2258.
+    [InlineData(10000, 7, 31, 2258)]
+    // Exactly a half rounds away from zero rather than to even: half of 5 is 2.5, so 3.
+    [InlineData(5, 1, 2, 3)]
+    [InlineData(-5, 1, 2, -3)]
+    [InlineData(10000, 31, 31, 10000)]
+    [InlineData(10000, 0, 31, 0)]
+    // A whole period, which is the default fraction, never scales anything.
+    [InlineData(10000, 0, 0, 10000)]
+    public void Proration_rounds_to_the_nearest_minor_unit_with_halves_away_from_zero(
+        long amountMinor,
+        int coveredDays,
+        int totalDays,
+        long expected) =>
+        CalendarBillingAlignment.Prorate(amountMinor, coveredDays, totalDays)
+            .Should().Be(expected);
+
+    [Fact]
+    public void A_default_fraction_is_a_whole_period()
+    {
+        var whole = default(BillingDayFraction);
+
+        whole.IsPartial.Should().BeFalse();
+        whole.Apply(8900).Should().Be(8900,
+            "every call site that does not know about proration must keep charging full periods");
+    }
+
+    [Fact]
+    public void A_snapshot_whose_cadence_contradicts_its_alignment_is_not_calendar_aligned()
+    {
+        CalendarBillingAlignment.IsCalendarAligned(new PriceSnapshot
+        {
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            Interval = BillingInterval.Month,
+            IntervalCount = 3
+        }).Should().BeFalse("a quarterly price has no single first of the month to renew on");
+
+        CalendarBillingAlignment.IsCalendarAligned(new PriceSnapshot
+        {
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            Interval = BillingInterval.Month,
+            IntervalCount = 1
+        }).Should().BeTrue();
+
+        CalendarBillingAlignment.IsCalendarAligned(null).Should().BeFalse();
+    }
+
+    private static void Resolve(DateTime nowUtc, out CalendarFirstPeriod period) =>
+        CalendarBillingAlignment.TryResolveFirstPeriod(nowUtc, Zurich, out period)
+            .Should().BeTrue();
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(
+            new DateTime(year, month, day, 0, 0, 0),
+            TimeZoneInfo.FindSystemTimeZoneById(Zurich));
+}

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -422,6 +422,93 @@ public sealed class SubscriptionActivationProcessorTests
                 }
             ]);
 
+    /// <summary>
+    /// A paid stub consumes one period of a limited promotion, read from what checkout froze.
+    /// </summary>
+    /// <remarks>
+    /// The promotion here expired between the charge being raised and this activation settling it,
+    /// which is exactly the case that must not be re-evaluated: the money already taken was reduced
+    /// by the discount, so the period is spent whatever the clock now says.
+    /// </remarks>
+    [Fact]
+    public async Task A_paid_stub_consumes_a_discount_period_even_once_the_promotion_has_lapsed()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSubscription(subscription =>
+        {
+            subscription.InitialChargeAmountMinor = 1_608;
+            subscription.InitialChargeProrated = true;
+            subscription.InitialChargeDiscountApplied = true;
+            subscription.ProrationDays = 7;
+            subscription.ProrationTotalDays = 31;
+            subscription.Discount = new DiscountTerms
+            {
+                Code = "welcome",
+                Kind = DiscountKind.Percent,
+                PercentBasisPoints = 2_000,
+                DurationPeriods = 3,
+                // Lapsed before the webhook arrived.
+                ExpiresAtUtc = _time.GetUtcNow().UtcDateTime.AddHours(-1)
+            };
+        });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().Be(1,
+            "the charge that was taken was discounted, so one of the three periods is spent");
+    }
+
+    [Fact]
+    public async Task A_stub_that_no_promotion_reduced_spends_nothing()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSubscription(subscription =>
+        {
+            subscription.InitialChargeAmountMinor = 2_010;
+            subscription.InitialChargeProrated = true;
+            subscription.InitialChargeDiscountApplied = false;
+        });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().BeNull();
+    }
+
+    /// <summary>
+    /// An anniversary first period deliberately still counts for nothing here — changing that
+    /// would shorten every existing plan's discount for reasons unrelated to calendar billing.
+    /// </summary>
+    [Fact]
+    public async Task A_whole_first_period_does_not_spend_a_discount_period()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSubscription(subscription =>
+        {
+            subscription.InitialChargeAmountMinor = 7_120;
+            subscription.InitialChargeProrated = false;
+            subscription.InitialChargeDiscountApplied = true;
+        });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().BeNull();
+    }
+
+    private void GivenSubscription(Action<SubscriptionDetail> configure) =>
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var subscription = NewSubscription();
+                configure(subscription);
+
+                return subscription;
+            });
+
     private SubscriptionActivationProcessor Processor() => new(
         _links.Object,
         _subscriptions.Object,


### PR DESCRIPTION
## What this adds

A monthly price can now choose where its renewal boundary falls:

- **`Anniversary`** — current behaviour. An August 25 signup renews September 25.
- **`CalendarMonth`** — charge a prorated August 25–31 stub, then renew for full months at local midnight on the first.

Selected per price inside the price card in the plan builder, and snapshotted onto every subscription sold on it.

```json
{ "interval": "Month", "intervalCount": 1, "billingAlignment": "CalendarMonth" }
```

`Anniversary` is the default and the enum's zero, so every existing price and subscription deserializes to exactly the behaviour it was sold on.

## How it works

**The recurring cadence needed nothing new.** A calendar-aligned `BillingSchedule` is an ordinary monthly one anchored on the first at local midnight, so `BillingPeriodCalculator` derives every later boundary as it always has. Only the *first* period is special, because it starts mid-month.

**Calendar dates, counted inclusively, in the subscriber's own time zone.** The 25th through the 31st is seven dates over the 31 August has. February uses 28 or 29 as appropriate. The time of day never enters into it — everyone signing up on the 25th pays the same fraction — and a signup on the *local* first gets a whole month that is not reported as prorated.

**The first charge is frozen when the subscription is built**, not derived at settlement. A checkout paid the next morning, resumed later, or picked up by the recovery sweep settles the figure the customer was quoted; a stub priced by the day would otherwise shrink underneath somebody who left the page open overnight.

**The day fraction is applied to the gross once, at the front**, so the volume band, promotional discount and tax all apply to a prorated gross:

1. Gross from price and quantities
2. Prorate by covered calendar days (nearest minor unit, halves away from zero)
3. Band and promotional discount — a *fixed* discount is prorated by the same fraction, a percentage needs no scaling
4. Tax, at the price's own rate and mode
5. Banked credit, last

**Metering is untouched.** The usage schedule keeps the plan's own independent cadence and the allowance stays whole for the stub — an allowance is capacity for a period, not money to be prorated.

## Notable decisions

- **A paid stub consumes one limited-discount period**, but an anniversary first period deliberately still does not. The field's own docs say it should, but making that change here would shorten every existing plan's discount by a period for reasons unrelated to calendar billing.
- **`CalendarMonth` is refused for any other cadence** as `subscription_billing_alignment_invalid`, at authoring time. A quarterly price has no single "first" to renew on that is not also a choice of which month, so there is nothing honest to clamp it to.
- **A snapshot whose alignment and cadence disagree bills by its cadence.** Only reachable by bypassing validation, but it must never bill half-way between the two.
- **Plan changes net two different prorations on purpose.** Unused time on the outgoing plan is credited by *elapsed time* (it is time they paid for); the target stub is priced by *calendar dates* (the same 7/31 a fresh signup would pay).

## New response fields

On subscriptions — populated while checkout is pending, kept afterwards for tracing. `recurringAmountMinor` still means the next *full* month.

```json
{
  "billingAlignment": "CalendarMonth",
  "initialChargeAmountMinor": 3274,
  "initialChargeProrated": true,
  "prorationDays": 7,
  "prorationTotalDays": 31
}
```

## Tests

45 new tests across five server files and three client files, covering the 7/31 case, February in common and leap years, signup on the first, UTC-boundary and daylight-saving dates, the frozen charge surviving a resumed checkout, quantity/tax/discount ordering, fixed-discount proration, the untouched usage allowance, a payment-free trial ending mid-month (including a late-running worker), plan-change netting, the full renewal after a stub, retry-on-the-same-boundary, and anniversary prices being unaffected.

- Server: `0 Error(s)`; full suite shows **no new failures** — the 154 failures are 150 Mongo-dependent `XUnitTest.Integration.*` tests plus 4 pre-existing `SubscriptionSimulationGuard`/permission failures, all present on `dev` before this change.
- Client: `211 passed` across the subscription module, `npm run type-check` clean, `npm run build` clean.

## Docs

`server/Subscription.DomainService/README.md` gains a "Calendar-aligned billing" section covering calendar-day inclusivity and time zones, checkout-creation anchoring, the discount/tax/credit ordering, trials, plan changes, the unchanged invoice boundary, and the validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
