### PR TITLE
Collect a card up front when nothing is due today

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -63,6 +63,13 @@ export interface SimulatedSubscription {
   recurringAmountMinor: number;
   /** Only present while payment is outstanding; null once activated. */
   checkoutUrl: string | null;
+  /** Card-only checkout state; setup never represents money moving. */
+  pendingCheckout?: {
+    purpose: "PaymentMethodSetup";
+    state: "Pending" | "Failed" | "Expired";
+    errorCode: string | null;
+    checkoutUrl: string | null;
+  } | null;
   version: number;
 }
 

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { FormProvider, useForm } from "react-hook-form";
+
+import {
+  defaultSubscriptionPlanFormValues,
+  type CreateSubscriptionPlanFormValues,
+} from "../../schemas/subscription-plan.schema";
+import { StepTrial } from "./step-trial";
+
+const Harness = () => {
+  const form = useForm<CreateSubscriptionPlanFormValues>({
+    defaultValues: defaultSubscriptionPlanFormValues,
+  });
+
+  return (
+    <FormProvider {...form}>
+      <StepTrial />
+    </FormProvider>
+  );
+};
+
+const cardRequirement = () =>
+  screen.getByLabelText(
+    /Require a payment method before activation, even when nothing is due today/i,
+  );
+
+describe("requiring a card before activation", () => {
+  /**
+   * The setting is not about trials, and a plan with no trial is exactly the case it was added
+   * for — a free tier that will one day be billed. So it must be reachable without one.
+   */
+  it("is offered on a plan with no trial at all", () => {
+    render(<Harness />);
+
+    expect(cardRequirement()).toBeInTheDocument();
+    expect(cardRequirement()).not.toBeChecked();
+  });
+
+  it("explains what changes when it is on", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    expect(screen.getByText(/starts straight away/i)).toBeInTheDocument();
+
+    await user.click(cardRequirement());
+
+    expect(cardRequirement()).toBeChecked();
+    expect(screen.getByText(/card form that charges nothing/i)).toBeInTheDocument();
+  });
+
+  it("leaves the trial's own card question alone", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(cardRequirement());
+
+    expect(screen.getByLabelText(/Require a card to start the trial/i)).toBeChecked();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -26,6 +26,10 @@ export const StepTrial = () => {
     control,
     name: "trialRequiresPaymentMethod",
   });
+  const requirePaymentMethodUpfront = useWatch({
+    control,
+    name: "requirePaymentMethodUpfront",
+  });
   const meters = useWatch({ control, name: "meters" });
 
   return (
@@ -67,6 +71,36 @@ export const StepTrial = () => {
                 {trialRequiresPaymentMethod
                   ? "The first period is charged at signup — the payment path cannot hold a card without charging it. The trial then only governs the allowances below."
                   : "Genuinely free until the trial ends, when the first charge is taken. Your product must collect a card before then, or that charge has nothing to bill."}
+              </p>
+            </FormItem>
+          )}
+        />
+      </div>
+
+      {/*
+        Not a trial setting, but the same question — when is a card collected — so it belongs
+        beside the one above rather than a step away from it. It applies to a plan with no trial
+        at all, which is why it sits outside the block that appears only when there is one.
+      */}
+      <div className="space-y-3 rounded-md border p-4">
+        <h3 className="text-sm font-semibold">Payment method</h3>
+        <FormField
+          control={control}
+          name="requirePaymentMethodUpfront"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center gap-2">
+                <FormControl>
+                  <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+                <FormLabel className="!m-0">
+                  Require a payment method before activation, even when nothing is due today
+                </FormLabel>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {requirePaymentMethodUpfront
+                  ? "The subscriber is sent to a card form that charges nothing. Nothing is granted until the card is stored, so the next period has something to bill."
+                  : "A plan that costs nothing today starts straight away. Nothing has a card on file until the first charge, which is a problem only if there will be a later one."}
               </p>
             </FormItem>
           )}

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -189,6 +189,11 @@ export interface SubscriptionPlan {
   organizationId: string | null;
   trialDays: number | null;
   trialRequiresPaymentMethod: boolean;
+  /**
+   * Whether a card is collected before the subscription starts, even when the opening amount is
+   * zero. Absent on plans stored before the setting existed, which is the same as false.
+   */
+  requirePaymentMethodUpfront?: boolean;
   version: number;
   /**
    * Whether anything has ever subscribed to this plan. True closes editing: a subscription bills
@@ -262,6 +267,8 @@ export interface CreateSubscriptionPlanRequest {
   organizationId?: string;
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
+  /** Sent on every write, for the same reason the combination policy is. */
+  requirePaymentMethodUpfront: boolean;
   /** Sent on every write: omitted, the server would reset it to BestDiscount. */
   quantityDiscountCombinationPolicy: number;
   usageInterval: number;
@@ -286,6 +293,8 @@ export interface UpdateSubscriptionPlanRequest {
   organizationId?: string;
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
+  /** Sent on every write, for the same reason the combination policy is. */
+  requirePaymentMethodUpfront: boolean;
   /** Sent on every write: omitted, the server would reset it to BestDiscount. */
   quantityDiscountCombinationPolicy: number;
   usageInterval: number;

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -261,6 +261,7 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
       organizationId: z.string().min(1, "Choose an organization."),
       trialDays: z.coerce.number().int().min(1).max(365).optional(),
       trialRequiresPaymentMethod: z.boolean(),
+      requirePaymentMethodUpfront: z.boolean(),
       // Always in the form, whether or not any item has bands: a plan edited while the field
       // was absent came back from the server reset to BestDiscount, which changes what every
       // subscriber on it is charged.
@@ -404,6 +405,9 @@ export const defaultSubscriptionPlanFormValues: CreateSubscriptionPlanFormValues
   organizationId: TENANT_WIDE_ORGANIZATION,
   trialDays: undefined,
   trialRequiresPaymentMethod: true,
+  // False, which is what every plan authored before this existed meant: nothing due today, so
+  // nothing to collect.
+  requirePaymentMethodUpfront: false,
   quantityDiscountCombinationPolicy: 0,
   usageInterval: 2,
   usageIntervalCount: 1,

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -350,3 +350,23 @@ describe("automatic price discounts", () => {
     expect(values.prices[0].automaticDiscountPercent).toBeUndefined();
   });
 });
