### PR TITLE
Calendar-aligned yearly billing: state and charging

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -34,6 +34,7 @@ import {
   CALENDAR_ALIGNMENT_EXAMPLE,
   CALENDAR_YEARLY_ALIGNMENT_EXAMPLE,
   isCalendarEligible,
+  isCompatibleStubBasis,
   needsStubBasePrice,
   requiresStubBasePrice,
 } from "../../utilities/billing-alignment";
@@ -430,9 +431,9 @@ const PriceDiscountFields = ({ index }: { index: number }) => {
 /**
  * What the price costs, entered or derived.
  *
- * A calendar-aligned yearly price linked to a monthly one has no amount of its own: the server
- * derives it as twelve times the monthly figure, so the field is shown read-only rather than
- * offering an edit that would be discarded. Everything else is an ordinary amount input.
+ * Always the author's to set. A calendar-aligned yearly price is linked to a monthly one, but that
+ * link prices the opening period only — what a year costs stays a commercial decision, and an
+ * annual plan is usually not twelve monthly ones.
  */
 const PriceAmountField = ({ index }: { index: number }) => {
   const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
@@ -575,8 +576,17 @@ const PriceStubBasisField = ({
 }) => {
   const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
   const price = useWatch({ control, name: `prices.${index}` });
-  const eligible = monthlyPrices.filter(
-    (candidate) => candidate.currencyCode === price?.currencyCode,
+  // Every rule the server applies, so the picker cannot offer a choice the API refuses.
+  const eligible = monthlyPrices.filter((candidate) =>
+    isCompatibleStubBasis(candidate, {
+      currencyCode: price?.currencyCode ?? "",
+      quantityItemKey: price?.quantityItemKey,
+      taxPercent:
+        price?.taxPercent === undefined || price?.taxPercent === null
+          ? undefined
+          : Number(price.taxPercent),
+      taxMode: price?.taxMode,
+    }),
   );
 
   const basis = eligible.find(
@@ -589,8 +599,9 @@ const PriceStubBasisField = ({
 
       {eligible.length === 0 ? (
         <p className="text-xs text-muted-foreground" data-testid={`stub-basis-empty-${index}`}>
-          This plan has no monthly {price?.currencyCode} price yet. Add and save one first — a
-          yearly price on the calendar is charged from it, and derives its own amount from it.
+          This plan has no compatible monthly {price?.currencyCode} price yet. The opening period
+          is charged from one, so it has to match this price&apos;s currency, quantity item and tax
+          before it can be chosen. Add and save one first.
         </p>
       ) : (
         <>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -429,11 +429,12 @@ const PriceDiscountFields = ({ index }: { index: number }) => {
 };
 
 /**
- * What the price costs, entered or derived.
+ * What the price costs.
  *
- * Always the author's to set. A calendar-aligned yearly price is linked to a monthly one, but that
- * link prices the opening period only — what a year costs stays a commercial decision, and an
- * annual plan is usually not twelve monthly ones.
+ * Always the author's to set, on every cadence. A calendar-aligned yearly price is linked to a
+ * monthly one, but that link prices the opening period only — what a year costs stays a commercial
+ * decision, and an annual plan is usually not twelve monthly ones. Only the wording of the hint
+ * changes, to say which of the two figures this one is.
  */
 const PriceAmountField = ({ index }: { index: number }) => {
   const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
@@ -444,7 +445,6 @@ const PriceAmountField = ({ index }: { index: number }) => {
     intervalCount: Number(price?.intervalCount),
     billingAlignment: price?.billingAlignment,
   });
-  const derived = yearlyCalendar;
 
   return (
     <FormField
@@ -464,7 +464,7 @@ const PriceAmountField = ({ index }: { index: number }) => {
             />
           </FormControl>
           <FormDescription className="text-xs">
-            {derived
+            {yearlyCalendar
               ? "What a year costs, in major units. The monthly price below prices only the opening period."
               : "In major units — 89.00, not 8900."}
           </FormDescription>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -21,6 +21,7 @@ import {
   BILLING_ALIGNMENT_OPTIONS,
   BILLING_INTERVAL_OPTIONS,
   SUBSCRIPTION_CURRENCY_OPTIONS,
+  YEARLY_BILLING_ALIGNMENT_OPTIONS,
 } from "../../constants/subscription.constants";
 import type { PlanPrice } from "../../models/subscription-plan.model";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
@@ -30,9 +31,13 @@ import {
 } from "../../schemas/subscription-price.schema";
 import {
   CALENDAR_ALIGNMENT_EXAMPLE,
+  CALENDAR_YEARLY_ALIGNMENT_EXAMPLE,
   isCalendarEligible,
+  MONTHS_IN_A_YEAR,
+  needsStubBasePrice,
+  requiresStubBasePrice,
 } from "../../utilities/billing-alignment";
-import { formatPrice } from "../../utilities/subscription-format";
+import { formatMoney, formatPrice } from "../../utilities/subscription-format";
 import {
   AUTOMATIC_DISCOUNT_COMBINATION_OPTIONS,
   describeAutomaticDiscount,
@@ -423,6 +428,54 @@ const PriceDiscountFields = ({ index }: { index: number }) => {
 };
 
 /**
+ * What the price costs, entered or derived.
+ *
+ * A calendar-aligned yearly price linked to a monthly one has no amount of its own: the server
+ * derives it as twelve times the monthly figure, so the field is shown read-only rather than
+ * offering an edit that would be discarded. Everything else is an ordinary amount input.
+ */
+const PriceAmountField = ({ index }: { index: number }) => {
+  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const price = useWatch({ control, name: `prices.${index}` });
+
+  const derived = requiresStubBasePrice({
+    interval: Number(price?.interval),
+    intervalCount: Number(price?.intervalCount),
+    billingAlignment: price?.billingAlignment,
+  });
+
+  return (
+    <FormField
+      control={control}
+      name={`prices.${index}.amount`}
+      render={({ field: inputField }) => (
+        <FormItem>
+          <FormLabel className="text-xs">Amount</FormLabel>
+          <FormControl>
+            <Input
+              {...inputField}
+              type="number"
+              min={0}
+              step="0.01"
+              placeholder="89.00"
+              readOnly={derived}
+              aria-label={`Amount for price ${index + 1}`}
+              className={derived ? "bg-muted text-muted-foreground" : undefined}
+            />
+          </FormControl>
+          <FormDescription className="text-xs">
+            {derived
+              ? "Derived from the monthly price below — twelve times its amount."
+              : "In major units — 89.00, not 8900."}
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
+/**
  * When this price renews, for the one cadence that gets a choice.
  *
  * Hidden rather than disabled for every other cadence. A greyed-out "renew on the 1st" invites the
@@ -432,60 +485,157 @@ const PriceDiscountFields = ({ index }: { index: number }) => {
  * Its own component because it watches two fields of this row; watching them in the list body
  * would re-render every price card whenever either changed.
  */
-const PriceBillingAlignmentField = ({ index }: { index: number }) => {
+const PriceBillingAlignmentField = ({
+  index,
+  monthlyPrices,
+}: {
+  index: number;
+  /** The plan's active monthly prices, which a yearly one can be charged from. */
+  monthlyPrices: PlanPrice[];
+}) => {
   const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
   const price = useWatch({ control, name: `prices.${index}` });
 
-  if (
-    !price ||
-    !isCalendarEligible({
-      interval: Number(price.interval),
-      intervalCount: Number(price.intervalCount),
-    })
-  ) {
+  const cadence = {
+    interval: Number(price?.interval),
+    intervalCount: Number(price?.intervalCount),
+  };
+
+  if (!price || !isCalendarEligible(cadence)) {
     return null;
   }
 
+  // A year and a month are the same mechanism and the same stored value, but not the same
+  // sentence: "renew on the 1st" without saying of which month reads as monthly billing.
+  const yearly = needsStubBasePrice(cadence);
+  const options = yearly ? YEARLY_BILLING_ALIGNMENT_OPTIONS : BILLING_ALIGNMENT_OPTIONS;
+
   return (
-    <FormField
-      control={control}
-      name={`prices.${index}.billingAlignment`}
-      render={({ field: inputField }) => (
-        <FormItem>
-          <FormLabel className="text-xs">Billing cycle</FormLabel>
-          <Select value={inputField.value} onValueChange={inputField.onChange}>
-            <FormControl>
-              <SelectTrigger aria-label={`Billing cycle for price ${index + 1}`}>
-                <SelectValue />
-              </SelectTrigger>
-            </FormControl>
-            <SelectContent>
-              {BILLING_ALIGNMENT_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <FormDescription className="text-xs">
-            {
-              BILLING_ALIGNMENT_OPTIONS.find(
-                (option) => option.value === inputField.value,
-              )?.hint
-            }
-          </FormDescription>
-          {inputField.value === "CalendarMonth" && (
+    <>
+      <FormField
+        control={control}
+        name={`prices.${index}.billingAlignment`}
+        render={({ field: inputField }) => (
+          <FormItem>
+            <FormLabel className="text-xs">Billing cycle</FormLabel>
+            <Select value={inputField.value} onValueChange={inputField.onChange}>
+              <FormControl>
+                <SelectTrigger aria-label={`Billing cycle for price ${index + 1}`}>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormDescription className="text-xs">
+              {options.find((option) => option.value === inputField.value)?.hint}
+            </FormDescription>
+            {inputField.value === "CalendarMonth" && (
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid={`billing-alignment-example-${index}`}
+              >
+                {yearly ? CALENDAR_YEARLY_ALIGNMENT_EXAMPLE : CALENDAR_ALIGNMENT_EXAMPLE}
+              </p>
+            )}
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {yearly && price.billingAlignment === "CalendarMonth" && (
+        <PriceStubBasisField index={index} monthlyPrices={monthlyPrices} />
+      )}
+    </>
+  );
+};
+
+/**
+ * The monthly price a calendar-aligned yearly price is charged from, and the annual figure that
+ * follows from it.
+ *
+ * The annual amount is shown rather than entered, because the server derives it: an annual price
+ * and its own monthly equivalent cannot be allowed to disagree about what a year costs, and only
+ * one of the two can be the source of that truth. An editable field here would be overwritten,
+ * which is worse than one that never invited the edit.
+ *
+ * Offers only prices the plan already has. A yearly price cannot be charged from a monthly one
+ * being authored in the same submission, because that one has no id until it is created.
+ */
+const PriceStubBasisField = ({
+  index,
+  monthlyPrices,
+}: {
+  index: number;
+  monthlyPrices: PlanPrice[];
+}) => {
+  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const price = useWatch({ control, name: `prices.${index}` });
+  const eligible = monthlyPrices.filter(
+    (candidate) => candidate.currencyCode === price?.currencyCode,
+  );
+
+  const basis = eligible.find(
+    (candidate) => candidate.priceId === price?.calendarStubBasePriceId,
+  );
+
+  return (
+    <div className="space-y-2 rounded-md border border-dashed border-border/70 p-2">
+      <p className="text-xs font-medium">Charged from</p>
+
+      {eligible.length === 0 ? (
+        <p className="text-xs text-muted-foreground" data-testid={`stub-basis-empty-${index}`}>
+          This plan has no monthly {price?.currencyCode} price yet. Add and save one first — a
+          yearly price on the calendar is charged from it, and derives its own amount from it.
+        </p>
+      ) : (
+        <>
+          <FormField
+            control={control}
+            name={`prices.${index}.calendarStubBasePriceId`}
+            render={({ field: inputField }) => (
+              <FormItem>
+                <FormLabel className="text-xs">Monthly price</FormLabel>
+                <Select value={inputField.value ?? ""} onValueChange={inputField.onChange}>
+                  <FormControl>
+                    <SelectTrigger aria-label={`Monthly price for price ${index + 1}`}>
+                      <SelectValue placeholder="Choose the monthly price" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {eligible.map((candidate) => (
+                      <SelectItem key={candidate.priceId} value={candidate.priceId}>
+                        {formatPrice(candidate)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription className="text-xs">
+                  The opening period is a fraction of this price, counted in calendar days.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {basis && (
             <p
               className="text-xs text-muted-foreground"
-              data-testid={`billing-alignment-example-${index}`}
+              data-testid={`stub-basis-preview-${index}`}
             >
-              {CALENDAR_ALIGNMENT_EXAMPLE}
+              {formatMoney(basis.unitAmountMinor * MONTHS_IN_A_YEAR, basis.currencyCode)} a year,
+              derived as twelve times this monthly amount. Any automatic discount below applies to
+              both the opening period and the year.
             </p>
           )}
-          <FormMessage />
-        </FormItem>
+        </>
       )}
-    />
+    </div>
   );
 };
 
@@ -526,6 +676,12 @@ export const PlanPriceFields = ({
   const { control, formState } = useFormContext<CreateSubscriptionPlanFormValues>();
   const prices = useFieldArray({ control, name: "prices" });
   const quantityItems = useWatch({ control, name: "quantityItems" });
+
+  // Only prices the plan already has: one being authored in the same submission has no id yet, so
+  // nothing could be linked to it.
+  const monthlyPrices = existingPrices.filter(
+    (price) => price.interval === "Month" && price.intervalCount === 1,
+  );
 
   // The "add at least one" issue lands on the array itself, which no per-field FormMessage
   // renders — the same trap the rate-table tier ordering hit.
@@ -616,22 +772,7 @@ export const PlanPriceFields = ({
                   </FormItem>
                 )}
               />
-              <FormField
-                control={control}
-                name={`prices.${index}.amount`}
-                render={({ field: inputField }) => (
-                  <FormItem>
-                    <FormLabel className="text-xs">Amount</FormLabel>
-                    <FormControl>
-                      <Input {...inputField} type="number" min={0} step="0.01" placeholder="89.00" />
-                    </FormControl>
-                    <FormDescription className="text-xs">
-                      In major units — 89.00, not 8900.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              <PriceAmountField index={index} />
             </div>
 
             <div className="grid grid-cols-2 gap-2">
@@ -680,7 +821,7 @@ export const PlanPriceFields = ({
               />
             </div>
 
-            <PriceBillingAlignmentField index={index} />
+            <PriceBillingAlignmentField index={index} monthlyPrices={monthlyPrices} />
 
             <FormField
               control={control}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -20,6 +20,7 @@ import {
 import {
   BILLING_ALIGNMENT_OPTIONS,
   BILLING_INTERVAL_OPTIONS,
+  CALENDAR_ANNUAL_CHARGE_TIMING_OPTIONS,
   SUBSCRIPTION_CURRENCY_OPTIONS,
   YEARLY_BILLING_ALIGNMENT_OPTIONS,
 } from "../../constants/subscription.constants";
@@ -33,7 +34,6 @@ import {
   CALENDAR_ALIGNMENT_EXAMPLE,
   CALENDAR_YEARLY_ALIGNMENT_EXAMPLE,
   isCalendarEligible,
-  MONTHS_IN_A_YEAR,
   needsStubBasePrice,
   requiresStubBasePrice,
 } from "../../utilities/billing-alignment";
@@ -438,11 +438,12 @@ const PriceAmountField = ({ index }: { index: number }) => {
   const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
   const price = useWatch({ control, name: `prices.${index}` });
 
-  const derived = requiresStubBasePrice({
+  const yearlyCalendar = requiresStubBasePrice({
     interval: Number(price?.interval),
     intervalCount: Number(price?.intervalCount),
     billingAlignment: price?.billingAlignment,
   });
+  const derived = yearlyCalendar;
 
   return (
     <FormField
@@ -458,14 +459,12 @@ const PriceAmountField = ({ index }: { index: number }) => {
               min={0}
               step="0.01"
               placeholder="89.00"
-              readOnly={derived}
               aria-label={`Amount for price ${index + 1}`}
-              className={derived ? "bg-muted text-muted-foreground" : undefined}
             />
           </FormControl>
           <FormDescription className="text-xs">
             {derived
-              ? "Derived from the monthly price below — twelve times its amount."
+              ? "What a year costs, in major units. The monthly price below prices only the opening period."
               : "In major units — 89.00, not 8900."}
           </FormDescription>
           <FormMessage />
@@ -628,11 +627,46 @@ const PriceStubBasisField = ({
               className="text-xs text-muted-foreground"
               data-testid={`stub-basis-preview-${index}`}
             >
-              {formatMoney(basis.unitAmountMinor * MONTHS_IN_A_YEAR, basis.currencyCode)} a year,
-              derived as twelve times this monthly amount. Any automatic discount below applies to
-              both the opening period and the year.
+              A signup on 25 August pays 7/31 of{" "}
+              {formatMoney(basis.unitAmountMinor, basis.currencyCode)} for the rest of the month.
+              Any automatic discount below applies to that opening period as well as to the year;
+              a promotional code applies to the year alone.
             </p>
           )}
+
+          <FormField
+            control={control}
+            name={`prices.${index}.calendarAnnualChargeTiming`}
+            render={({ field: inputField }) => (
+              <FormItem>
+                <FormLabel className="text-xs">Collect the year</FormLabel>
+                <Select value={inputField.value} onValueChange={inputField.onChange}>
+                  <FormControl>
+                    <SelectTrigger
+                      aria-label={`Annual charge timing for price ${index + 1}`}
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {CALENDAR_ANNUAL_CHARGE_TIMING_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription className="text-xs">
+                  {
+                    CALENDAR_ANNUAL_CHARGE_TIMING_OPTIONS.find(
+                      (option) => option.value === inputField.value,
+                    )?.hint
+                  }
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
         </>
       )}
     </div>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-yearly-alignment.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-yearly-alignment.test.tsx
@@ -120,8 +120,35 @@ describe("a yearly price in the plan builder", () => {
     await chooseCalendar();
 
     expect(screen.getByTestId("stub-basis-empty-0")).toHaveTextContent(
-      /no monthly CHF price yet/i,
+      /no compatible monthly CHF price yet/i,
     );
+  });
+
+  /**
+   * The server refuses a basis that differs in quantity item or tax, so offering one here would
+   * only produce a rejection after the author had chosen it.
+   */
+  it.each([
+    ["a different quantity item", { quantityItemKey: "seat" }],
+    ["a different tax rate", { taxRateBasisPoints: 770, taxMode: "Exclusive" }],
+  ])("does not offer a monthly price with %s", async (_label, mismatch) => {
+    render(<Harness existingPrices={[monthly(mismatch as Partial<PlanPrice>)]} />);
+    await chooseCalendar();
+
+    expect(screen.getByTestId("stub-basis-empty-0")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Monthly price for price 1")).not.toBeInTheDocument();
+  });
+
+  it("offers a monthly price whose tax mode matches", async () => {
+    render(
+      <Harness
+        existingPrices={[monthly({ taxRateBasisPoints: 0 })]}
+      />,
+    );
+    const user = await chooseCalendar();
+    await user.click(screen.getByLabelText("Monthly price for price 1"));
+
+    expect(screen.getAllByRole("option")).toHaveLength(1);
   });
 
   it("offers only monthly prices in the same currency", async () => {

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-yearly-alignment.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-yearly-alignment.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+import type { ReactNode } from "react";
+
+import type { PlanPrice } from "../../models/subscription-plan.model";
+import {
+  defaultSubscriptionPlanFormValues,
+  type CreateSubscriptionPlanFormValues,
+} from "../../schemas/subscription-plan.schema";
+import { PlanPriceFields } from "./plan-price-fields";
+
+const monthly = (overrides: Partial<PlanPrice> = {}): PlanPrice => ({
+  priceId: "price-monthly",
+  currencyCode: "CHF",
+  unitAmountMinor: 95_000,
+  interval: "Month",
+  intervalCount: 1,
+  quantityItemKey: null,
+  ...overrides,
+});
+
+const Harness = ({
+  children,
+  existingPrices = [],
+}: {
+  children?: ReactNode;
+  existingPrices?: PlanPrice[];
+}) => {
+  const form = useForm<CreateSubscriptionPlanFormValues>({
+    defaultValues: {
+      ...defaultSubscriptionPlanFormValues,
+      prices: [
+        {
+          ...defaultSubscriptionPlanFormValues.prices[0],
+          currencyCode: "CHF",
+          // Yearly, once a year.
+          interval: 3,
+          intervalCount: 1,
+        },
+      ],
+    },
+  });
+
+  return (
+    <FormProvider {...form}>
+      {children ?? <PlanPriceFields isEditing existingPrices={existingPrices} />}
+    </FormProvider>
+  );
+};
+
+const chooseCalendar = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByLabelText("Billing cycle for price 1"));
+  await user.click(screen.getByRole("option", { name: /start on the 1st/i }));
+
+  return user;
+};
+
+describe("a yearly price in the plan builder", () => {
+  it("is offered a billing cycle, worded for a year", () => {
+    render(<Harness existingPrices={[monthly()]} />);
+
+    expect(screen.getByLabelText("Billing cycle for price 1")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Billing cycle for price 1" }))
+      .toHaveTextContent("Subscription anniversary");
+  });
+
+  it("explains that the stub comes first and the year follows", async () => {
+    render(<Harness existingPrices={[monthly()]} />);
+    await chooseCalendar();
+
+    expect(screen.getByTestId("billing-alignment-example-0")).toHaveTextContent(
+      "A signup on August 25 pays 7/31 of the monthly price above, then a full year from September 1.",
+    );
+  });
+
+  it("asks which monthly price the opening period is charged from", async () => {
+    render(<Harness existingPrices={[monthly()]} />);
+    await chooseCalendar();
+
+    expect(screen.getByLabelText("Monthly price for price 1")).toBeInTheDocument();
+  });
+
+  /**
+   * The annual figure is the server's to derive. Offering an editable field would promise an edit
+   * that gets overwritten, which is worse than never inviting it.
+   */
+  it("shows the annual amount as derived rather than entered", async () => {
+    render(<Harness existingPrices={[monthly()]} />);
+    const user = await chooseCalendar();
+
+    expect(screen.getByLabelText("Amount for price 1")).toHaveAttribute("readonly");
+
+    await user.click(screen.getByLabelText("Monthly price for price 1"));
+    await user.click(screen.getByRole("option", { name: /950\.00/ }));
+
+    expect(screen.getByTestId("stub-basis-preview-0")).toHaveTextContent(
+      /CHF\s*11.400\.00 a year/,
+    );
+  });
+
+  it("says so when the plan has no monthly price to charge from", async () => {
+    render(<Harness existingPrices={[]} />);
+    await chooseCalendar();
+
+    expect(screen.getByTestId("stub-basis-empty-0")).toHaveTextContent(
+      /no monthly CHF price yet/i,
+    );
+  });
+
+  it("offers only monthly prices in the same currency", async () => {
+    render(
+      <Harness
+        existingPrices={[
+          monthly(),
+          monthly({ priceId: "price-eur", currencyCode: "EUR" }),
+          monthly({ priceId: "price-yearly-other", interval: "Year" }),
+        ]}
+      />,
+    );
+    const user = await chooseCalendar();
+    await user.click(screen.getByLabelText("Monthly price for price 1"));
+
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+  });
+
+  it("asks nothing about a monthly counterpart while the price is on its anniversary", () => {
+    render(<Harness existingPrices={[monthly()]} />);
+
+    expect(screen.queryByLabelText("Monthly price for price 1")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Amount for price 1")).not.toHaveAttribute("readonly");
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-yearly-alignment.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-yearly-alignment.test.tsx
@@ -87,18 +87,32 @@ describe("a yearly price in the plan builder", () => {
    * The annual figure is the server's to derive. Offering an editable field would promise an edit
    * that gets overwritten, which is worse than never inviting it.
    */
-  it("shows the annual amount as derived rather than entered", async () => {
+  /**
+   * The annual amount stays the author's to set — a year is usually not twelve months, and
+   * deriving it would take that decision away from whoever is selling it. The linked monthly price
+   * prices the opening period and nothing else, which the preview says in those terms.
+   */
+  it("keeps the annual amount editable and explains what the monthly price buys", async () => {
     render(<Harness existingPrices={[monthly()]} />);
     const user = await chooseCalendar();
 
-    expect(screen.getByLabelText("Amount for price 1")).toHaveAttribute("readonly");
+    expect(screen.getByLabelText("Amount for price 1")).not.toHaveAttribute("readonly");
 
     await user.click(screen.getByLabelText("Monthly price for price 1"));
     await user.click(screen.getByRole("option", { name: /950\.00/ }));
 
     expect(screen.getByTestId("stub-basis-preview-0")).toHaveTextContent(
-      /CHF\s*11.400\.00 a year/,
+      /7\/31 of CHF\s*950\.00 for the rest of the month/,
     );
+  });
+
+  it("asks when the year should be collected", async () => {
+    render(<Harness existingPrices={[monthly()]} />);
+    await chooseCalendar();
+
+    const timing = screen.getByLabelText("Annual charge timing for price 1");
+    expect(timing).toBeInTheDocument();
+    expect(timing).toHaveTextContent("When the year starts");
   });
 
   it("says so when the plan has no monthly price to charge from", async () => {

--- a/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
+++ b/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
@@ -30,6 +30,24 @@ export const BILLING_ALIGNMENT_OPTIONS = [
   },
 ] as const;
 
+/**
+ * The same choice, worded for a yearly price. The mechanism is identical and the stored value is
+ * the same; what differs is what the subscriber gets, and saying "renew on the 1st" without saying
+ * "of which month" would read as monthly billing.
+ */
+export const YEARLY_BILLING_ALIGNMENT_OPTIONS = [
+  {
+    value: "Anniversary",
+    label: "Subscription anniversary",
+    hint: "Renews on the day of the year they subscribed.",
+  },
+  {
+    value: "CalendarMonth",
+    label: "Calendar year — start on the 1st",
+    hint: "A prorated month first, then a full year from the 1st of next month.",
+  },
+] as const;
+
 export const METER_AGGREGATION_OPTIONS = [
   { value: 0, label: "Sum — add up every recorded amount" },
   { value: 1, label: "Max — the highest single recording" },

--- a/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
+++ b/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
@@ -48,6 +48,26 @@ export const YEARLY_BILLING_ALIGNMENT_OPTIONS = [
   },
 ] as const;
 
+/**
+ * When a calendar-aligned yearly price collects its annual amount.
+ *
+ * Both come to the same money; they differ in when it is taken and what a cancellation during the
+ * opening stub leaves the subscriber holding. Worth saying plainly, because an author choosing
+ * between them is choosing a refund policy as much as a collection date.
+ */
+export const CALENDAR_ANNUAL_CHARGE_TIMING_OPTIONS = [
+  {
+    value: "AtBoundary",
+    label: "When the year starts",
+    hint: "Collect the opening period now, and the year on the 1st. Cancelling before then ends access with the opening period.",
+  },
+  {
+    value: "AtCheckout",
+    label: "Up front, with the first payment",
+    hint: "Collect both together now. The year is prepaid, so cancelling before it starts refunds nothing and access runs to its end.",
+  },
+] as const;
+
 export const METER_AGGREGATION_OPTIONS = [
   { value: 0, label: "Sum — add up every recorded amount" },
   { value: 1, label: "Max — the highest single recording" },

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -41,6 +41,12 @@ export const BILLING_INTERVAL_NAMES = ["Day", "Week", "Month", "Year"] as const;
  */
 export const BILLING_ALIGNMENT_NAMES = ["Anniversary", "CalendarMonth"] as const;
 
+/** When a calendar-aligned yearly price collects its annual amount. Sent and returned by name. */
+export const CALENDAR_ANNUAL_CHARGE_TIMING_NAMES = ["AtBoundary", "AtCheckout"] as const;
+
+export type CalendarAnnualChargeTimingName =
+  (typeof CALENDAR_ANNUAL_CHARGE_TIMING_NAMES)[number];
+
 export type BillingAlignmentName = (typeof BILLING_ALIGNMENT_NAMES)[number];
 
 export type BillingIntervalName = keyof typeof BILLING_INTERVAL;
@@ -144,6 +150,8 @@ export interface PlanPrice {
    */
   calendarStubBasePriceId?: string | null;
   calendarStubBaseUnitAmountMinor?: number | null;
+  /** "AtBoundary" or "AtCheckout". Null on every price that is not calendar-aligned yearly. */
+  calendarAnnualChargeTiming?: CalendarAnnualChargeTimingName | null;
   displayPriceNote?: string | null;
   quantityItemKey: string | null;
   /** Basis points — 770 is 7.7%. Absent when the price carries no tax. */
@@ -309,6 +317,8 @@ export interface CreateSubscriptionPriceRequest {
    * `unitAmountMinor` server-derived, so that field is omitted rather than guessed at.
    */
   calendarStubBasePriceId?: string;
+  /** Omitted means "AtBoundary". Refused on any price that is not calendar-aligned yearly. */
+  calendarAnnualChargeTiming?: CalendarAnnualChargeTimingName;
   displayPriceNote?: string;
   quantityItemKey?: string;
   /** Basis points. Omitted for an untaxed price; the mode is required whenever this is positive. */

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -138,6 +138,12 @@ export interface PlanPrice {
    * which only ever sold anniversary prices.
    */
   billingAlignment?: BillingAlignmentName;
+  /**
+   * The monthly price a calendar-aligned yearly price charges its opening period from, and that
+   * price's amount when this one was authored. Null on every other price.
+   */
+  calendarStubBasePriceId?: string | null;
+  calendarStubBaseUnitAmountMinor?: number | null;
   displayPriceNote?: string | null;
   quantityItemKey: string | null;
   /** Basis points — 770 is 7.7%. Absent when the price carries no tax. */
@@ -289,11 +295,20 @@ export interface CreateSubscriptionPriceRequest {
   /** Omitted for a tenant-wide plan; honoured for the console only. */
   organizationId?: string;
   currencyCode: string;
-  unitAmountMinor: number;
+  /**
+   * Omitted for a calendar-aligned yearly price, where the server derives it as twelve times the
+   * linked monthly amount. Sending a conflicting figure is refused rather than ignored.
+   */
+  unitAmountMinor?: number;
   interval: number;
   intervalCount: number;
   /** Omitted means "Anniversary". Only a monthly price billed once a month may be calendar-aligned. */
   billingAlignment?: BillingAlignmentName;
+  /**
+   * Required for a calendar-aligned yearly price, refused on every other. Naming it also makes
+   * `unitAmountMinor` server-derived, so that field is omitted rather than guessed at.
+   */
+  calendarStubBasePriceId?: string;
   displayPriceNote?: string;
   quantityItemKey?: string;
   /** Basis points. Omitted for an untaxed price; the mode is required whenever this is positive. */

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
 import { AUTOMATIC_DISCOUNT_COMBINATIONS } from "../utilities/subscription-discount";
-import { BILLING_ALIGNMENT_NAMES } from "../models/subscription-plan.model";
+import {
+  BILLING_ALIGNMENT_NAMES,
+  CALENDAR_ANNUAL_CHARGE_TIMING_NAMES,
+} from "../models/subscription-plan.model";
 import { TAX_MODES } from "../utilities/subscription-tax";
 
 /**
@@ -44,6 +47,13 @@ export const subscriptionPriceFieldsSchema = z.object({
    * The server refuses the combination regardless.
    */
   calendarStubBasePriceId: z.string().optional(),
+  /**
+   * When the annual amount is collected. Defaulted rather than required, because "unstated" already
+   * means the conservative answer everywhere else: collect the year when the year starts.
+   */
+  calendarAnnualChargeTiming: z
+    .enum(CALENDAR_ANNUAL_CHARGE_TIMING_NAMES)
+    .default("AtBoundary"),
   displayPriceNote: z.string().trim().max(200).optional().or(z.literal("")),
   quantityItemKey: z.string().min(1),
   /**
@@ -107,6 +117,7 @@ export const defaultSubscriptionPriceFormValues: CreateSubscriptionPriceFormValu
   // would have.
   billingAlignment: "Anniversary",
   calendarStubBasePriceId: undefined,
+  calendarAnnualChargeTiming: "AtBoundary",
   displayPriceNote: "",
   quantityItemKey: FLAT_FEE,
   taxPercent: undefined,

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-price.schema.ts
@@ -35,6 +35,15 @@ export const subscriptionPriceFieldsSchema = z.object({
    * invalid combination through this form; the server refuses it regardless.
    */
   billingAlignment: z.enum(BILLING_ALIGNMENT_NAMES).default("Anniversary"),
+  /**
+   * The monthly price a calendar-aligned yearly price is charged from. Empty for every other
+   * price; submit drops it rather than sending one the server would refuse.
+   *
+   * Not required here even when the cadence needs one: the field only appears for that cadence, and
+   * a resolver error on a hidden control is a form that cannot be submitted and cannot say why.
+   * The server refuses the combination regardless.
+   */
+  calendarStubBasePriceId: z.string().optional(),
   displayPriceNote: z.string().trim().max(200).optional().or(z.literal("")),
   quantityItemKey: z.string().min(1),
   /**
@@ -97,6 +106,7 @@ export const defaultSubscriptionPriceFormValues: CreateSubscriptionPriceFormValu
   // Anniversary by default, so an author who never opens this section sells the price they always
   // would have.
   billingAlignment: "Anniversary",
+  calendarStubBasePriceId: undefined,
   displayPriceNote: "",
   quantityItemKey: FLAT_FEE,
   taxPercent: undefined,

--- a/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.test.ts
@@ -9,12 +9,17 @@ describe("isCalendarEligible", () => {
     expect(isCalendarEligible({ interval: 2, intervalCount: 1 })).toBe(true);
   });
 
+  it("accepts a price billed every single year", () => {
+    // A year aligns too, but by starting on the first rather than by prorating a year.
+    expect(isCalendarEligible({ interval: 3, intervalCount: 1 })).toBe(true);
+  });
+
   it.each([
     ["quarterly", 2, 3],
     ["annually as twelve months", 2, 12],
     ["daily", 0, 1],
     ["fortnightly", 1, 2],
-    ["yearly", 3, 1],
+    ["every two years", 3, 2],
   ])("refuses %s, which has no single first to renew on", (_label, interval, intervalCount) => {
     expect(isCalendarEligible({ interval, intervalCount })).toBe(false);
   });

--- a/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.ts
@@ -1,11 +1,14 @@
 import { BILLING_INTERVAL } from "../models/subscription-plan.model";
 
+/** A year, in months. Named because a bare 12 in a money calculation is not obvious. */
+export const MONTHS_IN_A_YEAR = 12;
+
 /**
  * Whether a price's cadence can be aligned to the calendar at all.
  *
- * Monthly, once a month, and nothing else — the same rule the server validates. A fortnight and a
- * quarter both have boundaries that only sometimes land on a first, so there is no honest "the
- * 1st" to offer an author for them.
+ * Once a month or once a year, and nothing else — the same rule the server validates. A fortnight
+ * and a quarter both have boundaries that only sometimes land on a first, so there is no honest
+ * "the 1st" to offer an author for them.
  *
  * Takes the numeric interval the form holds rather than the name a response carries, because this
  * decides what the plan builder shows while it is being filled in.
@@ -14,7 +17,36 @@ export const isCalendarEligible = (price: {
   interval: number;
   intervalCount: number;
 }): boolean =>
-  price.interval === BILLING_INTERVAL.Month && price.intervalCount === 1;
+  price.intervalCount === 1 &&
+  (price.interval === BILLING_INTERVAL.Month || price.interval === BILLING_INTERVAL.Year);
+
+/**
+ * Whether this price prices its opening stub from a separate monthly price.
+ *
+ * Yearly only. A month's stub is a fraction of the very price being charged; a year's cannot be,
+ * because days of an annual amount are not a quantity anybody can charge. The monthly equivalent
+ * has to be named.
+ */
+export const needsStubBasePrice = (price: {
+  interval: number;
+  intervalCount: number;
+}): boolean =>
+  price.interval === BILLING_INTERVAL.Year && price.intervalCount === 1;
+
+/** Whether this price is authored as calendar-aligned *and* on a cadence that allows it. */
+export const isCalendarAligned = (price: {
+  interval: number;
+  intervalCount: number;
+  billingAlignment?: string;
+}): boolean =>
+  price.billingAlignment === "CalendarMonth" && isCalendarEligible(price);
+
+/** Whether the author has to pick a monthly counterpart for this price. */
+export const requiresStubBasePrice = (price: {
+  interval: number;
+  intervalCount: number;
+  billingAlignment?: string;
+}): boolean => isCalendarAligned(price) && needsStubBasePrice(price);
 
 /**
  * The worked example an author needs to believe the arithmetic.
@@ -25,3 +57,6 @@ export const isCalendarEligible = (price: {
  */
 export const CALENDAR_ALIGNMENT_EXAMPLE =
   "A signup on August 25 pays 7/31 of this monthly price, then renews on September 1.";
+
+export const CALENDAR_YEARLY_ALIGNMENT_EXAMPLE =
+  "A signup on August 25 pays 7/31 of the monthly price above, then a full year from September 1.";

--- a/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/billing-alignment.ts
@@ -1,4 +1,5 @@
 import { BILLING_INTERVAL } from "../models/subscription-plan.model";
+import { FLAT_FEE } from "../schemas/subscription-price.schema";
 
 /** A year, in months. Named because a bare 12 in a money calculation is not obvious. */
 export const MONTHS_IN_A_YEAR = 12;
@@ -47,6 +48,60 @@ export const requiresStubBasePrice = (price: {
   intervalCount: number;
   billingAlignment?: string;
 }): boolean => isCalendarAligned(price) && needsStubBasePrice(price);
+
+/**
+ * Whether a monthly price can be the stub basis for a yearly one being authored.
+ *
+ * Mirrors the server's own check, which refuses anything else. The stub is charged from this
+ * price's amount and the annual period from the yearly one, so a mismatch in what they multiply or
+ * how they are taxed produces two figures a subscriber cannot reconcile — and offering the choice
+ * in the picker only to have the API reject it is the worst version of that.
+ *
+ * Currency, quantity item and tax must all agree. The cadence is already guaranteed by the caller
+ * filtering to monthly prices.
+ */
+export const isCompatibleStubBasis = (
+  candidate: {
+    currencyCode: string;
+    quantityItemKey?: string | null;
+    taxRateBasisPoints?: number | null;
+    taxMode?: string | null;
+  },
+  yearly: {
+    currencyCode: string;
+    quantityItemKey?: string | null;
+    taxPercent?: number;
+    taxMode?: string;
+  },
+): boolean => {
+  if (candidate.currencyCode !== yearly.currencyCode) {
+    return false;
+  }
+
+  // The sentinel the price form uses for "flat fee" never leaves that form, so compare on the
+  // absence of a key rather than on its spelling.
+  const candidateItem = candidate.quantityItemKey ?? "";
+  const yearlyItem =
+    !yearly.quantityItemKey || yearly.quantityItemKey === FLAT_FEE ? "" : yearly.quantityItemKey;
+
+  if (candidateItem !== yearlyItem) {
+    return false;
+  }
+
+  const candidateRate = candidate.taxRateBasisPoints ?? 0;
+  const yearlyRate = yearly.taxPercent ? Math.round(yearly.taxPercent * 100) : 0;
+
+  if (candidateRate !== yearlyRate) {
+    return false;
+  }
+
+  // Mode only matters where there is a rate for it to describe, and an absent mode reads as
+  // exclusive — which is how the server charges a price authored before modes existed.
+  return (
+    candidateRate === 0 ||
+    (candidate.taxMode ?? "Exclusive") === (yearly.taxMode ?? "Exclusive")
+  );
+};
 
 /**
  * The worked example an author needs to believe the arithmetic.

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -209,6 +209,10 @@ const planPriceToFormValues = (price: PlanPrice): CreateSubscriptionPriceFormVal
   // before alignment existed was sold on. Reading it as anything else would silently re-anchor a
   // duplicated price onto a calendar its original never used.
   billingAlignment: price.billingAlignment ?? "Anniversary",
+  calendarStubBasePriceId: price.calendarStubBasePriceId ?? undefined,
+  // Absent means the conservative reading, the same one the server and the form both default to:
+  // collect the year when the year starts.
+  calendarAnnualChargeTiming: price.calendarAnnualChargeTiming ?? "AtBoundary",
   displayPriceNote: price.displayPriceNote ?? "",
   quantityItemKey: price.quantityItemKey ?? FLAT_FEE,
   taxPercent: price.taxRateBasisPoints

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-alignment.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-alignment.test.ts
@@ -67,7 +67,33 @@ describe("submitting a plan's prices", () => {
 
     expect(request.billingAlignment).toBe("CalendarMonth");
     expect(request.calendarStubBasePriceId).toBe("price-monthly");
-    expect(request.unitAmountMinor).toBeUndefined();
+    // Authored, not derived: what a year costs is a commercial decision, and the linked monthly
+    // price prices only the opening stub.
+    expect(request.unitAmountMinor).toBeDefined();
+    expect(request.calendarAnnualChargeTiming).toBe("AtBoundary");
+  });
+
+  it("sends the chosen annual charge timing", async () => {
+    const [request] = await submit({
+      interval: 3,
+      intervalCount: 1,
+      billingAlignment: "CalendarMonth",
+      calendarStubBasePriceId: "price-monthly",
+      calendarAnnualChargeTiming: "AtCheckout",
+    });
+
+    expect(request.calendarAnnualChargeTiming).toBe("AtCheckout");
+  });
+
+  it("drops a charge timing the cadence cannot carry", async () => {
+    const [request] = await submit({
+      interval: 2,
+      intervalCount: 1,
+      billingAlignment: "CalendarMonth",
+      calendarAnnualChargeTiming: "AtCheckout",
+    });
+
+    expect(request.calendarAnnualChargeTiming).toBeUndefined();
   });
 
   it("sends nothing for a price billed every two years", async () => {

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-alignment.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-alignment.test.ts
@@ -57,14 +57,44 @@ describe("submitting a plan's prices", () => {
     expect(request.intervalCount).toBe(3);
   });
 
-  it("sends nothing for a yearly price", async () => {
+  it("sends the calendar alignment for a yearly price too", async () => {
     const [request] = await submit({
       interval: 3,
       intervalCount: 1,
       billingAlignment: "CalendarMonth",
+      calendarStubBasePriceId: "price-monthly",
+    });
+
+    expect(request.billingAlignment).toBe("CalendarMonth");
+    expect(request.calendarStubBasePriceId).toBe("price-monthly");
+    expect(request.unitAmountMinor).toBeUndefined();
+  });
+
+  it("sends nothing for a price billed every two years", async () => {
+    const [request] = await submit({
+      interval: 3,
+      intervalCount: 2,
+      billingAlignment: "CalendarMonth",
     });
 
     expect(request.billingAlignment).toBeUndefined();
+  });
+
+  /**
+   * The monthly link only means something on a calendar-aligned yearly price, and the server
+   * refuses it anywhere else. A form can drift into that state by an author choosing yearly,
+   * picking a counterpart, then switching the cadence back to monthly.
+   */
+  it("drops a monthly counterpart the cadence can no longer carry", async () => {
+    const [request] = await submit({
+      interval: 2,
+      intervalCount: 1,
+      billingAlignment: "CalendarMonth",
+      calendarStubBasePriceId: "price-monthly",
+    });
+
+    expect(request.calendarStubBasePriceId).toBeUndefined();
+    expect(request.unitAmountMinor).toBeDefined();
   });
 
   it("sends the anniversary explicitly when that is what was chosen", async () => {
@@ -85,7 +115,7 @@ describe("submitting a plan's prices", () => {
 
     expect(requests.map((request) => request.billingAlignment)).toEqual([
       "CalendarMonth",
-      undefined,
+      "Anniversary",
     ]);
   });
 });

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
@@ -48,12 +48,7 @@ export const submitPlanWithPrices = async <TPlanRequest,>({
         // resolves each request on its own — without naming it, the plan reads as missing.
         organizationId: plan.organizationId ?? undefined,
         currencyCode: price.currencyCode,
-        // Omitted when the server derives it from the linked monthly price. Sending a figure the
-        // server would only recompute invites the two to disagree, and it refuses a mismatch
-        // rather than silently overwriting.
-        unitAmountMinor: requiresStubBasePrice(price)
-          ? undefined
-          : toMinorUnits(price.amount, price.currencyCode),
+        unitAmountMinor: toMinorUnits(price.amount, price.currencyCode),
         interval: price.interval,
           intervalCount: price.intervalCount,
           // Only for the cadence that can carry it. Sending "CalendarMonth" alongside a quarterly
@@ -64,6 +59,11 @@ export const submitPlanWithPrices = async <TPlanRequest,>({
           // yearly-calendar and then changed the cadence is refused outright by the server.
           calendarStubBasePriceId: requiresStubBasePrice(price)
             ? price.calendarStubBasePriceId
+            : undefined,
+          // Same cadence rule as the link it belongs to. A timing left behind by an author who
+          // changed the cadence is refused outright by the server.
+          calendarAnnualChargeTiming: requiresStubBasePrice(price)
+            ? price.calendarAnnualChargeTiming
             : undefined,
           displayPriceNote: price.displayPriceNote?.trim() || undefined,
         quantityItemKey:

--- a/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/submit-plan-with-prices.ts
@@ -4,7 +4,7 @@ import type {
 } from "../models/subscription-plan.model";
 import type { CreateSubscriptionPriceFormValues } from "../schemas/subscription-price.schema";
 import { FLAT_FEE } from "../schemas/subscription-price.schema";
-import { isCalendarEligible } from "./billing-alignment";
+import { isCalendarEligible, requiresStubBasePrice } from "./billing-alignment";
 import { toMinorUnits } from "./subscription-format";
 import { toBasisPoints } from "./subscription-tax";
 
@@ -48,13 +48,23 @@ export const submitPlanWithPrices = async <TPlanRequest,>({
         // resolves each request on its own — without naming it, the plan reads as missing.
         organizationId: plan.organizationId ?? undefined,
         currencyCode: price.currencyCode,
-        unitAmountMinor: toMinorUnits(price.amount, price.currencyCode),
+        // Omitted when the server derives it from the linked monthly price. Sending a figure the
+        // server would only recompute invites the two to disagree, and it refuses a mismatch
+        // rather than silently overwriting.
+        unitAmountMinor: requiresStubBasePrice(price)
+          ? undefined
+          : toMinorUnits(price.amount, price.currencyCode),
         interval: price.interval,
           intervalCount: price.intervalCount,
           // Only for the cadence that can carry it. Sending "CalendarMonth" alongside a quarterly
           // cadence is the one combination the server refuses outright, and the form can drift
           // into it by an author choosing the calendar and then changing the interval.
           billingAlignment: isCalendarEligible(price) ? price.billingAlignment : undefined,
+          // Only for the one cadence that carries it. A link left behind by an author who chose
+          // yearly-calendar and then changed the cadence is refused outright by the server.
+          calendarStubBasePriceId: requiresStubBasePrice(price)
+            ? price.calendarStubBasePriceId
+            : undefined,
           displayPriceNote: price.displayPriceNote?.trim() || undefined,
         quantityItemKey:
           price.quantityItemKey === FLAT_FEE ? undefined : price.quantityItemKey,

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1597,9 +1597,76 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
   "quantityDiscountCombination": "Additive" }</code></pre>
           <p class="prose">
             <code>billingAlignment</code> uses the string values <code>Anniversary</code> and
-            <code>CalendarMonth</code>. Omit it for anniversary billing. Calendar-month alignment is
-            valid only for a one-month cadence and creates a prorated opening period ending on the
-            first day of the next month.
+            <code>CalendarMonth</code>. Omit it for anniversary billing. Calendar alignment is valid
+            for a one-month or a one-year cadence, and nothing else &mdash; a quarterly price has no
+            single &ldquo;first&rdquo; to renew on that is not also a choice of which month. Anything
+            else is rejected with <code>subscription_billing_alignment_invalid</code>.
+          </p>
+
+          <h4>Calendar-aligned yearly prices</h4>
+          <p class="prose">
+            A calendar-aligned <em>month</em> prorates the price being charged. A calendar-aligned
+            <em>year</em> cannot: a week of an annual amount is not a quantity anybody can charge. So
+            a yearly price must name the monthly price its opening period is a fraction of, through
+            <code>calendarStubBasePriceId</code>, and choose when the year itself is collected,
+            through <code>calendarAnnualChargeTiming</code>.
+          </p>
+          <pre><code>// CHF 950 a month, CHF 11,400 a year, 8% off for paying annually.
+{ "planId": "9f2c…", "currencyCode": "CHF", "unitAmountMinor": 1140000,
+  "interval": 3, "intervalCount": 1,
+  "billingAlignment": "CalendarMonth",
+  "calendarStubBasePriceId": "price-monthly-chf",
+  "calendarAnnualChargeTiming": "AtBoundary",  // or "AtCheckout"; omitted = AtBoundary
+  "automaticDiscountBasisPoints": 800 }</code></pre>
+          <p class="prose">
+            The linked price prices the opening period and nothing else. <code>unitAmountMinor</code>
+            stays the authored annual amount &mdash; what a year costs is a commercial decision, and
+            an annual plan is usually not twelve monthly ones.
+          </p>
+          <p class="prose">
+            For a signup on 25 August, the two timings differ only in when the money moves:
+          </p>
+          <table>
+            <thead>
+              <tr><th></th><th>At checkout</th><th>On 1 September</th><th>Cancelling before then</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><code>AtBoundary</code></td>
+                <td>CHF 197.36 (the stub)</td>
+                <td>CHF 10,488.00 charged</td>
+                <td>access ends with the stub; the year is never charged</td>
+              </tr>
+              <tr>
+                <td><code>AtCheckout</code></td>
+                <td>CHF 10,685.36 (both)</td>
+                <td>the year opens, nothing is charged</td>
+                <td>nothing is refunded; access runs to the end of the year</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="prose">
+            The stub is <code>7/31</code> of the monthly price &mdash; calendar dates, counted
+            inclusively, in the subscription&rsquo;s own time zone. The yearly price&rsquo;s automatic
+            discount and volume band apply to both the stub and the year; a <em>promotional code</em>
+            applies to the year alone and is consumed once when the year settles.
+          </p>
+          <p class="prose">
+            The linked price is validated at authoring time: same plan, active, one-month cadence,
+            same currency, same quantity item, same tax rate and mode. A mismatch is rejected with
+            <code>subscription_calendar_stub_base_price_invalid</code>; a missing link on a
+            calendar-aligned yearly price with
+            <code>subscription_calendar_stub_base_price_required</code>; and either field on a price
+            that cannot carry it with
+            <code>subscription_calendar_stub_base_price_unexpected</code> or
+            <code>subscription_calendar_annual_charge_timing_unexpected</code>.
+          </p>
+          <p class="prose">
+            While a subscription is inside its opening stub with a year still pending, plan and
+            quantity changes are refused with <code>409</code>
+            <code>subscription_initial_annual_period_pending</code>. Repricing then would have to
+            unpick a settled annual charge or discard one about to be collected. The wait is at most
+            a month.
           </p>
           <p class="prose">
             <code>quantityDiscountCombination</code> may be omitted; it reads as

--- a/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
+++ b/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
@@ -1,0 +1,62 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The year a calendar-aligned yearly subscription has bought but not yet started.
+/// </summary>
+/// <remarks>
+/// Exists only between a mid-month signup and the first of the following month. A subscriber who
+/// joins on 25 August holds a stub covering the rest of August and a year that begins on
+/// 1 September; this is that year, waiting.
+/// <para>
+/// Every figure is frozen when the checkout is created, and none of them is recalculated when the
+/// boundary arrives. The whole point of collecting them here is that the subscriber has been quoted
+/// a year — its dates, its amount, its tax — and a boundary charge that re-derived any of it could
+/// take a different sum than the one they agreed to.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class PendingAnnualPeriod
+{
+    /// <summary>The local first the year begins on, and the same date a year later.</summary>
+    public DateTime StartUtc { get; set; }
+
+    public DateTime EndUtc { get; set; }
+
+    /// <summary>What the year costs the payer, after discounts, tax and any credit.</summary>
+    public long AmountMinor { get; set; }
+
+    /// <summary>The charge before tax, and the tax on it — the split an invoice has to show.</summary>
+    public long NetAmountMinor { get; set; }
+
+    public long TaxAmountMinor { get; set; }
+
+    /// <summary>The undiscounted annual amount, before anything came off it.</summary>
+    public long GrossAmountMinor { get; set; }
+
+    /// <summary>What the price's automatic discount and volume band took off.</summary>
+    public long BuiltInDiscountMinor { get; set; }
+
+    /// <summary>What a promotional code took off. Codes apply to the year, never to the stub.</summary>
+    public long PromotionalDiscountMinor { get; set; }
+
+    /// <summary>
+    /// Whether a promotional code actually reduced this year, so it can be counted once against
+    /// <see cref="DiscountTerms.DurationPeriods"/> when the year is settled.
+    /// </summary>
+    public bool DiscountApplied { get; set; }
+
+    /// <summary>
+    /// Whether the year was collected with the opening charge rather than at its own boundary.
+    /// </summary>
+    /// <remarks>
+    /// True for a price configured <c>AtCheckout</c>. The boundary then moves the subscription into
+    /// this period without charging anything, and cancelling during the stub refunds nothing —
+    /// the subscriber bought the year.
+    /// </remarks>
+    public bool IsPrepaid { get; set; }
+
+    /// <summary>The payment that settled this year, once one has. Null while it is still owed.</summary>
+    public string? PaymentDetailId { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
+++ b/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
@@ -48,12 +48,23 @@ public sealed class PendingAnnualPeriod
     public bool DiscountApplied { get; set; }
 
     /// <summary>
-    /// Whether the year was collected with the opening charge rather than at its own boundary.
+    /// Whether this year was <em>meant</em> to be collected with the opening charge.
     /// </summary>
     /// <remarks>
-    /// True for a price configured <c>AtCheckout</c>. The boundary then moves the subscription into
-    /// this period without charging anything, and cancelling during the stub refunds nothing —
-    /// the subscriber bought the year.
+    /// The price's configuration, copied at signup. It says what was billed for, not what was
+    /// paid — an unpaid checkout carries this exactly as a paid one does.
+    /// </remarks>
+    public bool CollectedWithCheckout { get; set; }
+
+    /// <summary>
+    /// Whether the money for this year has actually arrived.
+    /// </summary>
+    /// <remarks>
+    /// Set by the activation that records the opening payment, never at signup. The distinction
+    /// from <see cref="CollectedWithCheckout"/> is load-bearing twice over: this flag is what tells
+    /// the boundary to skip the gateway, so deriving it from configuration would let an unpaid
+    /// checkout open a year nobody paid for — and it is what a client reads to say whether the
+    /// subscriber owes anything, so a pending checkout must not report itself as settled.
     /// </remarks>
     public bool IsPrepaid { get; set; }
 

--- a/server/Subscription.DomainService/Entities/Price.cs
+++ b/server/Subscription.DomainService/Entities/Price.cs
@@ -52,12 +52,24 @@ public sealed class Price
     /// quantity — what they owe is a week of the monthly equivalent, which has to be named rather
     /// than guessed at by dividing the annual figure by twelve.
     /// <para>
-    /// Naming it also fixes <see cref="UnitAmountMinor"/>: an annual price linked this way is
-    /// derived as the monthly amount times twelve rather than authored, so the two can never
-    /// disagree about what a year costs.
+    /// It prices the stub and nothing else. <see cref="UnitAmountMinor"/> stays independently
+    /// authored, because what a year costs is a commercial decision — an annual plan is usually
+    /// not twelve monthly ones.
     /// </para>
     /// </remarks>
     public string? CalendarStubBasePriceId { get; set; }
+
+    /// <summary>
+    /// When a calendar-aligned yearly price collects its annual amount: at the boundary the year
+    /// begins, or up front alongside the stub.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful on a calendar-aligned yearly price, and refused elsewhere. Defaults to
+    /// <see cref="Enums.CalendarAnnualChargeTiming.AtBoundary"/>, the enum's zero and the more
+    /// conservative reading: a year nobody has started is a year nobody has paid for.
+    /// </remarks>
+    public CalendarAnnualChargeTiming CalendarAnnualChargeTiming { get; set; } =
+        CalendarAnnualChargeTiming.AtBoundary;
 
     /// <summary>
     /// The linked monthly price's unit amount, copied at authoring time.

--- a/server/Subscription.DomainService/Entities/Price.cs
+++ b/server/Subscription.DomainService/Entities/Price.cs
@@ -43,6 +43,32 @@ public sealed class Price
     /// </remarks>
     public BillingAlignment BillingAlignment { get; set; } = BillingAlignment.Anniversary;
 
+    /// <summary>
+    /// The monthly price a calendar-aligned <em>yearly</em> price prices its opening stub from.
+    /// </summary>
+    /// <remarks>
+    /// Required for a calendar-aligned yearly price and refused on every other price. A subscriber
+    /// joining on 25 August owes a week, and a week of an annual price is not a meaningful
+    /// quantity — what they owe is a week of the monthly equivalent, which has to be named rather
+    /// than guessed at by dividing the annual figure by twelve.
+    /// <para>
+    /// Naming it also fixes <see cref="UnitAmountMinor"/>: an annual price linked this way is
+    /// derived as the monthly amount times twelve rather than authored, so the two can never
+    /// disagree about what a year costs.
+    /// </para>
+    /// </remarks>
+    public string? CalendarStubBasePriceId { get; set; }
+
+    /// <summary>
+    /// The linked monthly price's unit amount, copied at authoring time.
+    /// </summary>
+    /// <remarks>
+    /// Stored here as well as on the linked price so a stub can be priced without a second
+    /// catalogue read, and so retiring or repricing the monthly price later cannot change what an
+    /// annual price is derived from.
+    /// </remarks>
+    public long? CalendarStubBaseUnitAmountMinor { get; set; }
+
     public string? DisplayPriceNote { get; set; }
 
     /// <summary>

--- a/server/Subscription.DomainService/Entities/PriceSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PriceSnapshot.cs
@@ -46,6 +46,18 @@ public sealed class PriceSnapshot
     /// </remarks>
     public string? CalendarStubBasePriceId { get; set; }
 
+    /// <summary>
+    /// When a calendar-aligned yearly price collects its annual amount: at the boundary the year
+    /// begins, or up front alongside the stub.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful on a calendar-aligned yearly price, and refused elsewhere. Defaults to
+    /// <see cref="Enums.CalendarAnnualChargeTiming.AtBoundary"/>, the enum's zero and the more
+    /// conservative reading: a year nobody has started is a year nobody has paid for.
+    /// </remarks>
+    public CalendarAnnualChargeTiming CalendarAnnualChargeTiming { get; set; } =
+        CalendarAnnualChargeTiming.AtBoundary;
+
     public long? CalendarStubBaseUnitAmountMinor { get; set; }
 
     public string? DisplayPriceNote { get; set; }

--- a/server/Subscription.DomainService/Entities/PriceSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PriceSnapshot.cs
@@ -34,6 +34,20 @@ public sealed class PriceSnapshot
     /// </remarks>
     public BillingAlignment BillingAlignment { get; set; } = BillingAlignment.Anniversary;
 
+    /// <summary>
+    /// The monthly price this yearly price's opening stub was priced from, and that price's unit
+    /// amount as it stood when this subscription was sold.
+    /// </summary>
+    /// <remarks>
+    /// Snapshotted like everything else here, and for a sharper reason than most: the stub is
+    /// charged at checkout and the annual period a month later, so a live catalogue read would let
+    /// somebody editing the monthly price in between change what an annual subscriber already
+    /// agreed to. Null on every price that is not a calendar-aligned yearly one.
+    /// </remarks>
+    public string? CalendarStubBasePriceId { get; set; }
+
+    public long? CalendarStubBaseUnitAmountMinor { get; set; }
+
     public string? DisplayPriceNote { get; set; }
 
     public string? QuantityItemKey { get; set; }

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -145,6 +145,18 @@ public sealed class SubscriptionDetail
     public List<PendingUsagePeriod> PendingUsagePeriods { get; set; } = [];
 
     /// <summary>
+    /// The year a calendar-aligned yearly subscription has bought but not yet started, if it is
+    /// still inside its opening stub.
+    /// </summary>
+    /// <remarks>
+    /// Present only between a mid-month signup and the first of the following month. While it is
+    /// here the subscription is mid-transaction in a way plan and quantity changes cannot safely
+    /// reason about — a year is already priced and possibly already paid for — so both are refused
+    /// until the boundary settles it.
+    /// </remarks>
+    public PendingAnnualPeriod? PendingAnnualPeriod { get; set; }
+
+    /// <summary>
     /// A reduction in purchased quantity waiting for the paid period to end, if one is scheduled.
     /// </summary>
     /// <remarks>

--- a/server/Subscription.DomainService/Enums/CalendarAnnualChargeTiming.cs
+++ b/server/Subscription.DomainService/Enums/CalendarAnnualChargeTiming.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// When a calendar-aligned yearly price collects its annual amount.
+/// </summary>
+/// <remarks>
+/// Only meaningful alongside <see cref="BillingAlignment.CalendarMonth"/> on a yearly price, which
+/// is the one arrangement with two separate things to charge for: the stub covering the rest of the
+/// month, and the year that begins on the first.
+/// <para>
+/// Serialized by name, like every other enum crossing this boundary — a client that has to know
+/// <c>1</c> means prepaid is coupled to our storage format.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum CalendarAnnualChargeTiming
+{
+    /// <summary>
+    /// Collect the stub now and the annual amount when the year actually begins.
+    /// </summary>
+    /// <remarks>
+    /// Zero, and therefore what a price authored without an opinion gets. It is also the more
+    /// conservative of the two: the subscriber has paid for exactly what they hold, and a year they
+    /// have not started is a year they have not paid for.
+    /// </remarks>
+    AtBoundary = 0,
+
+    /// <summary>
+    /// Collect the stub and the whole year together, at checkout.
+    /// </summary>
+    /// <remarks>
+    /// The year is then prepaid: the boundary moves the subscription into it without charging
+    /// anything. Nothing is refunded if they cancel during the stub — they bought the year.
+    /// </remarks>
+    AtCheckout = 1
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -299,6 +299,12 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                 ActivatedAtUtc = _time.GetUtcNow().UtcDateTime,
                 InitialPaymentDetailId = payment.ItemId,
                 DiscountPeriodsApplied = StubConsumedDiscountPeriod(subscription) ? 1 : null,
+                // The opening charge included the year on a price that collects it here, and this
+                // is the transition that says that charge was confirmed. Marking it any earlier
+                // would report an unpaid checkout as settled; any later leaves the boundary unable
+                // to tell a paid year from one still owed.
+                MarkPendingAnnualPeriodPrepaid =
+                    subscription.PendingAnnualPeriod is { CollectedWithCheckout: true },
 
                 Event = _events.Create(
                     subscription,

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -298,7 +298,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             {
                 ActivatedAtUtc = _time.GetUtcNow().UtcDateTime,
                 InitialPaymentDetailId = payment.ItemId,
-                DiscountPeriodsApplied = StubConsumedDiscountPeriod(subscription) ? 1 : null,
+                DiscountPeriodsApplied = OpeningChargeSpentDiscountPeriod(subscription) ? 1 : null,
                 // The opening charge included the year on a price that collects it here, and this
                 // is the transition that says that charge was confirmed. Marking it any earlier
                 // would report an unpaid checkout as settled; any later leaves the boundary unable
@@ -335,7 +335,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     }
 
     /// <summary>
-    /// Whether this activation just paid for a prorated stub that a promotion reduced.
+    /// Whether the charge this activation confirmed was one a promotion reduced.
     /// </summary>
     /// <remarks>
     /// Read from what checkout froze, never recalculated. Whether a discount applies depends on
@@ -343,13 +343,16 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     /// that lapsed in between would look inactive here while the money already taken was reduced
     /// by it, and the subscriber would get one more discounted renewal than they paid for.
     /// <para>
-    /// Deliberately only a *stub*. An anniversary first period has never counted here, and making
-    /// it start to would shorten every existing plan's discount by one period for reasons that
-    /// have nothing to do with calendar billing.
+    /// Stub or whole period, so long as the price is calendar-aligned: both are charges a promotion
+    /// reduced, and a signup on the first that escaped counting would discount two annual payments
+    /// out of a one-period promotion. What is deliberately excluded is *anniversary* — its first
+    /// period has never counted here, and making it start to would shorten every existing plan's
+    /// discount for reasons that have nothing to do with calendar billing.
     /// </para>
     /// </remarks>
-    private static bool StubConsumedDiscountPeriod(SubscriptionDetail subscription) =>
-        subscription.InitialChargeProrated && subscription.InitialChargeDiscountApplied;
+    private static bool OpeningChargeSpentDiscountPeriod(SubscriptionDetail subscription) =>
+        subscription.InitialChargeDiscountApplied &&
+        CalendarBillingAlignment.IsCalendarAligned(subscription.Price);
 
     /// <summary>
     /// Records the provider's customer from the card the charge saved.

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -180,9 +180,21 @@ price, snapshotted onto every subscription sold on it:
 `Anniversary` is the default and the enum's zero, so every price and subscription written before
 alignment existed deserializes to exactly the behaviour it was sold on.
 
-**Only `Month` with an `intervalCount` of 1 may be calendar-aligned.** A quarterly price has no
-single "first" to renew on that is not also a choice of which month, so the combination is refused
-at authoring time as `subscription_billing_alignment_invalid` rather than guessed at on an invoice.
+**Only `Month` or `Year` with an `intervalCount` of 1 may be calendar-aligned.** A quarterly price
+has no single "first" to renew on that is not also a choice of which month, so the combination is
+refused at authoring time as `subscription_billing_alignment_invalid` rather than guessed at on an
+invoice.
+
+The two cadences align differently, and the difference is the whole of the yearly feature:
+
+| | Anchors on | Opening period | Then |
+|---|---|---|---|
+| `Month` × 1 | the first of the month it starts in | the rest of that month, prorated | the 1st, every month |
+| `Year` × 1 | the first of the month **after** | the rest of that month, prorated | the same 1st, every year |
+
+A year anchored on the month it started in would end on the 1 August after a 25 August signup —
+eleven months for a year's money — and no later boundary could correct it, because every one is
+derived from the anchor.
 
 ### The opening period is a stub
 
@@ -203,6 +215,49 @@ Two consequences worth stating:
 - **The subscriber's calendar decides, not the server's.** 31 August 23:00 UTC is already
   1 September in Zurich, and a Zurich subscriber signing up then gets a whole month rather than a
   one-day stub. A signup on the local first is a full period and is *not* reported as prorated.
+
+### A yearly stub is priced from a linked monthly price
+
+A monthly stub is a fraction of the very price being charged. A yearly one cannot be: a subscriber
+joining on 25 August owes a week, and a week of an annual amount is not a quantity anybody can
+charge. So a calendar-aligned **yearly** price must name the monthly price its opening period is a
+fraction of, through `calendarStubBasePriceId`.
+
+That link is required for `Year` × 1 calendar prices
+(`subscription_calendar_stub_base_price_required`) and refused on every other price
+(`subscription_calendar_stub_base_price_unexpected`), since nothing else would ever read it. The
+referenced price is validated at authoring time — same plan, active, `Month` × 1, same currency,
+same quantity item, same tax rate and mode — because every one of those, left to differ, produces
+two figures a subscriber cannot reconcile and only discovers on an invoice.
+
+Naming it also makes the annual amount **server-derived**: `unitAmountMinor` is twelve times the
+monthly amount. Clients omit the field; a conflicting one is refused
+(`subscription_calendar_stub_base_price_amount_conflict`) rather than silently overwritten. An
+annual price and its own monthly equivalent cannot be allowed to disagree about what a year costs,
+and only one of the two can be the source of that truth.
+
+Worked through for a plan at CHF 950 a month with 8% off for paying annually, signing up 25 August:
+
+| | Calculation | Amount |
+|---|---|---|
+| 25–31 August | `95000 × 7/31` = 21452, less 8% | **CHF 197.36** |
+| 1 September | `95000 × 12` = 1140000, less 8% | **CHF 10,488.00** |
+| 1 September next year | the same again | **CHF 10,488.00** |
+
+The yearly price's own automatic discount applies to the stub as well as the year: somebody who
+buys an 8%-off annual plan on the 25th is on that plan from the 25th, and charging them
+undiscounted for the first week would be selling them the discount a week late.
+
+The monthly amount and price id are **snapshotted onto the subscription**, so the stub is priced
+without ever reading the monthly price again — not at checkout, not at renewal, not by a recovery
+sweep. The stub is charged at checkout and the annual period a month later, so a live read would
+let somebody editing the monthly price in between change what an annual subscriber already agreed
+to.
+
+> A yearly snapshot that carries no monthly basis cannot price a stub, and falls back to an
+> ordinary anniversary year rather than prorating the annual amount by days. That fallback is
+> deliberate: the alternative bills a week at roughly a twelfth of what it is worth, which is the
+> one failure mode worth failing closed against.
 
 ### The first charge is frozen at checkout creation
 
@@ -288,7 +343,8 @@ an allowance is capacity for a period, not money to be prorated.
   12/31 August stub it owes, keys it to August, advances to 1 September and leaves the
   subscription due again, so the next pass raises September as its own separate charge. Anchoring
   on the clock instead would silently write off the days in between.
-- A trial ending **on the first** starts with a full month.
+- A trial ending **on the first** starts with a full period — a month for a monthly price, a year
+  for a yearly one.
 - A **payment-required trial** is charged up front at checkout, so its first fee uses the calendar
   stub exactly as an ordinary signup does.
 
@@ -306,6 +362,10 @@ This holds for a whole target month as much as for a stub. A change landing on t
 `30/30` rather than "no fraction given", because the latter means "scale by elapsed clock time",
 and that would charge a subscriber who moved at noon less than one who signed up fresh at noon for
 the identical month. Calendar dates decide; the time of day is not one of them.
+
+A change onto a calendar-aligned **yearly** price settles only the target stub immediately, priced
+from that price's monthly basis exactly as a fresh signup would be. The annual cycle then opens on
+the first like any other calendar-aligned year.
 
 A positive difference is charged immediately; a negative one is banked as credit. The target
 schedule is installed atomically with the settled plan change, and the outgoing usage period is

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -230,23 +230,62 @@ referenced price is validated at authoring time — same plan, active, `Month` �
 same quantity item, same tax rate and mode — because every one of those, left to differ, produces
 two figures a subscriber cannot reconcile and only discovers on an invoice.
 
-Naming it also makes the annual amount **server-derived**: `unitAmountMinor` is twelve times the
-monthly amount. Clients omit the field; a conflicting one is refused
-(`subscription_calendar_stub_base_price_amount_conflict`) rather than silently overwritten. An
-annual price and its own monthly equivalent cannot be allowed to disagree about what a year costs,
-and only one of the two can be the source of that truth.
+The link prices the stub and nothing else. **The annual `unitAmountMinor` stays independently
+authored**, because what a year costs is a commercial decision — an annual plan is usually not
+twelve monthly ones — and deriving it would take that decision away from whoever is selling it.
 
-Worked through for a plan at CHF 950 a month with 8% off for paying annually, signing up 25 August:
+Worked through for a plan at CHF 950 a month and CHF 11,400 a year, with 8% off for paying
+annually, signing up 25 August:
 
 | | Calculation | Amount |
 |---|---|---|
 | 25–31 August | `95000 × 7/31` = 21452, less 8% | **CHF 197.36** |
-| 1 September | `95000 × 12` = 1140000, less 8% | **CHF 10,488.00** |
+| 1 September | `1140000`, less 8% | **CHF 10,488.00** |
 | 1 September next year | the same again | **CHF 10,488.00** |
 
-The yearly price's own automatic discount applies to the stub as well as the year: somebody who
-buys an 8%-off annual plan on the 25th is on that plan from the 25th, and charging them
-undiscounted for the first week would be selling them the discount a week late.
+The yearly price's own automatic discount and volume band apply to the stub as well as the year:
+somebody who buys an 8%-off annual plan on the 25th is on that plan from the 25th, and charging
+them undiscounted for the first week would be selling them the discount a week late.
+
+A **promotional code is the exception — it applies to the year alone**, and is consumed once when
+the year is settled. Spending a month of a customer's three-month promotion on a seven-day stub
+would exchange a month of their discount for a week of it.
+
+### When the year is collected
+
+`calendarAnnualChargeTiming` decides that, and it is the only difference between the two calendar
+yearly modes. Both come to the same money.
+
+| | At checkout | On 1 September | Cancelling during the stub |
+|---|---|---|---|
+| `AtBoundary` (default) | the stub | the year is charged | access ends with the stub; the year is never charged |
+| `AtCheckout` | the stub **and** the year | the year opens, nothing is charged | nothing is refunded; access runs to the end of the year |
+
+An author choosing between these is choosing a refund policy as much as a collection date, which is
+why the plan builder states both consequences rather than only the timing.
+
+The field is required to be absent on every price that is not calendar-aligned yearly
+(`subscription_calendar_annual_charge_timing_unexpected`) — anywhere else it would describe a choice
+nothing acts on.
+
+### The year in between
+
+Between a mid-month signup and the first, the subscription carries a `PendingAnnualPeriod`: the
+year's dates, its full financial breakdown, whether a promotion reduced it, and whether it has
+already been paid for. Every figure is frozen when the checkout is created and **none is
+recalculated at the boundary** — that boundary is a month later, and a charge that re-derived its
+own amount could take a different sum than the one the subscriber agreed to.
+
+The boundary charge and the period it opens are written in one transition, so opening the year and
+forgetting that it was pending cannot come apart; a boundary that did the first and not the second
+would find the year again on the next sweep and charge for it twice. A declined boundary charge
+leaves the year pending and enters ordinary dunning, so the retry still owes exactly the frozen
+amount.
+
+**Plan and quantity changes are refused while a year is pending**, with
+`subscription_initial_annual_period_pending`. Repricing then would have to unpick a settled annual
+charge or silently discard one about to be collected, and neither is something a caller can be told
+about after the fact. The wait is at most a month.
 
 The monthly amount and price id are **snapshotted onto the subscription**, so the stub is priced
 without ever reading the monthly price again — not at checkout, not at renewal, not by a recovery
@@ -258,6 +297,12 @@ to.
 > ordinary anniversary year rather than prorating the annual amount by days. That fallback is
 > deliberate: the alternative bills a week at roughly a twelfth of what it is worth, which is the
 > one failure mode worth failing closed against.
+
+Invoices follow the charges: `AtBoundary` produces a stub invoice at checkout and a separate annual
+invoice at the boundary, `AtCheckout` a single invoice covering both. Line-level breakdown of that
+combined invoice, and persisted invoice snapshots behind the history and PDF endpoints, are not
+built yet — invoice history is still derived from settled payments, and begins at the first
+renewal.
 
 ### The first charge is frozen at checkout creation
 

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -842,6 +842,20 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         {
             update = update.Set(subscription => subscription.PendingAnnualPeriod, null);
         }
+        else if (transition.PendingAnnualPeriod is { } pendingAnnualPeriod)
+        {
+            update = update.Set(
+                subscription => subscription.PendingAnnualPeriod,
+                pendingAnnualPeriod);
+        }
+        else if (transition.MarkPendingAnnualPeriodPrepaid)
+        {
+            // Only the flag, so a concurrent writer that changed something else about the year
+            // does not have its work replaced by a stale copy of the whole document.
+            update = update.Set(
+                subscription => subscription.PendingAnnualPeriod!.IsPrepaid,
+                true);
+        }
 
         if (transition.CreditBalanceMinor is { } creditBalanceMinor)
         {

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -838,6 +838,11 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
                 .Set(subscription => subscription.ProrationTotalDays, prorationTotalDays);
         }
 
+        if (transition.ClearPendingAnnualPeriod)
+        {
+            update = update.Set(subscription => subscription.PendingAnnualPeriod, null);
+        }
+
         if (transition.CreditBalanceMinor is { } creditBalanceMinor)
         {
             update = update.Set(

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -67,6 +67,16 @@ public sealed record SubscriptionTransition(
 
     public int? ProrationTotalDays { get; init; }
 
+    /// <summary>
+    /// Whether to discard the pending annual period, because this transition is the one opening it.
+    /// </summary>
+    /// <remarks>
+    /// Written with the period it opens, so moving into the year and forgetting that it was pending
+    /// cannot come apart. A boundary that opened the year and then failed to clear this would find
+    /// it again on the next sweep and charge for it twice.
+    /// </remarks>
+    public bool ClearPendingAnnualPeriod { get; init; }
+
     public long? CreditBalanceMinor { get; init; }
 
     public DateTime? CurrentUsagePeriodStartUtc { get; init; }

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -77,6 +77,21 @@ public sealed record SubscriptionTransition(
     /// </remarks>
     public bool ClearPendingAnnualPeriod { get; init; }
 
+    /// <summary>
+    /// The year to start holding, when this transition is the one that priced it.
+    /// </summary>
+    /// <remarks>
+    /// Written by a card-free trial converting to paid, which is the only path where the year is
+    /// not knowable at signup — what it covers depends on when the trial ends.
+    /// </remarks>
+    public PendingAnnualPeriod? PendingAnnualPeriod { get; init; }
+
+    /// <summary>
+    /// Marks the pending year as paid, because this transition recorded the payment that covered
+    /// it. Set by activation on a price that collects the year at checkout.
+    /// </summary>
+    public bool MarkPendingAnnualPeriodPrepaid { get; init; }
+
     public long? CreditBalanceMinor { get; init; }
 
     public DateTime? CurrentUsagePeriodStartUtc { get; init; }

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -37,6 +37,17 @@ public sealed class CreatePriceRequest
     /// </remarks>
     public BillingAlignment BillingAlignment { get; set; } = BillingAlignment.Anniversary;
 
+    /// <summary>
+    /// The monthly price a calendar-aligned yearly price prices its opening stub from.
+    /// </summary>
+    /// <remarks>
+    /// Required when this price is <c>Year</c> × 1 and calendar-aligned; refused on every other
+    /// price. Naming it also makes <see cref="UnitAmountMinor"/> server-derived — twelve times the
+    /// monthly amount — so send that field empty, or send the figure the server would derive.
+    /// A different one is refused rather than ignored.
+    /// </remarks>
+    public string? CalendarStubBasePriceId { get; set; }
+
     public string? DisplayPriceNote { get; set; }
 
     /// <summary>Which quantity item this multiplies. Null is a flat fee.</summary>

--- a/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePriceRequest.cs
@@ -42,11 +42,16 @@ public sealed class CreatePriceRequest
     /// </summary>
     /// <remarks>
     /// Required when this price is <c>Year</c> × 1 and calendar-aligned; refused on every other
-    /// price. Naming it also makes <see cref="UnitAmountMinor"/> server-derived — twelve times the
-    /// monthly amount — so send that field empty, or send the figure the server would derive.
-    /// A different one is refused rather than ignored.
+    /// price. It prices the opening stub only — <see cref="UnitAmountMinor"/> remains the authored
+    /// annual amount, which is a commercial decision rather than twelve times anything.
     /// </remarks>
     public string? CalendarStubBasePriceId { get; set; }
+
+    /// <summary>
+    /// When a calendar-aligned yearly price collects its annual amount. Omitted means
+    /// <c>AtBoundary</c>. Refused on any other price.
+    /// </summary>
+    public CalendarAnnualChargeTiming? CalendarAnnualChargeTiming { get; set; }
 
     public string? DisplayPriceNote { get; set; }
 

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -186,6 +186,19 @@ public sealed class PlanPriceResponse
     /// </summary>
     public string BillingAlignment { get; init; } = string.Empty;
 
+    /// <summary>
+    /// The monthly price a calendar-aligned yearly price charges its opening period from, and that
+    /// price's amount as it stood when this one was authored. Null on every other price.
+    /// </summary>
+    /// <remarks>
+    /// The amount is returned alongside the id so a client can show what the annual figure was
+    /// derived from without a second read — and can show that it is derived at all, rather than
+    /// offering an editable field that would be overwritten.
+    /// </remarks>
+    public string? CalendarStubBasePriceId { get; init; }
+
+    public long? CalendarStubBaseUnitAmountMinor { get; init; }
+
     public string? DisplayPriceNote { get; init; }
 
     public string? QuantityItemKey { get; init; }

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -199,6 +199,12 @@ public sealed class PlanPriceResponse
 
     public long? CalendarStubBaseUnitAmountMinor { get; init; }
 
+    /// <summary>
+    /// "AtBoundary" or "AtCheckout" — when a calendar-aligned yearly price collects its annual
+    /// amount. Null on every other price.
+    /// </summary>
+    public string? CalendarAnnualChargeTiming { get; init; }
+
     public string? DisplayPriceNote { get; init; }
 
     public string? QuantityItemKey { get; init; }

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -146,11 +146,41 @@ public sealed class SubscriptionResponse
     public long? CalendarStubBaseUnitAmountMinor { get; init; }
 
     /// <summary>
+    /// The year this subscription has bought but not yet started, while it is inside its opening
+    /// stub. Null at every other moment of its life.
+    /// </summary>
+    /// <remarks>
+    /// Present so a client can show what the subscriber has actually committed to — a stub on
+    /// screen with no sign of the year behind it reads as a much smaller purchase than it was.
+    /// </remarks>
+    public PendingAnnualPeriodResponse? PendingAnnualPeriod { get; init; }
+
+    /// <summary>
     /// Where to send the customer to pay. Present only while the first charge is outstanding.
     /// </summary>
     public string? CheckoutUrl { get; init; }
 
     public int Version { get; init; }
+}
+
+/// <summary>The year a calendar-aligned yearly subscription has bought but not yet started.</summary>
+public sealed class PendingAnnualPeriodResponse
+{
+    public DateTime StartUtc { get; init; }
+
+    public DateTime EndUtc { get; init; }
+
+    public long AmountMinor { get; init; }
+
+    public long NetAmountMinor { get; init; }
+
+    public long TaxAmountMinor { get; init; }
+
+    /// <summary>
+    /// Whether the year was collected with the opening charge. False means it is still owed, and
+    /// will be taken when the year begins.
+    /// </summary>
+    public bool IsPrepaid { get; init; }
 }
 
 public sealed class SubscriptionQuantityResponse

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -136,6 +136,16 @@ public sealed class SubscriptionResponse
     public int? ProrationTotalDays { get; init; }
 
     /// <summary>
+    /// The monthly amount a calendar-aligned yearly subscription's opening stub was charged from.
+    /// </summary>
+    /// <remarks>
+    /// From the subscription's own snapshot, so it answers "what was this stub a fraction of"
+    /// years later, whatever has happened to the catalogue since. Null unless the subscription is
+    /// on a calendar-aligned yearly price.
+    /// </remarks>
+    public long? CalendarStubBaseUnitAmountMinor { get; init; }
+
+    /// <summary>
     /// Where to send the customer to pay. Present only while the first charge is outstanding.
     /// </summary>
     public string? CheckoutUrl { get; init; }

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -20,6 +20,9 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     private readonly ISubscriptionContextResolver _contextResolver;
     private readonly IValidator<CreatePlanRequest> _planValidator;
     private readonly IValidator<UpdatePlanRequest> _planUpdateValidator;
+    /// <summary>A year, in months. Named because a bare 12 in a money calculation is not obvious.</summary>
+    private const int MonthsInAYear = 12;
+
     private readonly IValidator<CreatePriceRequest> _priceValidator;
     private readonly IPlanResponseMapper _mapper;
     private readonly ILogger<PlanCatalogueService> _logger;
@@ -245,12 +248,43 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
                 correlationId);
         }
 
+        var stubBasis = await ResolveStubBasisAsync(
+            request, plan, context, correlationId, cancellationToken);
+
+        if (!stubBasis.IsSuccess)
+        {
+            return stubBasis.ToFailure<PlanResponse>();
+        }
+
+        var stubBasePrice = stubBasis.Value;
+
+        // Derived, never authored, when a monthly price is linked: an annual amount and its own
+        // monthly equivalent cannot be allowed to disagree about what a year costs, and only one
+        // of the two can be the source of that truth.
+        var unitAmountMinor = stubBasePrice is null
+            ? request.UnitAmountMinor
+            : stubBasePrice.UnitAmountMinor * MonthsInAYear;
+
+        if (stubBasePrice is not null &&
+            request.UnitAmountMinor != 0 &&
+            request.UnitAmountMinor != unitAmountMinor)
+        {
+            // Refused rather than ignored. Silently overwriting an amount somebody typed is how a
+            // catalogue ends up priced differently from the page that authored it.
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_calendar_stub_base_price_amount_conflict",
+                "An annual price charged from a monthly one is twelve times that monthly amount. " +
+                "Send no amount, or send the derived one.",
+                correlationId);
+        }
+
         var price = new Price
         {
             TenantId = context.TenantId,
             PlanId = plan.ItemId,
             CurrencyCode = request.CurrencyCode.ToUpperInvariant(),
-            UnitAmountMinor = request.UnitAmountMinor,
+            UnitAmountMinor = unitAmountMinor,
             Interval = request.Interval,
             IntervalCount = request.IntervalCount,
             BillingAlignment = request.BillingAlignment,
@@ -265,6 +299,11 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
                 ? request.QuantityDiscountCombination
                     ?? AutomaticDiscountCombination.BestDiscount
                 : null,
+            CalendarStubBasePriceId = stubBasePrice?.ItemId,
+            // Copied, not referenced. Repricing or retiring the monthly price afterwards must not
+            // change what this annual price is derived from, nor what a stub already sold on it
+            // costs.
+            CalendarStubBaseUnitAmountMinor = stubBasePrice?.UnitAmountMinor,
             Status = CatalogueStatus.Active
         };
 
@@ -292,6 +331,90 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             context.OrganizationId,
             correlationId,
             cancellationToken);
+    }
+
+    /// <summary>
+    /// Finds and vets the monthly price a calendar-aligned yearly price is charged from.
+    /// </summary>
+    /// <remarks>
+    /// Every check here exists because the stub is charged from this price's amount and the annual
+    /// period from twelve times it. A link to something on another plan, in another currency, or
+    /// charging for a different quantity item would produce two figures a subscriber could not
+    /// reconcile, and would only be discovered on an invoice.
+    /// <para>
+    /// Returns null, successfully, for every price that does not need one. The validator has
+    /// already refused a link on a price that may not carry one.
+    /// </para>
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<Price?>> ResolveStubBasisAsync(
+        CreatePriceRequest request,
+        Plan plan,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.CalendarStubBasePriceId))
+        {
+            return SubscriptionOperationResult<Price?>.Success(null, correlationId);
+        }
+
+        var basis = await _catalogue.GetPriceAsync(
+            context.TenantId,
+            request.CalendarStubBasePriceId,
+            cancellationToken);
+
+        SubscriptionOperationResult<Price?> Invalid(string message) =>
+            SubscriptionOperationResult<Price?>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_calendar_stub_base_price_invalid",
+                message,
+                correlationId);
+
+        if (basis is null ||
+            !string.Equals(basis.PlanId, plan.ItemId, StringComparison.Ordinal))
+        {
+            return Invalid("The monthly price does not exist on this plan.");
+        }
+
+        if (basis.Status != CatalogueStatus.Active)
+        {
+            return Invalid("The monthly price is retired and cannot be charged from.");
+        }
+
+        if (basis.Interval != BillingInterval.Month || basis.IntervalCount != 1)
+        {
+            return Invalid("An annual price can only be charged from a price billed every month.");
+        }
+
+        if (!string.Equals(
+                basis.CurrencyCode,
+                request.CurrencyCode.ToUpperInvariant(),
+                StringComparison.Ordinal))
+        {
+            return Invalid(
+                "The monthly price is in another currency, and a subscription is billed in one.");
+        }
+
+        if (!string.Equals(
+                basis.QuantityItemKey ?? string.Empty,
+                request.QuantityItemKey ?? string.Empty,
+                StringComparison.Ordinal))
+        {
+            return Invalid(
+                "The monthly price charges for a different quantity item, so the two would " +
+                "multiply by different things.");
+        }
+
+        // Tax has to agree in both rate and reading. A stub quoted inclusive and an annual period
+        // quoted exclusive are two different prices to the customer for one subscription.
+        if (basis.TaxRateBasisPoints != request.TaxRateBasisPoints ||
+            (basis.TaxRateBasisPoints > 0 &&
+             (basis.TaxMode ?? TaxMode.Exclusive) != (request.TaxMode ?? TaxMode.Exclusive)))
+        {
+            return Invalid("The monthly price is taxed differently from this one.");
+        }
+
+        return SubscriptionOperationResult<Price?>.Success(basis, correlationId);
     }
 
     public async Task<SubscriptionOperationResult<PlanResponse>> ArchivePriceAsync(

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -20,9 +20,6 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     private readonly ISubscriptionContextResolver _contextResolver;
     private readonly IValidator<CreatePlanRequest> _planValidator;
     private readonly IValidator<UpdatePlanRequest> _planUpdateValidator;
-    /// <summary>A year, in months. Named because a bare 12 in a money calculation is not obvious.</summary>
-    private const int MonthsInAYear = 12;
-
     private readonly IValidator<CreatePriceRequest> _priceValidator;
     private readonly IPlanResponseMapper _mapper;
     private readonly ILogger<PlanCatalogueService> _logger;
@@ -258,33 +255,15 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
 
         var stubBasePrice = stubBasis.Value;
 
-        // Derived, never authored, when a monthly price is linked: an annual amount and its own
-        // monthly equivalent cannot be allowed to disagree about what a year costs, and only one
-        // of the two can be the source of that truth.
-        var unitAmountMinor = stubBasePrice is null
-            ? request.UnitAmountMinor
-            : stubBasePrice.UnitAmountMinor * MonthsInAYear;
-
-        if (stubBasePrice is not null &&
-            request.UnitAmountMinor != 0 &&
-            request.UnitAmountMinor != unitAmountMinor)
-        {
-            // Refused rather than ignored. Silently overwriting an amount somebody typed is how a
-            // catalogue ends up priced differently from the page that authored it.
-            return SubscriptionOperationResult<PlanResponse>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_calendar_stub_base_price_amount_conflict",
-                "An annual price charged from a monthly one is twelve times that monthly amount. " +
-                "Send no amount, or send the derived one.",
-                correlationId);
-        }
-
         var price = new Price
         {
             TenantId = context.TenantId,
             PlanId = plan.ItemId,
             CurrencyCode = request.CurrencyCode.ToUpperInvariant(),
-            UnitAmountMinor = unitAmountMinor,
+            // Authored, never derived. The linked monthly price prices the opening stub; what a
+            // year costs is a separate commercial decision, and an annual plan is usually not
+            // twelve monthly ones.
+            UnitAmountMinor = request.UnitAmountMinor,
             Interval = request.Interval,
             IntervalCount = request.IntervalCount,
             BillingAlignment = request.BillingAlignment,
@@ -304,6 +283,9 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             // change what this annual price is derived from, nor what a stub already sold on it
             // costs.
             CalendarStubBaseUnitAmountMinor = stubBasePrice?.UnitAmountMinor,
+            CalendarAnnualChargeTiming = stubBasePrice is null
+                ? CalendarAnnualChargeTiming.AtBoundary
+                : request.CalendarAnnualChargeTiming ?? CalendarAnnualChargeTiming.AtBoundary,
             Status = CatalogueStatus.Active
         };
 

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -319,10 +319,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     /// Finds and vets the monthly price a calendar-aligned yearly price is charged from.
     /// </summary>
     /// <remarks>
-    /// Every check here exists because the stub is charged from this price's amount and the annual
-    /// period from twelve times it. A link to something on another plan, in another currency, or
-    /// charging for a different quantity item would produce two figures a subscriber could not
-    /// reconcile, and would only be discovered on an invoice.
+    /// Every check here exists because the stub is charged from this price's amount while the annual
+    /// period is charged from the yearly price's own. A link to something on another plan, in
+    /// another currency, or charging for a different quantity item would produce two figures a
+    /// subscriber could not reconcile, and would only be discovered on an invoice.
     /// <para>
     /// Returns null, successfully, for every price that does not need one. The validator has
     /// already refused a link on a price that may not carry one.

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -110,6 +110,8 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     Interval = price.Interval.ToString(),
                     IntervalCount = price.IntervalCount,
                     BillingAlignment = price.BillingAlignment.ToString(),
+                    CalendarStubBasePriceId = price.CalendarStubBasePriceId,
+                    CalendarStubBaseUnitAmountMinor = price.CalendarStubBaseUnitAmountMinor,
                     DisplayPriceNote = price.DisplayPriceNote,
                     QuantityItemKey = price.QuantityItemKey,
                     TaxRateBasisPoints = price.TaxRateBasisPoints,

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -112,6 +112,11 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     BillingAlignment = price.BillingAlignment.ToString(),
                     CalendarStubBasePriceId = price.CalendarStubBasePriceId,
                     CalendarStubBaseUnitAmountMinor = price.CalendarStubBaseUnitAmountMinor,
+                    // Reported only where it means something, so a monthly price does not appear to
+                    // carry a choice it never had.
+                    CalendarAnnualChargeTiming = price.CalendarStubBasePriceId is null
+                        ? null
+                        : price.CalendarAnnualChargeTiming.ToString(),
                     DisplayPriceNote = price.DisplayPriceNote,
                     QuantityItemKey = price.QuantityItemKey,
                     TaxRateBasisPoints = price.TaxRateBasisPoints,

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -46,10 +46,17 @@ public static class SubscriptionAmountCalculator
     /// checkout needs the number, and re-deriving one from the other would be two answers to the
     /// same question.
     /// </remarks>
+    /// <param name="includePromotionalDiscount">
+    /// False to price without the subscriber's code. Used for the opening stub of a calendar-aligned
+    /// yearly price, where the code belongs to the year rather than to the days before it: a
+    /// three-month promotion spent on a seven-day stub would be a month of the customer's discount
+    /// exchanged for a week of it.
+    /// </param>
     public static PeriodCharge FirstPeriodCharge(
         SubscriptionDetail subscription,
         BillingDayFraction fraction,
-        DateTime nowUtc)
+        DateTime nowUtc,
+        bool includePromotionalDiscount = true)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -57,7 +64,7 @@ public static class SubscriptionAmountCalculator
 
         var discounted = DiscountedAmountMinor(
             subscription.Plan,
-            subscription.Discount,
+            includePromotionalDiscount ? subscription.Discount : null,
             price,
             quantities,
             0,

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -53,19 +53,21 @@ public static class SubscriptionAmountCalculator
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
+        var (price, quantities) = PricingBasis(subscription, fraction);
+
         var discounted = DiscountedAmountMinor(
             subscription.Plan,
             subscription.Discount,
-            subscription.Price,
-            subscription.QuantityItems,
+            price,
+            quantities,
             0,
             nowUtc,
             fraction);
 
         var breakdown = TaxBreakdownFor(
             discounted.AmountMinor,
-            subscription.Price.TaxRateBasisPoints,
-            subscription.Price.TaxMode);
+            price.TaxRateBasisPoints,
+            price.TaxMode);
 
         return discounted with
         {
@@ -91,19 +93,21 @@ public static class SubscriptionAmountCalculator
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
+        var (price, quantities) = PricingBasis(subscription, fraction);
+
         var discounted = DiscountedAmountMinor(
             subscription.Plan,
             subscription.Discount,
-            subscription.Price,
-            subscription.QuantityItems,
+            price,
+            quantities,
             subscription.DiscountPeriodsApplied,
             nowUtc,
             fraction);
 
         var breakdown = TaxBreakdownFor(
             discounted.AmountMinor,
-            subscription.Price.TaxRateBasisPoints,
-            subscription.Price.TaxMode);
+            price.TaxRateBasisPoints,
+            price.TaxMode);
 
         var creditConsumed = Math.Min(
             Math.Max(0, subscription.CreditBalanceMinor),
@@ -206,6 +210,30 @@ public static class SubscriptionAmountCalculator
             }
         }
     }
+
+    /// <summary>
+    /// Which price and quantities a period is charged from.
+    /// </summary>
+    /// <remarks>
+    /// Normally the subscription's own, and for every monthly subscription always its own. The
+    /// exception is a partial period on a calendar-aligned <em>yearly</em> price: a week of an
+    /// annual amount is not a meaningful quantity, so the stub is priced from the monthly price
+    /// that annual price was linked to and snapshotted from.
+    /// <para>
+    /// A whole period is never re-based. Once the annual cycle opens on the first, the subscriber
+    /// is buying a year and is charged the annual amount.
+    /// </para>
+    /// </remarks>
+    private static (PriceSnapshot Price, IReadOnlyList<SubscriptionQuantityItem> Quantities)
+        PricingBasis(SubscriptionDetail subscription, BillingDayFraction fraction) =>
+        fraction.IsPartial &&
+        CalendarBillingAlignment.TryStubBasis(
+            subscription.Price,
+            subscription.QuantityItems,
+            out var stubPrice,
+            out var stubQuantities)
+            ? (stubPrice, stubQuantities)
+            : (subscription.Price, subscription.QuantityItems);
 
     /// <summary>
     /// A volume band re-expressed against a prorated gross.

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -93,10 +93,15 @@ public static class SubscriptionAmountCalculator
     /// total, never below zero. A credit offsets what the subscriber owes including tax; it does not
     /// shrink the taxable base, which is why it is applied last.
     /// </summary>
+    /// <param name="includePromotionalDiscount">
+    /// False to price without the subscriber's code — the opening stub of a calendar-aligned yearly
+    /// price, where the code belongs to the year that follows rather than to the days before it.
+    /// </param>
     public static PeriodCharge PeriodAmountMinor(
         SubscriptionDetail subscription,
         DateTime nowUtc,
-        BillingDayFraction fraction = default)
+        BillingDayFraction fraction = default,
+        bool includePromotionalDiscount = true)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -104,7 +109,7 @@ public static class SubscriptionAmountCalculator
 
         var discounted = DiscountedAmountMinor(
             subscription.Plan,
-            subscription.Discount,
+            includePromotionalDiscount ? subscription.Discount : null,
             price,
             quantities,
             subscription.DiscountPeriodsApplied,

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -106,6 +106,19 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         // checkout as an immediate cancellation even when the caller uses the default flag.
         var endsImmediately = immediately || subscription.Status == SubscriptionStatus.Incomplete;
 
+        // A year already paid for is a year the subscriber keeps. Ending access now would take the
+        // money and the entitlement together, and this module refunds nothing — so an immediate
+        // request is honoured as far as it can be: cancelled, no renewal, access to the end of the
+        // term they bought. The subscriber loses nothing they paid for, which is the only reading
+        // of "cancel now" that does not quietly become a forfeiture.
+        //
+        // Only for a *settled* year. One still owed is dropped by the ordinary path below without
+        // charging for it.
+        if (endsImmediately && subscription.PendingAnnualPeriod is { IsPrepaid: true })
+        {
+            endsImmediately = false;
+        }
+
         var applied = endsImmediately
             ? await EndNowAsync(subscription, reason, now, correlationId, cancellationToken)
             : await EndAtPeriodEndAsync(subscription, reason, now, correlationId, cancellationToken);
@@ -222,6 +235,21 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         subscription.CanceledAtUtc = now;
         subscription.CancellationReason = reason;
         subscription.NextFeeBillingAtUtc = null;
+
+        // The pending year is settled either way, so the response must stop advertising one. A 200
+        // still showing a year as pending would have a client offering to cancel something the
+        // write it is reporting has already dealt with.
+        if (subscription.PendingAnnualPeriod is { } pendingAnnual)
+        {
+            // Prepaid, entitlement now runs to the end of the year they bought; unpaid, the year is
+            // simply dropped and the current period is the last one.
+            if (!immediately && pendingAnnual.IsPrepaid)
+            {
+                subscription.CurrentPeriodEndUtc = pendingAnnual.EndUtc;
+            }
+
+            subscription.PendingAnnualPeriod = null;
+        }
 
         if (immediately)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -159,6 +159,18 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 CanceledAtUtc = now,
                 CancellationReason = reason,
                 ClearNextFeeBillingAt = true,
+                // A year already paid for is a year the subscriber keeps. Cancelling inside the
+                // opening stub of a prepaid annual price therefore runs entitlement through to the
+                // end of that year rather than stopping with the stub — they bought it, and this
+                // module refunds nothing.
+                CurrentPeriodEndUtc = subscription.PendingAnnualPeriod is { IsPrepaid: true } prepaid
+                    ? prepaid.EndUtc
+                    : null,
+                // Either way the pending year stops being pending. Prepaid, it has just been folded
+                // into the period above; unpaid, clearing the next billing instant above already
+                // stopped its charge, and leaving the record behind would invite a later sweep to
+                // find a year nobody is going to pay for.
+                ClearPendingAnnualPeriod = subscription.PendingAnnualPeriod is not null,
                 Event = _events.Create(
                     subscription,
                     SubscriptionConstants.SubscriptionCancellationRequested,
@@ -182,6 +194,9 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 EndedAtUtc = now,
                 CancellationReason = reason,
                 ClearNextFeeBillingAt = true,
+                // Entitlement stops now, so a year that had not started never will. Dropped so no
+                // later sweep can find it and charge for a period this subscription never held.
+                ClearPendingAnnualPeriod = subscription.PendingAnnualPeriod is not null,
                 // Nothing more will be metered once entitlement stops immediately, so the usage
                 // sweep should stop looking at this subscription too. Any usage already recorded
                 // in the still-open final period goes unrated — a known, stated gap, not a

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -100,10 +100,12 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         var calendarAligned = CalendarBillingAlignment.IsCalendarAligned(
             price.BillingAlignment,
             price.Interval,
-            price.IntervalCount);
+            price.IntervalCount,
+            price.CalendarStubBaseUnitAmountMinor);
 
         var feeScheduleBuilt = calendarAligned
-            ? CalendarBillingAlignment.TryCreateSchedule(now, request.TimeZoneId, out var feeSchedule)
+            ? CalendarBillingAlignment.TryCreateSchedule(
+                price.Interval, now, request.TimeZoneId, out var feeSchedule)
             : BillingPeriodCalculator.TryCreateSchedule(
                 price.Interval,
                 price.IntervalCount,
@@ -429,14 +431,22 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 return false;
             }
 
-            // The stub, not the whole month the schedule derives. A subscriber joining on the 25th
-            // is entitled from the 25th and pays from the 25th; the derived period starting on the
-            // 1st is a month they were not here for.
-            feePeriod = feePeriod with
+            // The stub, not the whole period the schedule derives. A subscriber joining on the
+            // 25th is entitled from the 25th and pays from the 25th; the derived period starting
+            // on the 1st is time they were not here for.
+            //
+            // Only when there *is* a stub. A signup on the local first opens a whole period at the
+            // price's own cadence — a month for a monthly price, a year for a yearly one — and the
+            // derived period already says so. Overriding it here would cut an annual subscription
+            // down to its first month.
+            if (first.IsProrated)
             {
-                StartUtc = first.StartUtc,
-                EndUtc = first.EndUtc
-            };
+                feePeriod = feePeriod with
+                {
+                    StartUtc = first.StartUtc,
+                    EndUtc = first.EndUtc
+                };
+            }
 
             fraction = BillingDayFraction.Of(first);
         }

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -103,9 +103,18 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             price.IntervalCount,
             price.CalendarStubBaseUnitAmountMinor);
 
+        // A card-free trial defers the first paid period to the day it ends, and for a yearly
+        // price that day decides the whole annual cycle: a 25 August signup on a trial running to
+        // 20 September starts its year on 1 October, not 1 September. The trial's end is known
+        // here, so the schedule is anchored on it rather than corrected later — every boundary
+        // derives from the anchor, and one anchored a month early stays a month early forever.
+        var scheduleAnchorUtc = plan.TrialDays is { } trialDays && !plan.TrialRequiresPaymentMethod
+            ? now.AddDays(trialDays)
+            : now;
+
         var feeScheduleBuilt = calendarAligned
             ? CalendarBillingAlignment.TryCreateSchedule(
-                price.Interval, now, request.TimeZoneId, out var feeSchedule)
+                price.Interval, scheduleAnchorUtc, request.TimeZoneId, out var feeSchedule)
             : BillingPeriodCalculator.TryCreateSchedule(
                 price.Interval,
                 price.IntervalCount,
@@ -455,7 +464,12 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // stub, and the year that starts on the first. The year is priced and frozen here even
         // though it may not be collected until its boundary — what the subscriber was quoted is
         // what settles, whichever of the two timings the price is on.
-        var annual = fraction.IsPartial
+        //
+        // A card-free trial is the exception, for the same reason its stub is: which month the
+        // trial ends in decides both. A signup on 25 August whose trial runs to 20 September owes
+        // a 20–30 September stub and a year starting 1 October, and a year frozen today would say
+        // 1 September. It is priced at conversion instead, atomically with the stub it follows.
+        var annual = fraction.IsPartial && subscription.Trial is not { RequiresPaymentMethod: false }
             ? BuildPendingAnnualPeriod(subscription, feePeriod.EndUtc, now)
             : null;
 
@@ -481,11 +495,12 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 now,
                 includePromotionalDiscount: annual is null);
 
-            subscription.InitialChargeAmountMinor = annual is { IsPrepaid: true }
+            subscription.InitialChargeAmountMinor = annual is { CollectedWithCheckout: true }
                 ? charge.AmountMinor + annual.AmountMinor
                 : charge.AmountMinor;
             subscription.InitialChargeDiscountApplied =
-                charge.DiscountApplied || annual is { IsPrepaid: true, DiscountApplied: true };
+                charge.DiscountApplied ||
+                annual is { CollectedWithCheckout: true, DiscountApplied: true };
             subscription.InitialChargeProrated = fraction.IsPartial;
             subscription.ProrationDays = fraction.IsPartial ? fraction.CoveredDays : null;
             subscription.ProrationTotalDays = fraction.IsPartial ? fraction.TotalDays : null;
@@ -516,14 +531,15 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
     /// </summary>
     /// <remarks>
     /// Null for everything else, including a monthly calendar price — whose stub is followed by
-    /// another month of the same price, not by a separate term that has to be remembered.
+    /// another month of the same price, not by a separate term that has to be remembered. Shared
+    /// with the renewal service, which builds the same record when a card-free trial converts.
     /// <para>
     /// Priced at the full annual amount with the subscriber's promotional code applied, because the
     /// code applies to the year. Frozen here and never recalculated: the boundary is a month away,
     /// and a charge that re-derived its own amount could take a different sum than the one quoted.
     /// </para>
     /// </remarks>
-    private static PendingAnnualPeriod? BuildPendingAnnualPeriod(
+    internal static PendingAnnualPeriod? BuildPendingAnnualPeriod(
         SubscriptionDetail subscription,
         DateTime annualStartUtc,
         DateTime now)
@@ -554,7 +570,10 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             BuiltInDiscountMinor = charge.BuiltInDiscountMinor,
             PromotionalDiscountMinor = charge.PromotionalDiscountMinor,
             DiscountApplied = charge.DiscountApplied,
-            IsPrepaid = subscription.Price.CalendarAnnualChargeTiming ==
+            // What the price says to bill for. Whether the money arrived is a separate question,
+            // answered by the activation that records the opening payment — a checkout nobody pays
+            // must not leave behind a year that reports itself as settled.
+            CollectedWithCheckout = subscription.Price.CalendarAnnualChargeTiming ==
                 CalendarAnnualChargeTiming.AtCheckout
         };
     }

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -451,6 +451,16 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             fraction = BillingDayFraction.Of(first);
         }
 
+        // A calendar-aligned yearly subscription that opens mid-month has bought two things: the
+        // stub, and the year that starts on the first. The year is priced and frozen here even
+        // though it may not be collected until its boundary — what the subscriber was quoted is
+        // what settles, whichever of the two timings the price is on.
+        var annual = fraction.IsPartial
+            ? BuildPendingAnnualPeriod(subscription, feePeriod.EndUtc, now)
+            : null;
+
+        subscription.PendingAnnualPeriod = annual;
+
         // A card-free trial charges nothing now, and what its first paid period will cost depends
         // on when the trial ends — a date that is not this one. Every initial-charge field is left
         // unset rather than filled in from today, because a stored 26/31 that the eventual charge
@@ -462,10 +472,20 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // underneath a customer who left the page open overnight.
         if (subscription.Trial is not { RequiresPaymentMethod: false })
         {
-            var charge = SubscriptionAmountCalculator.FirstPeriodCharge(subscription, fraction, now);
+            // A promotional code belongs to the year, not to the days before it — so a yearly stub
+            // is priced without one. Its automatic discount and volume band still apply, because
+            // those are properties of the price rather than something the customer spends.
+            var charge = SubscriptionAmountCalculator.FirstPeriodCharge(
+                subscription,
+                fraction,
+                now,
+                includePromotionalDiscount: annual is null);
 
-            subscription.InitialChargeAmountMinor = charge.AmountMinor;
-            subscription.InitialChargeDiscountApplied = charge.DiscountApplied;
+            subscription.InitialChargeAmountMinor = annual is { IsPrepaid: true }
+                ? charge.AmountMinor + annual.AmountMinor
+                : charge.AmountMinor;
+            subscription.InitialChargeDiscountApplied =
+                charge.DiscountApplied || annual is { IsPrepaid: true, DiscountApplied: true };
             subscription.InitialChargeProrated = fraction.IsPartial;
             subscription.ProrationDays = fraction.IsPartial ? fraction.CoveredDays : null;
             subscription.ProrationTotalDays = fraction.IsPartial ? fraction.TotalDays : null;
@@ -489,6 +509,54 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         subscription.NextUsageBillingAtUtc = usagePeriod.EndUtc;
 
         return true;
+    }
+
+    /// <summary>
+    /// The year a mid-month calendar-aligned yearly signup has bought but not yet started.
+    /// </summary>
+    /// <remarks>
+    /// Null for everything else, including a monthly calendar price — whose stub is followed by
+    /// another month of the same price, not by a separate term that has to be remembered.
+    /// <para>
+    /// Priced at the full annual amount with the subscriber's promotional code applied, because the
+    /// code applies to the year. Frozen here and never recalculated: the boundary is a month away,
+    /// and a charge that re-derived its own amount could take a different sum than the one quoted.
+    /// </para>
+    /// </remarks>
+    private static PendingAnnualPeriod? BuildPendingAnnualPeriod(
+        SubscriptionDetail subscription,
+        DateTime annualStartUtc,
+        DateTime now)
+    {
+        if (!CalendarBillingAlignment.IsCalendarAligned(subscription.Price) ||
+            !CalendarBillingAlignment.NeedsStubBasePrice(
+                subscription.Price.Interval,
+                subscription.Price.IntervalCount) ||
+            !BillingPeriodCalculator.TryGetPeriod(
+                subscription.FeeSchedule,
+                annualStartUtc,
+                out var annualPeriod))
+        {
+            return null;
+        }
+
+        // The whole year, undiminished by any day fraction — the stub covered the days before it.
+        var charge = SubscriptionAmountCalculator.FirstPeriodCharge(subscription, default, now);
+
+        return new PendingAnnualPeriod
+        {
+            StartUtc = annualPeriod.StartUtc,
+            EndUtc = annualPeriod.EndUtc,
+            AmountMinor = charge.AmountMinor,
+            NetAmountMinor = charge.NetAmountMinor,
+            TaxAmountMinor = charge.TaxAmountMinor,
+            GrossAmountMinor = charge.GrossAmountMinor,
+            BuiltInDiscountMinor = charge.BuiltInDiscountMinor,
+            PromotionalDiscountMinor = charge.PromotionalDiscountMinor,
+            DiscountApplied = charge.DiscountApplied,
+            IsPrepaid = subscription.Price.CalendarAnnualChargeTiming ==
+                CalendarAnnualChargeTiming.AtCheckout
+        };
     }
 
     private static SubscriptionOperationResult<SubscriptionDetail> Failure(

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -559,7 +559,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         var calendarAligned = CalendarBillingAlignment.IsCalendarAligned(targetPrice);
 
         var feeBuilt = calendarAligned
-            ? CalendarBillingAlignment.TryCreateSchedule(now, timeZoneId, out var fee)
+            ? CalendarBillingAlignment.TryCreateSchedule(
+                targetPrice.Interval, now, timeZoneId, out var fee)
             : BillingPeriodCalculator.TryCreateSchedule(
                 targetPrice.Interval, targetPrice.IntervalCount, now, timeZoneId, out fee);
 
@@ -583,8 +584,14 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 return false;
             }
 
-            feeStartUtc = first.StartUtc;
-            feeEndUtc = first.EndUtc;
+            // Only a stub replaces the derived period; a change landing on the first opens a
+            // whole period at the target's own cadence, which the schedule already derived.
+            if (first.IsProrated)
+            {
+                feeStartUtc = first.StartUtc;
+                feeEndUtc = first.EndUtc;
+            }
+
             fraction = BillingDayFraction.Of(first);
         }
 

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -163,6 +163,22 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 correlationId);
         }
 
+
+        // A calendar-aligned yearly subscription inside its opening stub has a year already priced
+        // and, on a prepaid price, already paid for. Repricing it now would have to unpick a
+        // settled annual charge or silently discard one that is about to be collected, and neither
+        // is something a caller can be told about after the fact. Refused until the boundary
+        // settles it, which is at most a month away.
+        if (subscription.PendingAnnualPeriod is not null)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_initial_annual_period_pending",
+                "This subscription is in its opening period and its first year is not yet " +
+                "settled. Changes can be made once the annual period begins.",
+                correlationId);
+        }
+
         var terms = await ResolveTargetAsync(request, context, subscription, correlationId, cancellationToken);
 
         if (!terms.IsSuccess)

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -63,14 +63,31 @@ public static class SubscriptionProrationCalculator
             subscription.DiscountPeriodsApplied,
             nowUtc);
 
+        // A partial period on a calendar-aligned yearly target is charged from the monthly price
+        // that annual price was linked to, exactly as a fresh signup on it would be. Prorating the
+        // annual amount by days instead would bill a week at roughly twelve times its worth.
+        var newPrice = targetPrice;
+        var newQuantityItems = targetQuantityItems;
+
+        if (targetFraction.IsPartial &&
+            CalendarBillingAlignment.TryStubBasis(
+                targetPrice,
+                targetQuantityItems,
+                out var stubPrice,
+                out var stubQuantityItems))
+        {
+            newPrice = stubPrice;
+            newQuantityItems = stubQuantityItems;
+        }
+
         // The target's own fraction, where it has one. A move onto a calendar-aligned price buys
         // the days from here to the first of next month, and those are counted as calendar dates
         // rather than as elapsed time — the same 7/31 a fresh signup on the same day would pay.
         var newDiscounted = SubscriptionAmountCalculator.DiscountedAmountMinor(
             targetPlan,
             subscription.Discount,
-            targetPrice,
-            targetQuantityItems,
+            newPrice,
+            newQuantityItems,
             subscription.DiscountPeriodsApplied,
             nowUtc,
             targetFraction);
@@ -85,8 +102,8 @@ public static class SubscriptionProrationCalculator
             subscription.Price.TaxMode).TotalAmountMinor;
         var newTaxInclusive = SubscriptionAmountCalculator.TaxBreakdownFor(
             newDiscounted.AmountMinor,
-            targetPrice.TaxRateBasisPoints,
-            targetPrice.TaxMode).TotalAmountMinor;
+            newPrice.TaxRateBasisPoints,
+            newPrice.TaxMode).TotalAmountMinor;
 
         var oldRemainingValue = Prorate(oldTaxInclusive, remainingTicks, totalTicks);
         var targetTotalTicks = (targetPeriodEndUtc - targetPeriodStartUtc).Ticks;

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -219,6 +219,22 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 correlationId);
         }
 
+
+        // A calendar-aligned yearly subscription inside its opening stub has a year already priced
+        // and, on a prepaid price, already paid for. Repricing it now would have to unpick a
+        // settled annual charge or silently discard one that is about to be collected, and neither
+        // is something a caller can be told about after the fact. Refused until the boundary
+        // settles it, which is at most a month away.
+        if (!preview && subscription.PendingAnnualPeriod is not null)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_initial_annual_period_pending",
+                "This subscription is in its opening period and its first year is not yet " +
+                "settled. Changes can be made once the annual period begins.",
+                correlationId);
+        }
+
         var target = BuildTargetQuantities(subscription, request, out var unknownItemKey);
 
         if (unknownItemKey is not null)

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -163,10 +163,40 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         // contractual period cost two different figures depending on sweep latency. Only the
         // conversion moves it; an ordinary renewal begins at the boundary it is running on.
         var pricingInstantUtc = converting ? trialEndUtc : now;
-        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(
-            subscription,
-            pricingInstantUtc,
-            fraction);
+
+        // The year a calendar-aligned yearly subscription bought at signup, now due to open. Its
+        // amount was frozen with the quote and is not re-derived here — the boundary is a month
+        // after the checkout that priced it.
+        var openingAnnualPeriod = DueAnnualPeriod(subscription, period);
+
+        var charge = openingAnnualPeriod is { } annual
+            ? new PeriodCharge(
+                // Prepaid means the money came in with the opening charge, so this boundary moves
+                // the subscription into the year and takes nothing. Charging again here would be
+                // the same year billed twice.
+                annual.IsPrepaid ? 0 : annual.AmountMinor,
+                annual.DiscountApplied,
+                NetAmountMinor: annual.NetAmountMinor,
+                TaxAmountMinor: annual.TaxAmountMinor,
+                GrossAmountMinor: annual.GrossAmountMinor,
+                BuiltInDiscountMinor: annual.BuiltInDiscountMinor,
+                PromotionalDiscountMinor: annual.PromotionalDiscountMinor)
+            : SubscriptionAmountCalculator.PeriodAmountMinor(
+                subscription,
+                pricingInstantUtc,
+                fraction);
+
+        if (openingAnnualPeriod is not null)
+        {
+            // The period is the one that was quoted, not one derived now. They agree in the
+            // ordinary case; using the stored pair means they cannot drift if anything about the
+            // schedule is later corrected.
+            period = period with
+            {
+                StartUtc = openingAnnualPeriod.StartUtc,
+                EndUtc = openingAnnualPeriod.EndUtc
+            };
+        }
 
         var outcome = charge.AmountMinor <= 0
             ? SubscriptionOperationResult<string>.Success(string.Empty, subscription.CorrelationId)
@@ -229,6 +259,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 outcome.Value,
                 attemptNumber,
                 pendingQuantities,
+                openingAnnualPeriod is not null,
                 cancellationToken);
 
             return;
@@ -339,6 +370,10 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
     /// therefore the moment those tracing fields become knowable. Null on every ordinary renewal,
     /// which must never overwrite what the original checkout froze.
     /// </param>
+    /// <param name="openedAnnualPeriod">
+    /// Whether this transition is the one moving a calendar-aligned yearly subscription out of its
+    /// opening stub and into the year it bought, so the pending record is discarded with it.
+    /// </param>
     private async Task ApplySuccessAsync(
         SubscriptionDetail subscription,
         BillingPeriod period,
@@ -347,6 +382,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         string? paymentDetailId,
         int attemptNumber,
         List<SubscriptionQuantityItem>? appliedQuantities,
+        bool openedAnnualPeriod,
         CancellationToken cancellationToken)
     {
         var applied = await _subscriptions.TryTransitionAsync(
@@ -369,6 +405,9 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 // must not come apart, or the next renewal applies it again.
                 QuantityItems = appliedQuantities,
                 ClearPendingQuantityChange = appliedQuantities is not null,
+                // Opening the year and forgetting that it was pending must be one write, or the
+                // next sweep finds it again and charges for the same year twice.
+                ClearPendingAnnualPeriod = openedAnnualPeriod,
                 DiscountPeriodsApplied = subscription.DiscountPeriodsApplied +
                     (charge.DiscountApplied ? 1 : 0),
                 // Written in the same transition that opens the period they describe, so a trial
@@ -472,6 +511,22 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 PaymentLogValue.Label(period.Key));
         }
     }
+
+    /// <summary>
+    /// The pending year this renewal is opening, or null when it is an ordinary renewal.
+    /// </summary>
+    /// <remarks>
+    /// Due once the boundary it was quoted for has arrived. A subscription still inside its stub
+    /// has nothing to open — its stub is the period it is being renewed out of, and that renewal
+    /// is this one.
+    /// </remarks>
+    private static PendingAnnualPeriod? DueAnnualPeriod(
+        SubscriptionDetail subscription,
+        BillingPeriod period) =>
+        subscription.PendingAnnualPeriod is { } pending &&
+        pending.StartUtc <= period.StartUtc
+            ? pending
+            : null;
 
     private async Task ApplyFailureAsync(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -151,7 +151,13 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         // different charge rather than colliding with this one.
         var fraction = converting ? BillingDayFraction.Of(stub) : default;
 
-        if (converting)
+        // A trial that ends on the local first has no stub to buy: the period it converts into is a
+        // whole one at the price's own cadence, which the schedule already derived. Truncating it
+        // to the stub's month would charge a year's money for a month and leave a second year
+        // pending behind it.
+        var convertingToStub = converting && stub.IsProrated;
+
+        if (convertingToStub)
         {
             period = period with { StartUtc = stub.StartUtc, EndUtc = stub.EndUtc };
         }
@@ -171,7 +177,10 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
 
         // A converting trial's year, priced here for the same reason its stub is: which month the
         // trial ended in decides both, and neither was knowable at signup.
-        var convertingAnnual = converting
+        // Only a stub is followed by a year that has to be remembered. A conversion that opened a
+        // whole year is already inside it, and holding another would bill the same subscriber for
+        // two.
+        var convertingAnnual = convertingToStub
             ? SubscriptionCreationService.BuildPendingAnnualPeriod(
                 subscription,
                 period.EndUtc,
@@ -293,6 +302,9 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 subscription,
                 period,
                 charge,
+                // Every conversion records what its first paid charge was, stub or whole year — a
+                // card-free trial leaves these unset at signup, so this is the only place they can
+                // be filled in. A whole period simply records a fraction that is not partial.
                 converting ? fraction : null,
                 outcome.Value,
                 attemptNumber,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -188,7 +188,14 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 // year that was meant to be collected at checkout but never was is a year still
                 // owed, and only the payment can say which it is.
                 annual.IsPrepaid ? 0 : annual.AmountMinor,
-                annual.DiscountApplied,
+                // A limited promotion is spent by the charge that reduced money, and a prepaid year
+                // reduced it once already — at the checkout or the trial conversion that collected
+                // it. Counting it again here, where nothing is taken, would expire a three-month
+                // promotion after two bills.
+                //
+                // A year still owed is the opposite case: this boundary is the charge that spends
+                // it, so it is reported as applied exactly once, here.
+                DiscountApplied: !annual.IsPrepaid && annual.DiscountApplied,
                 NetAmountMinor: annual.NetAmountMinor,
                 TaxAmountMinor: annual.TaxAmountMinor,
                 GrossAmountMinor: annual.GrossAmountMinor,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -169,11 +169,24 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         // after the checkout that priced it.
         var openingAnnualPeriod = DueAnnualPeriod(subscription, period);
 
+        // A converting trial's year, priced here for the same reason its stub is: which month the
+        // trial ended in decides both, and neither was knowable at signup.
+        var convertingAnnual = converting
+            ? SubscriptionCreationService.BuildPendingAnnualPeriod(
+                subscription,
+                period.EndUtc,
+                pricingInstantUtc)
+            : null;
+
         var charge = openingAnnualPeriod is { } annual
             ? new PeriodCharge(
-                // Prepaid means the money came in with the opening charge, so this boundary moves
-                // the subscription into the year and takes nothing. Charging again here would be
-                // the same year billed twice.
+                // Settled means the money came in with the opening charge, so this boundary moves
+                // the subscription into the year and takes nothing. Charging again would bill the
+                // same year twice.
+                //
+                // Read from what the activation recorded, never from the price's configuration: a
+                // year that was meant to be collected at checkout but never was is a year still
+                // owed, and only the payment can say which it is.
                 annual.IsPrepaid ? 0 : annual.AmountMinor,
                 annual.DiscountApplied,
                 NetAmountMinor: annual.NetAmountMinor,
@@ -184,7 +197,25 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             : SubscriptionAmountCalculator.PeriodAmountMinor(
                 subscription,
                 pricingInstantUtc,
-                fraction);
+                fraction,
+                // A promotional code belongs to the year, so a yearly stub is priced without one.
+                includePromotionalDiscount: convertingAnnual is null);
+
+        // "Collect the year with the first payment" — and for a card-free trial this conversion is
+        // the first payment there has ever been. Taken together with the stub in one charge, and
+        // the year is settled from the moment it succeeds.
+        if (convertingAnnual is { CollectedWithCheckout: true })
+        {
+            charge = charge with
+            {
+                AmountMinor = charge.AmountMinor + convertingAnnual.AmountMinor,
+                NetAmountMinor = charge.NetAmountMinor + convertingAnnual.NetAmountMinor,
+                TaxAmountMinor = charge.TaxAmountMinor + convertingAnnual.TaxAmountMinor,
+                DiscountApplied = charge.DiscountApplied || convertingAnnual.DiscountApplied
+            };
+
+            convertingAnnual.IsPrepaid = true;
+        }
 
         if (openingAnnualPeriod is not null)
         {
@@ -260,6 +291,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 attemptNumber,
                 pendingQuantities,
                 openingAnnualPeriod is not null,
+                convertingAnnual,
                 cancellationToken);
 
             return;
@@ -383,6 +415,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         int attemptNumber,
         List<SubscriptionQuantityItem>? appliedQuantities,
         bool openedAnnualPeriod,
+        PendingAnnualPeriod? annualPeriodToHold,
         CancellationToken cancellationToken)
     {
         var applied = await _subscriptions.TryTransitionAsync(
@@ -408,6 +441,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 // Opening the year and forgetting that it was pending must be one write, or the
                 // next sweep finds it again and charges for the same year twice.
                 ClearPendingAnnualPeriod = openedAnnualPeriod,
+                PendingAnnualPeriod = annualPeriodToHold,
                 DiscountPeriodsApplied = subscription.DiscountPeriodsApplied +
                     (charge.DiscountApplied ? 1 : 0),
                 // Written in the same transition that opens the period they describe, so a trial

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -75,6 +75,17 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             ProrationDays = subscription.ProrationDays,
             ProrationTotalDays = subscription.ProrationTotalDays,
             CalendarStubBaseUnitAmountMinor = subscription.Price.CalendarStubBaseUnitAmountMinor,
+            PendingAnnualPeriod = subscription.PendingAnnualPeriod is { } pending
+                ? new PendingAnnualPeriodResponse
+                {
+                    StartUtc = pending.StartUtc,
+                    EndUtc = pending.EndUtc,
+                    AmountMinor = pending.AmountMinor,
+                    NetAmountMinor = pending.NetAmountMinor,
+                    TaxAmountMinor = pending.TaxAmountMinor,
+                    IsPrepaid = pending.IsPrepaid
+                }
+                : null,
             CheckoutUrl = checkoutUrl,
             Version = subscription.Version
         };

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -74,6 +74,7 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             InitialChargeProrated = subscription.InitialChargeProrated,
             ProrationDays = subscription.ProrationDays,
             ProrationTotalDays = subscription.ProrationTotalDays,
+            CalendarStubBaseUnitAmountMinor = subscription.Price.CalendarStubBaseUnitAmountMinor,
             CheckoutUrl = checkoutUrl,
             Version = subscription.Version
         };

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -99,6 +99,10 @@ internal static class SubscriptionSnapshotBuilder
             // Snapshotted with the cadence it qualifies, for the same reason the cadence is:
             // re-authoring the catalogue must not move an existing subscriber's renewal date.
             BillingAlignment = price.BillingAlignment,
+            // Copied so the opening stub can be priced without ever reading the monthly price
+            // again — not at checkout, not at renewal, not by a recovery sweep.
+            CalendarStubBasePriceId = price.CalendarStubBasePriceId,
+            CalendarStubBaseUnitAmountMinor = price.CalendarStubBaseUnitAmountMinor,
             DisplayPriceNote = price.DisplayPriceNote,
             QuantityItemKey = price.QuantityItemKey,
             TaxRateBasisPoints = price.TaxRateBasisPoints,

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -103,6 +103,7 @@ internal static class SubscriptionSnapshotBuilder
             // again — not at checkout, not at renewal, not by a recovery sweep.
             CalendarStubBasePriceId = price.CalendarStubBasePriceId,
             CalendarStubBaseUnitAmountMinor = price.CalendarStubBaseUnitAmountMinor,
+            CalendarAnnualChargeTiming = price.CalendarAnnualChargeTiming,
             DisplayPriceNote = price.DisplayPriceNote,
             QuantityItemKey = price.QuantityItemKey,
             TaxRateBasisPoints = price.TaxRateBasisPoints,

--- a/server/Subscription.DomainService/Utilities/CalendarBillingAlignment.cs
+++ b/server/Subscription.DomainService/Utilities/CalendarBillingAlignment.cs
@@ -23,12 +23,31 @@ public static class CalendarBillingAlignment
     /// Whether a cadence can be aligned to the calendar at all.
     /// </summary>
     /// <remarks>
-    /// Monthly, once a month, and nothing else. A fortnight and a quarter both have boundaries
-    /// that only sometimes land on a first, so aligning them would mean silently changing the
-    /// cadence the author chose — the request is refused instead.
+    /// Once a month or once a year, and nothing else. A fortnight and a quarter both have
+    /// boundaries that only sometimes land on a first, so aligning them would mean silently
+    /// changing the cadence the author chose — the request is refused instead.
+    /// <para>
+    /// The two supported cadences align differently, which is the whole of
+    /// <see cref="TryCreateSchedule"/>: a month aligns to the first of the month it starts in, a
+    /// year to the first of the month after — because a year that began mid-August and renewed the
+    /// following 1 August would be eleven months long.
+    /// </para>
     /// </remarks>
     public static bool Supports(BillingInterval interval, int intervalCount) =>
-        interval == BillingInterval.Month && intervalCount == 1;
+        intervalCount == 1 &&
+        interval is BillingInterval.Month or BillingInterval.Year;
+
+    /// <summary>
+    /// Whether a calendar-aligned price prices its opening stub from a separate monthly price.
+    /// </summary>
+    /// <remarks>
+    /// Yearly only. A month's stub is a fraction of the very price being charged, so it needs no
+    /// second one; a year's cannot be — a subscriber joining on 25 August owes a week, and a week
+    /// of an annual price is not a meaningful quantity. What they owe is a week of the monthly
+    /// equivalent, which has to be named rather than derived from the annual figure.
+    /// </remarks>
+    public static bool NeedsStubBasePrice(BillingInterval interval, int intervalCount) =>
+        interval == BillingInterval.Year && intervalCount == 1;
 
     /// <summary>Whether this alignment is valid for this cadence.</summary>
     public static bool IsValid(
@@ -44,26 +63,61 @@ public static class CalendarBillingAlignment
         int intervalCount) =>
         alignment == BillingAlignment.CalendarMonth && Supports(interval, intervalCount);
 
-    /// <summary>Whether a snapshotted price actually bills on calendar boundaries.</summary>
+    /// <summary>
+    /// Whether a price with these terms actually bills on calendar boundaries.
+    /// </summary>
     /// <remarks>
     /// Re-checks the cadence rather than trusting the stored alignment alone. A snapshot is only
     /// as good as what was validated when it was taken, and a subscription whose alignment and
     /// cadence disagree must bill the way its cadence says — never half-way between the two.
+    /// <para>
+    /// A yearly price also has to be able to price its opening stub, which means carrying the
+    /// monthly amount it was linked to. Without one there is nothing to charge a week from, and
+    /// the only safe reading is that this is not a calendar-aligned price at all: it falls back to
+    /// an ordinary anniversary year. The alternative — keeping the alignment and prorating the
+    /// annual amount by days — would bill a week at a twelfth of what it is worth, which is the
+    /// one failure mode worth failing closed against.
+    /// </para>
     /// </remarks>
+    public static bool IsCalendarAligned(
+        BillingAlignment alignment,
+        BillingInterval interval,
+        int intervalCount,
+        long? stubBaseUnitAmountMinor) =>
+        IsCalendarAligned(alignment, interval, intervalCount) &&
+        (!NeedsStubBasePrice(interval, intervalCount) || stubBaseUnitAmountMinor is > 0);
+
+    /// <summary>Whether a snapshotted price actually bills on calendar boundaries.</summary>
     public static bool IsCalendarAligned(PriceSnapshot? price) =>
         price is not null &&
-        IsCalendarAligned(price.BillingAlignment, price.Interval, price.IntervalCount);
+        IsCalendarAligned(
+            price.BillingAlignment,
+            price.Interval,
+            price.IntervalCount,
+            price.CalendarStubBaseUnitAmountMinor);
 
     /// <summary>
-    /// Builds the recurring schedule a calendar-aligned price renews on: local midnight, on the
-    /// first, every month.
+    /// Builds the recurring schedule a calendar-aligned price renews on: local midnight, on a
+    /// first, at the price's own cadence.
     /// </summary>
     /// <remarks>
-    /// Anchored on the first of the month <paramref name="anchorInstantUtc"/> falls in — not the
-    /// next one. The anchor only has to be *a* boundary for the derivation to be right, and using
-    /// the current month keeps the first period's index at zero, where a reader expects it.
+    /// Which first depends on the cadence, and the difference matters.
+    /// <para>
+    /// A <b>monthly</b> price anchors on the first of the month
+    /// <paramref name="anchorInstantUtc"/> falls in. The anchor only has to be <em>a</em> boundary
+    /// for the derivation to be right, and using the current month keeps the opening period's
+    /// index at zero, where a reader expects it.
+    /// </para>
+    /// <para>
+    /// A <b>yearly</b> price anchors on the first of the <em>next</em> month, because that is when
+    /// its twelve months actually begin. Anchoring it on the current month's first would make the
+    /// subscriber's year end on the 1 August after a 25 August signup — eleven months for a year's
+    /// money — and no later boundary could correct it, since every one derives from the anchor.
+    /// A signup already on the first anchors there and starts its year immediately.
+    /// </para>
     /// </remarks>
     public static bool TryCreateSchedule(
+        BillingInterval interval,
         DateTime anchorInstantUtc,
         string timeZoneId,
         out BillingSchedule schedule)
@@ -78,10 +132,17 @@ public static class CalendarBillingAlignment
         var local = BillingLocalTime.ToLocal(anchorInstantUtc, timeZone);
         var firstOfMonthLocal = new DateTime(local.Year, local.Month, 1);
 
+        // A year that starts mid-month starts its cycle at the next boundary, not the one already
+        // behind it. A month's opening period is the remainder of the month it is in, so it keeps
+        // the first it is already inside.
+        var anchorLocal = interval == BillingInterval.Year && local.Day != 1
+            ? firstOfMonthLocal.AddMonths(1)
+            : firstOfMonthLocal;
+
         return BillingPeriodCalculator.TryCreateSchedule(
-            BillingInterval.Month,
+            interval,
             1,
-            BillingLocalTime.ToUtc(firstOfMonthLocal, timeZone),
+            BillingLocalTime.ToUtc(anchorLocal, timeZone),
             timeZoneId,
             out schedule);
     }
@@ -137,6 +198,84 @@ public static class CalendarBillingAlignment
             coveredDays,
             daysInMonth,
             IsProrated: true);
+
+        return true;
+    }
+
+    /// <summary>
+    /// The monthly basis a calendar-aligned yearly price prices its opening stub from.
+    /// </summary>
+    /// <remarks>
+    /// Returns the yearly price and quantities re-expressed at the monthly amounts they were
+    /// linked to, so the stub then runs through the <em>identical</em> pricing path a monthly
+    /// subscription's stub does — same automatic discount, same volume band, same promotional
+    /// code, same tax. Anything else would be a second implementation of the money, and the two
+    /// would disagree the first time either changed.
+    /// <para>
+    /// The yearly price's own reductions are deliberately carried across unchanged. A subscriber
+    /// who buys an 8%-off annual plan on the 25th is on that plan from the 25th, and charging them
+    /// undiscounted for the stub would be selling them the discount a week late.
+    /// </para>
+    /// <para>
+    /// The quantity items are re-expressed too. They snapshot the <em>annual</em> per-unit amount
+    /// the subscriber agreed to, which is twelve times too much for a week — and dividing it back
+    /// down would lose a minor unit rather than reproduce the monthly price that was actually
+    /// linked.
+    /// </para>
+    /// </remarks>
+    public static bool TryStubBasis(
+        PriceSnapshot price,
+        IReadOnlyList<SubscriptionQuantityItem> quantityItems,
+        out PriceSnapshot stubPrice,
+        out List<SubscriptionQuantityItem> stubQuantityItems)
+    {
+        ArgumentNullException.ThrowIfNull(quantityItems);
+
+        stubPrice = null!;
+        stubQuantityItems = null!;
+
+        if (price is null ||
+            !IsCalendarAligned(price) ||
+            !NeedsStubBasePrice(price.Interval, price.IntervalCount) ||
+            price.CalendarStubBaseUnitAmountMinor is not { } baseUnitAmountMinor)
+        {
+            return false;
+        }
+
+        stubPrice = new PriceSnapshot
+        {
+            PriceId = price.PriceId,
+            CurrencyCode = price.CurrencyCode,
+            UnitAmountMinor = baseUnitAmountMinor,
+            // A month, because that is the period being bought. The stub is a fraction of the
+            // monthly equivalent, not a fraction of a year.
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            DisplayPriceNote = price.DisplayPriceNote,
+            QuantityItemKey = price.QuantityItemKey,
+            TaxRateBasisPoints = price.TaxRateBasisPoints,
+            TaxMode = price.TaxMode,
+            AutomaticDiscountBasisPoints = price.AutomaticDiscountBasisPoints,
+            QuantityDiscountCombination = price.QuantityDiscountCombination,
+            PriceVersion = price.PriceVersion,
+            CapturedAtUtc = price.CapturedAtUtc
+        };
+
+        stubQuantityItems = quantityItems
+            .Select(item => new SubscriptionQuantityItem
+            {
+                ItemKey = item.ItemKey,
+                UnitLabel = item.UnitLabel,
+                Quantity = item.Quantity,
+                UnitAmountMinor = string.Equals(
+                    item.ItemKey,
+                    price.QuantityItemKey,
+                    StringComparison.Ordinal)
+                    ? baseUnitAmountMinor
+                    : item.UnitAmountMinor
+            })
+            .ToList();
 
         return true;
     }

--- a/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
@@ -69,8 +69,39 @@ public sealed class CreatePriceRequestValidator : AbstractValidator<CreatePriceR
                 request.IntervalCount))
             .WithName(nameof(CreatePriceRequest.BillingAlignment))
             .WithMessage(
-                "Calendar-month billing is only available for a price billed every single month.")
+                "Calendar billing is only available for a price billed every single month or " +
+                "every single year.")
             .WithErrorCode("subscription_billing_alignment_invalid");
+
+        // A calendar-aligned year has an opening stub measured in days, and days of an annual
+        // amount mean nothing. The monthly price it is a fraction of has to be named.
+        RuleFor(request => request)
+            .Must(request =>
+                !CalendarBillingAlignment.IsCalendarAligned(
+                    request.BillingAlignment, request.Interval, request.IntervalCount) ||
+                !CalendarBillingAlignment.NeedsStubBasePrice(
+                    request.Interval, request.IntervalCount) ||
+                !string.IsNullOrWhiteSpace(request.CalendarStubBasePriceId))
+            .WithName(nameof(CreatePriceRequest.CalendarStubBasePriceId))
+            .WithMessage(
+                "A calendar-aligned yearly price needs the monthly price its opening period is " +
+                "charged from.")
+            .WithErrorCode("subscription_calendar_stub_base_price_required");
+
+        // And refused everywhere else, rather than stored and never read. A monthly price's stub
+        // is a fraction of the very price being charged; a link would describe a second basis that
+        // nothing consults.
+        RuleFor(request => request)
+            .Must(request =>
+                string.IsNullOrWhiteSpace(request.CalendarStubBasePriceId) ||
+                (CalendarBillingAlignment.IsCalendarAligned(
+                     request.BillingAlignment, request.Interval, request.IntervalCount) &&
+                 CalendarBillingAlignment.NeedsStubBasePrice(
+                     request.Interval, request.IntervalCount)))
+            .WithName(nameof(CreatePriceRequest.CalendarStubBasePriceId))
+            .WithMessage(
+                "Only a calendar-aligned yearly price is charged from a separate monthly price.")
+            .WithErrorCode("subscription_calendar_stub_base_price_unexpected");
 
         RuleFor(request => request)
             .Must(request => IsChargeable(currencyResolver, request))

--- a/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CreatePriceRequestValidator.cs
@@ -88,6 +88,24 @@ public sealed class CreatePriceRequestValidator : AbstractValidator<CreatePriceR
                 "charged from.")
             .WithErrorCode("subscription_calendar_stub_base_price_required");
 
+        RuleFor(request => request.CalendarAnnualChargeTiming!.Value)
+            .IsInEnum()
+            .When(request => request.CalendarAnnualChargeTiming.HasValue);
+
+        // The timing only means something where there are two things to charge for — a stub and a
+        // year. Anywhere else it would describe a choice nothing acts on.
+        RuleFor(request => request)
+            .Must(request =>
+                !request.CalendarAnnualChargeTiming.HasValue ||
+                (CalendarBillingAlignment.IsCalendarAligned(
+                     request.BillingAlignment, request.Interval, request.IntervalCount) &&
+                 CalendarBillingAlignment.NeedsStubBasePrice(
+                     request.Interval, request.IntervalCount)))
+            .WithName(nameof(CreatePriceRequest.CalendarAnnualChargeTiming))
+            .WithMessage(
+                "Only a calendar-aligned yearly price chooses when its annual amount is collected.")
+            .WithErrorCode("subscription_calendar_annual_charge_timing_unexpected");
+
         // And refused everywhere else, rather than stored and never read. A monthly price's stub
         // is a fraction of the very price being charged; a link would describe a second basis that
         // nothing consults.

--- a/server/XUnitTest/Subscription/CalendarAlignedPriceValidationTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPriceValidationTests.cs
@@ -38,7 +38,7 @@ public sealed class CalendarAlignedPriceValidationTests
     [InlineData(BillingInterval.Month, 12)]
     [InlineData(BillingInterval.Day, 1)]
     [InlineData(BillingInterval.Week, 2)]
-    [InlineData(BillingInterval.Year, 1)]
+    [InlineData(BillingInterval.Year, 2)]
     public void Every_other_cadence_is_refused_by_error_code(
         BillingInterval interval,
         int intervalCount)
@@ -85,10 +85,52 @@ public sealed class CalendarAlignedPriceValidationTests
             .IsValid.Should().BeTrue();
     }
 
+    /// <summary>
+    /// A year aligns to the calendar too, but only with the monthly price its opening stub is a
+    /// fraction of — days of an annual amount are not a quantity anybody can charge.
+    /// </summary>
+    [Fact]
+    public void A_yearly_price_may_be_aligned_when_it_names_its_monthly_basis()
+    {
+        Validate(BillingAlignment.CalendarMonth, BillingInterval.Year, 1, "price-monthly")
+            .IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_yearly_price_without_a_monthly_basis_is_refused()
+    {
+        var result = Validate(BillingAlignment.CalendarMonth, BillingInterval.Year, 1);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_calendar_stub_base_price_required");
+    }
+
+    /// <summary>
+    /// Refused rather than stored and never read: a monthly price's stub is a fraction of the very
+    /// price being charged, so a second basis would describe something nothing consults.
+    /// </summary>
+    [Theory]
+    [InlineData(BillingAlignment.CalendarMonth, BillingInterval.Month, 1)]
+    [InlineData(BillingAlignment.Anniversary, BillingInterval.Year, 1)]
+    [InlineData(BillingAlignment.Anniversary, BillingInterval.Month, 1)]
+    public void A_monthly_basis_on_a_price_that_cannot_use_one_is_refused(
+        BillingAlignment alignment,
+        BillingInterval interval,
+        int intervalCount)
+    {
+        var result = Validate(alignment, interval, intervalCount, "price-monthly");
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_calendar_stub_base_price_unexpected");
+    }
+
     private FluentValidation.Results.ValidationResult Validate(
         BillingAlignment alignment,
         BillingInterval interval,
-        int intervalCount) =>
+        int intervalCount,
+        string? calendarStubBasePriceId = null) =>
         new CreatePriceRequestValidator(_currency.Object).Validate(new CreatePriceRequest
         {
             PlanId = "plan-1",
@@ -96,6 +138,7 @@ public sealed class CalendarAlignedPriceValidationTests
             UnitAmountMinor = 8900,
             Interval = interval,
             IntervalCount = intervalCount,
-            BillingAlignment = alignment
+            BillingAlignment = alignment,
+            CalendarStubBasePriceId = calendarStubBasePriceId
         });
 }

--- a/server/XUnitTest/Subscription/CalendarAlignedYearlyLifecycleTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedYearlyLifecycleTests.cs
@@ -1,0 +1,263 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// A calendar-aligned yearly subscription after signup: converting from a trial, surviving a
+/// decline, and being moved onto from a monthly plan.
+/// </summary>
+/// <remarks>
+/// Each of these has to produce the same two charges a fresh mid-month signup does — a stub priced
+/// from the monthly basis, then a whole year opening on the first — reached by a different route.
+/// Tier 2 throughout: CHF 950 a month, 8% off annually.
+/// </remarks>
+public sealed class CalendarAlignedYearlyLifecycleTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+    private const long MonthlyMinor = 95_000;
+    private const long YearlyGrossMinor = MonthlyMinor * 12;
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionTransition? _transition;
+    private SubscriptionChargeRequest? _charge;
+    private string? _idempotencyKey;
+    private bool _declineCharge;
+
+    public CalendarAlignedYearlyLifecycleTests()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                ProviderName = "STRIPE",
+                DefaultPaymentMethodId = "pm-1"
+            });
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionChargeRequest, string, string, CancellationToken>(
+                (request, key, _, _) =>
+                {
+                    _charge = request;
+                    _idempotencyKey = key;
+                })
+            .ReturnsAsync(() => _declineCharge
+                ? SubscriptionOperationResult<string>.Failure(
+                    PaymentFailureKind.ProviderRejected, "card_declined", "Declined.", "corr-1")
+                : SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+    }
+
+    /// <summary>
+    /// A trial ending mid-month buys the rest of that month at the monthly price, and only then
+    /// starts paying for a year.
+    /// </summary>
+    [Fact]
+    public async Task A_card_free_trial_ending_mid_month_charges_the_monthly_stub()
+    {
+        var subscription = ConvertingTrial();
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        // 95000 x 12/31 is 36774; less 8% (2941) is 33833.
+        _charge!.AmountMinor.Should().Be(33_833);
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _transition.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2026, 9, 1),
+            "the year itself is still due, and is charged separately on the first");
+    }
+
+    [Fact]
+    public async Task The_year_after_the_conversion_stub_is_charged_in_full_and_separately()
+    {
+        var subscription = ConvertingTrial();
+        await Service().RenewAsync(subscription, CancellationToken.None);
+        var stubKey = _idempotencyKey;
+
+        // The subscription as the conversion left it, now on the first.
+        subscription.Status = SubscriptionStatus.Active;
+        subscription.InitialChargeAmountMinor = _transition!.InitialChargeAmountMinor;
+        subscription.CurrentPeriodStartUtc = _transition.CurrentPeriodStartUtc!.Value;
+        subscription.CurrentPeriodEndUtc = _transition.CurrentPeriodEndUtc!.Value;
+        _time.Advance(LocalMidnight(2026, 9, 1) - _time.GetUtcNow());
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(1_048_800, "a whole discounted year");
+        _idempotencyKey.Should().NotBe(stubKey,
+            "the stub and the year are different periods and must not collide on one key");
+        _transition!.CurrentPeriodStartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _transition.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+    }
+
+    /// <summary>
+    /// The dunning guarantee established for monthly stubs, on a yearly one: a declined conversion
+    /// is no longer <c>Trialing</c>, and the retry must still owe the stub.
+    /// </summary>
+    [Fact]
+    public async Task A_declined_yearly_conversion_still_retries_the_monthly_stub()
+    {
+        var subscription = ConvertingTrial();
+
+        _declineCharge = true;
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.PastDue);
+
+        subscription.Status = SubscriptionStatus.PastDue;
+        subscription.DunningAttemptCount = 1;
+        _declineCharge = false;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(33_833,
+            "still a fraction of the month, not a fraction of the year and not a whole year");
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+    }
+
+    /// <summary>
+    /// Moving from a monthly plan onto a calendar-aligned yearly one settles only the target stub
+    /// now; the annual cycle opens on the first like any other calendar-aligned year.
+    /// </summary>
+    [Fact]
+    public void A_monthly_to_yearly_change_settles_only_the_target_stub()
+    {
+        var now = new DateTime(2026, 8, 25, 0, 0, 0, DateTimeKind.Utc);
+
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = "sub-1",
+            CurrencyCode = "CHF",
+            Plan = new PlanSnapshot { Code = "tier-2", DisplayName = "Tier 2" },
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = MonthlyMinor,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1
+            },
+            // A whole month from 1 August, so seven days of it are unused on the 25th.
+            CurrentPeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            CurrentPeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            new PlanSnapshot { Code = "tier-2", DisplayName = "Tier 2" },
+            YearlySnapshot(),
+            [],
+            now,
+            now,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            new BillingDayFraction(7, 31));
+
+        // Arriving: the same 19736 stub a fresh signup pays. Leaving: 95000 x 7/31 of the monthly
+        // plan is 21451 unused. The difference is banked rather than charged, because the annual
+        // discount makes the stub cheaper than the month it replaces.
+        outcome.ChargeMinor.Should().Be(0);
+        outcome.NewCreditBalanceMinor.Should().Be(1_715);
+    }
+
+    private SubscriptionDetail ConvertingTrial()
+    {
+        var subscription = YearlySubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = new DateTime(2026, 8, 6, 12, 0, 0, DateTimeKind.Utc),
+            EndsAtUtc = new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc),
+            RequiresPaymentMethod = false
+        };
+
+        return subscription;
+    }
+
+    private SubscriptionRenewalService Service() => new(
+        _subscriptions.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new OptionsStub(),
+        NullLogger<SubscriptionRenewalService>.Instance,
+        _time);
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(
+            new DateTime(year, month, day, 0, 0, 0),
+            TimeZoneInfo.FindSystemTimeZoneById(Zurich));
+
+    private static PriceSnapshot YearlySnapshot() => new()
+    {
+        PriceId = "price-yearly",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = YearlyGrossMinor,
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        CalendarStubBasePriceId = "price-monthly",
+        CalendarStubBaseUnitAmountMinor = MonthlyMinor,
+        AutomaticDiscountBasisPoints = 800
+    };
+
+    private static SubscriptionDetail YearlySubscription(SubscriptionStatus status) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = status,
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot { Code = "tier-2", DisplayName = "Tier 2" },
+        Price = YearlySnapshot(),
+        FeeSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            AnchorInstantUtc = LocalMidnight(2026, 9, 1),
+            TimeZoneId = Zurich,
+            AnchorDayOfMonth = 1,
+            AnchorMinutesFromMidnight = 0
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new() { DunningMaxAttempts = 4 };
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/CalendarAlignedYearlyTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedYearlyTests.cs
@@ -1,0 +1,364 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// A yearly price aligned to the calendar: a stub measured in days, then twelve whole months.
+/// </summary>
+/// <remarks>
+/// The stub is the reason this is not simply the monthly feature with a different interval. Days of
+/// an annual amount are not a quantity anyone can charge, so the opening period is priced from the
+/// monthly price the annual one was linked to — and the annual cycle does not begin until the
+/// first, or a year bought on 25 August would end on 1 August.
+/// <para>
+/// Worked against Tier 2: CHF 950 a month, 8% off for paying annually.
+/// </para>
+/// </remarks>
+public sealed class CalendarAlignedYearlyTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+
+    /// <summary>CHF 950.00 a month, so CHF 11,400.00 a year before the annual discount.</summary>
+    private const long MonthlyMinor = 95_000;
+
+    private const long YearlyGrossMinor = MonthlyMinor * 12;
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+
+    /// <summary>25 August 2026, 09:30 UTC — 11:30 in Zurich, so the 25th either way.</summary>
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 25, 9, 30, 0, TimeSpan.Zero));
+
+    private Price _price = YearlyPrice();
+    private SubscriptionDetail? _created;
+
+    public CalendarAlignedYearlyTests()
+    {
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "tier-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPlan);
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-yearly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _price);
+
+        _accounts
+            .Setup(repository => repository.GetOrCreateAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionDetail, CancellationToken>((subscription, _) => _created = subscription)
+            .ReturnsAsync(true);
+    }
+
+    /// <summary>
+    /// The worked example: CHF 950 x 7/31 x 92% for the stub, then a full year from 1 September.
+    /// </summary>
+    [Fact]
+    public async Task An_august_25_signup_pays_a_monthly_stub_then_starts_its_year_on_september_1()
+    {
+        await Subscribe();
+
+        _created!.CurrentPeriodStartUtc.Should().Be(
+            new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc));
+        _created.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _created.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2026, 9, 1));
+
+        _created.InitialChargeProrated.Should().BeTrue();
+        _created.ProrationDays.Should().Be(7);
+        _created.ProrationTotalDays.Should().Be(31);
+
+        // 95000 x 7/31 is 21451.6, so 21452; 8% off that is 1716 (truncated), leaving 19736.
+        _created.InitialChargeAmountMinor.Should().Be(19_736,
+            "CHF 197.36 — a week of the monthly price, at the annual plan's discount");
+    }
+
+    [Fact]
+    public async Task The_annual_cycle_runs_first_to_first_a_year_apart()
+    {
+        await Subscribe();
+
+        var schedule = _created!.FeeSchedule;
+        schedule.Interval.Should().Be(BillingInterval.Year);
+        schedule.IntervalCount.Should().Be(1);
+        schedule.AnchorDayOfMonth.Should().Be(1);
+        schedule.AnchorMinutesFromMidnight.Should().Be(0);
+
+        // The year opens on 1 September and closes on 1 September, not on 1 August.
+        PeriodAt(schedule, new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc))
+            .Should().Be((LocalMidnight(2026, 9, 1), LocalMidnight(2027, 9, 1)));
+        PeriodAt(schedule, new DateTime(2027, 10, 1, 0, 0, 0, DateTimeKind.Utc))
+            .Should().Be((LocalMidnight(2027, 9, 1), LocalMidnight(2028, 9, 1)));
+    }
+
+    /// <summary>
+    /// The full annual charge, which is the derived twelve months rather than anything prorated.
+    /// </summary>
+    [Fact]
+    public async Task The_charge_on_the_first_is_the_whole_discounted_year()
+    {
+        await Subscribe();
+
+        var annual = SubscriptionAmountCalculator.PeriodAmountMinor(
+            _created!,
+            LocalMidnight(2026, 9, 1));
+
+        // 1140000 less 8% is 1048800: CHF 10,488.00.
+        annual.AmountMinor.Should().Be(1_048_800);
+    }
+
+    /// <summary>
+    /// A signup already on the first buys a year from that day, with no stub at all.
+    /// </summary>
+    [Fact]
+    public async Task A_signup_on_the_local_first_starts_its_year_immediately()
+    {
+        _time.Advance(new DateTimeOffset(2026, 9, 1, 8, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        await Subscribe();
+
+        _created!.InitialChargeProrated.Should().BeFalse();
+        _created.ProrationDays.Should().BeNull();
+        _created.InitialChargeAmountMinor.Should().Be(1_048_800, "a whole discounted year");
+        _created.CurrentPeriodStartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _created.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1),
+            "a year, not the month the calendar-month rule would have given a monthly price");
+    }
+
+    [Theory]
+    // February in a common year, then a leap year, then a 30-day month.
+    // 95000 x 19/28 is 64464; less 8% (5157) is 59307.
+    [InlineData(2026, 2, 10, 19, 28, 59_307)]
+    // The leap day changes the denominator: 95000 x 20/29 is 65517, less 8% (5241) is 60276.
+    [InlineData(2028, 2, 10, 20, 29, 60_276)]
+    // 95000 x 16/30 is 50667; less 8% (4053) is 46614.
+    [InlineData(2026, 4, 15, 16, 30, 46_614)]
+    public async Task The_stub_is_split_by_the_days_the_month_actually_has(
+        int year,
+        int month,
+        int day,
+        int expectedDays,
+        int expectedTotalDays,
+        long expectedAmountMinor)
+    {
+        _time.Advance(new DateTimeOffset(year, month, day, 12, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        await Subscribe();
+
+        _created!.ProrationDays.Should().Be(expectedDays);
+        _created.ProrationTotalDays.Should().Be(expectedTotalDays);
+        _created.InitialChargeAmountMinor.Should().Be(expectedAmountMinor);
+    }
+
+    /// <summary>
+    /// The stub is a fraction of the monthly price, not of a daily rate derived from the annual
+    /// one. Those differ, and only one of them is a number the subscriber was shown.
+    /// </summary>
+    [Fact]
+    public async Task The_stub_is_a_fraction_of_the_monthly_price_not_of_the_year()
+    {
+        await Subscribe();
+
+        var aFractionOfTheYear = CalendarBillingAlignment.Prorate(YearlyGrossMinor, 7, 31);
+
+        _created!.InitialChargeAmountMinor.Should().NotBe(aFractionOfTheYear);
+        _created.InitialChargeAmountMinor.Should().BeLessThan(aFractionOfTheYear / 10,
+            "a week of a month is roughly a twelfth of a week of a year");
+    }
+
+    [Fact]
+    public async Task The_monthly_basis_is_snapshotted_onto_the_subscription()
+    {
+        await Subscribe();
+
+        _created!.Price.CalendarStubBasePriceId.Should().Be("price-monthly");
+        _created.Price.CalendarStubBaseUnitAmountMinor.Should().Be(MonthlyMinor,
+            "the stub must be reproducible without ever reading the monthly price again");
+    }
+
+    /// <summary>
+    /// Editing the monthly price afterwards must not move an annual subscriber's stub. The
+    /// snapshot is the whole defence, since the stub is charged at checkout and the year a month
+    /// later.
+    /// </summary>
+    [Fact]
+    public async Task Repricing_the_monthly_price_afterwards_changes_nothing_already_sold()
+    {
+        await Subscribe();
+        var quoted = _created!.InitialChargeAmountMinor;
+
+        _price.CalendarStubBaseUnitAmountMinor = 500_000;
+
+        SubscriptionAmountCalculator
+            .FirstPeriodCharge(_created, new BillingDayFraction(7, 31), _time.GetUtcNow().UtcDateTime)
+            .AmountMinor.Should().Be(quoted);
+    }
+
+    [Fact]
+    public async Task A_quantity_priced_yearly_stub_multiplies_the_monthly_amount()
+    {
+        _price.QuantityItemKey = "seat";
+
+        await Subscribe(quantity: 4);
+
+        // 4 seats at 95000 is 380000 a month; 7/31 of that is 85806; less 8% is 78942.
+        _created!.InitialChargeAmountMinor.Should().Be(78_942);
+    }
+
+    /// <summary>
+    /// The annual per-seat amount snapshotted on the quantity item is twelve times too much for a
+    /// week, so the stub has to be re-expressed at the monthly amount rather than reusing it.
+    /// </summary>
+    [Fact]
+    public async Task A_quantity_priced_stub_does_not_use_the_annual_per_seat_amount()
+    {
+        _price.QuantityItemKey = "seat";
+
+        await Subscribe(quantity: 4);
+
+        _created!.QuantityItems.Single().UnitAmountMinor.Should().Be(YearlyGrossMinor,
+            "the subscriber agreed an annual per-seat amount, and that is what renewals charge");
+        _created.InitialChargeAmountMinor.Should().BeLessThan(100_000,
+            "but the stub is a week of the monthly equivalent, not a week of the annual one");
+    }
+
+    [Fact]
+    public async Task An_anniversary_yearly_price_is_completely_unaffected()
+    {
+        _price.BillingAlignment = BillingAlignment.Anniversary;
+        _price.CalendarStubBasePriceId = null;
+        _price.CalendarStubBaseUnitAmountMinor = null;
+
+        await Subscribe();
+
+        _created!.InitialChargeProrated.Should().BeFalse();
+        _created.InitialChargeAmountMinor.Should().Be(1_048_800);
+        _created.FeeSchedule.AnchorDayOfMonth.Should().Be(25);
+        _created.CurrentPeriodEndUtc.Should().Be(
+            BillingLocalTime.ToUtc(new DateTime(2027, 8, 25, 11, 30, 0), Zone()),
+            "25 August renews 25 August the following year");
+    }
+
+    /// <summary>
+    /// A yearly price whose stub basis never made it onto the snapshot cannot price a stub, so it
+    /// must bill as an ordinary anniversary year rather than guess at one.
+    /// </summary>
+    [Fact]
+    public async Task A_yearly_price_with_no_snapshotted_basis_falls_back_to_a_whole_year()
+    {
+        _price.CalendarStubBaseUnitAmountMinor = null;
+
+        await Subscribe();
+
+        _created!.InitialChargeAmountMinor.Should().Be(1_048_800,
+            "with nothing to price a week from, the subscriber buys a year");
+    }
+
+    [Fact]
+    public async Task The_usage_schedule_keeps_its_own_monthly_cadence()
+    {
+        await Subscribe();
+
+        _created!.UsageSchedule.Interval.Should().Be(BillingInterval.Month);
+        _created.UsageSchedule.AnchorDayOfMonth.Should().Be(25,
+            "metering is independent of the fee, and an annual plan still meters monthly");
+        _created.Plan.Meters[0].IncludedQuantity.Should().Be(500);
+    }
+
+    private async Task Subscribe(long quantity = 1)
+    {
+        var request = new CreateSubscriptionRequest
+        {
+            PlanCode = "tier-2",
+            PriceId = "price-yearly",
+            TimeZoneId = Zurich,
+            Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = quantity }]
+        };
+
+        var result = await Service().CreateAsync(
+            request,
+            new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1"),
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorCode ?? "creation should succeed");
+    }
+
+    private SubscriptionCreationService Service() => new(
+        _catalogue.Object,
+        _subscriptions.Object,
+        _discounts.Object,
+        _accounts.Object,
+        new CreateSubscriptionRequestValidator(),
+        NullLogger<SubscriptionCreationService>.Instance,
+        _time);
+
+    private static (DateTime StartUtc, DateTime EndUtc) PeriodAt(
+        BillingSchedule schedule,
+        DateTime instantUtc)
+    {
+        BillingPeriodCalculator.TryGetPeriod(schedule, instantUtc, out var period)
+            .Should().BeTrue();
+
+        return (period.StartUtc, period.EndUtc);
+    }
+
+    private static TimeZoneInfo Zone() => TimeZoneInfo.FindSystemTimeZoneById(Zurich);
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(new DateTime(year, month, day, 0, 0, 0), Zone());
+
+    private static Price YearlyPrice() => new()
+    {
+        ItemId = "price-yearly",
+        TenantId = TenantId,
+        PlanId = "plan-2",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = YearlyGrossMinor,
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        CalendarStubBasePriceId = "price-monthly",
+        CalendarStubBaseUnitAmountMinor = MonthlyMinor,
+        AutomaticDiscountBasisPoints = 800,
+        Status = CatalogueStatus.Active
+    };
+
+    private static Plan NewPlan() => new()
+    {
+        ItemId = "plan-2",
+        TenantId = TenantId,
+        Code = "tier-2",
+        DisplayName = "Tier 2",
+        Status = CatalogueStatus.Active,
+        Version = 1,
+        QuantityItems =
+        [
+            new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat", DefaultQuantity = 1 }
+        ],
+        Meters =
+        [
+            new PlanMeter { MeterKey = "screening", UnitLabel = "screening", IncludedQuantity = 500 }
+        ]
+    };
+}

--- a/server/XUnitTest/Subscription/CalendarAnnualBoundaryTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualBoundaryTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// What happens on 1 September, when the year a subscriber bought in August actually begins.
+/// </summary>
+/// <remarks>
+/// Two outcomes from one code path: an unpaid year is collected here, a prepaid one is simply
+/// opened. Both end with the subscription inside the year and nothing left pending — the difference
+/// is only whether money moves.
+/// </remarks>
+public sealed class CalendarAnnualBoundaryTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+    private const long DiscountedAnnualMinor = 1_048_800;
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+
+    /// <summary>1 September 2026, 00:00 in Zurich — the boundary itself.</summary>
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 31, 22, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionTransition? _transition;
+    private SubscriptionChargeRequest? _charge;
+    private int _chargeCount;
+    private bool _declineCharge;
+
+    public CalendarAnnualBoundaryTests()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                ProviderName = "STRIPE",
+                DefaultPaymentMethodId = "pm-1"
+            });
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionChargeRequest, string, string, CancellationToken>(
+                (request, _, _, _) =>
+                {
+                    _charge = request;
+                    _chargeCount++;
+                })
+            .ReturnsAsync(() => _declineCharge
+                ? SubscriptionOperationResult<string>.Failure(
+                    PaymentFailureKind.ProviderRejected, "card_declined", "Declined.", "corr-1")
+                : SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+    }
+
+    [Fact]
+    public async Task An_unpaid_year_is_collected_at_its_boundary()
+    {
+        var subscription = InStub(prepaid: false);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(DiscountedAnnualMinor);
+        _transition!.CurrentPeriodStartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _transition.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+        _transition.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2027, 9, 1));
+        _transition.ClearPendingAnnualPeriod.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The one that would double-charge if the prepaid flag were ignored.
+    /// </summary>
+    [Fact]
+    public async Task A_prepaid_year_opens_without_taking_anything()
+    {
+        var subscription = InStub(prepaid: true);
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _chargeCount.Should().Be(0, "the money came in with the opening charge a month ago");
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Active);
+        _transition.CurrentPeriodStartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        _transition.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+        _transition.ClearPendingAnnualPeriod.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The frozen figure, not one derived at the boundary. A month has passed since the quote and
+    /// nothing about the catalogue is guaranteed to have stood still.
+    /// </summary>
+    [Fact]
+    public async Task The_boundary_charges_what_was_quoted_not_what_the_price_now_says()
+    {
+        var subscription = InStub(prepaid: false);
+        subscription.PendingAnnualPeriod!.AmountMinor = 999_999;
+        subscription.Price.UnitAmountMinor = 5_000_000;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(999_999);
+    }
+
+    [Fact]
+    public async Task A_declined_annual_charge_enters_dunning_and_keeps_the_year_pending()
+    {
+        var subscription = InStub(prepaid: false);
+        _declineCharge = true;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.PastDue);
+        _transition.ClearPendingAnnualPeriod.Should().BeFalse(
+            "the year is still owed, so it must still be found on the retry");
+    }
+
+    [Fact]
+    public async Task A_dunning_retry_charges_the_same_frozen_year()
+    {
+        var subscription = InStub(prepaid: false);
+        _declineCharge = true;
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        subscription.Status = SubscriptionStatus.PastDue;
+        subscription.DunningAttemptCount = 1;
+        _declineCharge = false;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(DiscountedAnnualMinor);
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+        _transition.ClearPendingAnnualPeriod.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The year that follows is an ordinary renewal, priced from the price rather than from a
+    /// record that no longer exists.
+    /// </summary>
+    [Fact]
+    public async Task The_second_year_renews_normally()
+    {
+        var subscription = InStub(prepaid: true);
+        subscription.PendingAnnualPeriod = null;
+        subscription.CurrentPeriodStartUtc = LocalMidnight(2026, 9, 1);
+        subscription.CurrentPeriodEndUtc = LocalMidnight(2027, 9, 1);
+        _time.Advance(LocalMidnight(2027, 9, 1) - _time.GetUtcNow());
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _charge!.AmountMinor.Should().Be(DiscountedAnnualMinor);
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2028, 9, 1));
+    }
+
+    /// <summary>
+    /// A subscription still inside its stub has nothing to open — the boundary has not arrived, and
+    /// the renewal running is the one closing the stub itself.
+    /// </summary>
+    [Fact]
+    public async Task A_year_whose_boundary_has_not_arrived_is_left_alone()
+    {
+        var subscription = InStub(prepaid: false);
+        subscription.PendingAnnualPeriod!.StartUtc = LocalMidnight(2026, 10, 1);
+        subscription.PendingAnnualPeriod.EndUtc = LocalMidnight(2027, 10, 1);
+
+        // A figure no ordinary calculation could produce, so the charge below can only match it by
+        // having been taken from the pending record.
+        subscription.PendingAnnualPeriod.AmountMinor = 999_999;
+
+        await Service().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.ClearPendingAnnualPeriod.Should().BeFalse();
+        _charge!.AmountMinor.Should().NotBe(999_999,
+            "the year is not due yet, so this renewal must price itself from the price");
+        _charge.AmountMinor.Should().Be(DiscountedAnnualMinor);
+    }
+
+    private SubscriptionRenewalService Service() => new(
+        _subscriptions.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new OptionsStub(),
+        NullLogger<SubscriptionRenewalService>.Instance,
+        _time);
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(
+            new DateTime(year, month, day, 0, 0, 0),
+            TimeZoneInfo.FindSystemTimeZoneById(Zurich));
+
+    /// <summary>A subscription that signed up 25 August and is inside its stub.</summary>
+    private static SubscriptionDetail InStub(bool prepaid) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot { Code = "tier-2", DisplayName = "Tier 2" },
+        Price = new PriceSnapshot
+        {
+            PriceId = "price-yearly",
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 1_140_000,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = 95_000,
+            CalendarAnnualChargeTiming = prepaid
+                ? CalendarAnnualChargeTiming.AtCheckout
+                : CalendarAnnualChargeTiming.AtBoundary,
+            AutomaticDiscountBasisPoints = 800
+        },
+        FeeSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            AnchorInstantUtc = LocalMidnight(2026, 9, 1),
+            TimeZoneId = Zurich,
+            AnchorDayOfMonth = 1,
+            AnchorMinutesFromMidnight = 0
+        },
+        CurrentPeriodStartUtc = new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc),
+        CurrentPeriodEndUtc = LocalMidnight(2026, 9, 1),
+        InitialChargeAmountMinor = prepaid ? 19_736 + DiscountedAnnualMinor : 19_736,
+        InitialChargeProrated = true,
+        ProrationDays = 7,
+        ProrationTotalDays = 31,
+        PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = LocalMidnight(2026, 9, 1),
+            EndUtc = LocalMidnight(2027, 9, 1),
+            AmountMinor = DiscountedAnnualMinor,
+            NetAmountMinor = DiscountedAnnualMinor,
+            GrossAmountMinor = 1_140_000,
+            BuiltInDiscountMinor = 91_200,
+            IsPrepaid = prepaid
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new() { DunningMaxAttempts = 4 };
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
@@ -103,7 +103,9 @@ public sealed class CalendarAnnualChargeTimingTests
         pending!.StartUtc.Should().Be(LocalMidnight(2026, 9, 1));
         pending.EndUtc.Should().Be(LocalMidnight(2027, 9, 1));
         pending.AmountMinor.Should().Be(DiscountedAnnualMinor);
-        pending.IsPrepaid.Should().BeFalse("a year nobody has started is a year nobody has paid for");
+        pending.CollectedWithCheckout.Should().BeFalse(
+            "a year nobody has started is a year nobody has paid for");
+        pending.IsPrepaid.Should().BeFalse();
     }
 
     [Fact]
@@ -117,7 +119,7 @@ public sealed class CalendarAnnualChargeTimingTests
             "CHF 197.36 for the stub and CHF 10,488.00 for the year, in one charge");
 
         var pending = _created.PendingAnnualPeriod;
-        pending!.IsPrepaid.Should().BeTrue();
+        pending!.CollectedWithCheckout.Should().BeTrue();
         pending.AmountMinor.Should().Be(DiscountedAnnualMinor);
         pending.StartUtc.Should().Be(LocalMidnight(2026, 9, 1));
         pending.EndUtc.Should().Be(LocalMidnight(2027, 9, 1));
@@ -143,6 +145,25 @@ public sealed class CalendarAnnualChargeTimingTests
         _created!.InitialChargeAmountMinor.Should().Be(atBoundaryTotal);
         _created.PendingAnnualPeriod!.AmountMinor.Should().Be(DiscountedAnnualMinor,
             "the year is still worth what it was worth; it has only been paid for early");
+    }
+
+    /// <summary>
+    /// Nothing is paid at signup, whatever the price says it will collect. The subscription is
+    /// still Incomplete and the checkout may never be paid at all — reporting the year as settled
+    /// here would tell a client the subscriber owes nothing when they owe everything.
+    /// </summary>
+    [Fact]
+    public async Task A_year_billed_at_checkout_is_not_settled_until_the_checkout_is()
+    {
+        _price = CalendarPrice(CalendarAnnualChargeTiming.AtCheckout);
+
+        await Subscribe();
+
+        _created!.Status.Should().Be(SubscriptionStatus.Incomplete);
+        _created.PendingAnnualPeriod!.CollectedWithCheckout.Should().BeTrue(
+            "the charge raised for this subscription includes the year");
+        _created.PendingAnnualPeriod.IsPrepaid.Should().BeFalse(
+            "but nobody has paid it, and the boundary must be able to tell the difference");
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
@@ -1,0 +1,337 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The three ways a yearly price can be sold, priced from one signup on 25 August.
+/// </summary>
+/// <remarks>
+/// Tier 2: CHF 950 a month, CHF 11,400 a year authored independently, 8% off for paying annually.
+/// The annual amount is deliberately not derived from the monthly one — what a year costs is a
+/// commercial decision, and an annual plan is usually not twelve monthly ones.
+/// <para>
+/// All three charge the same subscriber for the same plan on the same day. What differs is when the
+/// year is collected and when it starts, which is the whole of the configuration.
+/// </para>
+/// </remarks>
+public sealed class CalendarAnnualChargeTimingTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+    private const long MonthlyMinor = 95_000;
+    private const long AnnualMinor = 1_140_000;
+
+    /// <summary>CHF 10,488.00 — the annual amount less its 8% automatic discount.</summary>
+    private const long DiscountedAnnualMinor = 1_048_800;
+
+    /// <summary>CHF 197.36 — seven of August's thirty-one dates of the monthly price, less 8%.</summary>
+    private const long StubMinor = 19_736;
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 25, 9, 30, 0, TimeSpan.Zero));
+
+    private Price _price = CalendarPrice(CalendarAnnualChargeTiming.AtBoundary);
+    private SubscriptionDetail? _created;
+
+    public CalendarAnnualChargeTimingTests()
+    {
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "tier-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPlan);
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-yearly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _price);
+
+        _accounts
+            .Setup(repository => repository.GetOrCreateAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionDetail, CancellationToken>((subscription, _) => _created = subscription)
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task Anniversary_collects_the_year_now_and_starts_it_now()
+    {
+        _price = AnniversaryPrice();
+
+        await Subscribe();
+
+        _created!.InitialChargeAmountMinor.Should().Be(DiscountedAnnualMinor);
+        _created.InitialChargeProrated.Should().BeFalse();
+        _created.PendingAnnualPeriod.Should().BeNull("the year starts today, so nothing is pending");
+        _created.CurrentPeriodStartUtc.Should().Be(
+            new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc));
+        _created.CurrentPeriodEndUtc.Should().Be(
+            BillingLocalTime.ToUtc(new DateTime(2027, 8, 25, 11, 30, 0), Zone()));
+    }
+
+    [Fact]
+    public async Task At_boundary_collects_the_stub_now_and_leaves_the_year_owed()
+    {
+        await Subscribe();
+
+        _created!.InitialChargeAmountMinor.Should().Be(StubMinor,
+            "only the stub is collected at checkout");
+        _created.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1));
+
+        var pending = _created.PendingAnnualPeriod;
+        pending.Should().NotBeNull();
+        pending!.StartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        pending.EndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+        pending.AmountMinor.Should().Be(DiscountedAnnualMinor);
+        pending.IsPrepaid.Should().BeFalse("a year nobody has started is a year nobody has paid for");
+    }
+
+    [Fact]
+    public async Task At_checkout_collects_the_stub_and_the_year_together()
+    {
+        _price = CalendarPrice(CalendarAnnualChargeTiming.AtCheckout);
+
+        await Subscribe();
+
+        _created!.InitialChargeAmountMinor.Should().Be(StubMinor + DiscountedAnnualMinor,
+            "CHF 197.36 for the stub and CHF 10,488.00 for the year, in one charge");
+
+        var pending = _created.PendingAnnualPeriod;
+        pending!.IsPrepaid.Should().BeTrue();
+        pending.AmountMinor.Should().Be(DiscountedAnnualMinor);
+        pending.StartUtc.Should().Be(LocalMidnight(2026, 9, 1));
+        pending.EndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+
+        _created.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 9, 1),
+            "the stub is still the period they hold — the year has not started");
+    }
+
+    /// <summary>
+    /// The two calendar modes charge different totals now and identical totals overall. That is the
+    /// only difference between them, and it is worth asserting as one statement.
+    /// </summary>
+    [Fact]
+    public async Task Both_calendar_modes_come_to_the_same_money()
+    {
+        await Subscribe();
+        var atBoundaryTotal = _created!.InitialChargeAmountMinor +
+            _created.PendingAnnualPeriod!.AmountMinor;
+
+        _price = CalendarPrice(CalendarAnnualChargeTiming.AtCheckout);
+        await Subscribe();
+
+        _created!.InitialChargeAmountMinor.Should().Be(atBoundaryTotal);
+        _created.PendingAnnualPeriod!.AmountMinor.Should().Be(DiscountedAnnualMinor,
+            "the year is still worth what it was worth; it has only been paid for early");
+    }
+
+    [Fact]
+    public async Task The_annual_amount_is_authored_rather_than_twelve_monthly_ones()
+    {
+        // Priced deliberately below twelve months, which is the ordinary reason to sell a year.
+        _price.UnitAmountMinor = 1_000_000;
+
+        await Subscribe();
+
+        _created!.PendingAnnualPeriod!.GrossAmountMinor.Should().Be(1_000_000);
+        _created.InitialChargeAmountMinor.Should().Be(StubMinor,
+            "the stub still comes from the monthly price, which has not moved");
+    }
+
+    /// <summary>
+    /// A promotional code buys a discount on the year. Spending it on the seven days before the
+    /// year would exchange a month of the customer's promotion for a week of it.
+    /// </summary>
+    [Fact]
+    public async Task A_promotional_code_reduces_the_year_and_not_the_stub()
+    {
+        GivenDiscount(new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 1_000,
+            DurationPeriods = 1
+        });
+
+        await Subscribe(discountCode: "welcome");
+
+        _created!.InitialChargeAmountMinor.Should().Be(StubMinor,
+            "the stub is priced without the code");
+
+        var pending = _created.PendingAnnualPeriod!;
+        // 10% of the 1140000 gross beats the automatic 8%, so the code wins: 1026000.
+        pending.AmountMinor.Should().Be(1_026_000);
+        pending.DiscountApplied.Should().BeTrue("the code reduced the year, so it is being used");
+    }
+
+    [Fact]
+    public async Task A_prepaid_year_carries_its_discount_into_the_single_charge()
+    {
+        _price = CalendarPrice(CalendarAnnualChargeTiming.AtCheckout);
+        GivenDiscount(new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 1_000
+        });
+
+        await Subscribe(discountCode: "welcome");
+
+        _created!.InitialChargeAmountMinor.Should().Be(StubMinor + 1_026_000);
+        _created.InitialChargeDiscountApplied.Should().BeTrue(
+            "the code reduced money taken in this charge, so the period is spent");
+    }
+
+    [Fact]
+    public async Task A_signup_on_the_first_has_no_stub_and_nothing_pending_in_either_mode()
+    {
+        _time.Advance(new DateTimeOffset(2026, 9, 1, 8, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+
+        foreach (var timing in new[]
+                 {
+                     CalendarAnnualChargeTiming.AtBoundary,
+                     CalendarAnnualChargeTiming.AtCheckout
+                 })
+        {
+            _price = CalendarPrice(timing);
+
+            await Subscribe();
+
+            _created!.PendingAnnualPeriod.Should().BeNull(
+                $"the year starts today under {timing}, so there is nothing to hold");
+            _created.InitialChargeAmountMinor.Should().Be(DiscountedAnnualMinor);
+            _created.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+        }
+    }
+
+    [Fact]
+    public async Task A_monthly_calendar_price_never_carries_a_pending_year()
+    {
+        _price = new Price
+        {
+            ItemId = "price-yearly",
+            TenantId = TenantId,
+            PlanId = "plan-2",
+            CurrencyCode = "CHF",
+            UnitAmountMinor = MonthlyMinor,
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            Status = CatalogueStatus.Active
+        };
+
+        await Subscribe();
+
+        _created!.PendingAnnualPeriod.Should().BeNull(
+            "a month's stub is followed by another month of the same price, not a separate term");
+    }
+
+    private async Task Subscribe(string? discountCode = null)
+    {
+        var result = await Service().CreateAsync(
+            new CreateSubscriptionRequest
+            {
+                PlanCode = "tier-2",
+                PriceId = "price-yearly",
+                TimeZoneId = Zurich,
+                DiscountCode = discountCode,
+                Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 1 }]
+            },
+            new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1"),
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorCode ?? "creation should succeed");
+    }
+
+    private void GivenDiscount(DiscountTerms terms) =>
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, terms.Code, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                TenantId = TenantId,
+                Code = terms.Code,
+                CurrencyCode = "CHF",
+                Terms = terms
+            });
+
+    private SubscriptionCreationService Service() => new(
+        _catalogue.Object,
+        _subscriptions.Object,
+        _discounts.Object,
+        _accounts.Object,
+        new CreateSubscriptionRequestValidator(),
+        NullLogger<SubscriptionCreationService>.Instance,
+        _time);
+
+    private static TimeZoneInfo Zone() => TimeZoneInfo.FindSystemTimeZoneById(Zurich);
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(new DateTime(year, month, day, 0, 0, 0), Zone());
+
+    private static Price CalendarPrice(CalendarAnnualChargeTiming timing) => new()
+    {
+        ItemId = "price-yearly",
+        TenantId = TenantId,
+        PlanId = "plan-2",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = AnnualMinor,
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        CalendarStubBasePriceId = "price-monthly",
+        CalendarStubBaseUnitAmountMinor = MonthlyMinor,
+        CalendarAnnualChargeTiming = timing,
+        AutomaticDiscountBasisPoints = 800,
+        Status = CatalogueStatus.Active
+    };
+
+    private static Price AnniversaryPrice()
+    {
+        var price = CalendarPrice(CalendarAnnualChargeTiming.AtBoundary);
+        price.BillingAlignment = BillingAlignment.Anniversary;
+        price.CalendarStubBasePriceId = null;
+        price.CalendarStubBaseUnitAmountMinor = null;
+
+        return price;
+    }
+
+    private static Plan NewPlan() => new()
+    {
+        ItemId = "plan-2",
+        TenantId = TenantId,
+        Code = "tier-2",
+        DisplayName = "Tier 2",
+        Status = CatalogueStatus.Active,
+        Version = 1,
+        QuantityItems =
+        [
+            new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat", DefaultQuantity = 1 }
+        ],
+        Meters =
+        [
+            new PlanMeter { MeterKey = "screening", UnitLabel = "screening", IncludedQuantity = 500 }
+        ]
+    };
+}

