### PR TITLE
Fix billing-alignment price creation

### DIFF
--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.test.ts
@@ -121,6 +121,37 @@ describe("submitPlanWithPrices", () => {
     expect(result.failures[0]).toContain("A price with these terms already exists.");
   });
 
+  it("can add a missing price to the same editable plan after partial creation", async () => {
+    const existingPlan = createdPlan();
+    const createPrice = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Invalid billing alignment."))
+      .mockResolvedValueOnce(existingPlan);
+
+    const firstAttempt = await submitPlanWithPrices({
+      planRequest,
+      prices: [price({ billingAlignment: "CalendarMonth" })],
+      createPlan: vi.fn().mockResolvedValue(existingPlan),
+      createPrice,
+    });
+
+    expect(firstAttempt.plan.planId).toBe("plan-1");
+    expect(firstAttempt.failures).toHaveLength(1);
+
+    const repairAttempt = await submitPlanWithPrices({
+      planRequest,
+      prices: [price({ billingAlignment: "CalendarMonth" })],
+      createPlan: vi.fn().mockResolvedValue(existingPlan),
+      createPrice,
+    });
+
+    expect(repairAttempt.plan.planId).toBe("plan-1");
+    expect(repairAttempt.failures).toEqual([]);
+    expect(createPrice).toHaveBeenLastCalledWith(
+      expect.objectContaining({ planId: "plan-1", billingAlignment: "CalendarMonth" }),
+    );
+  });
+
   it("carries on after a failing price so a later one still lands", async () => {
     const createPrice = vi
       .fn()

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -111,10 +111,18 @@ public sealed class SubscriptionPlansController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> CreatePrice(
-        [FromBody] CreatePriceRequest request,
+        [FromBody] CreatePriceRequest? request,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
+
+        if (request is null)
+        {
+            return BadRequest(ApiResponse<PlanResponse>.Fail(
+                "subscription_price_request_required",
+                "A price request body is required.",
+                correlationId));
+        }
 
         var result = await _catalogue.CreatePriceAsync(
             request,

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1560,6 +1560,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
   "unitAmountMinor": 300,        // 300 = EUR 3.00
   "interval": 2,                 // 2 = Month
   "intervalCount": 1,
+  "billingAlignment": "CalendarMonth", // or "Anniversary"; omitted = Anniversary
   "quantityItemKey": null,       // null = flat fee
   "taxRateBasisPoints": 770,     // optional, 7.7%
   "taxMode": "Exclusive"         // required whenever the rate is positive
@@ -1575,24 +1576,31 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
           <h4>Three prices, three shapes</h4>
           <pre><code>// Untaxed: nothing to say about tax.
 { "planId": "9f2c…", "currencyCode": "USD", "unitAmountMinor": 8900,
-  "interval": 2, "intervalCount": 1 }
+  "interval": 2, "intervalCount": 1, "billingAlignment": "Anniversary" }
 
 // Tax-exclusive: CHF 145.00 plus 7.7%. The customer is charged CHF 156.17.
 { "planId": "9f2c…", "currencyCode": "CHF", "unitAmountMinor": 14500,
-  "interval": 2, "intervalCount": 1,
+  "interval": 2, "intervalCount": 1, "billingAlignment": "CalendarMonth",
   "taxRateBasisPoints": 770, "taxMode": "Exclusive" }
 
 // Tax-inclusive: CHF 145.00 including 7.7%. The customer is charged CHF 145.00,
 // of which CHF 10.37 is tax.
 { "planId": "9f2c…", "currencyCode": "CHF", "unitAmountMinor": 14500,
-  "interval": 2, "intervalCount": 1,
+  "interval": 2, "intervalCount": 1, "billingAlignment": "CalendarMonth",
   "taxRateBasisPoints": 770, "taxMode": "Inclusive" }
 
 // Yearly at 8% off, added to any volume band the quantity selects.
 { "planId": "9f2c…", "currencyCode": "CHF", "unitAmountMinor": 100000,
-  "interval": 3, "intervalCount": 1, "quantityItemKey": "seat",
+  "interval": 3, "intervalCount": 1, "billingAlignment": "Anniversary",
+  "quantityItemKey": "seat",
   "automaticDiscountBasisPoints": 800,
   "quantityDiscountCombination": "Additive" }</code></pre>
+          <p class="prose">
+            <code>billingAlignment</code> uses the string values <code>Anniversary</code> and
+            <code>CalendarMonth</code>. Omit it for anniversary billing. Calendar-month alignment is
+            valid only for a one-month cadence and creates a prorated opening period ending on the
+            first day of the next month.
+          </p>
           <p class="prose">
             <code>quantityDiscountCombination</code> may be omitted; it reads as
             <code>BestDiscount</code>, the answer that cannot give away more than the larger of the

--- a/server/Subscription.DomainService/Enums/BillingAlignment.cs
+++ b/server/Subscription.DomainService/Enums/BillingAlignment.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Subscription.DomainService.Enums;
 
 /// <summary>
@@ -8,6 +10,7 @@ namespace Subscription.DomainService.Enums;
 /// cadence whether it renews on the day the subscriber signed up or on the first of the month —
 /// which is why this is its own concept rather than another <see cref="BillingInterval"/> member.
 /// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BillingAlignment
 {
     /// <summary>

--- a/server/XUnitTest/Subscription/BillingAlignmentJsonBindingTests.cs
+++ b/server/XUnitTest/Subscription/BillingAlignmentJsonBindingTests.cs
@@ -1,0 +1,122 @@
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+
+namespace XUnitTest.Subscription;
+
+public sealed class BillingAlignmentJsonBindingTests
+{
+    [Theory]
+    [InlineData("CalendarMonth", BillingAlignment.CalendarMonth)]
+    [InlineData("Anniversary", BillingAlignment.Anniversary)]
+    public async Task Price_request_accepts_named_billing_alignment(
+        string wireValue,
+        BillingAlignment expected)
+    {
+        var (result, modelState) = await BindAsync($$"""
+            {
+              "planId": "plan-1",
+              "currencyCode": "CHF",
+              "unitAmountMinor": 14500,
+              "interval": 2,
+              "intervalCount": 1,
+              "billingAlignment": "{{wireValue}}"
+            }
+            """);
+
+        result.HasError.Should().BeFalse();
+        modelState.IsValid.Should().BeTrue();
+        result.Model.Should().BeOfType<CreatePriceRequest>()
+            .Which.BillingAlignment.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Omitted_billing_alignment_defaults_to_anniversary()
+    {
+        var (result, modelState) = await BindAsync("""
+            {
+              "planId": "plan-1",
+              "currencyCode": "CHF",
+              "unitAmountMinor": 14500,
+              "interval": 2,
+              "intervalCount": 1
+            }
+            """);
+
+        result.HasError.Should().BeFalse();
+        modelState.IsValid.Should().BeTrue();
+        result.Model.Should().BeOfType<CreatePriceRequest>()
+            .Which.BillingAlignment.Should().Be(BillingAlignment.Anniversary);
+    }
+
+    [Fact]
+    public async Task Unknown_billing_alignment_is_a_field_specific_binding_error()
+    {
+        var (result, modelState) = await BindAsync("""
+            {
+              "planId": "plan-1",
+              "currencyCode": "CHF",
+              "unitAmountMinor": 14500,
+              "interval": 2,
+              "intervalCount": 1,
+              "billingAlignment": "EndOfMonth"
+            }
+            """);
+
+        result.HasError.Should().BeTrue();
+        modelState.IsValid.Should().BeFalse();
+        modelState.Keys.Should().Contain("$.billingAlignment");
+        modelState.Keys.Should().NotContain("request");
+    }
+
+    [Fact]
+    public async Task Numeric_billing_alignment_remains_compatible()
+    {
+        var (result, modelState) = await BindAsync("""
+            {
+              "planId": "plan-1",
+              "currencyCode": "CHF",
+              "unitAmountMinor": 14500,
+              "interval": 2,
+              "intervalCount": 1,
+              "billingAlignment": 1
+            }
+            """);
+
+        result.HasError.Should().BeFalse();
+        modelState.IsValid.Should().BeTrue();
+        result.Model.Should().BeOfType<CreatePriceRequest>()
+            .Which.BillingAlignment.Should().Be(BillingAlignment.CalendarMonth);
+    }
+
+    private static async Task<(InputFormatterResult Result, ModelStateDictionary ModelState)> BindAsync(
+        string json)
+    {
+        var options = new JsonOptions();
+        var formatter = new SystemTextJsonInputFormatter(
+            options,
+            NullLogger<SystemTextJsonInputFormatter>.Instance);
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.ContentType = "application/json";
+        httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        var metadata = new EmptyModelMetadataProvider()
+            .GetMetadataForType(typeof(CreatePriceRequest));
+        var modelState = new ModelStateDictionary();
+        var context = new InputFormatterContext(
+            httpContext,
+            "request",
+            modelState,
+            metadata,
+            (stream, encoding) => new StreamReader(stream, encoding));
+
+        return (await formatter.ReadAsync(context), modelState);
+    }
+}


### PR DESCRIPTION
## Summary
- accept Anniversary and CalendarMonth as public JSON values for BillingAlignment while retaining numeric compatibility
- remove the misleading implicit request-required error from invalid enum payloads and keep an explicit missing-body response
- document string alignment values and preserve/retest partial plan creation and price repair

## Verification
- dotnet test server/XUnitTest/XUnitTest.csproj --filter FullyQualifiedName~BillingAlignmentJsonBindingTests (5 passed)
- git diff --check
- Client test execution was attempted from the clean worktree, but it has no local node_modules; the pre-existing string-wire assertion remains and a partial-creation repair regression was added.

## Repair existing AMLora plan
The already-created AMLora Tier 1 plan remains valid. Add its missing price from the plan edit page after deploying this fix; do not recreate the plan.