+
+describe("requiring a card before activation", () => {
+  it("survives the trip through the form and back onto an edit", () => {
+    const values = planToFormValues(storedPlan({ requirePaymentMethodUpfront: true }));
+
+    expect(values.requirePaymentMethodUpfront).toBe(true);
+    expect(toUpdatePlanRequest(values).requirePaymentMethodUpfront).toBe(true);
+  });
+
+  /**
+   * A plan stored before the setting existed answers with nothing at all. Reading that as "leave
+   * it as it was" would turn an edit — or a duplicate — into a plan that suddenly demands a card.
+   */
+  it("reads an older plan that never had the field as off", () => {
+    const values = planToFormValues(storedPlan());
+
+    expect(values.requirePaymentMethodUpfront).toBe(false);
+    expect(toUpdatePlanRequest(values).requirePaymentMethodUpfront).toBe(false);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -26,6 +26,7 @@ const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
   featuresJson: values.featuresJson?.trim() || undefined,
   trialDays: values.trialDays,
   trialRequiresPaymentMethod: values.trialRequiresPaymentMethod,
+  requirePaymentMethodUpfront: values.requirePaymentMethodUpfront,
   usageInterval: values.usageInterval,
   usageIntervalCount: values.usageIntervalCount,
   quantityDiscountCombinationPolicy: values.quantityDiscountCombinationPolicy,
@@ -136,6 +137,10 @@ export const planToFormValues = (
   organizationId: plan.organizationId ?? TENANT_WIDE_ORGANIZATION,
   trialDays: plan.trialDays ?? undefined,
   trialRequiresPaymentMethod: plan.trialRequiresPaymentMethod,
+  // Defaulted here rather than in the schema, because a plan the server stored before this
+  // existed answers with nothing at all — and reading that as "leave it as it was" would turn a
+  // duplicate of an old plan into one that suddenly demands a card.
+  requirePaymentMethodUpfront: plan.requirePaymentMethodUpfront ?? false,
   usageInterval: plan.usageInterval
     ? (BILLING_INTERVAL[plan.usageInterval] ?? BILLING_INTERVAL.Month)
     : BILLING_INTERVAL.Month,

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1037,11 +1037,23 @@ stateDiagram-v2
       <p>
         The response looks exactly like a paid one:
       </p>
-      <pre><code>{ "status": "Incomplete", "checkoutUrl": "https://checkout.stripe.com/…" }</code></pre>
+      <pre><code>{
+  "status": "Incomplete",
+  "checkoutUrl": "https://checkout.stripe.com/…",
+  "pendingCheckout": {
+    "purpose": "PaymentMethodSetup",
+    "state": "Pending",
+    "errorCode": null,
+    "checkoutUrl": "https://checkout.stripe.com/…"
+  }
+}</code></pre>
       <p>
         and becomes <code>Active</code> or <code>Trialing</code> with <code>checkoutUrl: null</code>
         once setup succeeds. <code>GET /api/subscriptions/current</code> returns the pending
-        subscription and a usable <code>checkoutUrl</code> throughout.
+        subscription and a usable <code>checkoutUrl</code> throughout. A failed or expired setup
+        remains <code>Incomplete</code>, but <code>pendingCheckout.state</code> becomes
+        <code>Failed</code> or <code>Expired</code>, its URL becomes null, and
+        <code>errorCode</code> tells the client why it must offer a retry.
       </p>
       <p>
         Subscribing again while a setup is outstanding returns the same page. If that page has
@@ -1871,7 +1883,9 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             (<code>Trialing</code>, <code>Active</code>, or <code>PastDue</code>) take priority. When
             checkout has started but payment has not completed, it returns
             <code>status: "Incomplete"</code> and the still-valid <code>checkoutUrl</code> when one
-            is available. It does not return <code>Unpaid</code> or ended subscriptions.
+            is available. For card-only setup, <code>pendingCheckout</code> distinguishes
+            <code>Pending</code>, <code>Failed</code>, and <code>Expired</code>; only Pending carries
+            a usable URL. It does not return <code>Unpaid</code> or ended subscriptions.
           </p>
           <p class="prose">
             <code>quantities</code> is what the subscriber holds and is paying for now.
@@ -1912,6 +1926,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
     "currentTier": null,
     "recurringAmountMinor": 300,
     "checkoutUrl": null,
+    "pendingCheckout": null,
     "version": 2
   },
   "error": null,

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -594,6 +594,7 @@
             <tr><td>featuresJson</td><td class="type">string?</td><td class="prose">Arbitrary JSON, stored verbatim and returned untouched. Nothing interprets it — this is where your product puts its own flags.</td></tr>
             <tr><td>trialDays</td><td class="type">int?</td><td class="prose">Trial length. <code>null</code> means no trial.</td></tr>
             <tr><td>trialRequiresPaymentMethod</td><td class="type">bool</td><td class="prose">Whether a card is taken before the trial starts. See <a href="#branches">Branches</a> — this changes when money moves.</td></tr>
+            <tr><td>requirePaymentMethodUpfront</td><td class="type">bool</td><td class="prose">Whether a card is collected before activation even when nothing is due today. Defaults to <code>false</code>. See <a href="#branches">Branches</a>.</td></tr>
             <tr><td>version</td><td class="type">int</td><td class="prose">Bumps on every edit. Starts at 1.</td></tr>
             <tr><td>hasSubscribers</td><td class="type">bool</td><td class="prose">True once anything has subscribed. Editing is closed from that moment.</td></tr>
             <tr><td>quantityItems</td><td class="type">array</td><td class="prose">See below.</td></tr>
@@ -1003,11 +1004,52 @@ stateDiagram-v2
 
       <h3>2 · Card required, or genuinely free</h3>
       <p>
-        With <code>trialRequiresPaymentMethod: true</code> the first period is
-        <strong>charged at signup</strong> — the payment path cannot hold a card without charging it.
-        The trial then governs the allowances, not the price. With <code>false</code> the trial is
-        free, the response carries <strong>no <code>checkoutUrl</code></strong>, and your product must
-        collect a card before the trial ends or the first charge has nothing to bill.
+        When there <em>is</em> something to charge, <code>trialRequiresPaymentMethod: true</code>
+        charges the first period at signup and the trial then governs the allowances rather than
+        the price. With <code>false</code> the trial is free and the response carries
+        <strong>no <code>checkoutUrl</code></strong>.
+      </p>
+      <p>
+        When the opening amount is <strong>zero</strong> — a free plan, a fully discounted first
+        period, a card-free trial — a card can still be required, and collecting one is no longer
+        the same thing as charging for a period. Either
+        <code>requirePaymentMethodUpfront: true</code> on the plan or a trial with
+        <code>trialRequiresPaymentMethod: true</code> is enough:
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Opening amount</th><th>Card required</th><th>What the subscriber gets</th></tr></thead>
+          <tbody>
+            <tr><td>&gt; 0</td><td class="type">—</td><td class="prose">A payment checkout. <code>Incomplete</code> until the charge is confirmed.</td></tr>
+            <tr><td>0</td><td class="type">no</td><td class="prose">Nothing to visit. <code>Active</code> (or <code>Trialing</code>) immediately, <code>checkoutUrl: null</code>.</td></tr>
+            <tr><td>0</td><td class="type">yes</td><td class="prose">A <strong>card-setup</strong> checkout. <code>Incomplete</code> with a <code>checkoutUrl</code> until the card is stored.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        A card setup is <strong>not a payment</strong>. Nothing is charged, no payment and no
+        invoice are produced by it, and it appears in neither payment nor invoice history — a
+        zero-total period may still produce a zero-value invoice, but that comes from the period,
+        not from the card. Access is granted only once the provider confirms the card was stored,
+        which is the same rule a paid signup follows and for the same reason: a browser returning
+        from a redirect is not evidence.
+      </p>
+      <p>
+        The response looks exactly like a paid one:
+      </p>
+      <pre><code>{ "status": "Incomplete", "checkoutUrl": "https://checkout.stripe.com/…" }</code></pre>
+      <p>
+        and becomes <code>Active</code> or <code>Trialing</code> with <code>checkoutUrl: null</code>
+        once setup succeeds. <code>GET /api/subscriptions/current</code> returns the pending
+        subscription and a usable <code>checkoutUrl</code> throughout.
+      </p>
+      <p>
+        Subscribing again while a setup is outstanding returns the same page. If that page has
+        expired, a fresh one is opened — nothing was paid, so there is nothing to reconcile.
+        A setup that fails or expires leaves the subscription <code>Incomplete</code> and open to
+        another attempt, unlike a declined charge, which ends it. Cancelling while one is
+        outstanding closes it, so finishing the card form afterwards cannot start the
+        subscription.
       </p>
 
       <h3>3 · Overage billed, blocked, or free</h3>
@@ -1449,6 +1491,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
     "organizationId": "org-1",
     "trialDays": null,
     "trialRequiresPaymentMethod": true,
+    "requirePaymentMethodUpfront": false,
     "version": 1,
     "hasSubscribers": false,
     "quantityItems": [],
@@ -1506,6 +1549,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
   "organizationId": "org-1",          // omit for tenant-wide
   "trialDays": 14,
   "trialRequiresPaymentMethod": true,
+  "requirePaymentMethodUpfront": false,   // true to collect a card even when nothing is due
   "quantityItems": [],
   "meters": [{
     "meterKey": "ses-signatures",

--- a/server/Payment.DomainService/Enums/PaymentFlows.cs
+++ b/server/Payment.DomainService/Enums/PaymentFlows.cs
@@ -17,6 +17,23 @@ public static class PaymentFlows
     /// </remarks>
     public const string SubscriptionInvoice = "SUBSCRIPTION_INVOICE";
 
+    /// <summary>
+    /// Collecting a card without charging it, so a later off-session charge has a mandate.
+    /// </summary>
+    /// <remarks>
+    /// A payment record with no money in it. It exists because everything that tracks a hosted
+    /// session — the initiation lease, the redirect URL, the webhook route, the stored-card
+    /// write — already hangs off <see cref="Entities.PaymentDetail"/>, and a parallel entity
+    /// would have to reimplement all of it to describe something simpler.
+    /// <para>
+    /// Deliberately absent from <see cref="All"/>. That list is what a caller may filter the
+    /// payments endpoint by, and these are not payments: the amount is always zero, so anything
+    /// that sums, refunds or reconciles them is reading a financial record that does not exist.
+    /// Every such reader excludes this flow explicitly.
+    /// </para>
+    /// </remarks>
+    public const string PaymentMethodSetup = "PAYMENT_METHOD_SETUP";
+
     public static readonly string[] All =
     [
         HostedCheckout,

--- a/server/Payment.DomainService/Enums/WebhookIntent.cs
+++ b/server/Payment.DomainService/Enums/WebhookIntent.cs
@@ -12,5 +12,15 @@ public enum WebhookIntent
     Refund = 2,
     Capture = 3,
     StoredMethod = 4,
-    Cancelled = 5
+    Cancelled = 5,
+
+    /// <summary>
+    /// A card was collected without being charged, or the attempt to collect one ended.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Authorization"/> because the authorisation path proves the event
+    /// against the payment's amount and currency, and a setup has neither. Routed the same way:
+    /// the reference this service minted is echoed back on the object.
+    /// </remarks>
+    PaymentMethodSetup = 6
 }

--- a/server/Payment.DomainService/Providers/IPaymentMethodSetupRequestFactory.cs
+++ b/server/Payment.DomainService/Providers/IPaymentMethodSetupRequestFactory.cs
@@ -1,0 +1,32 @@
+using Payment.DomainService.Entities;
+using Payment.DomainService.Models;
+using Payment.DomainService.Requests;
+
+namespace Payment.DomainService.Providers;
+
+/// <summary>
+/// Builds one provider's card-collection request, for a session that takes no money.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="IProviderInitiationRequestFactory"/> rather than a flag on it. The
+/// two requests share a transport and nothing else: one has line items, a capture mode and an
+/// amount, and the other exists precisely because there are none. A provider that cannot
+/// collect a card without charging it simply has no factory here.
+/// </remarks>
+public interface IPaymentMethodSetupRequestFactory
+{
+    bool Supports(string providerName);
+
+    /// <param name="providerPayerReference">
+    /// The provider's own identifier for this shopper, where a card they saved earlier already
+    /// established one. Null the first time, and the provider then mints its own.
+    /// </param>
+    ProviderInitiationRequest Create(
+        CreatePaymentMethodSetupRequest request,
+        PaymentDetail payment,
+        PaymentProvider provider,
+        string returnUrl,
+        string providerReference,
+        string shopperReference,
+        string? providerPayerReference);
+}

--- a/server/Payment.DomainService/Providers/IPaymentMethodSetupRequestFactoryResolver.cs
+++ b/server/Payment.DomainService/Providers/IPaymentMethodSetupRequestFactoryResolver.cs
@@ -1,0 +1,10 @@
+namespace Payment.DomainService.Providers;
+
+public interface IPaymentMethodSetupRequestFactoryResolver
+{
+    /// <summary>
+    /// The card-collection factory for <paramref name="providerName"/>, or
+    /// <see langword="null"/> when that provider cannot collect a card without charging it.
+    /// </summary>
+    IPaymentMethodSetupRequestFactory? Resolve(string providerName);
+}

--- a/server/Payment.DomainService/Providers/PaymentMethodSetupRequestFactoryResolver.cs
+++ b/server/Payment.DomainService/Providers/PaymentMethodSetupRequestFactoryResolver.cs
@@ -1,0 +1,16 @@
+namespace Payment.DomainService.Providers;
+
+public sealed class PaymentMethodSetupRequestFactoryResolver :
+    IPaymentMethodSetupRequestFactoryResolver
+{
+    private readonly IReadOnlyCollection<IPaymentMethodSetupRequestFactory> _factories;
+
+    public PaymentMethodSetupRequestFactoryResolver(
+        IEnumerable<IPaymentMethodSetupRequestFactory> factories)
+    {
+        _factories = factories.ToArray();
+    }
+
+    public IPaymentMethodSetupRequestFactory? Resolve(string providerName) =>
+        _factories.FirstOrDefault(factory => factory.Supports(providerName));
+}

--- a/server/Payment.DomainService/Providers/Stripe/StripeSetupSessionRequestFactory.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeSetupSessionRequestFactory.cs
@@ -1,0 +1,143 @@
+using MongoDB.Bson;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Models;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Utilities;
+
+namespace Payment.DomainService.Providers.Stripe;
+
+/// <summary>
+/// Builds a Stripe Checkout Session in <c>setup</c> mode: a card is collected and stored, and
+/// nothing is charged.
+/// </summary>
+/// <remarks>
+/// Deliberately not a one-cent PaymentIntent, and not a zero-value one either. A token charge
+/// appears on the cardholder's statement and has to be refunded; a zero-value PaymentIntent is
+/// rejected outright. Setup mode is the operation Stripe provides for this, and the SetupIntent
+/// it produces is what carries the off-session mandate the first renewal will rely on.
+/// </remarks>
+public sealed class StripeSetupSessionRequestFactory : IPaymentMethodSetupRequestFactory
+{
+    /// <inheritdoc cref="StripeInitiationRequestFactory"/>
+    private const string SessionIdTemplate = "sessionId={CHECKOUT_SESSION_ID}";
+
+    public bool Supports(string providerName) =>
+        string.Equals(
+            providerName,
+            PaymentConstants.StripeProvider,
+            StringComparison.OrdinalIgnoreCase);
+
+    public ProviderInitiationRequest Create(
+        CreatePaymentMethodSetupRequest request,
+        PaymentDetail payment,
+        PaymentProvider provider,
+        string returnUrl,
+        string providerReference,
+        string shopperReference,
+        string? providerPayerReference)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(payment);
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var successUrl = AppendSessionIdTemplate(returnUrl);
+        var metadata = RoutingMetadata(payment, provider, providerReference, shopperReference);
+
+        var form = new StripeForm()
+            .Add("mode", "setup")
+            .Add("success_url", successUrl)
+            .Add("cancel_url", successUrl)
+            .Add("client_reference_id", Truncate(providerReference))
+            // Required in setup mode: Stripe decides which payment methods to offer from the
+            // currency the card will later be charged in, and there is no amount to infer it
+            // from.
+            .Add("currency", payment.CurrencyCode.ToLowerInvariant())
+            .Add(
+                "customer_email",
+                string.IsNullOrWhiteSpace(providerPayerReference)
+                    ? request.CustomerEmail
+                    : null)
+            .AddMetadata(metadata);
+
+        if (!string.IsNullOrWhiteSpace(providerPayerReference))
+        {
+            // The same reason payment mode names a known customer: without it a returning
+            // shopper becomes a second Stripe customer, and the card is saved somewhere the
+            // subscription's billing account will never look.
+            //
+            // No customer_creation counterpart is needed. Setup mode has nowhere to attach a
+            // payment method except a Customer, so Stripe always makes one when none is named.
+            form.Add("customer", providerPayerReference);
+        }
+
+        form.AddObject("setup_intent_data", intent =>
+        {
+            // Session metadata does not reach the SetupIntent, and setup_intent.succeeded is
+            // raised against the intent. Without this copy the one event that says the card was
+            // stored arrives with nothing to route it home — which is the same defect the
+            // payment path has already been bitten by on payment_intent events.
+            intent.AddMetadata(metadata);
+
+            if (!string.IsNullOrWhiteSpace(request.Description))
+            {
+                intent.Add("description", request.Description);
+            }
+        });
+
+        return new ProviderInitiationRequest
+        {
+            ProviderName = provider.ProviderName,
+            Reference = providerReference,
+            MerchantAccount = provider.MerchantId,
+            // Zero, and it stays zero everywhere downstream. Nothing is authorised here, so
+            // there is no figure a later event could be checked against.
+            AmountMinorUnits = 0,
+            CurrencyCode = payment.CurrencyCode,
+            ReturnUrl = successUrl,
+            CaptureMode = PaymentCaptureModes.AccountDefault,
+            CaptureDelayHours = null,
+            SiteId = provider.SiteId,
+            Payload = ToPayload(form)
+        };
+    }
+
+    /// <summary>
+    /// What Stripe echoes back on the session and on the SetupIntent, so an inbound event can be
+    /// routed to its tenant, its payment record and the shopper whose card was stored.
+    /// </summary>
+    private static Dictionary<string, string?> RoutingMetadata(
+        PaymentDetail payment,
+        PaymentProvider provider,
+        string providerReference,
+        string shopperReference) => new()
+    {
+        ["tenant_reference"] = providerReference,
+        ["payment_id"] = payment.ItemId,
+        ["merchant_account"] = provider.MerchantId,
+        [StripeRoutingMetadata.OrganizationKey] = payment.OrganizationId,
+        [StripeRoutingMetadata.ShopperReferenceKey] = shopperReference
+    };
+
+    private static BsonDocument ToPayload(StripeForm form)
+    {
+        var payload = new BsonDocument();
+
+        foreach (var (key, value) in form.Fields)
+        {
+            payload.Add(key, value);
+        }
+
+        return payload;
+    }
+
+    private static string AppendSessionIdTemplate(string returnUrl) =>
+        returnUrl.Contains('?', StringComparison.Ordinal)
+            ? $"{returnUrl}&{SessionIdTemplate}"
+            : $"{returnUrl}?{SessionIdTemplate}";
+
+    private static string Truncate(string value) =>
+        value.Length <= StripeConstants.MaximumClientReferenceLength
+            ? value
+            : value[..StripeConstants.MaximumClientReferenceLength];
+}

--- a/server/Payment.DomainService/Providers/Stripe/StripeWebhookNormalizer.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeWebhookNormalizer.cs
@@ -104,6 +104,13 @@ public sealed class StripeWebhookNormalizer : IWebhookNormalizer
         // by the payment_intent events above, so this is recorded but not acted on.
         "checkout.session.completed" => WebhookIntent.Ignored,
         "checkout.session.expired" => WebhookIntent.Cancelled,
+
+        // A session that only ever collected a card. It reports no money, so it cannot be an
+        // authorisation: the authorisation path proves an event against the payment's amount and
+        // currency, and there is neither here.
+        "setup_intent.succeeded" => WebhookIntent.PaymentMethodSetup,
+        "setup_intent.setup_failed" => WebhookIntent.PaymentMethodSetup,
+        "setup_intent.canceled" => WebhookIntent.PaymentMethodSetup,
         "payment_intent.canceled" => WebhookIntent.Cancelled,
 
         // A refunded charge reports the charge, which carries the *payment's* routing
@@ -171,9 +178,12 @@ public sealed class StripeWebhookNormalizer : IWebhookNormalizer
 
             // Stripe has no token object of its own: the saved card is the payment method the
             // intent was paid with, reported on the authorization event.
-            StoredPaymentMethodToken = intent == WebhookIntent.Authorization
-                ? GetString(subject, "payment_method")
-                : null,
+            // A SetupIntent reports the card it stored in the same field an authorised
+            // PaymentIntent does, and storing it is the entire purpose of that event.
+            StoredPaymentMethodToken =
+                intent is WebhookIntent.Authorization or WebhookIntent.PaymentMethodSetup
+                    ? GetString(subject, "payment_method")
+                    : null,
             PaymentMethodType = GetString(subject, "type") ?? "card",
             Brand = card.ValueKind == JsonValueKind.Object
                 ? GetString(card, "brand")
@@ -193,6 +203,9 @@ public sealed class StripeWebhookNormalizer : IWebhookNormalizer
     {
         "payment_intent.succeeded" => true,
         "payment_intent.amount_capturable_updated" => true,
+        "setup_intent.succeeded" => true,
+        "setup_intent.setup_failed" => false,
+        "setup_intent.canceled" => false,
         "checkout.session.async_payment_succeeded" => true,
         "payment_intent.payment_failed" => false,
         "checkout.session.async_payment_failed" => false,
@@ -259,8 +272,16 @@ public sealed class StripeWebhookNormalizer : IWebhookNormalizer
         return null;
     }
 
+    /// <summary>
+    /// Why the last attempt failed. A SetupIntent reports it under its own name, because what
+    /// failed was storing the card rather than taking money with it.
+    /// </summary>
     private static string? ReadFailureCode(JsonElement subject) =>
-        subject.TryGetProperty("last_payment_error", out var error) &&
+        ReadErrorCode(subject, "last_payment_error") ??
+        ReadErrorCode(subject, "last_setup_error");
+
+    private static string? ReadErrorCode(JsonElement subject, string name) =>
+        subject.TryGetProperty(name, out var error) &&
         error.ValueKind == JsonValueKind.Object
             ? ProviderRejectionParser.SanitizeErrorCode(
                 GetString(error, "decline_code") ?? GetString(error, "code"))

--- a/server/Payment.DomainService/README.md
+++ b/server/Payment.DomainService/README.md
@@ -529,6 +529,36 @@ ring to use.
 > `OrganizationId`, which is where their tokens really are. Nothing backfills the field:
 > stamping it would claim an encryption scope those tokens never used.
 
+## Storing a card without charging it
+
+`IPaymentMethodSetupService` opens a hosted session whose only purpose is to leave a card behind.
+Stripe Checkout in `setup` mode — deliberately not a one-cent charge, which lands on a statement
+and has to be refunded, and not a zero-value PaymentIntent, which Stripe rejects. The SetupIntent
+it produces carries the same off-session mandate `setup_future_usage` establishes on a charge.
+
+It is internal on purpose. Collecting a card costs nothing and so has none of the natural limits a
+charge has — no amount to check, no money to reconcile — so `CreatePaymentMethodSetupRequest` is
+never bound from an HTTP body, and no endpoint exposes it. The subscription module is the only
+caller today.
+
+The record it writes carries `PaymentFlows.PaymentMethodSetup` and a zero amount. That flow is
+absent from `PaymentFlows.All`, which is what a caller may filter the payments endpoint by, and
+every reader that counts money excludes it explicitly: it does not appear in payment listings, it
+cannot be refunded or captured, and invoice history never sees it. It settles at `Authorized` and
+never captures, so nothing that sums captured money picks it up.
+
+`setup_intent.succeeded` and `setup_intent.setup_failed` normalise to
+`WebhookIntent.PaymentMethodSetup`, handled apart from the authorisation path because that path
+proves an event against the payment's amount and currency and there is neither here. What stands
+in for the check is a flow guard: the handler only ever writes to a record created as a setup, so
+a stray event cannot settle a real payment through the cheaper route. The card itself is recorded
+through the same lifecycle service a saved card from a charge goes through — including the
+provider read-back that fills in the brand and last four, which a SetupIntent does not carry.
+
+A provider with no `IPaymentMethodSetupRequestFactory` cannot do this, and callers are told so
+rather than handed a broken session. `ProviderConformanceTests` lists it as optional by design
+for exactly that reason.
+
 ## Which payments a caller sees
 
 | Caller | Sees |

--- a/server/Payment.DomainService/Repositories/PaymentQueryRepository.cs
+++ b/server/Payment.DomainService/Repositories/PaymentQueryRepository.cs
@@ -178,6 +178,15 @@ public sealed class PaymentQueryRepository :
 
         AddOptionalEqualityFilters(filters, criteria);
 
+        // Card setups are not payments. They carry a zero amount, settle at Authorized and never
+        // capture, so listing them puts rows in a payment history that no one can reconcile and
+        // that every total has to remember to skip. Excluded here rather than at each caller, so
+        // a new report cannot forget.
+        filters.Add(
+            Builders<PaymentDetail>.Filter.Ne(
+                payment => payment.PaymentFlow,
+                PaymentFlows.PaymentMethodSetup));
+
         if (criteria.CursorBoundary != null)
         {
             filters.Add(BuildCursorFilter(criteria));

--- a/server/Payment.DomainService/Requests/CreatePaymentMethodSetupRequest.cs
+++ b/server/Payment.DomainService/Requests/CreatePaymentMethodSetupRequest.cs
@@ -1,0 +1,38 @@
+namespace Payment.DomainService.Requests;
+
+/// <summary>
+/// Asks a provider to collect and store a card without charging it.
+/// </summary>
+/// <remarks>
+/// Never bound from an HTTP body. Collecting a card costs nothing and therefore has none of the
+/// natural limits a charge has — no amount to check, no money to reconcile — so the ability to
+/// mint one belongs to callers inside the process that already know why they want it. The
+/// subscription module is the only one today.
+/// </remarks>
+public sealed class CreatePaymentMethodSetupRequest
+{
+    public string ProviderName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The currency the card will eventually be charged in. Carried because Stripe wants it on a
+    /// setup session, and because a card collected for one currency says nothing about another —
+    /// not because anything here is priced.
+    /// </summary>
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    /// <summary>The order this setup belongs to, so it can be found again the way a charge can.</summary>
+    public string OrderId { get; set; } = string.Empty;
+
+    /// <summary>Shown to the shopper on the provider's page.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>The subscriber, as opposed to the merchant taking the money later.</summary>
+    public string? CustomerOrganizationId { get; set; }
+
+    public string? CustomerEmail { get; set; }
+
+    /// <summary>
+    /// Which organization's provider configuration to use. Omit for the caller's own.
+    /// </summary>
+    public string? OrganizationId { get; set; }
+}

--- a/server/Payment.DomainService/Services/IPaymentMethodSetupService.cs
+++ b/server/Payment.DomainService/Services/IPaymentMethodSetupService.cs
@@ -1,0 +1,25 @@
+using Payment.DomainService.Requests;
+using Payment.DomainService.Responses;
+
+namespace Payment.DomainService.Services;
+
+/// <summary>
+/// Collects a card through the provider's hosted page without charging it.
+/// </summary>
+public interface IPaymentMethodSetupService
+{
+    /// <summary>
+    /// Starts, or resumes, a card-collection session.
+    /// </summary>
+    /// <remarks>
+    /// Idempotent on <paramref name="idempotencyKey"/> the way a charge is: the same key returns
+    /// the session already open rather than a second one. A key whose session has failed or
+    /// expired reports that failure, so the caller can decide whether to open a fresh attempt
+    /// under a new key — this method never silently starts one.
+    /// </remarks>
+    Task<PaymentOperationResult> CreateSetupAsync(
+        CreatePaymentMethodSetupRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Payment.DomainService/Services/IPaymentMethodSetupWebhookStateTransitionService.cs
+++ b/server/Payment.DomainService/Services/IPaymentMethodSetupWebhookStateTransitionService.cs
@@ -1,0 +1,11 @@
+using Payment.DomainService.Entities;
+
+namespace Payment.DomainService.Services;
+
+/// <summary>
+/// Applies an event that reports a card being stored, or the attempt to store one ending.
+/// </summary>
+public interface IPaymentMethodSetupWebhookStateTransitionService
+{
+    Task ApplyAsync(PaymentWebhookInbox webhook, CancellationToken cancellationToken);
+}

--- a/server/Payment.DomainService/Services/PaymentCapturePreflightService.cs
+++ b/server/Payment.DomainService/Services/PaymentCapturePreflightService.cs
@@ -96,7 +96,12 @@ public sealed class PaymentCapturePreflightService :
                 correlationId);
         }
 
-        if (payment.PaymentStatus is not
+        // See the refund preflight: a card setup looks capturable and holds nothing to capture.
+        if (string.Equals(
+                payment.PaymentFlow,
+                PaymentFlows.PaymentMethodSetup,
+                StringComparison.Ordinal) ||
+            payment.PaymentStatus is not
                 (PaymentStatuses.Authorized or
                  PaymentStatuses.PartiallyCaptured) ||
             string.IsNullOrWhiteSpace(payment.PspReference))

--- a/server/Payment.DomainService/Services/PaymentMethodSetupService.cs
+++ b/server/Payment.DomainService/Services/PaymentMethodSetupService.cs
@@ -1,0 +1,498 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Providers;
+using Payment.DomainService.Providers.HostedCheckout;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Responses;
+using Payment.DomainService.Utilities;
+
+namespace Payment.DomainService.Services;
+
+/// <summary>
+/// Opens a hosted session whose only purpose is to store a card.
+/// </summary>
+/// <remarks>
+/// A near-twin of <see cref="HostedCheckoutInitiationService"/>, and deliberately not a branch
+/// inside it. Everything that path does about money — the preflight that refuses a zero amount,
+/// the currency conversion, the capture mode, the line item — is exactly what must not happen
+/// here, and a flag threaded through all of it would leave the two behaviours interleaved in
+/// code whose whole job is to be unambiguous about whether money moved.
+/// <para>
+/// What it does share is the provider machinery: the same lease, the same signed return state,
+/// the same routing reference, the same session client, and the same state transitions. So a
+/// setup session is recovered, resumed and confirmed by the code that already does those things.
+/// </para>
+/// </remarks>
+public sealed class PaymentMethodSetupService : IPaymentMethodSetupService
+{
+    private readonly IPaymentExecutionContextResolver _contextResolver;
+    private readonly IPaymentDistributedLock _distributedLock;
+    private readonly IPaymentRepository _repository;
+    private readonly IPaymentProviderCache _providerCache;
+    private readonly ICheckoutUrlPolicy _checkoutUrlPolicy;
+    private readonly IProviderEndpointPolicyResolver _endpointPolicies;
+    private readonly IPaymentSessionClientResolver _sessionClients;
+    private readonly IPaymentMethodSetupRequestFactoryResolver _requestFactories;
+    private readonly IPaymentStateTransitionService _stateTransitions;
+    private readonly ICheckoutCallbackStateProtector _callbackStateProtector;
+    private readonly IShopperReferenceService _shopperReferenceService;
+    private readonly IPaymentWebhookReferenceService _webhookReferenceService;
+    private readonly IStoredPaymentMethodRepository _storedPaymentMethods;
+    private readonly IPaymentResponseMapper _responseMapper;
+    private readonly IOptionsMonitor<PaymentOptions> _options;
+    private readonly ILogger<PaymentMethodSetupService> _logger;
+
+    public PaymentMethodSetupService(
+        IPaymentExecutionContextResolver contextResolver,
+        IPaymentDistributedLock distributedLock,
+        IPaymentRepository repository,
+        IPaymentProviderCache providerCache,
+        ICheckoutUrlPolicy checkoutUrlPolicy,
+        IProviderEndpointPolicyResolver endpointPolicies,
+        IPaymentSessionClientResolver sessionClients,
+        IPaymentMethodSetupRequestFactoryResolver requestFactories,
+        IPaymentStateTransitionService stateTransitions,
+        ICheckoutCallbackStateProtector callbackStateProtector,
+        IShopperReferenceService shopperReferenceService,
+        IPaymentWebhookReferenceService webhookReferenceService,
+        IStoredPaymentMethodRepository storedPaymentMethods,
+        IPaymentResponseMapper responseMapper,
+        IOptionsMonitor<PaymentOptions> options,
+        ILogger<PaymentMethodSetupService> logger)
+    {
+        _contextResolver = contextResolver;
+        _distributedLock = distributedLock;
+        _repository = repository;
+        _providerCache = providerCache;
+        _checkoutUrlPolicy = checkoutUrlPolicy;
+        _endpointPolicies = endpointPolicies;
+        _sessionClients = sessionClients;
+        _requestFactories = requestFactories;
+        _stateTransitions = stateTransitions;
+        _callbackStateProtector = callbackStateProtector;
+        _shopperReferenceService = shopperReferenceService;
+        _webhookReferenceService = webhookReferenceService;
+        _storedPaymentMethods = storedPaymentMethods;
+        _responseMapper = responseMapper;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<PaymentOperationResult> CreateSetupAsync(
+        CreatePaymentMethodSetupRequest request,
+        string idempotencyKey,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var contextResolution = _contextResolver.Resolve(correlationId);
+        if (!contextResolution.IsSuccess) return contextResolution.Failure!;
+
+        var context = contextResolution.Context!;
+
+        await using var coordinationLock = await _distributedLock.TryAcquireAsync(
+            PaymentHashing.CreateLockResource(context.TenantId, idempotencyKey),
+            cancellationToken);
+
+        var reserved = await ReserveAsync(
+            request,
+            context,
+            idempotencyKey,
+            correlationId,
+            cancellationToken);
+
+        if (reserved.Terminal is not null) return reserved.Terminal;
+
+        return await InitiateAsync(
+            request,
+            context,
+            reserved.Payment!,
+            reserved.LeaseId!,
+            correlationId,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Claims the right to open a session for this key, or reports what the last attempt did.
+    /// </summary>
+    private async Task<(PaymentDetail? Payment, string? LeaseId, PaymentOperationResult? Terminal)>
+        ReserveAsync(
+            CreatePaymentMethodSetupRequest request,
+            PaymentExecutionContext context,
+            string idempotencyKey,
+            string correlationId,
+            CancellationToken cancellationToken)
+    {
+        var requestHash = PaymentHashing.CreateRequestHash(request);
+        var leaseId = Guid.NewGuid().ToString("N");
+        var leaseUntilUtc = DateTime.UtcNow.AddSeconds(
+            Math.Clamp(_options.CurrentValue.ProcessingLeaseSeconds, 10, 120));
+
+        var payment = CreateRecord(
+            request,
+            context,
+            idempotencyKey,
+            correlationId,
+            requestHash,
+            leaseId,
+            leaseUntilUtc);
+
+        if (await _repository.TryCreateAsync(payment, cancellationToken))
+        {
+            return (payment, leaseId, null);
+        }
+
+        var existing = await _repository.GetByIdempotencyKeyAsync(
+            context.TenantId,
+            idempotencyKey,
+            cancellationToken);
+
+        if (existing is null)
+        {
+            return (null, null, Conflict(
+                "payment_conflict",
+                "The card setup could not be reserved.",
+                correlationId));
+        }
+
+        if (!PaymentHashing.RequestHashesMatch(existing.RequestHash, requestHash) ||
+            !string.Equals(
+                existing.PaymentFlow,
+                PaymentFlows.PaymentMethodSetup,
+                StringComparison.Ordinal))
+        {
+            return (null, null, Conflict(
+                "idempotency_key_reused",
+                "The idempotency key was already used with a different request.",
+                correlationId));
+        }
+
+        // Already open, or already done. Either way the caller gets the existing record: the
+        // redirect URL on a live session is what lets someone resume a page they closed, and
+        // returning a second session would strand the first one Stripe already accepted.
+        if (existing.PaymentStatus is
+            PaymentStatuses.Processing or
+            PaymentStatuses.Authorized or
+            PaymentStatuses.Captured)
+        {
+            return (null, null, PaymentOperationResult.Success(
+                _responseMapper.Map(existing),
+                correlationId,
+                replay: true));
+        }
+
+        // A refused or failed attempt is terminal for *this* key. Reported rather than retried
+        // under the same key, because the provider would replay the failure: a fresh attempt
+        // needs a fresh key, and only the caller knows whether one is warranted.
+        if (existing.PaymentStatus is
+            PaymentStatuses.Refused or
+            PaymentStatuses.Cancelled or
+            PaymentStatuses.MakePaymentFailed)
+        {
+            return (null, null, PaymentOperationResult.Failure(
+                PaymentFailureKind.ProviderRejected,
+                existing.FailureCode ?? "payment_method_setup_failed",
+                "The previous card setup attempt did not complete.",
+                correlationId));
+        }
+
+        var claimed = await _repository.TryClaimInitiationAsync(
+            context.TenantId,
+            existing.ItemId,
+            leaseId,
+            leaseUntilUtc,
+            cancellationToken);
+
+        return claimed is null
+            ? (null, null, Conflict(
+                "payment_in_progress",
+                "The card setup is already being started.",
+                correlationId))
+            : (claimed, leaseId, null);
+    }
+
+    private async Task<PaymentOperationResult> InitiateAsync(
+        CreatePaymentMethodSetupRequest request,
+        PaymentExecutionContext context,
+        PaymentDetail payment,
+        string leaseId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var provider = await _providerCache.GetAsync(
+            payment.TenantId,
+            payment.OrganizationId,
+            request.ProviderName,
+            () => _repository.GetProviderAsync(
+                payment.TenantId,
+                payment.OrganizationId,
+                request.ProviderName,
+                cancellationToken));
+
+        if (provider is null || !provider.IsEnabled)
+        {
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.NotFound,
+                "payment_provider_not_found",
+                "The requested payment provider is unavailable.",
+                correlationId,
+                cancellationToken);
+        }
+
+        if (string.IsNullOrWhiteSpace(provider.ApiKey) ||
+            string.IsNullOrWhiteSpace(provider.MerchantId) ||
+            string.IsNullOrWhiteSpace(provider.ReturnStateHmacKey) ||
+            string.IsNullOrWhiteSpace(provider.ShopperReferenceHmacKey) ||
+            _endpointPolicies.Resolve(provider.ProviderName)?.IsAllowed(provider.ApiBaseUrl) != true)
+        {
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.Unavailable,
+                "payment_provider_misconfigured",
+                "The payment provider is temporarily unavailable.",
+                correlationId,
+                cancellationToken);
+        }
+
+        var sessionClient = _sessionClients.Resolve(provider.ProviderName);
+        var requestFactory = _requestFactories.Resolve(provider.ProviderName);
+
+        if (sessionClient is null || requestFactory is null)
+        {
+            // Not every provider can hold a card without charging it. Reported as unsupported
+            // rather than misconfigured: nothing is wrong with the configuration, this provider
+            // simply cannot do the thing being asked of it.
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.Validation,
+                "payment_method_setup_unsupported",
+                "This payment provider cannot store a card without charging it.",
+                correlationId,
+                cancellationToken);
+        }
+
+        if (!_shopperReferenceService.TryCreate(
+                payment.TenantId,
+                context.ActorId,
+                provider.ShopperReferenceHmacKey ?? string.Empty,
+                out var shopperReference))
+        {
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.Unavailable,
+                "payment_provider_misconfigured",
+                "The payment provider is temporarily unavailable.",
+                correlationId,
+                cancellationToken);
+        }
+
+        if (!_webhookReferenceService.TryCreate(
+                payment.TenantId,
+                payment.ItemId,
+                out var providerReference))
+        {
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.Unavailable,
+                "payment_routing_unavailable",
+                "The card setup could not be routed safely.",
+                correlationId,
+                cancellationToken);
+        }
+
+        // The whole point of this session is to leave a card behind, so an unresolved removal
+        // blocks it outright rather than merely hiding the saved cards, exactly as it does for a
+        // charge that asked to save one.
+        if (await _storedPaymentMethods.HasUnresolvedRemovalAsync(
+                payment.TenantId,
+                shopperReference,
+                cancellationToken))
+        {
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.Conflict,
+                "payment_method_removal_in_progress",
+                "A stored payment method removal is still being confirmed.",
+                correlationId,
+                cancellationToken);
+        }
+
+        ProtectedCheckoutCallbackState protectedState;
+        try
+        {
+            protectedState = _callbackStateProtector.Create(
+                payment.TenantId,
+                payment.OrganizationId,
+                payment.ItemId,
+                provider.ProviderName,
+                TimeSpan.FromMinutes(Math.Clamp(
+                    _options.CurrentValue.CheckoutCallbackStateLifetimeMinutes,
+                    5,
+                    24 * 60)),
+                provider.ReturnStateHmacKey ?? string.Empty);
+        }
+        catch (FormatException)
+        {
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.Unavailable,
+                "payment_provider_misconfigured",
+                "The payment provider is temporarily unavailable.",
+                correlationId,
+                cancellationToken);
+        }
+
+        if (!_checkoutUrlPolicy.TryResolveHostedUrls(
+                provider,
+                protectedState.Token,
+                out var returnUrl,
+                out var frontendResultUrl))
+        {
+            return await FailAsync(
+                payment,
+                leaseId,
+                PaymentFailureKind.Unavailable,
+                "payment_provider_misconfigured",
+                "The payment provider is temporarily unavailable.",
+                correlationId,
+                cancellationToken);
+        }
+
+        var providerRequest = requestFactory.Create(
+            request,
+            payment,
+            provider,
+            returnUrl,
+            providerReference,
+            shopperReference,
+            await _storedPaymentMethods.FindProviderPayerReferenceAsync(
+                payment.TenantId,
+                [new StoredPaymentMethodLookupScope(shopperReference, payment.OrganizationId)],
+                provider.ProviderName,
+                cancellationToken));
+
+        payment.InitiationRequest = providerRequest;
+
+        if (!await _repository.SaveInitiationRequestAsync(
+                payment.TenantId,
+                payment.ItemId,
+                leaseId,
+                providerRequest,
+                frontendResultUrl,
+                PaymentHashing.HashSensitiveValue(protectedState.State.Nonce),
+                shopperReference,
+                cancellationToken))
+        {
+            return Conflict(
+                "payment_state_conflict",
+                "The card setup changed while the provider request was being prepared.",
+                correlationId);
+        }
+
+        var providerResult = await sessionClient.CreateSessionAsync(
+            provider,
+            providerRequest,
+            payment.IdempotencyKey,
+            cancellationToken);
+
+        var result = await _stateTransitions.ApplyProviderResultAsync(
+            payment,
+            providerResult,
+            leaseId,
+            correlationId,
+            cancellationToken);
+
+        if (result.IsSuccess)
+        {
+            _logger.LogInformation(
+                "Card setup session opened TenantHash={TenantHash} PaymentHash={PaymentHash} " +
+                "Provider={Provider} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(payment.TenantId),
+                PaymentLogValue.Hash(payment.ItemId),
+                PaymentLogValue.Label(provider.ProviderName),
+                correlationId);
+        }
+
+        return result;
+    }
+
+    private PaymentDetail CreateRecord(
+        CreatePaymentMethodSetupRequest request,
+        PaymentExecutionContext context,
+        string idempotencyKey,
+        string correlationId,
+        string requestHash,
+        string leaseId,
+        DateTime leaseUntilUtc) =>
+        new()
+        {
+            TenantId = context.TenantId,
+            ProviderName = request.ProviderName.ToUpperInvariant(),
+            PaymentStatus = PaymentStatuses.Initiating,
+            PaymentFlow = PaymentFlows.PaymentMethodSetup,
+            // Zero, and never anything else. Every reader that adds money up excludes this flow,
+            // but a record that carried a plausible amount would be one careless join away from
+            // being counted anyway.
+            Amount = 0,
+            PreciseAmount = 0,
+            CurrencyCode = request.CurrencyCode.ToUpperInvariant(),
+            // The consent this session exists to obtain. Without it the webhook that reports the
+            // stored card declines to record it, and the setup succeeds having saved nothing.
+            RememberCard = true,
+            OrganizationId = context.OrganizationId,
+            CustomerOrganizationId = request.CustomerOrganizationId,
+            CustomerEmail = request.CustomerEmail,
+            UserId = context.UserId,
+            OrderId = request.OrderId,
+            Description = request.Description?.Trim(),
+            TransactionId = Guid.NewGuid().ToString(),
+            IdempotencyKey = idempotencyKey,
+            RequestHash = requestHash,
+            CorrelationId = correlationId,
+            ProcessingLeaseId = leaseId,
+            ProcessingLeaseExpiresAtUtc = leaseUntilUtc,
+            InitiationAttemptCount = 1,
+            CreatedAtUtc = DateTime.UtcNow,
+            LastUpdatedDateUtc = DateTime.UtcNow,
+            PaymentDate = DateTime.UtcNow
+        };
+
+    private Task<PaymentOperationResult> FailAsync(
+        PaymentDetail payment,
+        string leaseId,
+        PaymentFailureKind kind,
+        string errorCode,
+        string message,
+        string correlationId,
+        CancellationToken cancellationToken) =>
+        _stateTransitions.CompleteFailureAsync(
+            payment,
+            leaseId,
+            kind,
+            errorCode,
+            message,
+            correlationId,
+            cancellationToken);
+
+    private static PaymentOperationResult Conflict(
+        string code,
+        string message,
+        string correlationId) =>
+        PaymentOperationResult.Failure(
+            PaymentFailureKind.Conflict,
+            code,
+            message,
+            correlationId);
+}

--- a/server/Payment.DomainService/Services/PaymentMethodSetupWebhookStateTransitionService.cs
+++ b/server/Payment.DomainService/Services/PaymentMethodSetupWebhookStateTransitionService.cs
@@ -1,0 +1,174 @@
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Outbox;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Utilities;
+
+namespace Payment.DomainService.Services;
+
+/// <summary>
+/// Turns a provider's card-setup event into a settled setup record.
+/// </summary>
+/// <remarks>
+/// The authorisation path cannot be reused for this. It proves the event against the payment's
+/// amount and currency before accepting it, which is the right check for money and an impossible
+/// one here — a setup has no amount, and a check against zero would prove nothing anyway. What
+/// stands in for it is the flow guard below: this only ever writes to a record that was created
+/// as a setup, so a stray event cannot settle a real payment through the cheaper path.
+/// </remarks>
+public sealed class PaymentMethodSetupWebhookStateTransitionService :
+    IPaymentMethodSetupWebhookStateTransitionService
+{
+    private readonly IPaymentRepository _payments;
+    private readonly IStoredPaymentMethodLifecycleService _storedPaymentMethods;
+    private readonly IPaymentOutboxEventFactory _events;
+    private readonly ILogger<PaymentMethodSetupWebhookStateTransitionService> _logger;
+
+    public PaymentMethodSetupWebhookStateTransitionService(
+        IPaymentRepository payments,
+        IStoredPaymentMethodLifecycleService storedPaymentMethods,
+        IPaymentOutboxEventFactory events,
+        ILogger<PaymentMethodSetupWebhookStateTransitionService> logger)
+    {
+        _payments = payments;
+        _storedPaymentMethods = storedPaymentMethods;
+        _events = events;
+        _logger = logger;
+    }
+
+    public async Task ApplyAsync(PaymentWebhookInbox webhook, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(webhook);
+
+        var payload = webhook.NormalizedPayload;
+
+        if (string.IsNullOrWhiteSpace(payload.PaymentDetailId) ||
+            string.IsNullOrWhiteSpace(payload.PspReference) ||
+            !payload.Success.HasValue)
+        {
+            // A session ending is reported by one event name whatever the session was for, and
+            // an unroutable one belongs to a checkout this service has never been able to act
+            // on. Retrying it to the dead-letter queue would turn a long-standing no-op into a
+            // stream of alerts about abandoned baskets.
+            if (webhook.Intent == WebhookIntent.Cancelled)
+            {
+                _logger.LogInformation(
+                    "Session-ended event ignored Reason=incomplete_normalized_event");
+
+                return;
+            }
+
+            _logger.LogError(
+                "Card setup transition rejected Reason=incomplete_normalized_event " +
+                "HasPaymentId={HasPaymentId} HasPspReference={HasPspReference} HasSuccess={HasSuccess}",
+                !string.IsNullOrWhiteSpace(payload.PaymentDetailId),
+                !string.IsNullOrWhiteSpace(payload.PspReference),
+                payload.Success.HasValue);
+
+            throw new InvalidOperationException("Incomplete normalized card setup event.");
+        }
+
+        var payment = await _payments.GetByIdAsync(
+            webhook.TenantId,
+            payload.PaymentDetailId,
+            cancellationToken);
+
+        if (payment is null)
+        {
+            if (webhook.Intent == WebhookIntent.Cancelled)
+            {
+                _logger.LogInformation(
+                    "Session-ended event ignored Reason=payment_not_found");
+
+                return;
+            }
+
+            _logger.LogError("Card setup transition rejected Reason=payment_not_found");
+
+            throw new InvalidOperationException("Payment reference was not found.");
+        }
+
+        if (!string.Equals(
+                payment.PaymentFlow,
+                PaymentFlows.PaymentMethodSetup,
+                StringComparison.Ordinal))
+        {
+            // An expiring or cancelled *payment* session reaches here too, because a provider
+            // uses one event name for both. It has always been a no-op for those, and making it
+            // one now would be a change to how abandoned checkouts behave, decided somewhere
+            // other than a card-setup handler.
+            _logger.LogInformation(
+                "Card setup transition skipped Reason=not_a_setup_record PaymentFlow={PaymentFlow}",
+                PaymentLogValue.Label(payment.PaymentFlow));
+
+            return;
+        }
+
+        var succeeded = payload.Success.Value;
+
+        if (!succeeded && IsSettled(payment))
+        {
+            // The session expires after it was used, or the events arrive out of order. Either
+            // way the card is stored and the mandate exists; letting a later expiry overwrite
+            // that would take a subscription that is already running and mark its card as never
+            // collected.
+            _logger.LogInformation(
+                "Card setup expiry ignored Reason=already_stored PaymentHash={PaymentHash}",
+                PaymentLogValue.Hash(payment.ItemId));
+
+            return;
+        }
+
+        var eventType = succeeded
+            ? PaymentConstants.PaymentMethodSetupSucceeded
+            : PaymentConstants.PaymentMethodSetupFailed;
+        var status = succeeded ? PaymentStatuses.Authorized : PaymentStatuses.Refused;
+        var outbox = _events.Create(payment, eventType, status);
+        outbox.DeduplicationKey = $"{payment.ItemId}:{eventType}:{payload.PspReference}";
+
+        // Reused verbatim, zero amount included. Nothing about this write is about money: what
+        // it actually does is stamp the confirmed status and the webhook instant that the rest
+        // of the system treats as proof the provider spoke, and both are exactly what a settled
+        // setup needs. Never captured — there is nothing to capture — so the record stays at
+        // Authorized and every reader that sums captured money passes over it.
+        var applied = await _payments.ApplyAuthorisationAsync(
+            webhook.TenantId,
+            payment.ItemId,
+            succeeded,
+            0m,
+            capturedAutomatically: false,
+            payload.PspReference!,
+            webhook.EventDateUtc,
+            null,
+            outbox,
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Card setup transition applied Applied={Applied} Succeeded={Succeeded} " +
+            "PaymentHash={PaymentHash} ReasonWhenNotApplied=duplicate_or_stale_event",
+            applied,
+            succeeded,
+            PaymentLogValue.Hash(payment.ItemId));
+
+        if (!succeeded)
+        {
+            return;
+        }
+
+        // The card itself, recorded through the same path a saved card from a charge takes —
+        // including the provider lookup that fills in the brand and last four, which a
+        // SetupIntent does not carry.
+        await _storedPaymentMethods.ApplyAuthorisationTokenAsync(
+            webhook,
+            payment,
+            cancellationToken);
+    }
+
+    private static bool IsSettled(PaymentDetail payment) =>
+        payment.WebhookConfirmedAtUtc is not null &&
+        string.Equals(
+            payment.PaymentStatus,
+            PaymentStatuses.Authorized,
+            StringComparison.Ordinal);
+}

--- a/server/Payment.DomainService/Services/PaymentMethodSetupWebhookStateTransitionService.cs
+++ b/server/Payment.DomainService/Services/PaymentMethodSetupWebhookStateTransitionService.cs
@@ -127,6 +127,19 @@ public sealed class PaymentMethodSetupWebhookStateTransitionService :
         var outbox = _events.Create(payment, eventType, status);
         outbox.DeduplicationKey = $"{payment.ItemId}:{eventType}:{payload.PspReference}";
 
+        // A setup is not ready to activate until the token is durable. ApplyAuthorisationAsync
+        // publishes the outbox event observed by the subscription worker, so storing the card
+        // after that write leaves a race in which access is granted before renewal has a usable
+        // method. The lifecycle operation is idempotent, which also makes a retry after the
+        // payment-state write failed safe.
+        if (succeeded)
+        {
+            await _storedPaymentMethods.ApplyAuthorisationTokenAsync(
+                webhook,
+                payment,
+                cancellationToken);
+        }
+
         // Reused verbatim, zero amount included. Nothing about this write is about money: what
         // it actually does is stamp the confirmed status and the webhook instant that the rest
         // of the system treats as proof the provider spoke, and both are exactly what a settled
@@ -151,18 +164,6 @@ public sealed class PaymentMethodSetupWebhookStateTransitionService :
             succeeded,
             PaymentLogValue.Hash(payment.ItemId));
 
-        if (!succeeded)
-        {
-            return;
-        }
-
-        // The card itself, recorded through the same path a saved card from a charge takes —
-        // including the provider lookup that fills in the brand and last four, which a
-        // SetupIntent does not carry.
-        await _storedPaymentMethods.ApplyAuthorisationTokenAsync(
-            webhook,
-            payment,
-            cancellationToken);
     }
 
     private static bool IsSettled(PaymentDetail payment) =>

--- a/server/Payment.DomainService/Services/PaymentRefundPreflightService.cs
+++ b/server/Payment.DomainService/Services/PaymentRefundPreflightService.cs
@@ -102,7 +102,14 @@ public sealed class PaymentRefundPreflightService :
                 correlationId);
         }
 