--- a/server/XUnitTest/Subscription/CalendarAnnualDiscountConsumptionTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualDiscountConsumptionTests.cs
@@ -1,0 +1,281 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Services;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// How many periods of a limited promotion a calendar-aligned yearly subscription spends.
+/// </summary>
+/// <remarks>
+/// Exactly one, however the money arrives. A promotion is spent by the charge that reduced money,
+/// and each of the three routes reduces it once — so counting has to follow the payment rather than
+/// the period, or a subscriber who paid up front loses a month of their discount for doing so.
+/// <para>
+/// The prepaid boundary is the case that gets this wrong most easily: it opens a discounted year
+/// and looks exactly like a renewal, but takes nothing, because the money came in a month earlier.
+/// </para>
+/// </remarks>
+public sealed class CalendarAnnualDiscountConsumptionTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+    private const long DiscountedAnnualMinor = 1_026_000;
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 31, 22, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionTransition? _transition;
+
+    public CalendarAnnualDiscountConsumptionTests()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                ProviderName = "STRIPE",
+                DefaultPaymentMethodId = "pm-1"
+            });
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+    }
+
+    /// <summary>
+    /// The defect: a prepaid year was counted twice — once by the checkout that collected it, and
+    /// again by the boundary that merely opened it.
+    /// </summary>
+    [Fact]
+    public async Task A_prepaid_year_opening_spends_no_further_discount_period()
+    {
+        var subscription = InStub(prepaid: true);
+
+        // The checkout already spent the promotion when it took the money.
+        subscription.DiscountPeriodsApplied = 1;
+
+        await Renewal().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().Be(1,
+            "nothing was charged here, so nothing more of the promotion was used");
+    }
+
+    /// <summary>
+    /// The control. An unpaid year is charged at its boundary, and that charge is where the
+    /// promotion is spent — so this one must increment.
+    /// </summary>
+    [Fact]
+    public async Task An_unpaid_year_spends_its_discount_period_at_the_boundary()
+    {
+        var subscription = InStub(prepaid: false);
+
+        await Renewal().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().Be(1,
+            "this boundary is the charge that reduced money");
+    }
+
+    /// <summary>
+    /// End to end for the prepaid route: activation spends the period, the boundary does not, and a
+    /// one-period promotion is therefore gone after exactly one bill rather than none or two.
+    /// </summary>
+    [Fact]
+    public async Task An_at_checkout_signup_spends_exactly_one_period_across_both_transitions()
+    {
+        var subscription = InStub(prepaid: false);
+        subscription.Status = SubscriptionStatus.Incomplete;
+        subscription.PendingAnnualPeriod!.CollectedWithCheckout = true;
+        subscription.InitialChargeDiscountApplied = true;
+
+        // Activation: the combined charge landed, so the promotion is spent here.
+        await Activation().SettleLinkAsync(DueLink(), CancellationToken.None);
+        var afterActivation = _transition!.DiscountPeriodsApplied ?? 0;
+
+        afterActivation.Should().Be(1, "the charge that collected the year used the promotion");
+
+        // The boundary, a month later, with the year now settled.
+        var atBoundary = InStub(prepaid: true);
+        atBoundary.DiscountPeriodsApplied = afterActivation;
+
+        await Renewal().RenewAsync(atBoundary, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().Be(1,
+            "one payment reduced by the promotion means one period of it spent");
+    }
+
+    private SubscriptionRenewalService Renewal() => new(
+        _subscriptions.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new OptionsStub(),
+        NullLogger<SubscriptionRenewalService>.Instance,
+        _time);
+
+    private SubscriptionPaymentLink DueLink() => new()
+    {
+        ItemId = "link-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        SubscriptionId = "sub-1",
+        PaymentDetailId = "pay-1",
+        OrderId = "sub:sub-1",
+        Purpose = SubscriptionPaymentPurpose.InitialCharge,
+        State = SubscriptionPaymentLinkState.Pending,
+        CorrelationId = "corr-1"
+    };
+
+    private SubscriptionActivationProcessor Activation()
+    {
+        var links = new Mock<ISubscriptionPaymentLinkRepository>();
+        var payments = new Mock<IPaymentRepository>();
+        var storedMethods = new Mock<IStoredPaymentMethodRepository>();
+        var accounts = new Mock<IBillingAccountRepository>();
+
+        links
+            .Setup(repository => repository.TrySettleAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<SubscriptionPaymentLinkState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "pay-1",
+                PaymentStatus = PaymentStatuses.Authorized,
+                WebhookConfirmedAtUtc = _time.GetUtcNow().UtcDateTime
+            });
+
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var subscription = InStub(prepaid: false);
+                subscription.Status = SubscriptionStatus.Incomplete;
+                subscription.PendingAnnualPeriod!.CollectedWithCheckout = true;
+                subscription.InitialChargeDiscountApplied = true;
+
+                return subscription;
+            });
+
+        return new SubscriptionActivationProcessor(
+            links.Object,
+            _subscriptions.Object,
+            accounts.Object,
+            new SubscriptionOutboxEventFactory(),
+            payments.Object,
+            storedMethods.Object,
+            new SubscriptionOptionsMonitorStub(new SubscriptionOptions()),
+            NullLogger<SubscriptionActivationProcessor>.Instance,
+            _time);
+    }
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(
+            new DateTime(year, month, day, 0, 0, 0),
+            TimeZoneInfo.FindSystemTimeZoneById(Zurich));
+
+    /// <summary>A 25 August signup on a 10%-off promotion, inside its stub.</summary>
+    private static SubscriptionDetail InStub(bool prepaid) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        OrderId = "sub:sub-1",
+        CorrelationId = "corr-1",
+        Plan = new PlanSnapshot { Code = "tier-2", DisplayName = "Tier 2" },
+        Price = new PriceSnapshot
+        {
+            PriceId = "price-yearly",
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 1_140_000,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = 95_000,
+            CalendarAnnualChargeTiming = prepaid
+                ? CalendarAnnualChargeTiming.AtCheckout
+                : CalendarAnnualChargeTiming.AtBoundary
+        },
+        Discount = new DiscountTerms
+        {
+            Code = "welcome",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 1_000,
+            DurationPeriods = 1
+        },
+        FeeSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            AnchorInstantUtc = LocalMidnight(2026, 9, 1),
+            TimeZoneId = Zurich,
+            AnchorDayOfMonth = 1,
+            AnchorMinutesFromMidnight = 0
+        },
+        CurrentPeriodStartUtc = new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc),
+        CurrentPeriodEndUtc = LocalMidnight(2026, 9, 1),
+        InitialChargeProrated = true,
+        ProrationDays = 7,
+        ProrationTotalDays = 31,
+        PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = LocalMidnight(2026, 9, 1),
+            EndUtc = LocalMidnight(2027, 9, 1),
+            AmountMinor = DiscountedAnnualMinor,
+            NetAmountMinor = DiscountedAnnualMinor,
+            GrossAmountMinor = 1_140_000,
+            PromotionalDiscountMinor = 114_000,
+            DiscountApplied = true,
+            CollectedWithCheckout = prepaid,
+            IsPrepaid = prepaid
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new() { DunningMaxAttempts = 4 };
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
@@ -1,0 +1,386 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// A calendar-aligned yearly subscription reached through a trial, and what cancelling one does.
+/// </summary>
+/// <remarks>
+/// Driven from <c>CreateAsync</c> through to the conversion renewal rather than from a
+/// hand-built subscription, because the defect these cover is precisely a disagreement between what
+/// signup stores and what conversion needs: a trial that ends in a different month than the signup.
+/// </remarks>
+public sealed class CalendarAnnualTrialAndCancellationTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string Zurich = "Europe/Zurich";
+    private const long MonthlyMinor = 95_000;
+    private const long DiscountedAnnualMinor = 1_048_800;
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+
+    /// <summary>25 August 2026 — a signup whose trial will end in a different month.</summary>
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 25, 9, 30, 0, TimeSpan.Zero));
+
+    private CalendarAnnualChargeTiming _timing = CalendarAnnualChargeTiming.AtBoundary;
+    private SubscriptionDetail? _created;
+    private SubscriptionTransition? _transition;
+    private SubscriptionChargeRequest? _charge;
+    private int _chargeCount;
+
+    public CalendarAnnualTrialAndCancellationTests()
+    {
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "tier-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TrialPlan);
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-yearly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => YearlyPrice(_timing));
+
+        _accounts
+            .Setup(repository => repository.GetOrCreateAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        _accounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                ProviderName = "STRIPE",
+                DefaultPaymentMethodId = "pm-1"
+            });
+
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetAsync(
+                TenantId, OrganizationId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _cancelling);
+
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionDetail, CancellationToken>((subscription, _) => _created = subscription)
+            .ReturnsAsync(true);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionChargeRequest, string, string, CancellationToken>(
+                (request, _, _, _) =>
+                {
+                    _charge = request;
+                    _chargeCount++;
+                })
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("pay-1", "corr-1"));
+    }
+
+    /// <summary>
+    /// The defect this exists for: a 25 August signup on a 26-day trial ends 20 September, so the
+    /// year starts 1 October. A year frozen at signup would have said 1 September and skipped the
+    /// 20–30 September stub entirely.
+    /// </summary>
+    [Fact]
+    public async Task A_trial_ending_in_a_later_month_holds_no_year_until_it_converts()
+    {
+        await Subscribe();
+
+        _created!.Trial.Should().NotBeNull();
+        _created.PendingAnnualPeriod.Should().BeNull(
+            "which month the trial ends in decides when the year starts, and that is not today");
+        _created.InitialChargeAmountMinor.Should().BeNull("a card-free trial charges nothing");
+    }
+
+    [Fact]
+    public async Task The_conversion_prices_the_stub_and_the_year_from_the_trial_end()
+    {
+        await Subscribe();
+        await Convert();
+
+        // 20 September through 30 September is 11 of 30 dates: 95000 x 11/30 is 34833, less 8%
+        // (2786) is 32047.
+        _charge!.AmountMinor.Should().Be(32_047);
+        _transition!.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2026, 10, 1));
+
+        var held = _transition.PendingAnnualPeriod;
+        held.Should().NotBeNull();
+        held!.StartUtc.Should().Be(LocalMidnight(2026, 10, 1),
+            "the year starts after the month the trial ended in, not after the month of signup");
+        held.EndUtc.Should().Be(LocalMidnight(2027, 10, 1));
+        held.AmountMinor.Should().Be(DiscountedAnnualMinor);
+        held.IsPrepaid.Should().BeFalse("this price collects the year at its own boundary");
+    }
+
+    /// <summary>
+    /// "Collect the year with the first payment" — and for a card-free trial the conversion is the
+    /// first payment there has ever been.
+    /// </summary>
+    [Fact]
+    public async Task A_prepaid_trial_conversion_collects_the_stub_and_the_year_together()
+    {
+        _timing = CalendarAnnualChargeTiming.AtCheckout;
+
+        await Subscribe();
+        await Convert();
+
+        _charge!.AmountMinor.Should().Be(32_047 + DiscountedAnnualMinor);
+
+        var held = _transition!.PendingAnnualPeriod;
+        held!.IsPrepaid.Should().BeTrue("this charge is the one that collected it");
+        held.StartUtc.Should().Be(LocalMidnight(2026, 10, 1));
+    }
+
+    /// <summary>
+    /// A year already paid for is a year the subscriber keeps, whatever flag the caller sends.
+    /// Ending access now would take the money and the entitlement together.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Cancelling_a_prepaid_stub_keeps_access_to_the_end_of_the_year(bool immediately)
+    {
+        InPrepaidStub();
+
+        var result = await Cancellation().CancelAsync(
+            "sub-1", immediately, "not needed", null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _transition!.NewStatus.Should().NotBe(SubscriptionStatus.Canceled,
+            "the subscriber holds a year they paid for");
+        _transition.CancelAtPeriodEnd.Should().BeTrue();
+        _transition.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1),
+            "access runs to the end of the year they bought");
+        _transition.ClearPendingAnnualPeriod.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Cancelling_an_unpaid_stub_ends_with_the_stub_and_never_charges_the_year()
+    {
+        var subscription = InPrepaidStub();
+        subscription.PendingAnnualPeriod!.IsPrepaid = false;
+        subscription.PendingAnnualPeriod.CollectedWithCheckout = false;
+
+        await Cancellation().CancelAsync(
+            "sub-1", false, "not needed", null, "corr-1", CancellationToken.None);
+
+        _transition!.CancelAtPeriodEnd.Should().BeTrue();
+        _transition.CurrentPeriodEndUtc.Should().BeNull(
+            "the stub is the last period; there is no year to extend into");
+        _transition.ClearPendingAnnualPeriod.Should().BeTrue(
+            "so no later sweep can charge for a year this subscription will never hold");
+        _transition.ClearNextFeeBillingAt.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The response has to describe the write, not the state before it.
+    /// </summary>
+    [Fact]
+    public async Task The_cancellation_response_reflects_what_was_written()
+    {
+        InPrepaidStub();
+
+        var result = await Cancellation().CancelAsync(
+            "sub-1", false, "not needed", null, "corr-1", CancellationToken.None);
+
+        result.Value!.PendingAnnualPeriod.Should().BeNull(
+            "a 200 still advertising a pending year would have a client offering to cancel " +
+            "something this very write has already dealt with");
+        result.Value.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 9, 1));
+        result.Value.CancelAtPeriodEnd.Should().BeTrue();
+    }
+
+    private async Task Subscribe()
+    {
+        var result = await Creation().CreateAsync(
+            new CreateSubscriptionRequest
+            {
+                PlanCode = "tier-2",
+                PriceId = "price-yearly",
+                TimeZoneId = Zurich,
+                Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 1 }]
+            },
+            new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1"),
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorCode ?? "creation should succeed");
+    }
+
+    /// <summary>Runs the conversion renewal on the subscription signup actually produced.</summary>
+    private async Task Convert()
+    {
+        var subscription = _created!;
+        subscription.Status = SubscriptionStatus.Trialing;
+        subscription.BillingAccountId = "acct-1";
+        _time.Advance(subscription.Trial!.EndsAtUtc - _time.GetUtcNow());
+
+        await Renewal().RenewAsync(subscription, CancellationToken.None);
+    }
+
+    private SubscriptionCreationService Creation() => new(
+        _catalogue.Object,
+        _subscriptions.Object,
+        _discounts.Object,
+        _accounts.Object,
+        new CreateSubscriptionRequestValidator(),
+        NullLogger<SubscriptionCreationService>.Instance,
+        _time);
+
+    private SubscriptionRenewalService Renewal() => new(
+        _subscriptions.Object,
+        _accounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new OptionsStub(),
+        NullLogger<SubscriptionRenewalService>.Instance,
+        _time);
+
+    /// <summary>
+    /// Built with the real response mapper, so the assertions read the response a caller would
+    /// actually receive rather than an intermediate the test agreed with itself about.
+    /// </summary>
+    private SubscriptionCancellationService Cancellation() => new(
+        _subscriptions.Object,
+        _contextResolver.Object,
+        new SubscriptionOutboxEventFactory(),
+        new SubscriptionResponseMapper(_time),
+        _cache.Object,
+        NullLogger<SubscriptionCancellationService>.Instance,
+        _time);
+
+    private SubscriptionDetail? _cancelling;
+
+    /// <summary>A subscription inside a stub holding a paid year that starts 1 September.</summary>
+    private SubscriptionDetail InPrepaidStub()
+    {
+        _cancelling = new SubscriptionDetail
+        {
+            ItemId = "sub-1",
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            BillingAccountId = "acct-1",
+            Status = SubscriptionStatus.Active,
+            CurrencyCode = "CHF",
+            Plan = new PlanSnapshot { Code = "tier-2", DisplayName = "Tier 2" },
+            Price = SnapshotOf(YearlyPrice(CalendarAnnualChargeTiming.AtCheckout)),
+            CurrentPeriodStartUtc = new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc),
+            CurrentPeriodEndUtc = LocalMidnight(2026, 9, 1),
+            PendingAnnualPeriod = new PendingAnnualPeriod
+            {
+                StartUtc = LocalMidnight(2026, 9, 1),
+                EndUtc = LocalMidnight(2027, 9, 1),
+                AmountMinor = DiscountedAnnualMinor,
+                CollectedWithCheckout = true,
+                IsPrepaid = true
+            }
+        };
+
+        return _cancelling;
+    }
+
+    private static PriceSnapshot SnapshotOf(Price price) => new()
+    {
+        PriceId = price.ItemId,
+        CurrencyCode = price.CurrencyCode,
+        UnitAmountMinor = price.UnitAmountMinor,
+        Interval = price.Interval,
+        IntervalCount = price.IntervalCount,
+        BillingAlignment = price.BillingAlignment,
+        CalendarStubBasePriceId = price.CalendarStubBasePriceId,
+        CalendarStubBaseUnitAmountMinor = price.CalendarStubBaseUnitAmountMinor,
+        CalendarAnnualChargeTiming = price.CalendarAnnualChargeTiming,
+        AutomaticDiscountBasisPoints = price.AutomaticDiscountBasisPoints
+    };
+
+    private static DateTime LocalMidnight(int year, int month, int day) =>
+        BillingLocalTime.ToUtc(
+            new DateTime(year, month, day, 0, 0, 0),
+            TimeZoneInfo.FindSystemTimeZoneById(Zurich));
+
+    private static Price YearlyPrice(CalendarAnnualChargeTiming timing) => new()
+    {
+        ItemId = "price-yearly",
+        TenantId = TenantId,
+        PlanId = "plan-2",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 1_140_000,
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        CalendarStubBasePriceId = "price-monthly",
+        CalendarStubBaseUnitAmountMinor = MonthlyMinor,
+        CalendarAnnualChargeTiming = timing,
+        AutomaticDiscountBasisPoints = 800,
+        Status = CatalogueStatus.Active
+    };
+
+    /// <summary>A 26-day card-free trial, so a 25 August signup converts on 20 September.</summary>
+    private static Plan TrialPlan() => new()
+    {
+        ItemId = "plan-2",
+        TenantId = TenantId,
+        Code = "tier-2",
+        DisplayName = "Tier 2",
+        Status = CatalogueStatus.Active,
+        Version = 1,
+        TrialDays = 26,
+        TrialRequiresPaymentMethod = false,
+        QuantityItems =
+        [
+            new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat", DefaultQuantity = 1 }
+        ],
+        Meters =
+        [
+            new PlanMeter { MeterKey = "screening", UnitLabel = "screening", IncludedQuantity = 500 }
+        ]
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new() { DunningMaxAttempts = 4 };
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
@@ -43,6 +43,12 @@ public sealed class CalendarAnnualTrialAndCancellationTests
         new(new DateTimeOffset(2026, 8, 25, 9, 30, 0, TimeSpan.Zero));
 
     private CalendarAnnualChargeTiming _timing = CalendarAnnualChargeTiming.AtBoundary;
+
+    /// <summary>26 days from 25 August lands on 20 September, mid-month.</summary>
+    private int _trialDays = 26;
+
+    /// <summary>37 days from 25 August lands on 1 October, exactly on a boundary.</summary>
+    private const int TrialDaysEndingOnOctoberFirst = 37;
     private SubscriptionDetail? _created;
     private SubscriptionTransition? _transition;
     private SubscriptionChargeRequest? _charge;
@@ -167,6 +173,55 @@ public sealed class CalendarAnnualTrialAndCancellationTests
         var held = _transition!.PendingAnnualPeriod;
         held!.IsPrepaid.Should().BeTrue("this charge is the one that collected it");
         held.StartUtc.Should().Be(LocalMidnight(2026, 10, 1));
+    }
+
+    /// <summary>
+    /// A trial ending on the local first has no stub to buy: the subscriber steps straight into a
+    /// whole year. Charging the annual amount for a one-month period and then holding a second year
+    /// behind it would bill them twice for the same twelve months.
+    /// </summary>
+    [Theory]
+    [InlineData(CalendarAnnualChargeTiming.AtBoundary)]
+    [InlineData(CalendarAnnualChargeTiming.AtCheckout)]
+    public async Task A_trial_ending_on_the_first_opens_a_whole_year_and_holds_nothing(
+        CalendarAnnualChargeTiming timing)
+    {
+        _timing = timing;
+        _trialDays = TrialDaysEndingOnOctoberFirst;
+
+        await Subscribe();
+        await Convert();
+
+        _chargeCount.Should().Be(1);
+        _charge!.AmountMinor.Should().Be(DiscountedAnnualMinor,
+            "one annual amount, for the year that starts today");
+
+        _transition!.CurrentPeriodStartUtc.Should().Be(LocalMidnight(2026, 10, 1));
+        _transition.CurrentPeriodEndUtc.Should().Be(LocalMidnight(2027, 10, 1),
+            "a year, not the month a stub would have given");
+        _transition.NextFeeBillingAtUtc.Should().Be(LocalMidnight(2027, 10, 1),
+            "the next charge is a year away, not a month");
+
+        _transition.PendingAnnualPeriod.Should().BeNull(
+            "the subscriber is inside the year already; a second one would be billed twice");
+    }
+
+    [Fact]
+    public async Task A_trial_ending_on_the_first_is_not_reported_as_a_prorated_first_charge()
+    {
+        _trialDays = TrialDaysEndingOnOctoberFirst;
+
+        await Subscribe();
+        await Convert();
+
+        _transition!.InitialChargeProrated.Should().BeFalse(
+            "nothing about this charge is a fraction of anything");
+        _transition.ProrationDays.Should().BeNull();
+        _transition.ProrationTotalDays.Should().BeNull();
+
+        // Still recorded, though: a card-free trial leaves these unset at signup, so the conversion
+        // is the only place the first paid charge can be accounted for.
+        _transition.InitialChargeAmountMinor.Should().Be(DiscountedAnnualMinor);
     }
 
     /// <summary>