-        if (payment.PaymentStatus is not
+        // A card setup settles at Authorized with a provider reference, so it satisfies every
+        // condition below without ever having taken a penny. Refunding one would ask the provider
+        // to return money it was never sent.
+        if (string.Equals(
+                payment.PaymentFlow,
+                PaymentFlows.PaymentMethodSetup,
+                StringComparison.Ordinal) ||
+            payment.PaymentStatus is not
                 (PaymentStatuses.Authorized or
                  PaymentStatuses.Captured or
                  PaymentStatuses.PartiallyCaptured or

--- a/server/Payment.DomainService/Services/PaymentWebhookStateTransitionService.cs
+++ b/server/Payment.DomainService/Services/PaymentWebhookStateTransitionService.cs
@@ -18,6 +18,8 @@ public sealed class PaymentWebhookStateTransitionService : IPaymentWebhookStateT
         _refundTransitions;
     private readonly IPaymentCaptureWebhookStateTransitionService
         _captureTransitions;
+    private readonly IPaymentMethodSetupWebhookStateTransitionService
+        _setupTransitions;
     private readonly ILogger<PaymentWebhookStateTransitionService> _logger;
 
     public PaymentWebhookStateTransitionService(
@@ -29,6 +31,8 @@ public sealed class PaymentWebhookStateTransitionService : IPaymentWebhookStateT
             refundTransitions,
         IPaymentCaptureWebhookStateTransitionService
             captureTransitions,
+        IPaymentMethodSetupWebhookStateTransitionService
+            setupTransitions,
         ILogger<PaymentWebhookStateTransitionService> logger)
     {
         _payments = payments;
@@ -37,6 +41,7 @@ public sealed class PaymentWebhookStateTransitionService : IPaymentWebhookStateT
         _minorUnits = minorUnits;
         _refundTransitions = refundTransitions;
         _captureTransitions = captureTransitions;
+        _setupTransitions = setupTransitions;
         _logger = logger;
     }
 
@@ -86,6 +91,22 @@ public sealed class PaymentWebhookStateTransitionService : IPaymentWebhookStateT
                     "Webhook state transition selected Flow=payment_capture");
 
                 await _captureTransitions.ApplyAsync(webhook, cancellationToken);
+
+                return;
+
+            case WebhookIntent.PaymentMethodSetup:
+                _logger.LogInformation(
+                    "Webhook state transition selected Flow=payment_method_setup");
+
+                await _setupTransitions.ApplyAsync(webhook, cancellationToken);
+
+                return;
+
+            // A session that ended without being used. Only a card-setup session acts on it —
+            // the handler returns without writing anything for any other flow, which is what an
+            // abandoned checkout has always done.
+            case WebhookIntent.Cancelled:
+                await _setupTransitions.ApplyAsync(webhook, cancellationToken);
 
                 return;
 

--- a/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -148,6 +148,12 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             IProviderInitiationRequestFactoryResolver,
             ProviderInitiationRequestFactoryResolver>();
+        services.AddSingleton<
+            IPaymentMethodSetupRequestFactory,
+            StripeSetupSessionRequestFactory>();
+        services.AddSingleton<
+            IPaymentMethodSetupRequestFactoryResolver,
+            PaymentMethodSetupRequestFactoryResolver>();
         services.AddSingleton<IPaymentSessionClient, HostedCheckoutSessionClient>();
         services.AddSingleton<IPaymentSessionClient, StripeCheckoutSessionClient>();
         services.AddSingleton<
@@ -208,6 +214,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IPaymentWebhookStateTransitionService, PaymentWebhookStateTransitionService>();
         services.AddScoped<IPaymentRefundWebhookStateTransitionService, PaymentRefundWebhookStateTransitionService>();
         services.AddScoped<IPaymentCaptureWebhookStateTransitionService, PaymentCaptureWebhookStateTransitionService>();
+        services.AddScoped<IPaymentMethodSetupWebhookStateTransitionService, PaymentMethodSetupWebhookStateTransitionService>();
         services.AddScoped<IStoredPaymentMethodLifecycleService, StoredPaymentMethodLifecycleService>();
         services.AddScoped<IPaymentWebhookProcessor, PaymentWebhookProcessor>();
         services.AddScoped<IStoredPaymentMethodQueryService, StoredPaymentMethodQueryService>();
@@ -247,6 +254,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             IRecurringPaymentService,
             RecurringPaymentService>();
+        services.AddScoped<
+            IPaymentMethodSetupService,
+            PaymentMethodSetupService>();
         services.AddScoped<
             IOrganizationDirectory,
             IamOrganizationDirectory>();

--- a/server/Payment.DomainService/Utilities/PaymentConstants.cs
+++ b/server/Payment.DomainService/Utilities/PaymentConstants.cs
@@ -25,4 +25,17 @@ public static class PaymentConstants
     public const string PaymentCaptureFailed =
         "PaymentCaptureFailed";
     public const string PaymentCancelled = "PaymentCancelled";
+
+    /// <summary>
+    /// A card was stored without being charged, or the attempt to store one ended.
+    /// </summary>
+    /// <remarks>
+    /// Named apart from <see cref="PaymentAuthorized"/> and <see cref="PaymentRefused"/> even
+    /// though the underlying record moves through the same statuses. Subscribers act on the
+    /// event name, and one that says a payment was authorised would have them recording money
+    /// that nobody moved.
+    /// </remarks>
+    public const string PaymentMethodSetupSucceeded = "PaymentMethodSetupSucceeded";
+
+    public const string PaymentMethodSetupFailed = "PaymentMethodSetupFailed";
 }

--- a/server/Payment.DomainService/Utilities/PaymentHashing.cs
+++ b/server/Payment.DomainService/Utilities/PaymentHashing.cs
@@ -59,6 +59,33 @@ public static class PaymentHashing
         return Hash(JsonSerializer.Serialize(canonical));
     }
 
+    /// <summary>
+    /// What makes one card-collection request the same as another under a reused key.
+    /// </summary>
+    /// <remarks>
+    /// No amount, because there is none. What is left is who is collecting, for which subscriber,
+    /// in which currency and against which order — change any of those and it is a different
+    /// request wearing the same key, which is exactly what this exists to catch.
+    /// </remarks>
+    public static string CreateRequestHash(
+        CreatePaymentMethodSetupRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var canonical = new
+        {
+            ProviderName = NormalizeUpper(request.ProviderName),
+            CurrencyCode = NormalizeUpper(request.CurrencyCode),
+            OrderId = Normalize(request.OrderId),
+            Description = Normalize(request.Description),
+            CustomerEmail = NormalizeLower(request.CustomerEmail),
+            CustomerOrganizationId = Normalize(request.CustomerOrganizationId),
+            OrganizationId = Normalize(request.OrganizationId)
+        };
+
+        return Hash(JsonSerializer.Serialize(canonical));
+    }
+
     public static string CreateRefundRequestHash(
         string paymentDetailId,
         CreatePaymentRefundRequest request)

--- a/server/Subscription.DomainService/Entities/Plan.cs
+++ b/server/Subscription.DomainService/Entities/Plan.cs
@@ -69,6 +69,23 @@ public sealed class Plan
     public bool TrialRequiresPaymentMethod { get; set; } = true;
 
     /// <summary>
+    /// Whether a card must be collected before this plan grants anything, even when the opening
+    /// amount is zero.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to false, which is what every plan authored before this existed meant: nothing due
+    /// today, so nothing to collect, and the subscription starts at once. Turning it on separates
+    /// the two questions — a free first period no longer implies a subscriber with no card on file
+    /// when the second period is billed.
+    /// <para>
+    /// Distinct from <see cref="TrialRequiresPaymentMethod"/>, which asks the same thing of a
+    /// trial specifically. Either is enough to require a card; a plan with no trial has only this
+    /// one to go on.
+    /// </para>
+    /// </remarks>
+    public bool RequirePaymentMethodUpfront { get; set; }
+
+    /// <summary>
     /// How much of each meter a trial includes. A free trial of something with a real
     /// per-unit cost is otherwise an open invitation.
     /// </summary>

--- a/server/Subscription.DomainService/Entities/PlanSnapshot.cs
+++ b/server/Subscription.DomainService/Entities/PlanSnapshot.cs
@@ -35,6 +35,17 @@ public sealed class PlanSnapshot
     public List<PlanQuantityItem> QuantityItems { get; set; } = [];
 
     /// <summary>
+    /// Whether the plan required a card before activation, as it stood when this was sold.
+    /// </summary>
+    /// <remarks>
+    /// Snapshotted for the same reason everything else here is: what a subscriber was asked for at
+    /// signup is a fact about their signup, and a later edit to the catalogue must not be able to
+    /// rewrite it. Nothing after activation reads it — by then the card either exists or does not
+    /// — but it is what a support question about a stuck checkout is answered from.
+    /// </remarks>
+    public bool RequirePaymentMethodUpfront { get; set; }
+
+    /// <summary>
     /// Snapshotted with the bands themselves: how they combine with a promotion is part of what
     /// the subscriber was sold, so changing the plan's policy must not reprice them either.
     /// </summary>

--- a/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionDetail.cs
@@ -117,6 +117,17 @@ public sealed class SubscriptionDetail
 
     public string? InitialPaymentDetailId { get; set; }
 
+    /// <summary>
+    /// How many card-collection sessions this subscription has opened, when it activates on a
+    /// stored card rather than a charge.
+    /// </summary>
+    /// <remarks>
+    /// Part of the idempotency key each attempt is raised under, which is what makes a second
+    /// attempt a genuinely new session rather than a replay of the expired one. Zero for every
+    /// subscription that paid its way in, and for the first attempt.
+    /// </remarks>
+    public int PaymentMethodSetupAttempt { get; set; }
+
     /// <summary>The most recent renewal's payment, for support traceability.</summary>
     public string? LastRenewalPaymentDetailId { get; set; }
 

--- a/server/Subscription.DomainService/Enums/SubscriptionPaymentPurpose.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionPaymentPurpose.cs
@@ -18,5 +18,16 @@ public enum SubscriptionPaymentPurpose
     InitialCharge = 0,
 
     /// <summary>A period renewal. Reachable once a billing clock exists.</summary>
-    Renewal = 1
+    Renewal = 1,
+
+    /// <summary>
+    /// Collecting a card for a subscription that owes nothing today.
+    /// </summary>
+    /// <remarks>
+    /// Linked and swept exactly as a charge is, because what activation waits for is the same
+    /// thing either way: the provider confirming, over a signed channel, that what was asked for
+    /// happened. What differs is the consequence of failure — no money was lost, so the
+    /// subscription stays open for another attempt rather than expiring.
+    /// </remarks>
+    PaymentMethodSetup = 2
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -140,6 +140,22 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                 tenantId,
                 SubscriptionConstants.InitialChargeKeyFor(subscription.ItemId),
                 cancellationToken);
+            var purpose = SubscriptionPaymentPurpose.InitialCharge;
+
+            if (payment is null)
+            {
+                // A subscription that owed nothing was never charged, so there is no charge to
+                // find. What it may have is a card-collection session — under its own key, at the
+                // attempt it had reached — and losing the link to that would expire a signup
+                // whose card the provider has already stored.
+                payment = await _payments.GetByIdempotencyKeyAsync(
+                    tenantId,
+                    SubscriptionConstants.PaymentMethodSetupKeyFor(
+                        subscription.ItemId,
+                        subscription.PaymentMethodSetupAttempt),
+                    cancellationToken);
+                purpose = SubscriptionPaymentPurpose.PaymentMethodSetup;
+            }
 
             if (payment is null)
             {
@@ -157,7 +173,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                     SubscriptionId = subscription.ItemId,
                     PaymentDetailId = payment.ItemId,
                     OrderId = subscription.OrderId,
-                    Purpose = SubscriptionPaymentPurpose.InitialCharge,
+                    Purpose = purpose,
                     CorrelationId = subscription.CorrelationId
                 },
                 cancellationToken);
@@ -258,6 +274,10 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         ConfirmedStatuses.Contains(payment.PaymentStatus, StringComparer.Ordinal) &&
         payment.WebhookConfirmedAtUtc is not null;
 
+    /// <summary>Whether this link tracks a card being collected rather than money being taken.</summary>
+    private static bool IsCardSetup(SubscriptionPaymentLink link) =>
+        link.Purpose == SubscriptionPaymentPurpose.PaymentMethodSetup;
+
     private async Task<bool> ActivateAsync(
         SubscriptionPaymentLink link,
         PaymentDetail payment,
@@ -297,7 +317,12 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             new SubscriptionTransition(SubscriptionStatus.Incomplete, target)
             {
                 ActivatedAtUtc = _time.GetUtcNow().UtcDateTime,
-                InitialPaymentDetailId = payment.ItemId,
+                // Only when this record is a charge. A card setup produces a payment row so the
+                // provider machinery has something to hang a session off, but it holds no money —
+                // naming it as the initial payment would put a zero-value entry where every
+                // reader expects the opening charge, and invoice history would go looking for a
+                // document that was never issued.
+                InitialPaymentDetailId = IsCardSetup(link) ? null : payment.ItemId,
                 DiscountPeriodsApplied = OpeningChargeSpentDiscountPeriod(subscription) ? 1 : null,
                 // The opening charge included the year on a price that collects it here, and this
                 // is the transition that says that charge was confirmed. Marking it any earlier
@@ -439,10 +464,38 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         }
     }
 