@@ -355,7 +410,9 @@ public sealed class CalendarAnnualTrialAndCancellationTests
     };
 
     /// <summary>A 26-day card-free trial, so a 25 August signup converts on 20 September.</summary>
-    private static Plan TrialPlan() => new()
+    private Plan TrialPlan() => TrialPlanOf(_trialDays);
+
+    private static Plan TrialPlanOf(int trialDays) => new()
     {
         ItemId = "plan-2",
         TenantId = TenantId,
@@ -363,7 +420,7 @@ public sealed class CalendarAnnualTrialAndCancellationTests
         DisplayName = "Tier 2",
         Status = CatalogueStatus.Active,
         Version = 1,
-        TrialDays = 26,
+        TrialDays = trialDays,
         TrialRequiresPaymentMethod = false,
         QuantityItems =
         [

--- a/server/XUnitTest/Subscription/CalendarBillingAlignmentTests.cs
+++ b/server/XUnitTest/Subscription/CalendarBillingAlignmentTests.cs
@@ -25,7 +25,8 @@ public sealed class CalendarBillingAlignmentTests
     [InlineData(BillingInterval.Month, 12, false)]
     [InlineData(BillingInterval.Day, 1, false)]
     [InlineData(BillingInterval.Week, 1, false)]
-    [InlineData(BillingInterval.Year, 1, false)]
+    [InlineData(BillingInterval.Year, 1, true)]
+    [InlineData(BillingInterval.Year, 2, false)]
     public void Only_a_single_month_cadence_can_be_aligned_to_the_calendar(
         BillingInterval interval,
         int intervalCount,
@@ -137,7 +138,10 @@ public sealed class CalendarBillingAlignmentTests
     {
         CalendarBillingAlignment
             .TryCreateSchedule(
-                new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc), Zurich, out var schedule)
+                BillingInterval.Month,
+                new DateTime(2026, 8, 25, 9, 30, 0, DateTimeKind.Utc),
+                Zurich,
+                out var schedule)
             .Should().BeTrue();
 
         schedule.AnchorDayOfMonth.Should().Be(1);
@@ -168,7 +172,7 @@ public sealed class CalendarBillingAlignmentTests
     public void An_unknown_time_zone_fails_closed_rather_than_throwing()
     {
         CalendarBillingAlignment
-            .TryCreateSchedule(DateTime.UtcNow, "Mars/Olympus_Mons", out _)
+            .TryCreateSchedule(BillingInterval.Month, DateTime.UtcNow, "Mars/Olympus_Mons", out _)
             .Should().BeFalse();
 
         CalendarBillingAlignment

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -437,6 +437,7 @@ public sealed class SubscriptionActivationProcessorTests
         GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
         GivenSubscription(subscription =>
         {
+            subscription.Price = CalendarMonthly();
             subscription.InitialChargeAmountMinor = 1_608;
             subscription.InitialChargeProrated = true;
             subscription.InitialChargeDiscountApplied = true;
@@ -466,6 +467,7 @@ public sealed class SubscriptionActivationProcessorTests
         GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
         GivenSubscription(subscription =>
         {
+            subscription.Price = CalendarMonthly();
             subscription.InitialChargeAmountMinor = 2_010;
             subscription.InitialChargeProrated = true;
             subscription.InitialChargeDiscountApplied = false;
@@ -481,7 +483,7 @@ public sealed class SubscriptionActivationProcessorTests
     /// would shorten every existing plan's discount for reasons unrelated to calendar billing.
     /// </summary>
     [Fact]
-    public async Task A_whole_first_period_does_not_spend_a_discount_period()
+    public async Task An_anniversary_first_period_does_not_spend_a_discount_period()
     {
         GivenDueLink();
         GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
@@ -496,6 +498,39 @@ public sealed class SubscriptionActivationProcessorTests
 
         _transition!.DiscountPeriodsApplied.Should().BeNull();
     }
+
+    /// <summary>
+    /// A calendar-aligned signup on the first buys a whole period and is charged for it. A
+    /// promotion that reduced that charge has been used, and a one-period promotion escaping the
+    /// count here would go on to discount a second payment.
+    /// </summary>
+    [Fact]
+    public async Task A_calendar_first_period_spends_one_even_when_it_is_whole()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSubscription(subscription =>
+        {
+            subscription.Price = CalendarMonthly();
+            subscription.InitialChargeAmountMinor = 7_120;
+            subscription.InitialChargeProrated = false;
+            subscription.InitialChargeDiscountApplied = true;
+        });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().Be(1);
+    }
+
+    /// <summary>A calendar-aligned monthly price, which is what a stub can only arise on.</summary>
+    private static PriceSnapshot CalendarMonthly() => new()
+    {
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 8_900,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth
+    };
 
     private void GivenSubscription(Action<SubscriptionDetail> configure) =>
         _subscriptions


### PR DESCRIPTION
Implements the **billing-state half** of the Configurable Calendar-Aligned Yearly Billing plan. Invoice snapshots are the other half and are tracked in #315, which blocks the plan being complete.

Follows #307 (monthly calendar alignment) and sits on top of #306 and #310.

## Three ways to sell a year

Configured per price, so one plan can offer more than one and an organization-scoped catalogue can differ. Tier 2 — CHF 950 a month, CHF 11,400 a year authored independently, 8% off for paying annually — signing up 25 August:

| Mode | At checkout | On 1 September | Renews | Cancelling during the stub |
|---|---|---|---|---|
| `Anniversary` | CHF 10,488.00 | — | 25 August | ordinary rules |
| `CalendarMonth` + `AtBoundary` | CHF 197.36 | CHF 10,488.00 charged | 1 September | access ends with the stub; the year is never charged |
| `CalendarMonth` + `AtCheckout` | CHF 10,685.36 | year opens, nothing charged | 1 September | nothing refunded; access runs to the end of the year |

Both calendar modes come to the same money. They differ in when it is taken and in what a cancellation leaves the subscriber holding — which makes the choice a refund policy as much as a collection date, so the plan builder states both consequences rather than only the timing.

## Contract

- `billingAlignment`: `Anniversary` | `CalendarMonth`, now valid for `Month × 1` **and** `Year × 1`.
- `calendarStubBasePriceId`: the monthly price a yearly stub is a fraction of. Required for calendar-aligned yearly, refused elsewhere.
- `calendarAnnualChargeTiming`: `AtBoundary` | `AtCheckout`. Same cadence rule.

**The annual `unitAmountMinor` is authored, not derived.** What a year costs is a commercial decision and an annual plan is usually not twelve monthly ones; the linked monthly price prices the opening stub and nothing else.

The linked price is validated at authoring time — same plan, active, `Month × 1`, same currency, same quantity item, same tax rate and mode — and the price-card picker applies every one of those rules so it cannot offer a basis the API rejects.

## Discounts

The yearly price's automatic discount and volume band apply to the stub and the year. A **promotional code applies to the year alone** and is consumed once: spending a month of a three-month promotion on a seven-day stub would exchange a month of the customer's discount for a week of it.

## State

`PendingAnnualPeriod` carries the year between signup and its boundary — dates, full breakdown, whether a promotion reduced it, and two separate flags:

- `CollectedWithCheckout` — what the price says to bill for, written at signup.
- `IsPrepaid` — whether the money arrived, written only by the activation that records the opening payment.

The boundary skips the gateway on the second, never the first. Deriving it from configuration would let an unpaid checkout open a year nobody paid for, and would have `/current` report an incomplete checkout as settled.

Every figure is frozen at checkout and none is recalculated at the boundary a month later. Opening the year and discarding the pending record are one transition — a boundary that did the first and not the second would charge for the same year twice.

**Plan and quantity changes are refused while a year is pending** (`409 subscription_initial_annual_period_pending`).

## Trials

A card-free trial's year is priced at conversion, not at signup: a 25 August signup on a trial ending 20 September starts its year on 1 October. The schedule is anchored on the trial's end for the same reason — every boundary derives from the anchor, and one anchored a month early stays a month early forever. On an `AtCheckout` price the conversion is the first payment there has ever been, so it takes the stub and the year together.

## Verification

- Server: `0 Error(s)`. Full suite **2871 tests, 154 failures — unchanged from `dev`**: 150 Mongo-dependent `XUnitTest.Integration.*` plus 4 pre-existing `SubscriptionSimulationGuard`/permission failures.
- Client: 253 passed, `type-check`, `lint` (no new findings in touched files) and `build` clean.
- `server/Subscription.DomainService/README.md` and the maintained API guide both document the three-mode contract.

## Out of scope

Invoice snapshots, the two-line `AtCheckout` invoice, and history/PDF wiring — **#315**, with acceptance criteria. Invoice history remains payment-derived and begins at the first renewal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