+    /// <summary>
+    /// Gives up on this attempt, and on the subscription behind it unless another attempt is
+    /// reasonable.
+    /// </summary>
+    /// <remarks>
+    /// A declined charge ends the subscription: the money was refused, and leaving it Incomplete
+    /// would hold the organization's one live slot open indefinitely for a customer whose card
+    /// said no.
+    /// <para>
+    /// A card setup that failed or expired is a different thing entirely. Nothing was refused,
+    /// because nothing was asked for; the usual cause is a page left open past the session's
+    /// life. The subscription stays Incomplete so the next request can open a fresh session, and
+    /// the recovery sweep still expires it if nobody comes back — that sweep works from the
+    /// subscription's age rather than from this link.
+    /// </para>
+    /// </remarks>
     private async Task<bool> AbandonAsync(
         SubscriptionPaymentLink link,
         CancellationToken cancellationToken)
     {
+        if (IsCardSetup(link))
+        {
+            _logger.LogInformation(
+                "Subscription card setup abandoned; the subscription stays open for another attempt");
+
+            return await _links.TrySettleAsync(
+                link.TenantId,
+                link.ItemId,
+                SubscriptionPaymentLinkState.Abandoned,
+                cancellationToken);
+        }
+
         var subscription = await _subscriptions.GetByIdAsync(
             link.TenantId,
             link.SubscriptionId,

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -311,6 +311,15 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             ? SubscriptionConstants.SubscriptionTrialStarted
             : SubscriptionConstants.SubscriptionActivated;
 
+        // A setup confirmation is only useful when the exact stored card has also been wired to
+        // the billing account. Do this before granting access; unlike a paid checkout there is no
+        // captured money whose entitlement must be honoured while a repair is retried.
+        if (IsCardSetup(link) &&
+            !await AdoptProviderCustomerAsync(subscription, payment, cancellationToken))
+        {
+            return false;
+        }
+
         var applied = await _subscriptions.TryTransitionAsync(
             link.TenantId,
             link.SubscriptionId,
@@ -345,7 +354,10 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             return false;
         }
 
-        await AdoptProviderCustomerAsync(subscription, payment, cancellationToken);
+        if (!IsCardSetup(link))
+        {
+            await AdoptProviderCustomerAsync(subscription, payment, cancellationToken);
+        }
 
         _logger.LogInformation(
             "Subscription activated Status={Status} PaymentHash={PaymentHash}",
@@ -388,7 +400,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     /// on every signup. The renewal needs this identifier, so a failure here is logged rather
     /// than swallowed — but it does not undo an activation the customer has already paid for.
     /// </remarks>
-    private async Task AdoptProviderCustomerAsync(
+    private async Task<bool> AdoptProviderCustomerAsync(
         SubscriptionDetail subscription,
         PaymentDetail payment,
         CancellationToken cancellationToken)
@@ -399,7 +411,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                 "A paid subscription has no shopper reference to find its card by; renewals " +
                 "will fail until one is recorded");
 
-            return;
+            return false;
         }
 
         // Found by the reference the card was saved under, not by a link from the payment.
@@ -426,7 +438,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             _logger.LogWarning(
                 "No provider customer recorded for a subscription; renewals will need one");
 
-            return;
+            return false;
         }
 
         var outcome = await _billingAccounts.TrySetProviderCustomerAsync(
@@ -462,6 +474,8 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                     PaymentLogValue.Hash(subscription.ItemId));
                 break;
         }
+
+        return outcome != SetProviderCustomerOutcome.AccountMissing;
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -811,11 +811,60 @@ not turn them into customer notifications.
 Every event carries a correlation id, persisted at write time, because publication happens later
 in another process. Without it the trace ends at the queue.
 
+## Collecting a card without charging one
+
+An opening amount of zero and a subscriber with no card on file used to be the same thing,
+because the only way to hold a card was to charge it. `Plan.RequirePaymentMethodUpfront`
+separates them.
+
+The signup path forks three ways:
+
+| Opening amount | Card required | What happens |
+| --- | --- | --- |
+| more than zero | — | the existing payment checkout |
+| zero | no | activates immediately, no `checkoutUrl` |
+| zero | yes | a **card-setup** checkout; `Incomplete` until the card is stored |
+
+A card is required when the amount is zero and either the plan sets
+`RequirePaymentMethodUpfront`, or the subscription starts on a trial whose
+`TrialRequiresPaymentMethod` is set. Both together is the combination the setting was asked for:
+genuinely free until the trial ends, with a card on file so the charge that ends it has something
+to bill.
+
+The setup is a Stripe Checkout session in `setup` mode — not a one-cent charge, which appears on
+a statement and has to be refunded, and not a zero-value PaymentIntent, which Stripe rejects. The
+SetupIntent it produces carries the off-session mandate the first renewal relies on.
+
+It leaves a `PaymentDetail` behind, under `PaymentFlows.PaymentMethodSetup` with a zero amount.
+That record exists because everything which tracks a hosted session already hangs off one: the
+initiation lease, the redirect URL, the webhook route, the stored-card write. **It is not a
+payment.** It is excluded from payment listings, from refunds and captures, and from invoice
+history, and activation does not record it as the opening charge — `InitialPaymentDetailId` stays
+null, because there is no charge and no invoice behind one.
+
+Two things behave differently from a charge:
+
+- **Failure is not fatal.** A declined charge ends the subscription; nothing was refused here, so
+  it stays `Incomplete` and another attempt is free to succeed. The staleness sweep still expires
+  it if nobody comes back.
+- **An expired session is replaced.** A hosted session cannot be reopened and the provider would
+  replay it under the key that opened it, so a retry mints a new one —
+  `SubscriptionConstants.PaymentMethodSetupKeyFor` carries an attempt number, bumped by a
+  compare-and-set so two tabs retrying at once produce one session. An expired *charge* is still
+  a conflict: raising a second one is how the same money gets taken twice.
+
+Cancelling while a setup is outstanding settles its link, so completing the card form afterwards
+cannot start a subscription somebody has cancelled.
+
 ## Activation waits for the webhook
 
 A subscription becomes active only when the payment carries both a confirming status **and**
 `WebhookConfirmedAtUtc`. The shopper's return from checkout is not evidence: a redirect can be
 replayed, forged, bookmarked, or lost when someone shuts the laptop.
+
+This holds for a card setup too, on `setup_intent.succeeded` rather than a payment event. The
+setup record settles to `Authorized` and never captures, which is what keeps every total that
+sums captured money from picking it up.
 
 Clients should therefore expect a brief `Incomplete` window after paying — the browser usually
 comes back before the webhook lands.

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -186,6 +186,20 @@ public interface ISubscriptionRepository
         int expectedVersion,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Counts one more card-collection attempt, so the next one is raised under a fresh key.
+    /// </summary>
+    /// <remarks>
+    /// Compare-and-set on the attempt itself rather than the version: two tabs retrying at once
+    /// must produce one increment, and the loser is told so rather than opening a third session
+    /// under a number that is already taken.
+    /// </remarks>
+    Task<bool> TryBumpPaymentMethodSetupAttemptAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedAttempt,
+        CancellationToken cancellationToken);
+
     Task<bool> TryRemovePendingUsagePeriodAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -156,6 +156,7 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
             .Set(existing => existing.QuantityItems, plan.QuantityItems)
             .Set(existing => existing.TrialDays, plan.TrialDays)
             .Set(existing => existing.TrialRequiresPaymentMethod, plan.TrialRequiresPaymentMethod)
+            .Set(existing => existing.RequirePaymentMethodUpfront, plan.RequirePaymentMethodUpfront)
             .Set(existing => existing.TrialGrants, plan.TrialGrants)
             .Set(existing => existing.LastUpdatedDateUtc, DateTime.UtcNow)
             .Inc(existing => existing.Version, 1);

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -487,6 +487,32 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         return result.ModifiedCount == 1;
     }
 
+    public async Task<bool> TryBumpPaymentMethodSetupAttemptAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedAttempt,
+        CancellationToken cancellationToken)
+    {
+        var result = await Subscriptions(tenantId).UpdateOneAsync(
+            Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.ItemId,
+                    subscriptionId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.Status,
+                    SubscriptionStatus.Incomplete),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.PaymentMethodSetupAttempt,
+                    expectedAttempt)),
+            Builders<SubscriptionDetail>.Update
+                .Set(subscription => subscription.PaymentMethodSetupAttempt, expectedAttempt + 1)
+                .Set(subscription => subscription.LastUpdatedDateUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     /// <summary>One subscription at one exact version — the compare half of a compare-and-set.</summary>
     private static FilterDefinition<SubscriptionDetail> VersionedFilter(
         string tenantId,

--- a/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
+++ b/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
@@ -28,6 +28,12 @@ public abstract class PlanDefinitionRequest
 
     public bool TrialRequiresPaymentMethod { get; set; } = true;
 
+    /// <summary>
+    /// Require a card before activation even when nothing is due today. Omit for the historical
+    /// behaviour, which is to start a zero-amount subscription immediately.
+    /// </summary>
+    public bool RequirePaymentMethodUpfront { get; set; }
+
     public BillingInterval UsageInterval { get; set; } = BillingInterval.Month;
 
     public int UsageIntervalCount { get; set; } = 1;

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -40,6 +40,9 @@ public sealed class PlanResponse
 
     public bool TrialRequiresPaymentMethod { get; init; }
 
+    /// <summary>Whether a card is collected before activation even when nothing is due today.</summary>
+    public bool RequirePaymentMethodUpfront { get; init; }
+
     public int Version { get; init; }
 
     /// <summary>

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -160,7 +160,25 @@ public sealed class SubscriptionResponse
     /// </summary>
     public string? CheckoutUrl { get; init; }
 
+    /// <summary>The non-financial checkout that must finish before access is granted.</summary>
+    public PendingCheckoutResponse? PendingCheckout { get; init; }
+
     public int Version { get; init; }
+}
+
+public sealed class PendingCheckoutResponse
+{
+    /// <summary>Currently always PaymentMethodSetup; explicit for future checkout purposes.</summary>
+    public string Purpose { get; init; } = string.Empty;
+
+    /// <summary>Pending, Failed, or Expired.</summary>
+    public string State { get; init; } = string.Empty;
+
+    /// <summary>A safe machine-readable failure reason, when the setup failed.</summary>
+    public string? ErrorCode { get; init; }
+
+    /// <summary>Only present while the hosted session remains usable.</summary>
+    public string? CheckoutUrl { get; init; }
 }
 
 /// <summary>The year a calendar-aligned yearly subscription has bought but not yet started.</summary>

--- a/server/Subscription.DomainService/Services/ISubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionResponseMapper.cs
@@ -7,5 +7,6 @@ public interface ISubscriptionResponseMapper
 {
     SubscriptionResponse ToResponse(
         SubscriptionDetail subscription,
-        string? checkoutUrl = null);
+        string? checkoutUrl = null,
+        PendingCheckoutResponse? pendingCheckout = null);
 }

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -745,6 +745,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         Status = CatalogueStatus.Active,
         TrialDays = request.TrialDays,
         TrialRequiresPaymentMethod = request.TrialRequiresPaymentMethod,
+        RequirePaymentMethodUpfront = request.RequirePaymentMethodUpfront,
         QuantityItems = request.QuantityItems
             .Select(item => new PlanQuantityItem
             {

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -35,6 +35,7 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
             FeaturesJson = plan.FeaturesJson,
             TrialDays = plan.TrialDays,
             TrialRequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
+            RequirePaymentMethodUpfront = plan.RequirePaymentMethodUpfront,
             Version = plan.Version,
             HasSubscribers = hasSubscribers,
             QuantityItems = plan.QuantityItems

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -26,6 +26,7 @@ namespace Subscription.DomainService.Services;
 public sealed class SubscriptionCancellationService : ISubscriptionCancellationService
 {
     private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionPaymentLinkRepository _links;
     private readonly ISubscriptionContextResolver _contextResolver;
     private readonly ISubscriptionOutboxEventFactory _events;
     private readonly ISubscriptionResponseMapper _mapper;
@@ -35,6 +36,7 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
 
     public SubscriptionCancellationService(
         ISubscriptionRepository subscriptions,
+        ISubscriptionPaymentLinkRepository links,
         ISubscriptionContextResolver contextResolver,
         ISubscriptionOutboxEventFactory events,
         ISubscriptionResponseMapper mapper,
@@ -43,6 +45,7 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         TimeProvider? time = null)
     {
         _subscriptions = subscriptions;
+        _links = links;
         _contextResolver = contextResolver;
         _events = events;
         _mapper = mapper;
@@ -132,6 +135,8 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 correlationId);
         }
 
+        await InvalidatePendingCheckoutAsync(subscription, cancellationToken);
+
         // The cached snapshot decides what the customer may do, so it has to go now rather
         // than in a few seconds' time.
         _cache.Invalidate(context.TenantId, context.OrganizationId);
@@ -150,6 +155,48 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         return SubscriptionOperationResult<SubscriptionResponse>.Success(
             _mapper.ToResponse(Reflect(subscription, endsImmediately, now, reason)),
             correlationId);
+    }
+
+    /// <summary>
+    /// Closes the attempt that was still waiting on the provider, so a late confirmation cannot
+    /// resurrect a subscription somebody has cancelled.
+    /// </summary>
+    /// <remarks>
+    /// Belt and braces on top of the activation processor, which will not carry a subscription
+    /// across unless it is still Incomplete. The difference matters for a card setup: the shopper
+    /// may well complete the hosted page after cancelling — the tab is still open — and the
+    /// provider will duly report a stored card. Settling the link here means the sweep stops
+    /// looking, rather than returning to a subscription it can never act on until it runs out of
+    /// attempts.
+    /// <para>
+    /// Only while the subscription had not started. Once it is live its link has been applied,
+    /// and a renewal's link belongs to a charge this cancellation has nothing to say about.
+    /// </para>
+    /// </remarks>
+    private async Task InvalidatePendingCheckoutAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        if (subscription.Status != SubscriptionStatus.Incomplete)
+        {
+            return;
+        }
+
+        var link = await _links.FindBySubscriptionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            cancellationToken);
+
+        if (link is null || link.State != SubscriptionPaymentLinkState.Pending)
+        {
+            return;
+        }
+
+        await _links.TrySettleAsync(
+            subscription.TenantId,
+            link.ItemId,
+            SubscriptionPaymentLinkState.Abandoned,
+            cancellationToken);
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -31,6 +31,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     private readonly ISubscriptionOutboxEventFactory _events;
     private readonly ISubscriptionResponseMapper _mapper;
     private readonly IPaymentService _payments;
+    private readonly IPaymentMethodSetupService _paymentMethodSetups;
     private readonly IPaymentRepository _paymentRepository;
     private readonly ICurrencyMinorUnitResolver _currency;
     private readonly ILogger<SubscriptionCheckoutService> _logger;
@@ -43,6 +44,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         ISubscriptionOutboxEventFactory events,
         ISubscriptionResponseMapper mapper,
         IPaymentService payments,
+        IPaymentMethodSetupService paymentMethodSetups,
         IPaymentRepository paymentRepository,
         ICurrencyMinorUnitResolver currency,
         ILogger<SubscriptionCheckoutService> logger)
@@ -54,6 +56,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         _events = events;
         _mapper = mapper;
         _payments = payments;
+        _paymentMethodSetups = paymentMethodSetups;
         _paymentRepository = paymentRepository;
         _currency = currency;
         _logger = logger;
@@ -112,8 +115,17 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         var amountMinor = subscription.InitialChargeAmountMinor
             ?? SubscriptionAmountCalculator.PeriodAmountMinor(subscription);
 
-        return RequiresPayment(subscription, amountMinor)
-            ? await ChargeAsync(subscription, amountMinor, correlationId, cancellationToken)
+        if (RequiresPayment(subscription, amountMinor))
+        {
+            return await ChargeAsync(subscription, amountMinor, correlationId, cancellationToken);
+        }
+
+        // Nothing is payable today. Whether that means the subscription starts now depends on
+        // what the plan asked for: a card can be a condition of activation without being a
+        // charge, and the two questions were conflated for as long as the only way to hold a
+        // card was to take money with it.
+        return RequiresCardSetup(subscription)
+            ? await StartCardSetupAsync(subscription, correlationId, cancellationToken)
             : await StartWithoutPaymentAsync(subscription, correlationId, cancellationToken);
     }
 
@@ -135,19 +147,33 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
             return null;
         }
 
-        var checkoutUrl = await GetPendingCheckoutUrlAsync(
+        var link = await _links.FindBySubscriptionAsync(
             context.TenantId,
             subscription.ItemId,
             cancellationToken);
 
-        if (string.IsNullOrWhiteSpace(checkoutUrl))
-        {
-            return PendingCheckoutConflict(subscription, null, correlationId);
-        }
+        var checkoutUrl = await ResolveUsableCheckoutUrlAsync(
+            context.TenantId,
+            link,
+            cancellationToken);
 
         if (!MatchesPendingTerms(request, subscription))
         {
             return PendingCheckoutConflict(subscription, checkoutUrl, correlationId);
+        }
+
+        if (string.IsNullOrWhiteSpace(checkoutUrl))
+        {
+            // A card-collection session that has expired is not a dead end. Nothing was paid, so
+            // there is no money to reconcile and no reason to make someone cancel and start
+            // again — but the expired session cannot be reopened, so the retry has to be a new
+            // one under a new key.
+            //
+            // A *charge* is left alone. Raising a second one is how the same money gets taken
+            // twice, and the existing conflict tells the caller to finish or cancel the first.
+            return link is { Purpose: SubscriptionPaymentPurpose.PaymentMethodSetup }
+                ? await RetryCardSetupAsync(subscription, link, correlationId, cancellationToken)
+                : PendingCheckoutConflict(subscription, null, correlationId);
         }
 
         _logger.LogInformation(
@@ -167,13 +193,20 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     private async Task<string?> GetPendingCheckoutUrlAsync(
         string tenantId,
         string subscriptionId,
-        CancellationToken cancellationToken)
-    {
-        var link = await _links.FindBySubscriptionAsync(
+        CancellationToken cancellationToken) =>
+        await ResolveUsableCheckoutUrlAsync(
             tenantId,
-            subscriptionId,
+            await _links.FindBySubscriptionAsync(tenantId, subscriptionId, cancellationToken),
             cancellationToken);
 
+    /// <summary>
+    /// The hosted page this link still leads to, or null when there is nothing left to return to.
+    /// </summary>
+    private async Task<string?> ResolveUsableCheckoutUrlAsync(
+        string tenantId,
+        SubscriptionPaymentLink? link,
+        CancellationToken cancellationToken)
+    {
         if (link is null || link.State != SubscriptionPaymentLinkState.Pending)
         {
             return null;
@@ -311,6 +344,139 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         }
 
         return amountMinor > 0;
+    }
+
+    /// <summary>
+    /// Whether a card must be on file before this subscription grants anything, given that
+    /// nothing is payable today.
+    /// </summary>
+    /// <remarks>
+    /// Two separate reasons, either sufficient. The plan may require a card outright — a fully
+    /// discounted first period should not mean an unbillable second one. Or the subscription may
+    /// start on a trial the plan said needs a card, which until now could only be honoured by
+    /// charging for the first period at signup.
+    /// <para>
+    /// A card-free trial can still land here, when the plan asks for a card up front regardless.
+    /// That combination is deliberate and is the one this setting was asked for: genuinely free
+    /// until the trial ends, and with a card on file so the charge that ends it has something to
+    /// bill.
+    /// </para>
+    /// </remarks>
+    private static bool RequiresCardSetup(SubscriptionDetail subscription) =>
+        subscription.Plan.RequirePaymentMethodUpfront ||
+        subscription.Trial is { RequiresPaymentMethod: true };
+
+    /// <summary>
+    /// Opens a hosted session that stores a card and charges nothing.
+    /// </summary>
+    /// <remarks>
+    /// The subscription stays <see cref="SubscriptionStatus.Incomplete"/> and grants nothing
+    /// until the provider confirms the card was stored — the same rule a paid signup follows, and
+    /// for the same reason: a browser that came back is not evidence, and the webhook is.
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>> StartCardSetupAsync(
+        SubscriptionDetail subscription,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var setup = await _paymentMethodSetups.CreateSetupAsync(
+            new CreatePaymentMethodSetupRequest
+            {
+                ProviderName = PaymentConstants.StripeProvider,
+                CurrencyCode = subscription.CurrencyCode,
+                OrderId = subscription.OrderId,
+                Description = $"{subscription.Plan.DisplayName} subscription",
+                CustomerOrganizationId = subscription.OrganizationId
+            },
+            SubscriptionConstants.PaymentMethodSetupKeyFor(
+                subscription.ItemId,
+                subscription.PaymentMethodSetupAttempt),
+            correlationId,
+            cancellationToken);
+
+        if (!setup.IsSuccess || setup.Payment is null)
+        {
+            _logger.LogWarning(
+                "Subscription card setup failed TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} Reason={Reason} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(setup.ErrorCode),
+                correlationId);
+
+            // Incomplete, granting nothing, and recoverable. No money moved, so there is nothing
+            // to unwind and nothing that stops another attempt.
+            return Failure(
+                setup.FailureKind,
+                setup.ErrorCode,
+                setup.ErrorMessage,
+                correlationId);
+        }
+
+        await _links.TryCreateAsync(
+            new SubscriptionPaymentLink
+            {
+                TenantId = subscription.TenantId,
+                OrganizationId = subscription.OrganizationId,
+                SubscriptionId = subscription.ItemId,
+                PaymentDetailId = setup.Payment.PaymentDetailId,
+                OrderId = subscription.OrderId,
+                Purpose = SubscriptionPaymentPurpose.PaymentMethodSetup,
+                State = SubscriptionPaymentLinkState.Pending,
+                CorrelationId = correlationId
+            },
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Subscription card setup started TenantHash={TenantHash} " +
+            "SubscriptionHash={SubscriptionHash} PaymentHash={PaymentHash} Attempt={Attempt} " +
+            "CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Hash(setup.Payment.PaymentDetailId),
+            subscription.PaymentMethodSetupAttempt,
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Success(
+            _mapper.ToResponse(subscription, setup.Payment.RedirectUrl),
+            correlationId);
+    }
+
+    /// <summary>
+    /// Opens a fresh card-collection session after the last one expired.
+    /// </summary>
+    /// <remarks>
+    /// The attempt counter is bumped first, and that write is the gate: it is a compare-and-set on
+    /// the number itself, so two tabs retrying at once produce one new session and the loser is
+    /// told the setup is already in progress rather than opening a third.
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>> RetryCardSetupAsync(
+        SubscriptionDetail subscription,
+        SubscriptionPaymentLink link,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (!await _subscriptions.TryBumpPaymentMethodSetupAttemptAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                subscription.PaymentMethodSetupAttempt,
+                cancellationToken))
+        {
+            return PendingCheckoutConflict(subscription, null, correlationId);
+        }
+
+        // Nobody is going to finish the expired one, and a pending link is what the activation
+        // sweep keeps coming back to. Settled after the bump: an abandoned link with no
+        // replacement is recoverable, a second live session under a stale number is not.
+        await _links.TrySettleAsync(
+            subscription.TenantId,
+            link.ItemId,
+            SubscriptionPaymentLinkState.Abandoned,
+            cancellationToken);
+
+        subscription.PaymentMethodSetupAttempt++;
+
+        return await StartCardSetupAsync(subscription, correlationId, cancellationToken);
     }
 
     private async Task<SubscriptionOperationResult<SubscriptionResponse>> ChargeAsync(

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -186,7 +186,12 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
             correlationId);
 
         return SubscriptionOperationResult<SubscriptionResponse>.Success(
-            _mapper.ToResponse(subscription, checkoutUrl),
+            _mapper.ToResponse(
+                subscription,
+                checkoutUrl,
+                link is { Purpose: SubscriptionPaymentPurpose.PaymentMethodSetup }
+                    ? PendingSetup("Pending", checkoutUrl)
+                    : null),
             correlationId);
     }
 
@@ -198,6 +203,68 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
             tenantId,
             await _links.FindBySubscriptionAsync(tenantId, subscriptionId, cancellationToken),
             cancellationToken);
+
+    private async Task<PendingCheckoutResponse?> GetPendingSetupAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken)
+    {
+        var link = await _links.FindBySubscriptionAsync(
+            tenantId,
+            subscriptionId,
+            cancellationToken);
+
+        if (link is not { Purpose: SubscriptionPaymentPurpose.PaymentMethodSetup })
+        {
+            return null;
+        }
+
+        var payment = await _paymentRepository.GetByIdAsync(
+            tenantId,
+            link.PaymentDetailId,
+            cancellationToken);
+
+        if (payment is null)
+        {
+            return PendingSetup("Failed", null, "payment_method_setup_not_found");
+        }
+
+        var expired = payment.ExpirationDate != default &&
+                      payment.ExpirationDate <= DateTime.UtcNow;
+        if (expired)
+        {
+            return PendingSetup("Expired", null, "payment_method_setup_expired");
+        }
+
+        if (payment.PaymentStatus is PaymentStatuses.Refused or
+            PaymentStatuses.Cancelled or
+            PaymentStatuses.MakePaymentFailed)
+        {
+            return PendingSetup(
+                "Failed",
+                null,
+                "payment_method_setup_failed");
+        }
+
+        var url = link.State == SubscriptionPaymentLinkState.Pending
+            ? await ResolveUsableCheckoutUrlAsync(tenantId, link, cancellationToken)
+            : null;
+
+        return link.State == SubscriptionPaymentLinkState.Pending && url is not null
+            ? PendingSetup("Pending", url)
+            : PendingSetup("Expired", null, "payment_method_setup_expired");
+    }
+
+    private static PendingCheckoutResponse PendingSetup(
+        string state,
+        string? checkoutUrl,
+        string? errorCode = null) => new()
+    {
+        Purpose = nameof(SubscriptionPaymentPurpose.PaymentMethodSetup),
+        State = state,
+        ErrorCode = errorCode,
+        CheckoutUrl = checkoutUrl
+    };
 
     /// <summary>
     /// The hosted page this link still leads to, or null when there is nothing left to return to.
@@ -221,6 +288,9 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
             cancellationToken);
 
         return payment is null ||
+               payment.PaymentStatus is PaymentStatuses.Refused or
+                   PaymentStatuses.Cancelled or
+                   PaymentStatuses.MakePaymentFailed ||
                string.IsNullOrWhiteSpace(payment.RedirectUrl) ||
                payment.ExpirationDate != default && payment.ExpirationDate <= DateTime.UtcNow
             ? null
@@ -310,13 +380,20 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
 
         if (subscription is not null)
         {
-            var checkoutUrl = await GetPendingCheckoutUrlAsync(
+            var pendingSetup = await GetPendingSetupAsync(
                 context.TenantId,
                 subscription.ItemId,
                 cancellationToken);
 
+            var checkoutUrl = pendingSetup is not null
+                ? pendingSetup.CheckoutUrl
+                : await GetPendingCheckoutUrlAsync(
+                    context.TenantId,
+                    subscription.ItemId,
+                    cancellationToken);
+
             return SubscriptionOperationResult<SubscriptionResponse>.Success(
-                _mapper.ToResponse(subscription, checkoutUrl),
+                _mapper.ToResponse(subscription, checkoutUrl, pendingSetup),
                 correlationId);
         }
 
@@ -438,7 +515,10 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
             correlationId);
 
         return SubscriptionOperationResult<SubscriptionResponse>.Success(
-            _mapper.ToResponse(subscription, setup.Payment.RedirectUrl),
+            _mapper.ToResponse(
+                subscription,
+                setup.Payment.RedirectUrl,
+                PendingSetup("Pending", setup.Payment.RedirectUrl)),
             correlationId);
     }
 

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -12,7 +12,8 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
 
     public SubscriptionResponse ToResponse(
         SubscriptionDetail subscription,
-        string? checkoutUrl = null)
+        string? checkoutUrl = null,
+        PendingCheckoutResponse? pendingCheckout = null)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -87,6 +88,7 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
                 }
                 : null,
             CheckoutUrl = checkoutUrl,
+            PendingCheckout = pendingCheckout,
             Version = subscription.Version
         };
     }

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -24,6 +24,7 @@ internal static class SubscriptionSnapshotBuilder
             FeaturesJson = plan.FeaturesJson,
             UsageInterval = plan.UsageInterval,
             UsageIntervalCount = plan.UsageIntervalCount,
+            RequirePaymentMethodUpfront = plan.RequirePaymentMethodUpfront,
             PlanVersion = plan.Version,
             Entitlements = plan.Entitlements
                 .Select(entitlement => new PlanEntitlement

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -87,6 +87,18 @@ public static class SubscriptionConstants
     public static string RenewalKeyFor(string subscriptionId, string periodKey, int attempt) =>
         DeterministicKey($"sub-renew:{subscriptionId}:{periodKey}:{attempt}");
 
+    /// <summary>
+    /// The idempotency key one card-collection attempt is raised under.
+    /// </summary>
+    /// <remarks>
+    /// Carries the attempt number for the same reason a dunning retry does: a hosted session that
+    /// expired cannot be reopened, so a second attempt has to be a new session, and the provider
+    /// would replay the first one under the first key. Derived rather than random so a crash
+    /// between opening the session and recording the link to it can still find it.
+    /// </remarks>
+    public static string PaymentMethodSetupKeyFor(string subscriptionId, int attempt) =>
+        DeterministicKey($"sub-setup:{subscriptionId}:{attempt}");
+
     public static string PlanChangeKeyFor(string subscriptionId, int version) =>
         DeterministicKey($"sub-planchange:{subscriptionId}:{version}");
 

--- a/server/XUnitTest/Payment/PaymentCapturePreflightServiceTests.cs
+++ b/server/XUnitTest/Payment/PaymentCapturePreflightServiceTests.cs
@@ -114,6 +114,23 @@ public sealed class PaymentCapturePreflightServiceTests
         result.Failure.ErrorCode.Should().Be("payment_not_found");
     }
 
+    /// <summary>
+    /// A card setup settles at Authorized with a provider reference and a manual capture mode,
+    /// so it satisfies every condition a capture asks about without ever having held a penny.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_CardSetup_IsNotCapturable()
+    {
+        var payment = CapturablePayment();
+        payment.PaymentFlow = PaymentFlows.PaymentMethodSetup;
+        payment.AuthorizedAmount = 0;
+        _captures.Setup(c => c.GetPaymentAsync("tenant", _paymentId, It.IsAny<CancellationToken>())).ReturnsAsync(payment);
+
+        var result = await RunAsync();
+
+        result.Failure!.ErrorCode.Should().Be("payment_not_capturable");
+    }
+
     [Fact]
     public async Task ExecuteAsync_PaymentNotCapturable_ReturnsConflict()
     {

--- a/server/XUnitTest/Payment/PaymentMethodSetupTests.cs
+++ b/server/XUnitTest/Payment/PaymentMethodSetupTests.cs
@@ -1,0 +1,353 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Models;
+using Payment.DomainService.Models.Webhooks;
+using Payment.DomainService.Outbox;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+
+namespace XUnitTest.Payment;
+
+/// <summary>
+/// Collecting a card without charging it: the request that asks for it, the event that reports
+/// it, and the record it leaves behind.
+/// </summary>
+/// <remarks>
+/// The recurring hazard throughout is that a setup record looks enough like a payment to be
+/// mistaken for one — it settles at Authorized, it carries a provider reference, it lives in the
+/// payments collection. Several of these tests exist only to prove that the things which count,
+/// refund or capture money decline to touch it.
+/// </remarks>
+public sealed class PaymentMethodSetupTests
+{
+    private const string TenantId = "tenant-1";
+
+    private readonly StripeSetupSessionRequestFactory _factory = new();
+    private readonly StripeWebhookNormalizer _normalizer = new();
+
+    [Fact]
+    public void The_factory_serves_stripe_alone()
+    {
+        _factory.Supports(PaymentConstants.StripeProvider).Should().BeTrue();
+        _factory.Supports(PaymentConstants.AdyenOnlineProvider).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Setup mode, and nothing that would move money. A line item or an amount here is the
+    /// difference between storing a card and charging one.
+    /// </summary>
+    [Fact]
+    public void The_session_collects_a_card_and_charges_nothing()
+    {
+        var request = Create();
+        var form = ReadForm(request);
+
+        form["mode"].Should().Be("setup");
+        form["currency"].Should().Be("chf",
+            "Stripe decides which methods to offer from the currency, and there is no amount " +
+            "for it to infer one from");
+        form.Keys.Should().NotContain(key => key.StartsWith("line_items", StringComparison.Ordinal));
+        form.Keys.Should().NotContain("amount");
+        form.Keys.Should().NotContain("payment_intent_data[setup_future_usage]");
+        request.AmountMinorUnits.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Session metadata does not reach the SetupIntent, and setup_intent.succeeded is raised
+    /// against the intent. Without this copy the one event that reports the stored card arrives
+    /// with nothing to route it home.
+    /// </summary>
+    [Fact]
+    public void Routing_metadata_is_copied_onto_the_setup_intent()
+    {
+        var form = ReadForm(Create());
+
+        form["metadata[tenant_reference]"].Should().Be("p1.tenant.payment");
+        form["setup_intent_data[metadata][tenant_reference]"].Should().Be("p1.tenant.payment");
+        form[$"setup_intent_data[metadata][{StripeRoutingMetadata.ShopperReferenceKey}]"]
+            .Should().Be("shopper-1");
+        form[$"setup_intent_data[metadata][{StripeRoutingMetadata.OrganizationKey}]"]
+            .Should().Be("org-1");
+    }
+
+    /// <summary>
+    /// Naming a customer Stripe already knows is what keeps a returning shopper from becoming a
+    /// second customer with the card saved somewhere nothing will look.
+    /// </summary>
+    [Fact]
+    public void A_known_shopper_is_named_rather_than_created_again()
+    {
+        ReadForm(Create(providerPayerReference: "cus_1"))["customer"].Should().Be("cus_1");
+        ReadForm(Create()).Keys.Should().NotContain("customer");
+    }
+
+    [Fact]
+    public void A_succeeded_setup_intent_reports_the_card_it_stored()
+    {
+        var parsed = Parse(
+            """
+            {"id":"evt_1","type":"setup_intent.succeeded","created":1780000000,
+             "data":{"object":{"id":"seti_1","customer":"cus_1","payment_method":"pm_1",
+             "metadata":{"tenant_reference":"p1.tenant.payment","payment_id":"payment-1",
+             "shopper_reference":"shopper-1"}}}}
+            """);
+
+        parsed.Intent.Should().Be(WebhookIntent.PaymentMethodSetup,
+            "an authorisation is proved against the payment's amount, and there is none");
+        parsed.Payload.Success.Should().BeTrue();
+        parsed.Payload.StoredPaymentMethodToken.Should().Be("pm_1");
+        parsed.Payload.ProviderPayerReference.Should().Be("cus_1");
+        parsed.RoutingReference.Should().Be("p1.tenant.payment");
+    }
+
+    [Fact]
+    public void A_failed_setup_intent_reports_why_under_its_own_error_field()
+    {
+        var parsed = Parse(
+            """
+            {"id":"evt_2","type":"setup_intent.setup_failed","created":1780000000,
+             "data":{"object":{"id":"seti_2","last_setup_error":{"code":"card_declined"},
+             "metadata":{"tenant_reference":"p1.tenant.payment"}}}}
+            """);
+
+        parsed.Intent.Should().Be(WebhookIntent.PaymentMethodSetup);
+        parsed.Payload.Success.Should().BeFalse();
+        parsed.Payload.ProviderFailureCode.Should().Be("card_declined");
+    }
+
+    [Fact]
+    public async Task A_stored_card_settles_the_setup_and_is_recorded()
+    {
+        var harness = new TransitionHarness(SetupRecord());
+
+        await harness.ApplyAsync(SetupEvent(succeeded: true));
+
+        harness.Authorised.Should().BeTrue();
+        harness.AuthorisedAmount.Should().Be(0m);
+        harness.CapturedAutomatically.Should().BeFalse(
+            "there is nothing to capture, and a captured record is one every financial total " +
+            "would pick up");
+        harness.StoredCard.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_failed_setup_settles_without_recording_a_card()
+    {
+        var harness = new TransitionHarness(SetupRecord());
+
+        await harness.ApplyAsync(SetupEvent(succeeded: false));
+
+        harness.Authorised.Should().BeFalse();
+        harness.StoredCard.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A session expires after it has been used, or the events arrive out of order. Either way
+    /// the card is stored and the subscription may already be running.
+    /// </summary>
+    [Fact]
+    public async Task An_expiry_that_arrives_after_the_card_was_stored_changes_nothing()
+    {
+        var settled = SetupRecord();
+        settled.PaymentStatus = PaymentStatuses.Authorized;
+        settled.WebhookConfirmedAtUtc = DateTime.UtcNow.AddMinutes(-5);
+        var harness = new TransitionHarness(settled);
+
+        await harness.ApplyAsync(ExpiredSessionEvent());
+
+        harness.Applied.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// One provider event name covers every kind of session ending. An abandoned *checkout* has
+    /// always been a no-op, and that is not a decision for a card-setup handler to reverse.
+    /// </summary>
+    [Fact]
+    public async Task An_expiring_payment_session_is_left_alone()
+    {
+        var checkout = SetupRecord();
+        checkout.PaymentFlow = PaymentFlows.HostedCheckout;
+        var harness = new TransitionHarness(checkout);
+
+        await harness.ApplyAsync(ExpiredSessionEvent());
+
+        harness.Applied.Should().BeFalse();
+        harness.StoredCard.Should().BeFalse();
+    }
+
+    private static PaymentWebhookInbox SetupEvent(bool succeeded) => new()
+    {
+        TenantId = TenantId,
+        WebhookId = Guid.NewGuid().ToString(),
+        Intent = WebhookIntent.PaymentMethodSetup,
+        EventCode = succeeded ? "setup_intent.succeeded" : "setup_intent.setup_failed",
+        EventDateUtc = DateTime.UtcNow,
+        NormalizedPayload = new PaymentWebhookPayload
+        {
+            PaymentDetailId = "payment-1",
+            PspReference = "seti_1",
+            Success = succeeded,
+            ProviderName = PaymentConstants.StripeProvider,
+            ShopperReference = "shopper-1",
+            StoredPaymentMethodToken = succeeded ? "pm_1" : null
+        }
+    };
+
+    private static PaymentWebhookInbox ExpiredSessionEvent() => new()
+    {
+        TenantId = TenantId,
+        WebhookId = Guid.NewGuid().ToString(),
+        Intent = WebhookIntent.Cancelled,
+        EventCode = "checkout.session.expired",
+        EventDateUtc = DateTime.UtcNow,
+        NormalizedPayload = new PaymentWebhookPayload
+        {
+            PaymentDetailId = "payment-1",
+            PspReference = "cs_1",
+            Success = false
+        }
+    };
+
+    private static PaymentDetail SetupRecord() => new()
+    {
+        ItemId = "payment-1",
+        TenantId = TenantId,
+        PaymentFlow = PaymentFlows.PaymentMethodSetup,
+        PaymentStatus = PaymentStatuses.Processing,
+        CurrencyCode = "CHF",
+        PreciseAmount = 0,
+        RememberCard = true,
+        ShopperReference = "shopper-1",
+        OrganizationId = "org-1"
+    };
+
+    private ProviderInitiationRequest Create(string? providerPayerReference = null) =>
+        _factory.Create(
+            new CreatePaymentMethodSetupRequest
+            {
+                ProviderName = PaymentConstants.StripeProvider,
+                CurrencyCode = "CHF",
+                OrderId = "sub:subscription-1",
+                Description = "Community subscription",
+                CustomerOrganizationId = "subscriber-1"
+            },
+            new PaymentDetail
+            {
+                ItemId = "payment-1",
+                TenantId = TenantId,
+                CurrencyCode = "CHF",
+                OrganizationId = "org-1"
+            },
+            new PaymentProvider
+            {
+                ProviderName = PaymentConstants.StripeProvider,
+                MerchantId = "acct_1",
+                ApiBaseUrl = StripeConstants.ApiBaseUrl
+            },
+            "https://app.example.com/return",
+            "p1.tenant.payment",
+            "shopper-1",
+            providerPayerReference);
+
+    private static Dictionary<string, string> ReadForm(ProviderInitiationRequest request) =>
+        request.Payload.Elements.ToDictionary(
+            element => element.Name,
+            element => element.Value.AsString,
+            StringComparer.Ordinal);
+
+    private ParsedWebhookEvent Parse(string body)
+    {
+        var result = _normalizer.Parse(
+            body,
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [StripeConstants.SignatureHeader] = "t=1,v1=abc"
+            });
+
+        result.Events.Should().ContainSingle();
+
+        return result.Events[0];
+    }
+
+    /// <summary>
+    /// The transition service with its two collaborators watched: what it wrote to the payment,
+    /// and whether it went on to record the card.
+    /// </summary>
+    private sealed class TransitionHarness
+    {
+        private readonly Mock<IPaymentRepository> _payments = new();
+        private readonly Mock<IStoredPaymentMethodLifecycleService> _storedMethods = new();
+
+        public TransitionHarness(PaymentDetail payment)
+        {
+            _payments
+                .Setup(repository => repository.GetByIdAsync(
+                    TenantId, payment.ItemId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(payment);
+
+            _payments
+                .Setup(repository => repository.ApplyAuthorisationAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<decimal>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DateTime>(),
+                    It.IsAny<PaymentInstrument?>(),
+                    It.IsAny<PaymentOutboxEvent>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(
+                    (
+                        string _,
+                        string _,
+                        bool authorized,
+                        decimal amount,
+                        bool captured,
+                        string _,
+                        DateTime _,
+                        PaymentInstrument? _,
+                        PaymentOutboxEvent _,
+                        CancellationToken _) =>
+                    {
+                        Applied = true;
+                        Authorised = authorized;
+                        AuthorisedAmount = amount;
+                        CapturedAutomatically = captured;
+                    })
+                .ReturnsAsync(true);
+
+            _storedMethods
+                .Setup(service => service.ApplyAuthorisationTokenAsync(
+                    It.IsAny<PaymentWebhookInbox>(),
+                    It.IsAny<PaymentDetail>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => StoredCard = true)
+                .Returns(Task.CompletedTask);
+        }
+
+        public bool Applied { get; private set; }
+
+        public bool Authorised { get; private set; }
+
+        public decimal AuthorisedAmount { get; private set; }
+
+        public bool CapturedAutomatically { get; private set; }
+
+        public bool StoredCard { get; private set; }
+
+        public Task ApplyAsync(PaymentWebhookInbox webhook) =>
+            new PaymentMethodSetupWebhookStateTransitionService(
+                _payments.Object,
+                _storedMethods.Object,
+                new PaymentOutboxEventFactory(),
+                NullLogger<PaymentMethodSetupWebhookStateTransitionService>.Instance)
+                .ApplyAsync(webhook, CancellationToken.None);
+    }
+}

--- a/server/XUnitTest/Payment/PaymentMethodSetupTests.cs
+++ b/server/XUnitTest/Payment/PaymentMethodSetupTests.cs
@@ -134,6 +134,8 @@ public sealed class PaymentMethodSetupTests
             "there is nothing to capture, and a captured record is one every financial total " +
             "would pick up");
         harness.StoredCard.Should().BeTrue();
+        harness.Operations.Should().Equal(["store-card", "publish-confirmation"],
+            "activation can observe the payment outbox as soon as confirmation is written");
     }
 
     [Fact]
@@ -316,6 +318,7 @@ public sealed class PaymentMethodSetupTests
                         PaymentOutboxEvent _,
                         CancellationToken _) =>
                     {
+                        Operations.Add("publish-confirmation");
                         Applied = true;
                         Authorised = authorized;
                         AuthorisedAmount = amount;
@@ -328,7 +331,11 @@ public sealed class PaymentMethodSetupTests
                     It.IsAny<PaymentWebhookInbox>(),
                     It.IsAny<PaymentDetail>(),
                     It.IsAny<CancellationToken>()))
-                .Callback(() => StoredCard = true)
+                .Callback(() =>
+                {
+                    StoredCard = true;
+                    Operations.Add("store-card");
+                })
                 .Returns(Task.CompletedTask);
         }
 
@@ -341,6 +348,8 @@ public sealed class PaymentMethodSetupTests
         public bool CapturedAutomatically { get; private set; }
 
         public bool StoredCard { get; private set; }
+
+        public List<string> Operations { get; } = [];
 
         public Task ApplyAsync(PaymentWebhookInbox webhook) =>
             new PaymentMethodSetupWebhookStateTransitionService(

--- a/server/XUnitTest/Payment/PaymentRefundPreflightServiceTests.cs
+++ b/server/XUnitTest/Payment/PaymentRefundPreflightServiceTests.cs
@@ -114,6 +114,21 @@ public sealed class PaymentRefundPreflightServiceTests
         result.Failure.ErrorCode.Should().Be("payment_not_found");
     }
 
+    /// <summary>
+    /// A card setup settles at Authorized with a provider reference, so it passes every check a
+    /// refund makes without any money ever having been sent to return.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_CardSetup_IsNotRefundable()
+    {
+        var payment = RefundablePayment();
+        payment.PaymentFlow = PaymentFlows.PaymentMethodSetup;
+        _refunds.Setup(r => r.GetPaymentAsync("tenant", _paymentId, It.IsAny<CancellationToken>())).ReturnsAsync(payment);
+
+        var result = await RunAsync();
+        result.Failure!.ErrorCode.Should().Be("payment_not_refundable");
+    }
+
     [Fact]
     public async Task ExecuteAsync_PaymentNotRefundable_ReturnsConflict()
     {

--- a/server/XUnitTest/Payment/PaymentWebhookStateTransitionServiceTests.cs
+++ b/server/XUnitTest/Payment/PaymentWebhookStateTransitionServiceTests.cs
@@ -15,6 +15,7 @@ public sealed class PaymentWebhookStateTransitionServiceTests
     private readonly Mock<ICurrencyMinorUnitResolver> _minorUnits = new();
     private readonly Mock<IPaymentRefundWebhookStateTransitionService> _refundTransitions = new();
     private readonly Mock<IPaymentCaptureWebhookStateTransitionService> _captureTransitions = new();
+    private readonly Mock<IPaymentMethodSetupWebhookStateTransitionService> _setupTransitions = new();
 
     private PaymentWebhookStateTransitionService CreateService() => new(
         _payments.Object,
@@ -23,6 +24,7 @@ public sealed class PaymentWebhookStateTransitionServiceTests
         _minorUnits.Object,
         _refundTransitions.Object,
         _captureTransitions.Object,
+        _setupTransitions.Object,
         NullLogger<PaymentWebhookStateTransitionService>.Instance);
 
     private static PaymentWebhookInbox Webhook(

--- a/server/XUnitTest/Payment/ProviderConformanceTests.cs
+++ b/server/XUnitTest/Payment/ProviderConformanceTests.cs
@@ -51,7 +51,13 @@ public sealed class ProviderConformanceTests
     {
         [typeof(IStoredPaymentMethodDetailProviderGateway)] =
             "Adyen reports card brand and last four on the webhook that stores the card; " +
-            "Stripe does not, so only Stripe needs a read-back."
+            "Stripe does not, so only Stripe needs a read-back.",
+
+        [typeof(IPaymentMethodSetupRequestFactory)] =
+            "Collecting a card without charging it needs a provider operation for exactly that. " +
+            "Stripe has one; a provider without it can still take every payment, and asking it " +
+            "for a zero-amount charge instead is the thing this capability exists to avoid. " +
+            "Callers are told the provider cannot do it rather than being given a broken session."
     };
 
     private static readonly IPaymentProviderCatalog Catalog = new PaymentProviderCatalog();

--- a/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
@@ -32,6 +32,7 @@ public sealed class CalendarAnnualTrialAndCancellationTests
 
     private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
     private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
     private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
     private readonly Mock<IBillingAccountRepository> _accounts = new();
     private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
@@ -336,6 +337,7 @@ public sealed class CalendarAnnualTrialAndCancellationTests
     /// </summary>
     private SubscriptionCancellationService Cancellation() => new(
         _subscriptions.Object,
+        _links.Object,
         _contextResolver.Object,
         new SubscriptionOutboxEventFactory(),
         new SubscriptionResponseMapper(_time),

--- a/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
@@ -34,6 +34,26 @@ public sealed class PlanResponseMapperTests
         response.OrganizationId.Should().BeNull();
     }
 
+    /// <summary>
+    /// The console offers this and then has to show it again on the plan it built. A response
+    /// that dropped it would read as the setting not having been saved.
+    /// </summary>
+    [Fact]
+    public void A_plan_that_demands_a_card_up_front_says_so()
+    {
+        var plan = Plan("organization-1");
+        plan.RequirePaymentMethodUpfront = true;
+
+        _mapper.ToResponse(plan, []).RequirePaymentMethodUpfront.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_plan_that_says_nothing_about_a_card_reports_that_it_does_not_need_one()
+    {
+        _mapper.ToResponse(Plan("organization-1"), []).RequirePaymentMethodUpfront
+            .Should().BeFalse("which is what every plan authored before this existed meant");
+    }
+
     [Fact]
     public void A_meter_carries_the_thresholds_it_will_notify_on()
     {

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -556,6 +556,7 @@ public sealed class SubscriptionActivationProcessorTests
     {
         GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
         GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
 
         var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
 
@@ -563,6 +564,22 @@ public sealed class SubscriptionActivationProcessorTests
         _transition!.NewStatus.Should().Be(SubscriptionStatus.Active);
         _transition.InitialPaymentDetailId.Should().BeNull(
             "no money moved, so there is no opening charge and no invoice behind one");
+    }
+
+    [Fact]
+    public async Task A_confirmed_setup_waits_until_its_card_is_usable_for_renewal()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(0);
+        _transition.Should().BeNull(
+            "provider confirmation without a durable stored method must not grant access");
+        _links.Verify(repository => repository.TrySettleAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SubscriptionPaymentLinkState>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -357,7 +357,8 @@ public sealed class SubscriptionActivationProcessorTests
         _transition!.NewStatus.Should().Be(SubscriptionStatus.IncompleteExpired);
     }
 
-    private void GivenDueLink() =>
+    private void GivenDueLink(
+        SubscriptionPaymentPurpose purpose = SubscriptionPaymentPurpose.InitialCharge) =>
         _links
             .Setup(repository => repository.ListDueAsync(
                 TenantId,
@@ -373,6 +374,7 @@ public sealed class SubscriptionActivationProcessorTests
                     OrganizationId = "org-1",
                     SubscriptionId = "sub-1",
                     PaymentDetailId = "pay-1",
+                    Purpose = purpose,
                     CorrelationId = "corr-1"
                 }
             ]);
@@ -543,6 +545,62 @@ public sealed class SubscriptionActivationProcessorTests
 
                 return subscription;
             });
+
+    /// <summary>
+    /// A card setup settles into the same confirmed status a charge does, because that status is
+    /// how the provider says a thing it was asked to do happened. What must not follow is the
+    /// subscription reporting a zero-value record as the charge that opened it.
+    /// </summary>
+    [Fact]
+    public async Task A_stored_card_activates_without_being_recorded_as_the_opening_charge()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Active);
+        _transition.InitialPaymentDetailId.Should().BeNull(
+            "no money moved, so there is no opening charge and no invoice behind one");
+    }
+
+    /// <summary>
+    /// A declined charge ends the subscription — the money was refused. A card form that expired
+    /// refused nothing, and making somebody cancel and start over for it would be a penalty for
+    /// leaving a tab open.
+    /// </summary>
+    [Fact]
+    public async Task A_failed_card_setup_leaves_the_subscription_open_for_another_attempt()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Refused, webhookConfirmed: true);
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition.Should().BeNull(
+            "the subscription stays Incomplete; only the attempt is over");
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                TenantId,
+                "link-1",
+                SubscriptionPaymentLinkState.Abandoned,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the sweep has nothing left to wait for on this one");
+    }
+
+    /// <summary>The control: a declined charge still ends it.</summary>
+    [Fact]
+    public async Task A_declined_opening_charge_still_expires_the_subscription()
+    {
+        GivenDueLink();
+        GivenPayment(PaymentStatuses.Refused, webhookConfirmed: true);
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.IncompleteExpired);
+    }
 
     private SubscriptionActivationProcessor Processor() => new(
         _links.Object,

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -22,6 +22,7 @@ public sealed class SubscriptionCancellationServiceTests
     private const string OrganizationId = "org-1";
 
     private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
     private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
     private readonly Mock<IEntitlementSnapshotCache> _cache = new();
     private readonly ControlledTimeProvider _time =
@@ -236,8 +237,57 @@ public sealed class SubscriptionCancellationServiceTests
             "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
+    /// <summary>
+    /// The tab is still open. Someone can finish a card form after cancelling, and the provider
+    /// will duly report a stored card against a subscription that no longer wants one.
+    /// </summary>
+    [Fact]
+    public async Task Cancelling_before_activation_closes_the_attempt_still_waiting_on_the_provider()
+    {
+        _subscription!.Status = SubscriptionStatus.Incomplete;
+        _links
+            .Setup(repository => repository.FindBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionPaymentLink
+            {
+                ItemId = "link-1",
+                TenantId = TenantId,
+                SubscriptionId = "sub-1",
+                Purpose = SubscriptionPaymentPurpose.PaymentMethodSetup,
+                State = SubscriptionPaymentLinkState.Pending
+            });
+
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                TenantId,
+                "link-1",
+                SubscriptionPaymentLinkState.Abandoned,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Cancelling_a_live_subscription_leaves_its_payment_links_alone()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionPaymentLinkState>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a renewal's link belongs to a charge this cancellation has nothing to say about");
+    }
+
     private SubscriptionCancellationService Service() => new(
         _subscriptions.Object,
+        _links.Object,
         _contextResolver.Object,
         new SubscriptionOutboxEventFactory(),
         new SubscriptionResponseMapper(),

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -31,6 +31,7 @@ public sealed class SubscriptionCheckoutServiceTests
     private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
     private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
     private readonly Mock<IPaymentService> _payments = new();
+    private readonly Mock<IPaymentMethodSetupService> _paymentMethodSetups = new();
     private readonly Mock<IPaymentRepository> _paymentRepository = new();
     private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
 
@@ -423,6 +424,7 @@ public sealed class SubscriptionCheckoutServiceTests
         new SubscriptionOutboxEventFactory(),
         new SubscriptionResponseMapper(),
         _payments.Object,
+        _paymentMethodSetups.Object,
         _paymentRepository.Object,
         _currency.Object,
         NullLogger<SubscriptionCheckoutService>.Instance);

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -66,6 +66,22 @@ public sealed class SubscriptionCreationServiceTests
         _created!.CurrencyCode.Should().Be("CHF");
     }
 
+    /// <summary>
+    /// Copied onto the subscription like every other term, so a later edit to the catalogue
+    /// cannot rewrite what this subscriber was asked for at signup — and so checkout can decide
+    /// whether to collect a card from the subscription alone.
+    /// </summary>
+    [Fact]
+    public async Task Whether_a_card_was_demanded_up_front_is_snapshotted_with_the_plan()
+    {
+        _plan.RequirePaymentMethodUpfront = true;
+
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.Plan.RequirePaymentMethodUpfront.Should().BeTrue();
+    }
+
     [Fact]
     public async Task The_organization_comes_from_the_caller_not_the_request()
     {

--- a/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
+++ b/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
@@ -1,0 +1,445 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Responses;
+using Payment.DomainService.Services;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Signing up for something that costs nothing today, on a plan that still wants a card.
+/// </summary>
+/// <remarks>
+/// The two questions this separates — is anything payable, and must a card be on file — used to
+/// have one answer, because the only way to hold a card was to charge it. So the interesting
+/// cases here are all about a zero opening amount: whether it starts the subscription outright,
+/// sends the subscriber to a card form, or does neither because the plan said nothing.
+/// </remarks>
+public sealed class ZeroAmountCardSetupTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string SetupUrl = "https://checkout.stripe.com/setup";
+
+    private readonly Mock<ISubscriptionCreationService> _creation = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<IPaymentService> _payments = new();
+    private readonly Mock<IPaymentMethodSetupService> _setups = new();
+    private readonly Mock<IPaymentRepository> _paymentRepository = new();
+    private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
+
+    private readonly SubscriptionDetail _subscription = FreeSubscription();
+
+    private CreatePaymentMethodSetupRequest? _setupRequest;
+    private string? _setupKey;
+    private SubscriptionPaymentLink? _createdLink;
+    private SubscriptionTransition? _transition;
+
+    public ZeroAmountCardSetupTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _creation
+            .Setup(service => service.CreateAsync(
+                It.IsAny<CreateSubscriptionRequest>(),
+                It.IsAny<SubscriptionContext>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => SubscriptionOperationResult<SubscriptionDetail>.Success(
+                _subscription,
+                "corr-1"));
+
+        _setups
+            .Setup(service => service.CreateSetupAsync(
+                It.IsAny<CreatePaymentMethodSetupRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<CreatePaymentMethodSetupRequest, string, string, CancellationToken>(
+                (request, key, _, _) =>
+                {
+                    _setupRequest = request;
+                    _setupKey = key;
+                })
+            .ReturnsAsync(PaymentOperationResult.Success(
+                new PaymentResponse
+                {
+                    PaymentDetailId = "setup-1",
+                    RedirectUrl = SetupUrl
+                },
+                "corr-1"));
+
+        _links
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionPaymentLink>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionPaymentLink, CancellationToken>(
+                (link, _) => _createdLink = link)
+            .ReturnsAsync(true);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, transition, _) => _transition = transition)
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task A_free_plan_that_asks_for_nothing_starts_at_once()
+    {
+        var result = await Subscribe();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.CheckoutUrl.Should().BeNull();
+        _subscription.Status.Should().Be(SubscriptionStatus.Active);
+        _setups.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task A_free_plan_that_wants_a_card_sends_the_subscriber_to_collect_one()
+    {
+        _subscription.Plan.RequirePaymentMethodUpfront = true;
+
+        var result = await Subscribe();
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.CheckoutUrl.Should().Be(SetupUrl);
+        result.Value.Status.Should().Be(nameof(SubscriptionStatus.Incomplete),
+            "a card that has not been stored yet grants nothing");
+        _transition.Should().BeNull(
+            "activation waits for the provider, exactly as it does when money is taken");
+    }
+
+    /// <summary>
+    /// A fully discounted opening period is a zero amount like any other, and follows whatever the
+    /// plan configured rather than a rule of its own.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task A_fully_discounted_first_period_follows_the_plan(bool requireCard)
+    {
+        _subscription.Price.UnitAmountMinor = 8_900;
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "founders",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 10_000
+        };
+        _subscription.InitialChargeAmountMinor = 0;
+        _subscription.Plan.RequirePaymentMethodUpfront = requireCard;
+
+        var result = await Subscribe();
+
+        result.Value!.CheckoutUrl.Should().Be(requireCard ? SetupUrl : null);
+    }
+
+    /// <summary>
+    /// The setting a trial has always had, honoured without charging for a period to honour it.
+    /// </summary>
+    [Fact]
+    public async Task A_trial_that_requires_a_card_collects_one_without_taking_money()
+    {
+        _subscription.Trial = Trial(requiresPaymentMethod: true);
+
+        var result = await Subscribe();
+
+        result.Value!.CheckoutUrl.Should().Be(SetupUrl);
+        _payments.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task A_card_free_trial_still_starts_without_one()
+    {
+        _subscription.Trial = Trial(requiresPaymentMethod: false);
+
+        var result = await Subscribe();
+
+        result.Value!.CheckoutUrl.Should().BeNull();
+        _subscription.Status.Should().Be(SubscriptionStatus.Trialing);
+    }
+
+    /// <summary>
+    /// The combination the setting was asked for: free until the trial ends, with a card on file
+    /// so the charge that ends it has something to bill.
+    /// </summary>
+    [Fact]
+    public async Task A_card_free_trial_on_a_plan_that_demands_a_card_collects_one()
+    {
+        _subscription.Trial = Trial(requiresPaymentMethod: false);
+        _subscription.Plan.RequirePaymentMethodUpfront = true;
+
+        var result = await Subscribe();
+
+        result.Value!.CheckoutUrl.Should().Be(SetupUrl);
+    }
+
+    [Fact]
+    public async Task The_setup_is_linked_to_the_subscription_as_a_setup_rather_than_a_charge()
+    {
+        _subscription.Plan.RequirePaymentMethodUpfront = true;
+
+        await Subscribe();
+
+        _createdLink!.Purpose.Should().Be(SubscriptionPaymentPurpose.PaymentMethodSetup,
+            "the sweep treats a failed setup differently from a declined charge, and the " +
+            "purpose is how it tells them apart");
+        _createdLink.PaymentDetailId.Should().Be("setup-1");
+        _setupRequest!.CurrencyCode.Should().Be("CHF");
+        _setupRequest.CustomerOrganizationId.Should().Be(OrganizationId);
+        _setupKey.Should().Be(
+            SubscriptionConstants.PaymentMethodSetupKeyFor(_subscription.ItemId, 0));
+    }
+
+    [Fact]
+    public async Task A_provider_that_cannot_collect_a_card_leaves_the_subscription_recoverable()
+    {
+        _subscription.Plan.RequirePaymentMethodUpfront = true;
+        _setups
+            .Setup(service => service.CreateSetupAsync(
+                It.IsAny<CreatePaymentMethodSetupRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PaymentOperationResult.Failure(
+                PaymentFailureKind.Validation,
+                "payment_method_setup_unsupported",
+                "This payment provider cannot store a card without charging it.",
+                "corr-1"));
+
+        var result = await Subscribe();
+
+        result.ErrorCode.Should().Be("payment_method_setup_unsupported");
+        _transition.Should().BeNull(
+            "nothing was granted and nothing was ended: no money moved, so the subscription " +
+            "stays where it is and another attempt is free to succeed");
+    }
+
+    [Fact]
+    public async Task A_live_setup_session_is_returned_again_rather_than_replaced()
+    {
+        ArrangeReturningSubscriber(expired: false);
+
+        var result = await Subscribe(MatchingRequest());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.CheckoutUrl.Should().Be("https://checkout.stripe.com/open");
+        _setups.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// An expired card form is not a dead end. Nothing was paid, so there is nothing to reconcile
+    /// and no reason to make somebody cancel and start over — but the session itself cannot be
+    /// reopened, so the retry has to be a new one under a new key.
+    /// </summary>
+    [Fact]
+    public async Task An_expired_setup_session_is_replaced_by_a_fresh_attempt()
+    {
+        ArrangeReturningSubscriber(expired: true);
+        _subscriptions
+            .Setup(repository => repository.TryBumpPaymentMethodSetupAttemptAsync(
+                TenantId, _subscription.ItemId, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Subscribe(MatchingRequest());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.CheckoutUrl.Should().Be(SetupUrl);
+        _setupKey.Should().Be(
+            SubscriptionConstants.PaymentMethodSetupKeyFor(_subscription.ItemId, 1),
+            "the provider would replay the expired session under the key that opened it");
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                TenantId,
+                "link-1",
+                SubscriptionPaymentLinkState.Abandoned,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a pending link is what the activation sweep keeps coming back to");
+    }
+
+    [Fact]
+    public async Task Two_retries_at_once_produce_one_new_session()
+    {
+        ArrangeReturningSubscriber(expired: true);
+        _subscriptions
+            .Setup(repository => repository.TryBumpPaymentMethodSetupAttemptAsync(
+                TenantId, _subscription.ItemId, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Subscribe(MatchingRequest());
+
+        result.ErrorCode.Should().Be("subscription_checkout_pending");
+        _setups.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// The rule an expired *charge* keeps: raising a second one is how the same money gets taken
+    /// twice, so the caller is told to finish or cancel the first.
+    /// </summary>
+    [Fact]
+    public async Task An_expired_charge_is_still_a_conflict()
+    {
+        ArrangeReturningSubscriber(expired: true, purpose: SubscriptionPaymentPurpose.InitialCharge);
+
+        var result = await Subscribe(MatchingRequest());
+
+        result.ErrorCode.Should().Be("subscription_checkout_pending");
+        _setups.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task A_pending_setup_is_reported_by_the_current_subscription_endpoint()
+    {
+        ArrangeReturningSubscriber(expired: false);
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Incomplete));
+        result.Value.CheckoutUrl.Should().Be("https://checkout.stripe.com/open");
+    }
+
+    private Task<SubscriptionOperationResult<global::Subscription.DomainService.Responses.SubscriptionResponse>> Subscribe(
+        CreateSubscriptionRequest? request = null) =>
+        Service().SubscribeAsync(
+            request ?? new CreateSubscriptionRequest(),
+            "corr-1",
+            CancellationToken.None);
+
+    /// <summary>
+    /// A second signup request from an organization that already holds an incomplete attempt —
+    /// the shape a browser produces when somebody reloads the page.
+    /// </summary>
+    private void ArrangeReturningSubscriber(
+        bool expired,
+        SubscriptionPaymentPurpose purpose = SubscriptionPaymentPurpose.PaymentMethodSetup)
+    {
+        _subscription.Plan.RequirePaymentMethodUpfront = true;
+
+        _creation
+            .Setup(service => service.CreateAsync(
+                It.IsAny<CreateSubscriptionRequest>(),
+                It.IsAny<SubscriptionContext>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<SubscriptionDetail>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_already_active",
+                "This organization already has a live subscription.",
+                "corr-1"));
+
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_subscription);
+
+        _links
+            .Setup(repository => repository.FindBySubscriptionAsync(
+                TenantId, _subscription.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionPaymentLink
+            {
+                ItemId = "link-1",
+                TenantId = TenantId,
+                SubscriptionId = _subscription.ItemId,
+                PaymentDetailId = "setup-open",
+                Purpose = purpose,
+                State = SubscriptionPaymentLinkState.Pending
+            });
+
+        _paymentRepository
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "setup-open", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "setup-open",
+                RedirectUrl = "https://checkout.stripe.com/open",
+                ExpirationDate = expired
+                    ? DateTime.UtcNow.AddHours(-1)
+                    : DateTime.UtcNow.AddHours(1)
+            });
+
+        _links
+            .Setup(repository => repository.TrySettleAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionPaymentLinkState>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
+    private CreateSubscriptionRequest MatchingRequest() => new()
+    {
+        PlanCode = _subscription.Plan.Code,
+        PriceId = _subscription.Price.PriceId,
+        TimeZoneId = _subscription.FeeSchedule.TimeZoneId
+    };
+
+    private SubscriptionCheckoutService Service() => new(
+        _creation.Object,
+        _subscriptions.Object,
+        _links.Object,
+        _contextResolver.Object,
+        new SubscriptionOutboxEventFactory(),
+        new SubscriptionResponseMapper(),
+        _payments.Object,
+        _setups.Object,
+        _paymentRepository.Object,
+        _currency.Object,
+        NullLogger<SubscriptionCheckoutService>.Instance);
+
+    private static TrialTerms Trial(bool requiresPaymentMethod) => new()
+    {
+        StartsAtUtc = DateTime.UtcNow,
+        EndsAtUtc = DateTime.UtcNow.AddDays(14),
+        RequiresPaymentMethod = requiresPaymentMethod
+    };
+
+    /// <summary>A plan priced at nothing, which is the only case any of this is about.</summary>
+    private static SubscriptionDetail FreeSubscription()
+    {
+        var id = Guid.NewGuid().ToString();
+
+        return new SubscriptionDetail
+        {
+            ItemId = id,
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            Status = SubscriptionStatus.Incomplete,
+            CurrencyCode = "CHF",
+            OrderId = SubscriptionConstants.OrderIdFor(id),
+            Plan = new PlanSnapshot { Code = "community", DisplayName = "Community" },
+            Price = new PriceSnapshot
+            {
+                PriceId = "price-free",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 0
+            },
+            FeeSchedule = new BillingSchedule { TimeZoneId = "UTC" },
+            InitialChargeAmountMinor = 0
+        };
+    }
+}

--- a/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
+++ b/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
@@ -321,6 +321,38 @@ public sealed class ZeroAmountCardSetupTests
 
         result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Incomplete));
         result.Value.CheckoutUrl.Should().Be("https://checkout.stripe.com/open");
+        result.Value.PendingCheckout!.State.Should().Be("Pending");
+        result.Value.PendingCheckout.Purpose.Should().Be("PaymentMethodSetup");
+    }
+
+    [Fact]
+    public async Task A_failed_setup_is_explicit_on_the_current_subscription_endpoint()
+    {
+        ArrangeReturningSubscriber(expired: false, paymentStatus: PaymentStatuses.Refused);
+        _subscriptions.Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.Value!.PendingCheckout!.State.Should().Be("Failed");
+        result.Value.PendingCheckout.ErrorCode.Should().Be("payment_method_setup_failed");
+        result.Value.CheckoutUrl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task An_expired_setup_is_explicit_on_the_current_subscription_endpoint()
+    {
+        ArrangeReturningSubscriber(expired: true);
+        _subscriptions.Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.Value!.PendingCheckout!.State.Should().Be("Expired");
+        result.Value.PendingCheckout.ErrorCode.Should().Be("payment_method_setup_expired");
+        result.Value.CheckoutUrl.Should().BeNull();
     }
 
     private Task<SubscriptionOperationResult<global::Subscription.DomainService.Responses.SubscriptionResponse>> Subscribe(
@@ -336,7 +368,8 @@ public sealed class ZeroAmountCardSetupTests
     /// </summary>
     private void ArrangeReturningSubscriber(
         bool expired,
-        SubscriptionPaymentPurpose purpose = SubscriptionPaymentPurpose.PaymentMethodSetup)
+        SubscriptionPaymentPurpose purpose = SubscriptionPaymentPurpose.PaymentMethodSetup,
+        string paymentStatus = PaymentStatuses.Processing)
     {
         _subscription.Plan.RequirePaymentMethodUpfront = true;
 
@@ -376,6 +409,7 @@ public sealed class ZeroAmountCardSetupTests
             .ReturnsAsync(new PaymentDetail
             {
                 ItemId = "setup-open",
+                PaymentStatus = paymentStatus,
                 RedirectUrl = "https://checkout.stripe.com/open",
                 ExpirationDate = expired
                     ? DateTime.UtcNow.AddHours(-1)


### PR DESCRIPTION
## What

A zero opening amount and a subscriber with no card on file used to be the same thing, because the only way to hold a card was to charge it. `requirePaymentMethodUpfront` separates them.

Signup now forks three ways:

| Opening amount | Card required | What happens |
| --- | --- | --- |
| more than zero | — | the existing payment checkout |
| zero | no | activates immediately, no `checkoutUrl` |
| zero | yes | a **card-setup** checkout; `Incomplete` until the card is stored |

A card is required when the amount is zero and either the plan sets `requirePaymentMethodUpfront`, or the subscription starts on a trial whose `trialRequiresPaymentMethod` is set. Both together is the combination the setting was asked for: genuinely free until the trial ends, with a card on file so the charge that ends it has something to bill.

## How

Stripe Checkout in `setup` mode — not a one-cent charge, which lands on a statement and has to be refunded, and not a zero-value PaymentIntent, which Stripe rejects. The SetupIntent it produces carries the off-session mandate the first renewal relies on.

`IPaymentMethodSetupService` is a near-twin of `HostedCheckoutInitiationService` and deliberately not a branch inside it: everything that path does about money — the preflight that refuses a zero amount, the currency conversion, the capture mode, the line item — is exactly what must not happen here. What it does share is the provider machinery, so a setup session is leased, recovered, resumed and confirmed by the code that already does those things.

It is internal on purpose. Collecting a card costs nothing and so has none of the natural limits a charge has, so `CreatePaymentMethodSetupRequest` is never bound from an HTTP body and no endpoint exposes it.

## The record it leaves is not a payment

A `PaymentDetail` under `PAYMENT_METHOD_SETUP` with a zero amount, because everything that tracks a hosted session already hangs off one: the initiation lease, the redirect URL, the webhook route, the stored-card write.

The hazard throughout is that it looks enough like a payment to be mistaken for one — it settles at `Authorized`, it carries a provider reference, it lives in the payments collection. So every reader that counts money excludes the flow explicitly: payment listings, refunds, captures. Invoice history already required `SUBSCRIPTION_INVOICE`, so it was structurally excluded. Activation does not record it as the opening charge — `InitialPaymentDetailId` stays null, because there is no charge and no invoice behind one. It never captures, so nothing that sums captured money picks it up.

## Two things behave differently from a charge

- **Failure is not fatal.** A declined charge ends the subscription; nothing was refused here, so it stays `Incomplete` and another attempt is free to succeed. The staleness sweep still expires it if nobody comes back.
- **An expired session is replaced.** A hosted session cannot be reopened and the provider would replay it under the key that opened it, so a retry mints a new one. `PaymentMethodSetupKeyFor` carries an attempt number, bumped by a compare-and-set on the number itself so two tabs retrying at once produce one session and the loser is told so. An expired *charge* is still a conflict: raising a second one is how the same money gets taken twice.

Cancelling while a setup is outstanding settles its link, so finishing the card form afterwards cannot start a subscription somebody has cancelled.

## One change with wider reach than the feature

`checkout.session.expired` and `payment_intent.canceled` normalise to `WebhookIntent.Cancelled`, which the transition switch dropped through `default` and ignored. They now reach the setup handler, which returns without writing anything for any other flow — so an abandoned checkout behaves exactly as it always has. Making it do otherwise is a decision about abandoned baskets, not one for a card-setup handler. An unroutable expiry is logged and dropped rather than retried to the dead-letter queue, for the same reason. Both are covered by tests.

## Also

- `requirePaymentMethodUpfront` runs end to end: plan entity, request, response, Mongo update, `PlanSnapshot` (so a later catalogue edit cannot rewrite what a subscriber was asked for), and the builder UI beside the trial's own card question.
- `ProviderConformanceTests` lists `IPaymentMethodSetupRequestFactory` as optional by design — a provider without one can still take every payment, and callers are told it cannot store a card rather than being handed a broken session.
- Guide and both module READMEs updated.

## Not in scope

The plan notes a zero-total period may still produce a zero-value application invoice if the financial-document rules require it. That comes from the period, not from the card, and nothing here changes it.

`customerEmail` is not passed through to prefill the Stripe form — the paid checkout path does not either, and matching it seemed better than diverging in one branch.

## Tests

`ZeroAmountCardSetupTests` (14) covers the three-way fork, a fully discounted first period under both settings, both trial shapes, the link purpose and key, resume, retry-after-expiry, the concurrent-retry gate, and that an expired charge is still a conflict. `PaymentMethodSetupTests` (10) covers the Stripe form shape, metadata reaching the SetupIntent, normalisation of both setup events, and the transition service including a late expiry and a foreign flow. Plus activation, cancellation, refund/capture preflight, plan mapping, and client mapping and builder tests.

- Server: 2912 tests. **4 failures, all pre-existing** (`SubscriptionSimulationGuard` / permission), unchanged from `dev`. 150 `XUnitTest.Integration.*` failures are the usual Mongo-less environment.
- Client: 258 passed, typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
