### PR TITLE
fix(subscription): keep the organization scope across billing screens

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/billing-profile-incomplete-notice.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/billing-profile-incomplete-notice.tsx
@@ -1,0 +1,79 @@
+import { AlertCircle, ArrowRight } from "lucide-react";
+import { Link } from "react-router";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import { useSubscriptionLink } from "../../subscription/hooks/use-subscription-link";
+import type { BillingProfileGap } from "../../subscription/utilities/subscription-api-failure";
+import { describeMissingProfileFields } from "../../subscription/utilities/financial-document-format";
+
+/**
+ * A refusal the reader can act on: what is missing, and the screen that collects it.
+ *
+ * This replaces printing the server's error envelope, which is what the dialogs used to do — a
+ * subscriber saw a field list in JSON and no indication that the fix was one page away, or which
+ * organization it was one page away for.
+ *
+ * The two halves are separated because they are somebody else's job each. The subscriber's own
+ * details sit on their billing profile; a missing seller identity is the tenant's own configuration,
+ * and a subscriber sent to fix that would be looking for a form that is not theirs.
+ */
+export const BillingProfileIncompleteNotice = ({
+  gap,
+  organizationId,
+}: {
+  gap: BillingProfileGap;
+  /**
+   * The organization the refused operation was for, so the link lands on the profile that was
+   * actually refused rather than on whichever one the URL happens to be showing.
+   */
+  organizationId: string | undefined;
+}) => {
+  const subscriptionLink = useSubscriptionLink();
+
+  return (
+    <Card
+      className="flex flex-col gap-3 border-amber-300 bg-amber-50 p-4"
+      data-testid="billing-profile-incomplete"
+    >
+      <div className="flex items-start gap-3">
+        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+        <div className="space-y-1 text-sm">
+          <p className="font-medium">This organization cannot be invoiced yet.</p>
+          <p className="text-muted-foreground">
+            A paid subscription is refused before anything is charged, because the invoice it would
+            owe has to name who it is addressed to.
+          </p>
+        </div>
+      </div>
+
+      {gap.subscriberFields.length > 0 && (
+        <div className="space-y-2 pl-8 text-sm">
+          <p className="text-muted-foreground" data-testid="billing-profile-missing">
+            {describeMissingProfileFields(gap.subscriberFields)}
+          </p>
+          <Button asChild size="sm" variant="outline">
+            <Link to={subscriptionLink("billing-profile", organizationId)}>
+              Complete the billing profile
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+      )}
+
+      {gap.merchantMissing && (
+        <div className="space-y-2 pl-8 text-sm">
+          <p className="text-muted-foreground" data-testid="merchant-profile-missing">
+            This tenant has not named itself as the seller, and an invoice has to state who issued
+            it. That is set once, for the whole tenant, and not per organization.
+          </p>
+          <Button asChild size="sm" variant="outline">
+            <Link to={subscriptionLink("merchant-profile", null)}>
+              Name the seller
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -22,6 +22,12 @@ import {
 import { toast } from "@/hooks/use-toast";
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
 import { formatPrice } from "../../subscription/utilities/subscription-format";
+import {
+  billingProfileGapOf,
+  subscriptionApiFailure,
+  type BillingProfileGap,
+} from "../../subscription/utilities/subscription-api-failure";
+import { BillingProfileIncompleteNotice } from "./billing-profile-incomplete-notice";
 import { useChangeSubscriptionPlan } from "../hooks/use-change-subscription-plan";
 import type {
   SimulatedSubscription,
@@ -50,6 +56,7 @@ export const ChangePlanDialog = ({
   const [priceId, setPriceId] = useState("");
   const [quantities, setQuantities] = useState<Record<string, string>>({});
   const [formError, setFormError] = useState<string | null>(null);
+  const [profileGap, setProfileGap] = useState<BillingProfileGap | null>(null);
 
   const targetPlan = useMemo(
     () => plans.find((plan) => plan.planId === targetPlanId),
@@ -80,6 +87,7 @@ export const ChangePlanDialog = ({
 
   const submit = async () => {
     setFormError(null);
+    setProfileGap(null);
 
     if (!targetPlan || !priceId) {
       setFormError("Choose a target plan and price.");
@@ -130,7 +138,18 @@ export const ChangePlanDialog = ({
 
       onOpenChange(false);
     } catch (error) {
-      setFormError(error instanceof Error ? error.message : "The plan could not be changed.");
+      // A plan change moves money too, so it is refused for the same incomplete profile — and the
+      // fix is the same page. See the subscribe dialog.
+      const failure = subscriptionApiFailure(error);
+      const gap = billingProfileGapOf(failure);
+
+      setProfileGap(gap);
+      setFormError(
+        gap
+          ? null
+          : failure?.message ||
+              (error instanceof Error ? error.message : "The plan could not be changed."),
+      );
     }
   };
 
@@ -225,6 +244,10 @@ export const ChangePlanDialog = ({
             The change takes effect immediately and starts a full target billing period — an
             upgrade may charge immediately, a downgrade becomes credit toward future renewals.
           </p>
+
+          {profileGap && (
+            <BillingProfileIncompleteNotice gap={profileGap} organizationId={organizationId} />
+          )}
 
           {formError && <p className="text-sm text-destructive">{formError}</p>}
         </div>

--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+
+const toast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({ toast: (...args: unknown[]) => toast(...args) }));
+
+const mutateAsync = vi.fn();
+vi.mock("../hooks/use-subscribe-to-plan", () => ({
+  useSubscribeToPlan: () => ({ mutateAsync, isPending: false }),
+}));
+
+import { SubscribeDialog } from "./subscribe-dialog";
+
+const plan = {
+  planId: "plan-1",
+  code: "professional",
+  displayName: "Professional",
+  prices: [
+    {
+      priceId: "price-1",
+      currencyCode: "CHF",
+      unitAmountMinor: 4_500,
+      interval: "Month",
+      intervalCount: 1,
+      displayPriceNote: null,
+    },
+  ],
+  quantityItems: [],
+} as unknown as SubscriptionPlan;
+
+/**
+ * Mounted on the route the shell actually serves, because the notice links to a sibling screen and
+ * the link is only correct if the project segment and the organization are both on it.
+ */
+const renderDialog = (organizationId: string | undefined = "org-1") =>
+  render(
+    <MemoryRouter
+      initialEntries={[
+        `/app/project-1/subscription/simulation${
+          organizationId ? `?organizationId=${organizationId}` : ""
+        }`,
+      ]}
+    >
+      <Routes>
+        <Route
+          path="/app/:itemId/subscription/simulation"
+          element={
+            <SubscribeDialog
+              plan={plan}
+              organizationId={organizationId}
+              open
+              onOpenChange={() => {}}
+              onSubscribed={() => {}}
+            />
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+/** The refusal as it reaches the client: a 400, whose body is the API envelope. */
+const profileRefusal = (fields: string[]) => ({
+  status: 400,
+  errors: {
+    success: false,
+    data: null,
+    error: {
+      code: "subscription_billing_profile_incomplete",
+      message: "This organization's billing profile is missing details an invoice must carry.",
+      fields: { BillingProfile: fields },
+    },
+  },
+});
+
+describe("subscribe dialog", () => {
+  it("does not ask for a billing name or email", () => {
+    renderDialog();
+
+    // They looked like the details an invoice needs and satisfied none of them: the server reads the
+    // organization's billing profile, and these went to the billing account. Two forms for one
+    // answer, free to disagree, and the one on screen was not the one that counted.
+    expect(screen.queryByLabelText(/Billing email/)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Billing name/)).not.toBeInTheDocument();
+  });
+
+  it("sends no contact fields, leaving the server to use the saved profile", async () => {
+    mutateAsync.mockResolvedValueOnce({ status: "Active", checkoutUrl: null });
+
+    renderDialog();
+    await userEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+
+    const [request] = mutateAsync.mock.calls.at(-1)!;
+    expect(request).not.toHaveProperty("billingEmail");
+    expect(request).not.toHaveProperty("billingName");
+  });
+
+  it("turns an incomplete profile into the page that fixes it, for that organization", async () => {
+    mutateAsync.mockRejectedValueOnce(profileRefusal(["LegalName", "BillingContactEmail"]));
+
+    renderDialog("org-2");
+    await userEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    const notice = await screen.findByTestId("billing-profile-incomplete");
+    expect(notice).toBeInTheDocument();
+    expect(screen.getByTestId("billing-profile-missing")).toHaveTextContent(
+      "legal name and billing contact email",
+    );
+
+    // The organization the refusal was about, not whichever one the URL is showing: fixing the
+    // wrong profile leaves the retry refused for the same reason.
+    expect(screen.getByRole("link", { name: /Complete the billing profile/ })).toHaveAttribute(
+      "href",
+      "/app/project-1/subscription/billing-profile?organizationId=org-2",
+    );
+  });
+
+  it("sends a missing seller identity to the tenant's own page instead", async () => {
+    mutateAsync.mockRejectedValueOnce(profileRefusal(["merchantLegalName"]));
+
+    renderDialog();
+    await userEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    // The seller is the tenant, so this link carries no organization at all — and the subscriber's
+    // own fields are not listed, because none of them are missing.
+    expect(await screen.findByRole("link", { name: /Name the seller/ })).toHaveAttribute(
+      "href",
+      "/app/project-1/subscription/merchant-profile",
+    );
+    expect(screen.queryByTestId("billing-profile-missing")).not.toBeInTheDocument();
+  });
+
+  it("still reports a refusal it has no answer for", async () => {
+    mutateAsync.mockRejectedValueOnce({
+      status: 400,
+      errors: {
+        error: { code: "subscription_discount_unknown", message: "That code does not exist." },
+      },
+    });
+
+    renderDialog();
+    await userEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    expect(await screen.findByText("That code does not exist.")).toBeInTheDocument();
+    expect(screen.queryByTestId("billing-profile-incomplete")).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
@@ -24,6 +24,12 @@ import { useSubscribeToPlan } from "../hooks/use-subscribe-to-plan";
 import type { SubscriptionQuantity } from "../models/subscription-simulation.model";
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
 import { formatPrice } from "../../subscription/utilities/subscription-format";
+import {
+  billingProfileGapOf,
+  subscriptionApiFailure,
+  type BillingProfileGap,
+} from "../../subscription/utilities/subscription-api-failure";
+import { BillingProfileIncompleteNotice } from "./billing-profile-incomplete-notice";
 
 export const SubscribeDialog = ({
   plan,
@@ -47,9 +53,8 @@ export const SubscribeDialog = ({
     ),
   );
   const [discountCode, setDiscountCode] = useState("");
-  const [billingEmail, setBillingEmail] = useState("");
-  const [billingName, setBillingName] = useState("");
   const [formError, setFormError] = useState<string | null>(null);
+  const [profileGap, setProfileGap] = useState<BillingProfileGap | null>(null);
 
   const selectedPrice = useMemo(
     () => plan.prices.find((price) => price.priceId === priceId),
@@ -58,6 +63,7 @@ export const SubscribeDialog = ({
 
   const submit = async () => {
     setFormError(null);
+    setProfileGap(null);
 
     if (!priceId) {
       setFormError("Choose a price to subscribe on.");
@@ -89,8 +95,10 @@ export const SubscribeDialog = ({
         quantities: parsedQuantities,
         timeZoneId: detectBrowserTimeZone(),
         discountCode: discountCode.trim() || undefined,
-        billingEmail: billingEmail.trim() || undefined,
-        billingName: billingName.trim() || undefined,
+        // No billing name or email is sent. The request still accepts them for integrations that
+        // have their own record of a customer, and the server falls back to the organization's saved
+        // billing profile when they are absent - which is the same profile this dialog would have
+        // been collecting a second, unrelated copy of.
         organizationId,
       });
 
@@ -105,8 +113,19 @@ export const SubscribeDialog = ({
       onOpenChange(false);
       onSubscribed(subscription.checkoutUrl);
     } catch (error) {
+      // The refusal that has an answer is shown as that answer. Reduced to its message, an
+      // incomplete billing profile reads as a dead end, and the field list it carries reads as JSON.
+      const failure = subscriptionApiFailure(error);
+      const gap = billingProfileGapOf(failure);
+
+      setProfileGap(gap);
       setFormError(
-        error instanceof Error ? error.message : "The subscription could not be started.",
+        gap
+          ? null
+          : failure?.message ||
+              (error instanceof Error
+                ? error.message
+                : "The subscription could not be started."),
       );
     }
   };
@@ -178,25 +197,9 @@ export const SubscribeDialog = ({
             />
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="subscribe-email">Billing email (optional)</Label>
-              <Input
-                id="subscribe-email"
-                type="email"
-                value={billingEmail}
-                onChange={(event) => setBillingEmail(event.target.value)}
-              />
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="subscribe-name">Billing name (optional)</Label>
-              <Input
-                id="subscribe-name"
-                value={billingName}
-                onChange={(event) => setBillingName(event.target.value)}
-              />
-            </div>
-          </div>
+          {profileGap && (
+            <BillingProfileIncompleteNotice gap={profileGap} organizationId={organizationId} />
+          )}
 
           {formError && <p className="text-sm text-destructive">{formError}</p>}
         </div>

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -7,6 +7,7 @@ import {
   SUBSCRIPTIONS_CURRENT_ENDPOINT,
   SUBSCRIPTIONS_ENDPOINT,
 } from "../constants/subscription-simulation.constants";
+import { subscriptionApiFailure } from "../../subscription/utilities/subscription-api-failure";
 import type {
   CancelSubscriptionRequest,
   ChangeQuantityRequest,
@@ -46,11 +47,42 @@ export class SubscriptionOperationError extends Error {
     message: string,
     readonly code: string,
     readonly status?: number,
+    /**
+     * The server's field map, where it sent one.
+     *
+     * Carried because some refusals are answerable: an incomplete billing profile names exactly
+     * which details are still needed, and dropping them leaves the screen able only to say no.
+     */
+    readonly fields: Record<string, string[]> = {},
   ) {
     super(message);
     this.name = "SubscriptionOperationError";
   }
 }
+
+/**
+ * Turns whatever a money-moving call threw into the server's own refusal.
+ *
+ * The envelope arrives inside an `HttpError` for any failing status and inline in the body for a
+ * `success: false` with a 200, so both are read the same way here rather than at each call site.
+ * `fallback` is used only when there is no envelope to read — a network fault, or a shape nobody
+ * expected.
+ */
+const operationError = (error: unknown, fallback: string): SubscriptionOperationError => {
+  if (error instanceof SubscriptionOperationError) {
+    return error;
+  }
+
+  const failure = subscriptionApiFailure(error);
+  const status = error instanceof HttpError ? error.status : undefined;
+
+  return new SubscriptionOperationError(
+    failure?.message || (error instanceof Error && error.message) || fallback,
+    failure?.code ?? "unknown",
+    status,
+    failure?.fields ?? {},
+  );
+};
 
 class SubscriptionSimulationService {
   async getCurrentSubscription(
@@ -76,16 +108,26 @@ class SubscriptionSimulationService {
     }
   }
 
+  /**
+   * Starts a subscription, keeping the server's refusal code intact.
+   *
+   * The refusals here are answerable ones — an incomplete billing profile, an unknown discount code
+   * — and a screen can only offer the fix if it still knows which refusal it was.
+   */
   async subscribe(request: SubscribeToPlanRequest): Promise<SimulatedSubscription> {
-    const response = await serviceInstances.utitlitiesService.post<
-      SimulationApiResponse<SimulatedSubscription>
-    >(SUBSCRIPTIONS_ENDPOINT, request);
+    try {
+      const response = await serviceInstances.utitlitiesService.post<
+        SimulationApiResponse<SimulatedSubscription>
+      >(SUBSCRIPTIONS_ENDPOINT, request);
 
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "The subscription could not be started.");
+      if (!response.success || !response.data) {
+        throw operationError(response, "The subscription could not be started.");
+      }
+
+      return response.data;
+    } catch (error) {
+      throw operationError(error, "The subscription could not be started.");
     }
-
-    return response.data;
   }
 
   async cancel(request: CancelSubscriptionRequest): Promise<SimulatedSubscription> {
@@ -121,15 +163,21 @@ class SubscriptionSimulationService {
     subscriptionId: string,
     request: ChangeSubscriptionPlanRequest,
   ): Promise<SimulatedSubscription> {
-    const response = await serviceInstances.utitlitiesService.put<
-      SimulationApiResponse<SimulatedSubscription>
-    >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan`, request);
+    try {
+      const response = await serviceInstances.utitlitiesService.put<
+        SimulationApiResponse<SimulatedSubscription>
+      >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan`, request);
 
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "The plan could not be changed.");
+      if (!response.success || !response.data) {
+        throw operationError(response, "The plan could not be changed.");
+      }
+
+      return response.data;
+    } catch (error) {
+      // Changing a plan is a money-moving call and refuses for the same billing-profile reason a
+      // new subscription does, so it keeps the code as well.
+      throw operationError(error, "The plan could not be changed.");
     }
-
-    return response.data;
   }
 
   /**

--- a/client/app/cross-modules/utilities/subscription/hooks/use-subscription-link.ts
+++ b/client/app/cross-modules/utilities/subscription/hooks/use-subscription-link.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { useParams } from "react-router";
+import { useOrganizationScope, withOrganizationScope } from "./use-organization-scope";
+
+/**
+ * Builds a link to another subscription screen, keeping the organization currently being looked at.
+ *
+ * One helper rather than a template string per page, because the path has two moving parts — the
+ * project segment the shell owns and the organization scope this module owns — and every page that
+ * spelled them out by hand got one of them wrong. Three of them pointed at `/dashboard/subscription`,
+ * a route that does not exist.
+ *
+ * @returns
+ * A builder taking the part after `/subscription/`. The organization defaults to the current scope;
+ * pass one explicitly to link into a different organization, or `null` to link out of the scope
+ * deliberately.
+ */
+export const useSubscriptionLink = (): ((
+  suffix: string,
+  organizationId?: string | null,
+) => string) => {
+  const { itemId } = useParams();
+  const scope = useOrganizationScope();
+
+  return useCallback(
+    (suffix: string, organizationId: string | null | undefined = scope) =>
+      withOrganizationScope(`/app/${itemId ?? ""}/subscription/${suffix}`, organizationId),
+    [itemId, scope],
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-billing-profile-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-billing-profile-page.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import type { SubscriptionBillingProfile } from "../models/subscription-billing.model";
 
@@ -58,11 +58,22 @@ const mutation = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
-const renderPage = () =>
+/**
+ * @param at
+ * The address the page was reached at. Routed through `/app/:itemId/...` because that is the shape
+ * the shell actually mounts, and the organization scope lives in its query string — a page rendered
+ * at "/" cannot tell a link that keeps the scope from one that drops it.
+ */
+const renderPage = (at = "/app/project-1/subscription/billing-profile") =>
   render(
     <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
-      <MemoryRouter>
-        <SubscriptionBillingProfilePage />
+      <MemoryRouter initialEntries={[at]}>
+        <Routes>
+          <Route
+            path="/app/:itemId/subscription/billing-profile"
+            element={<SubscriptionBillingProfilePage />}
+          />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -172,6 +183,72 @@ describe("billing profile page", () => {
 
     expect(await screen.findByTestId("profile-error")).toHaveTextContent(
       "The billing profile is invalid.",
+    );
+  });
+
+  it("names the organization being edited, and its id", async () => {
+    useBillingProfile.mockReturnValue({ data: profile(), isLoading: false, error: null });
+    useUpdateBillingProfile.mockReturnValue(mutation());
+
+    renderPage("/app/project-1/subscription/billing-profile?organizationId=org-1");
+
+    // Every organization keeps its own profile, and the page used to show one without saying which.
+    // The id as well as the name, because two organizations may well share a name.
+    const scope = await screen.findByTestId("profile-scope");
+    expect(scope).toHaveTextContent("Billing profile for Northwind");
+    expect(scope).toHaveTextContent("org-1");
+  });
+
+  it("warns when the server answered about a different organization than the link asked for", async () => {
+    useBillingProfile.mockReturnValue({
+      data: profile({ organizationId: "org-1" }),
+      isLoading: false,
+      error: null,
+    });
+    useUpdateBillingProfile.mockReturnValue(mutation());
+
+    renderPage("/app/project-1/subscription/billing-profile?organizationId=org-2");
+
+    const mismatch = await screen.findByTestId("profile-scope-mismatch");
+    expect(mismatch).toHaveTextContent("org-2");
+    expect(mismatch).toHaveTextContent("org-1");
+
+    // And no green light. Naming another organization is honoured for the platform console alone,
+    // so "ready to be invoiced" here would be a promise about somebody else entirely.
+    expect(screen.queryByTestId("profile-complete")).not.toBeInTheDocument();
+  });
+
+  it("keeps the organization on the way back to the catalogue", async () => {
+    useBillingProfile.mockReturnValue({ data: profile(), isLoading: false, error: null });
+    useUpdateBillingProfile.mockReturnValue(mutation());
+
+    renderPage("/app/project-1/subscription/billing-profile?organizationId=org-1");
+
+    // The old link pointed at /dashboard/subscription/plans, a route that does not exist, and
+    // carried no organization if it had.
+    expect(await screen.findByRole("link", { name: /Back to plans/ })).toHaveAttribute(
+      "href",
+      "/app/project-1/subscription/plans?organizationId=org-1",
+    );
+  });
+
+  it("offers the way back to the same organizations catalogue after a save", async () => {
+    const mutate = vi.fn((_request, options?: { onSuccess?: () => void }) =>
+      options?.onSuccess?.(),
+    );
+    useBillingProfile.mockReturnValue({ data: profile(), isLoading: false, error: null });
+    useUpdateBillingProfile.mockReturnValue(mutation({ mutate }));
+
+    renderPage("/app/project-1/subscription/billing-profile?organizationId=org-1");
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Save billing profile" }),
+    );
+
+    // Usually somebody is here because a subscription was refused for the want of these details.
+    // Retrying it against a different organization would be refused for the same reason again.
+    expect(await screen.findByRole("link", { name: /Continue to plans/ })).toHaveAttribute(
+      "href",
+      "/app/project-1/subscription/plans?organizationId=org-1",
     );
   });
 

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-billing-profile-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-billing-profile-page.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { AlertCircle, CheckCircle2, ReceiptText } from "lucide-react";
+import { AlertCircle, ArrowRight, Building2, CheckCircle2, ReceiptText } from "lucide-react";
+import { Link } from "react-router";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import { Input } from "@/components/ui-kits/input/input";
@@ -7,6 +8,7 @@ import { Label } from "@/components/ui-kits/label/label";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
 import { useBillingProfile, useUpdateBillingProfile } from "../hooks/use-billing-profile";
 import { useOrganizationScope } from "../hooks/use-organization-scope";
+import { useSubscriptionLink } from "../hooks/use-subscription-link";
 import type { SubscriptionBillingProfile } from "../models/subscription-billing.model";
 import { describeMissingProfileFields } from "../utilities/financial-document-format";
 
@@ -71,6 +73,7 @@ const toForm = (profile: SubscriptionBillingProfile): ProfileForm => ({
  */
 export const SubscriptionBillingProfilePage = () => {
   const organizationId = useOrganizationScope();
+  const subscriptionLink = useSubscriptionLink();
   const { data: profile, isLoading, error } = useBillingProfile(organizationId);
   const update = useUpdateBillingProfile();
   const [form, setForm] = useState<ProfileForm>(emptyForm);
@@ -119,16 +122,67 @@ export const SubscriptionBillingProfilePage = () => {
   const fieldErrors = update.error instanceof Error ? update.error.message : null;
   const missing = profile ? describeMissingProfileFields(profile.missingFields) : "";
 
+  // The organization the server actually answered about, which is not always the one the URL asked
+  // for: naming another organization is honoured for the platform console alone, and for everybody
+  // else the server quietly resolves the caller's own. Taken from the response rather than the URL,
+  // so the page states what it loaded instead of what it hoped for.
+  const resolvedOrganizationId = profile?.organizationId;
+  const scopeHonoured =
+    !organizationId || !resolvedOrganizationId || resolvedOrganizationId === organizationId;
+
+  // The profile's own name, which is what the invoices will be addressed to. Blank until somebody
+  // fills it in, and a blank heading is better than one naming the organization it is not.
+  const subscriberName = (profile?.displayName || profile?.legalName || "").trim();
+
   return (
     <div className="flex flex-col gap-6">
       <SubscriptionPlanPageHeader
         title="Billing profile"
         description="The name, contact and address every invoice and credit note for this organization is addressed to."
-        backTo="/dashboard/subscription/plans"
+        backTo={subscriptionLink("plans")}
         icon={<ReceiptText className="h-6 w-6" />}
       />
 
-      {profile && !profile.isComplete && (
+      {resolvedOrganizationId && (
+        <Card
+          className="flex items-start gap-3 border-blocks-primary-200 bg-blocks-primary-shades-100 p-4"
+          data-testid="profile-scope"
+        >
+          <Building2 className="mt-0.5 h-5 w-5 shrink-0 text-blocks-primary-600" />
+          <div className="text-sm">
+            <p className="font-medium">
+              {subscriberName
+                ? `Billing profile for ${subscriberName}`
+                : "Billing profile for this organization"}{" "}
+              — <span className="font-mono text-xs">{resolvedOrganizationId}</span>
+            </p>
+            <p className="text-muted-foreground">
+              Every organization keeps its own. Saving here changes nothing for any other.
+            </p>
+          </div>
+        </Card>
+      )}
+
+      {!scopeHonoured && (
+        <Card
+          className="flex items-start gap-3 border-amber-300 bg-amber-50 p-4"
+          data-testid="profile-scope-mismatch"
+        >
+          <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+          <div className="text-sm">
+            <p className="font-medium">This is not the organization the link asked for.</p>
+            <p className="text-muted-foreground">
+              The address named{" "}
+              <span className="font-mono text-xs">{organizationId}</span>, and the server answered
+              about <span className="font-mono text-xs">{resolvedOrganizationId}</span>. Naming
+              another organization is honoured for the platform console only, so what is below
+              belongs to your own — check before saving.
+            </p>
+          </div>
+        </Card>
+      )}
+
+      {profile && scopeHonoured && !profile.isComplete && (
         <Card
           className="flex items-start gap-3 border-amber-300 bg-amber-50 p-4"
           data-testid="profile-incomplete"
@@ -141,7 +195,7 @@ export const SubscriptionBillingProfilePage = () => {
         </Card>
       )}
 
-      {profile?.isComplete && (
+      {profile?.isComplete && scopeHonoured && (
         <Card
           className="flex items-start gap-3 border-emerald-300 bg-emerald-50 p-4"
           data-testid="profile-complete"
@@ -298,9 +352,20 @@ export const SubscriptionBillingProfilePage = () => {
         )}
 
         {saved && (
-          <p className="text-sm text-emerald-700" data-testid="profile-saved">
-            Saved. Documents issued from now on carry these details.
-          </p>
+          <div className="flex flex-wrap items-center gap-3" data-testid="profile-saved">
+            <p className="text-sm text-emerald-700">
+              Saved. Documents issued from now on carry these details.
+            </p>
+            {/* Back to the catalogue for the same organization, because the usual reason for being
+                here is a subscription that was refused for the want of these details — and retrying
+                it against a different organization would fail for the same reason again. */}
+            <Button asChild variant="outline" size="sm">
+              <Link to={subscriptionLink("plans")}>
+                Continue to plans
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
         )}
 
         <div className="flex items-center gap-3">

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-invoices-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-invoices-page.tsx
@@ -24,6 +24,7 @@ import {
   useFinancialDocuments,
 } from "../hooks/use-financial-documents";
 import { useOrganizationScope } from "../hooks/use-organization-scope";
+import { useSubscriptionLink } from "../hooks/use-subscription-link";
 import type {
   FinancialDocumentStatus,
   FinancialDocumentType,
@@ -262,6 +263,7 @@ const DocumentRow = ({
  */
 export const SubscriptionInvoicesPage = () => {
   const organizationId = useOrganizationScope();
+  const subscriptionLink = useSubscriptionLink();
   const [documentType, setDocumentType] = useState<string>(ANY_DOCUMENT_FILTER);
   const [status, setStatus] = useState<string>(ANY_DOCUMENT_FILTER);
   const [issuedFrom, setIssuedFrom] = useState("");
@@ -295,7 +297,7 @@ export const SubscriptionInvoicesPage = () => {
       <SubscriptionPlanPageHeader
         title="Invoices & credit notes"
         description="Every document this application has issued: invoices, trial invoices and credit notes, with the figures each was issued on."
-        backTo="/dashboard/subscription/plans"
+        backTo={subscriptionLink("plans")}
         icon={<FileText className="h-6 w-6" />}
       />
 

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-merchant-profile-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-merchant-profile-page.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui-kits/input/input";
 import { Label } from "@/components/ui-kits/label/label";
 import { Textarea } from "@/components/ui-kits/textarea/textarea";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { useSubscriptionLink } from "../hooks/use-subscription-link";
 import {
   useMerchantProfile,
   useUpdateMerchantProfile,
@@ -73,6 +74,10 @@ const toForm = (profile: SubscriptionMerchantProfile): MerchantForm => ({
  * it from the console alone.
  */
 export const SubscriptionMerchantProfilePage = () => {
+  // The seller is the tenant, so nothing on this page is scoped to an organization. The link out of
+  // it still carries whichever organization the catalogue was being read as, so a detour through
+  // here does not silently reset it.
+  const subscriptionLink = useSubscriptionLink();
   const { data: profile, isLoading, error } = useMerchantProfile();
   const update = useUpdateMerchantProfile();
   const [form, setForm] = useState<MerchantForm>(emptyForm);
@@ -123,7 +128,7 @@ export const SubscriptionMerchantProfilePage = () => {
       <SubscriptionPlanPageHeader
         title="Merchant profile"
         description="The legal identity this tenant issues its invoices and credit notes under."
-        backTo="/dashboard/subscription/plans"
+        backTo={subscriptionLink("plans")}
         icon={<Building2 className="h-6 w-6" />}
       />
 

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-api-failure.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-api-failure.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  billingProfileGapOf,
+  subscriptionApiFailure,
+} from "./subscription-api-failure";
+
+/** The envelope the API returns, as it reaches the client for a refused call. */
+const envelope = (fields: Record<string, string[]>) => ({
+  success: false,
+  data: null,
+  error: {
+    code: "subscription_billing_profile_incomplete",
+    message: "This organization's billing profile is missing details an invoice must carry.",
+    fields,
+    traceId: "corr-1",
+  },
+});
+
+describe("subscription api failure", () => {
+  it("reads the envelope out of a failing status", () => {
+    // A 400 arrives as an HttpError whose `errors` is the parsed body, so the envelope sits a level
+    // down. Read from the wrong level, every named refusal becomes "something went wrong".
+    const failure = subscriptionApiFailure({
+      status: 400,
+      errors: envelope({ BillingProfile: ["LegalName"] }),
+    });
+
+    expect(failure?.code).toBe("subscription_billing_profile_incomplete");
+    expect(failure?.fields.BillingProfile).toEqual(["LegalName"]);
+  });
+
+  it("reads the envelope out of a body that came back with a 200", () => {
+    const failure = subscriptionApiFailure(envelope({ BillingProfile: ["LegalName"] }));
+
+    expect(failure?.code).toBe("subscription_billing_profile_incomplete");
+  });
+
+  it("is nothing when there is no envelope to read", () => {
+    expect(subscriptionApiFailure(new Error("Network request failed"))).toBeNull();
+    expect(subscriptionApiFailure(undefined)).toBeNull();
+  });
+
+  it("tolerates a field map whose values are plain strings", () => {
+    const failure = subscriptionApiFailure({
+      error: { code: "subscription_request_invalid", fields: { PriceId: "Required." } },
+    });
+
+    expect(failure?.fields.PriceId).toEqual(["Required."]);
+  });
+});
+
+describe("billing profile gap", () => {
+  it("separates what the subscriber owes from what the tenant owes", () => {
+    const gap = billingProfileGapOf(
+      subscriptionApiFailure(
+        envelope({ BillingProfile: ["LegalName", "merchantLegalName"] }),
+      ),
+    );
+
+    // Two different people fix these on two different screens. Sending a subscriber to add a legal
+    // name, when the missing one is the platform's own, sends them to correct something that was
+    // never theirs.
+    expect(gap).toEqual({ subscriberFields: ["LegalName"], merchantMissing: true });
+  });
+
+  it("is nothing for any other refusal", () => {
+    expect(
+      billingProfileGapOf({ code: "subscription_discount_unknown", message: "", fields: {} }),
+    ).toBeNull();
+    expect(billingProfileGapOf(null)).toBeNull();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-api-failure.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-api-failure.ts
@@ -1,0 +1,111 @@
+/**
+ * The server's own account of why a subscription call failed.
+ *
+ * Kept as a code, a sentence and a field map rather than flattened to a string, because the code is
+ * what tells one refusal from another and the fields are what tell somebody how to fix it. Reduced
+ * to `error.message`, an incomplete billing profile and a declined card read as the same kind of
+ * sorry.
+ */
+export interface SubscriptionApiFailure {
+  code: string;
+  message: string;
+  fields: Record<string, string[]>;
+}
+
+/** The failure codes this module acts on rather than merely reports. */
+export const BILLING_PROFILE_INCOMPLETE = "subscription_billing_profile_incomplete";
+
+/**
+ * Which field list the server returns the missing profile details under.
+ *
+ * One key holding the whole list, rather than one key per field: the server is answering "what is
+ * still needed", not "what did you type wrongly", and the subscriber has not typed anything yet.
+ */
+const PROFILE_FIELD_KEY = "BillingProfile";
+
+/**
+ * The tenant's own selling identity, which the same list can carry.
+ *
+ * Named apart from the subscriber's fields because the two are fixed by different people on
+ * different screens. Telling a subscriber to add a legal name, when the missing name is the
+ * platform's own, sends them to correct something that was never theirs.
+ */
+const MERCHANT_FIELD = "merchantLegalName";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const asFields = (value: unknown): Record<string, string[]> => {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      Array.isArray(entry) ? entry.map(String) : [String(entry)],
+    ]),
+  );
+};
+
+/**
+ * Digs the API's error envelope out of whatever the transport wrapped it in.
+ *
+ * Every failing status arrives as an `HttpError` whose `errors` is the parsed response body, so the
+ * envelope sits one level down; a failure the client noticed itself has no envelope at all. Both
+ * shapes are looked at rather than one being assumed, because assuming the wrong one turns every
+ * named refusal into "something went wrong" — and the whole point of a code is that the client can
+ * do something specific with it.
+ */
+export const subscriptionApiFailure = (error: unknown): SubscriptionApiFailure | null => {
+  const candidates: unknown[] = [];
+
+  if (isRecord(error)) {
+    candidates.push(error.error);
+
+    if (isRecord(error.errors)) {
+      candidates.push(error.errors.error, error.errors);
+    }
+
+    candidates.push(error);
+  }
+
+  for (const candidate of candidates) {
+    if (isRecord(candidate) && typeof candidate.code === "string" && candidate.code) {
+      return {
+        code: candidate.code,
+        message: typeof candidate.message === "string" ? candidate.message : "",
+        fields: asFields(candidate.fields),
+      };
+    }
+  }
+
+  return null;
+};
+
+/**
+ * What an organization still owes before it can be charged, split by who can supply it.
+ *
+ * Null when the failure was something else, so a caller can fall back to reporting the message.
+ */
+export interface BillingProfileGap {
+  /** Fields on the subscriber's own billing profile. */
+  subscriberFields: string[];
+  /** Whether the tenant has never named itself as the seller. */
+  merchantMissing: boolean;
+}
+
+export const billingProfileGapOf = (
+  failure: SubscriptionApiFailure | null,
+): BillingProfileGap | null => {
+  if (failure?.code !== BILLING_PROFILE_INCOMPLETE) {
+    return null;
+  }
+
+  const missing = failure.fields[PROFILE_FIELD_KEY] ?? [];
+
+  return {
+    subscriberFields: missing.filter((field) => field !== MERCHANT_FIELD),
+    merchantMissing: missing.includes(MERCHANT_FIELD),
+  };
+};

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-navigation.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-navigation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { Menu } from "@/models/menu-models";
+import { withSubscriptionOrganizationScope } from "./subscription-navigation";
+
+const menus = (): Menu[] => [
+  {
+    id: "payment",
+    type: "menu",
+    name: "Payment",
+    path: "/app/payment/list",
+  },
+  {
+    id: "subscription",
+    type: "menu",
+    name: "Subscriptions",
+    path: "/app/subscription/plans",
+    children: [
+      { id: "plans", type: "menu", name: "Plans", path: "/app/subscription/plans" },
+      { id: "invoices", type: "menu", name: "Invoices", path: "/app/subscription/invoices" },
+      {
+        id: "billing-profile",
+        type: "menu",
+        name: "Billing profile",
+        path: "/app/subscription/billing-profile",
+      },
+      { id: "sep", type: "separator" },
+    ],
+  },
+];
+
+const child = (result: Menu[], id: string): Extract<Menu, { type: "menu" }> => {
+  const parent = result[1];
+  if (parent.type !== "menu") throw new Error("the subscription group is a menu");
+
+  const found = parent.children?.find((entry) => entry.id === id);
+  if (found?.type !== "menu") throw new Error(`no menu child ${id}`);
+
+  return found;
+};
+
+describe("subscription menu scope", () => {
+  it("carries the organization onto subscription links", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org-1",
+      "/app/project-1/subscription/plans",
+    );
+
+    expect(child(result, "invoices").path).toBe(
+      "/app/subscription/invoices?organizationId=org-1",
+    );
+    expect(child(result, "billing-profile").path).toBe(
+      "/app/subscription/billing-profile?organizationId=org-1",
+    );
+  });
+
+  it("leaves other modules alone", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org-1",
+      "/app/project-1/subscription/plans",
+    );
+
+    // The scope is this module's idea. Putting it on Payment's link would advertise a filter
+    // Payment does not apply.
+    const payment = result[0];
+    expect(payment.type === "menu" && payment.path).toBe("/app/payment/list");
+  });
+
+  it("leaves the entry the page is already inside clean", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org-1",
+      "/app/project-1/subscription/plans/create",
+    );
+
+    // The sidebar marks an entry active by testing pathname.startsWith(menu.path); a query string
+    // appended there matches nothing and Plans would stop being highlighted while the reader is
+    // plainly inside it. Nothing is lost — that link navigates nowhere.
+    expect(child(result, "plans").path).toBe("/app/subscription/plans");
+    expect(child(result, "invoices").path).toBe(
+      "/app/subscription/invoices?organizationId=org-1",
+    );
+  });
+
+  it("returns the menus untouched when nothing is scoped", () => {
+    const original = menus();
+
+    expect(withSubscriptionOrganizationScope(original, undefined, "/app/project-1/dashboard")).toBe(
+      original,
+    );
+  });
+
+  it("escapes an organization id so it cannot forge another parameter", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org 1&admin=true",
+      "/app/project-1/dashboard",
+    );
+
+    expect(child(result, "invoices").path).toBe(
+      "/app/subscription/invoices?organizationId=org%201%26admin%3Dtrue",
+    );
+  });
+
+  it("keeps separators as they are", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org-1",
+      "/app/project-1/dashboard",
+    );
+    const parent = result[1];
+
+    expect(parent.type === "menu" && parent.children?.at(-1)?.type).toBe("separator");
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-navigation.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-navigation.ts
@@ -1,0 +1,85 @@
+import type { Menu } from "@/models/menu-models";
+import { ORGANIZATION_QUERY_PARAM } from "../constants/subscription.constants";
+
+/**
+ * The prefix every subscription entry in the navigation menu carries, as authored.
+ *
+ * Matched before the shell rewrites `/app/` to `/app/{itemId}/`, which is the only point at which a
+ * subscription path is still distinguishable from any other module's by its literal prefix.
+ */
+export const SUBSCRIPTION_MENU_PREFIX = "/app/subscription";
+
+/** A menu path with its `/app` root removed, which is what a rewritten pathname still ends with. */
+const routeOf = (menuPath: string): string => menuPath.slice("/app".length);
+
+/**
+ * The same, for a live pathname: `/app/{itemId}/subscription/plans` becomes `/subscription/plans`.
+ *
+ * Dropping the project segment rather than reconstructing it, because the shell inserts it and this
+ * only needs the two to be comparable.
+ */
+const routeOfPathname = (pathname: string): string => {
+  const [, root, , ...rest] = pathname.split("/");
+
+  return root === "app" ? `/${rest.join("/")}` : pathname;
+};
+
+/**
+ * Carries the current organization scope onto the subscription entries of a navigation menu.
+ *
+ * The scope lives in the URL and the shell's sidebar links are plain paths, so every trip through
+ * the sidebar used to drop it. Somebody would pick organization A on the plan list, click Billing
+ * profile, and edit whichever organization the server resolves for an unscoped request — usually the
+ * console's own. Nothing on the screen said so, which is what made it confusing rather than merely
+ * wrong.
+ *
+ * Only paths under {@link SUBSCRIPTION_MENU_PREFIX} are touched. The scope is this module's own idea
+ * and means nothing to Payment or IAM, so putting it on their links would advertise a filter they do
+ * not apply. Every subscription entry gets it, including the ones that ignore it — a menu rule with
+ * named exceptions is how the next entry added comes to be forgotten.
+ *
+ * @param pathname
+ * The current location. An entry the page is already inside is left alone, because the sidebar marks
+ * an entry active by testing `pathname.startsWith(menu.path)`, and a query string appended there
+ * matches nothing — the active item would quietly stop being highlighted. Nothing is lost: the link
+ * left clean is the one that navigates nowhere.
+ */
+export const withSubscriptionOrganizationScope = (
+  menus: Menu[],
+  organizationId: string | null | undefined,
+  pathname: string,
+): Menu[] => {
+  if (!organizationId) {
+    return menus;
+  }
+
+  const current = routeOfPathname(pathname);
+
+  const scoped = (menu: Menu): Menu => {
+    if (menu.type !== "menu") {
+      return menu;
+    }
+
+    const withChildren = menu.children
+      ? { ...menu, children: menu.children.map(scoped) }
+      : menu;
+
+    if (
+      !menu.path.startsWith(SUBSCRIPTION_MENU_PREFIX) ||
+      current.startsWith(routeOf(menu.path))
+    ) {
+      return withChildren;
+    }
+
+    const separator = menu.path.includes("?") ? "&" : "?";
+
+    return {
+      ...withChildren,
+      path: `${menu.path}${separator}${ORGANIZATION_QUERY_PARAM}=${encodeURIComponent(
+        organizationId,
+      )}`,
+    };
+  };
+
+  return menus.map(scoped);
+};

--- a/client/app/layouts/scoped-dashboard-route.test.tsx
+++ b/client/app/layouts/scoped-dashboard-route.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { Menu } from "@/models/menu-models";
+
+const received = vi.fn();
+
+vi.mock("@seliseblocks/genesis-os/layouts", () => ({
+  DashboardRoute: (props: { navigationMenus: Menu[] }) => {
+    received(props.navigationMenus);
+    return null;
+  },
+}));
+
+import { ScopedDashboardRoute } from "./scoped-dashboard-route";
+
+const menus: Menu[] = [
+  {
+    id: "subscription-invoices",
+    type: "menu",
+    name: "Invoices",
+    path: "/app/subscription/invoices",
+  },
+];
+
+describe("scoped dashboard route", () => {
+  it("hands the shell subscription links that keep the organization in view", () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/app/project-1/subscription/plans?organizationId=org-1"]}
+      >
+        <ScopedDashboardRoute navigationMenus={menus} redirectPaths={{}} />
+      </MemoryRouter>,
+    );
+
+    // The sidebar is rendered by the shell, above every page, so a page cannot reach the links that
+    // navigate away from it. This is the one place the menu tree and the current URL are both in
+    // hand.
+    expect(received).toHaveBeenCalledWith([
+      expect.objectContaining({ path: "/app/subscription/invoices?organizationId=org-1" }),
+    ]);
+  });
+
+  it("changes nothing when no organization is being looked at", () => {
+    render(
+      <MemoryRouter initialEntries={["/app/project-1/dashboard"]}>
+        <ScopedDashboardRoute navigationMenus={menus} redirectPaths={{}} />
+      </MemoryRouter>,
+    );
+
+    expect(received).toHaveBeenLastCalledWith(menus);
+  });
+});

--- a/client/app/layouts/scoped-dashboard-route.tsx
+++ b/client/app/layouts/scoped-dashboard-route.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+import { useLocation, useSearchParams } from "react-router";
+import { DashboardRoute } from "@seliseblocks/genesis-os/layouts";
+import { ORGANIZATION_QUERY_PARAM } from "@/cross-modules/utilities/subscription/constants/subscription.constants";
+import { withSubscriptionOrganizationScope } from "@/cross-modules/utilities/subscription/utilities/subscription-navigation";
+import type { Menu } from "@/models/menu-models";
+
+/**
+ * The dashboard shell, with the sidebar's subscription links kept on the organization in view.
+ *
+ * Wrapped here rather than solved inside the subscription module because the sidebar is rendered by
+ * the shell, above every page: a page cannot reach the links that navigate away from it. This is the
+ * one place both the menu tree and the current URL are in hand.
+ *
+ * Nothing else about the shell changes, and no other module's links are touched — see
+ * `withSubscriptionOrganizationScope`.
+ */
+export const ScopedDashboardRoute = ({
+  navigationMenus,
+  redirectPaths,
+}: {
+  navigationMenus: Menu[];
+  redirectPaths: Record<string, string>;
+}) => {
+  const [searchParams] = useSearchParams();
+  const { pathname } = useLocation();
+  const organizationId = searchParams.get(ORGANIZATION_QUERY_PARAM);
+
+  const menus = useMemo(
+    () => withSubscriptionOrganizationScope(navigationMenus, organizationId, pathname),
+    [navigationMenus, organizationId, pathname],
+  );
+
+  return <DashboardRoute redirectPaths={redirectPaths} navigationMenus={menus} />;
+};

--- a/client/app/router.tsx
+++ b/client/app/router.tsx
@@ -30,10 +30,8 @@ import {
   ProfilePage,
   DashboardOverview,
 } from "@seliseblocks/genesis-os";
-import {
-  DashboardRoute
-} from "@seliseblocks/genesis-os/layouts";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { ScopedDashboardRoute } from "@/layouts/scoped-dashboard-route";
 import { navigationMenus } from "./constants/navigation-menus";
 
 const redirectPaths: Record<string, string> = {
@@ -93,7 +91,7 @@ export const router = createBrowserRouter([
               {
                 path: ":itemId",
                 element: (
-                  <DashboardRoute
+                  <ScopedDashboardRoute
                     redirectPaths={redirectPaths}
                     navigationMenus={navigationMenus}
                   />

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -971,8 +971,17 @@
       <p class="prose">
         The profile also supplies the billing account&#39;s contact where
         <code>POST /api/subscriptions</code> did not name one, so renewal and usage-threshold mail
-        reaches the same address the invoices do. That is a default and not a snapshot: it is read
-        once, when the account is created.
+        reaches the same address the invoices do. It is applied on <strong>every</strong> subscribe,
+        to an account that already exists as well as a new one: a billing account outlives every
+        subscription on it, so an organization that subscribed before filling its profile in would
+        otherwise keep the blank contact for good and never receive that mail at all.
+      </p>
+      <p class="prose">
+        A field you do not send is left as it stands rather than blanked, so naming only an address
+        cannot erase a name. A field you do send overwrites — which is what lets a corrected profile
+        take effect, and also means an integration that sets a contact once and later subscribes
+        without naming it will see the profile&#39;s value take over. Send it on every request if you
+        keep your own record of the customer.
       </p>
       <div class="callout">
         <strong>One profile per organization, named explicitly.</strong> Every read and write takes

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -968,6 +968,21 @@
         renames their company keeps last year's invoices under the old name, which is what an auditor
         expects.
       </p>
+      <p class="prose">
+        The profile also supplies the billing account&#39;s contact where
+        <code>POST /api/subscriptions</code> did not name one, so renewal and usage-threshold mail
+        reaches the same address the invoices do. That is a default and not a snapshot: it is read
+        once, when the account is created.
+      </p>
+      <div class="callout">
+        <strong>One profile per organization, named explicitly.</strong> Every read and write takes
+        <code>organizationId</code>, and the response says which organization it answered about. For
+        anybody but the platform console a requested organization is <em>ignored</em> rather than
+        refused, and the caller&#39;s own is answered instead &mdash; so a client must render the
+        <code>organizationId</code> it got back rather than the one it asked for. A screen that shows
+        one organization&#39;s completeness under another&#39;s name is how somebody comes to fill in a
+        form for the wrong company.
+      </div>
 
       <h3 id="merchant-profile">Merchant profile</h3>
       <p>
@@ -2073,9 +2088,23 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
   ],
   "timeZoneId": "Europe/Zurich",  // IANA; decides when periods turn over
   "discountCode": null,
-  "billingEmail": "maya@example.com",
-  "billingName": "Maya Keller"
+  "billingEmail": "maya@example.com",  // optional; defaults to the billing profile
+  "billingName": "Maya Keller"         // optional; defaults to the billing profile
 }</code></pre>
+          <p class="prose">
+            <code>billingEmail</code> and <code>billingName</code> address the billing account&#39;s
+            renewal and usage-threshold mail, and nothing else &mdash; what an invoice states about
+            its recipient is copied from the organization&#39;s
+            <a href="#billing-profile">billing profile</a> when the document is issued. Both are
+            optional, and each falls back on its own to the profile&#39;s billing contact: send them
+            only if you keep your own record of the customer. A caller that sends an address and no
+            name keeps the profile&#39;s name.
+          </p>
+          <p class="prose">
+            They are not a way to satisfy the profile requirement. A paid subscription is still
+            refused with <code>subscription_billing_profile_incomplete</code> until the profile
+            itself is complete, because that is what the invoice will be addressed to.
+          </p>
           <h4>Sample response</h4>
           <pre><code>{
   "success": true,

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1197,8 +1197,8 @@ The address and the tax id are deliberately not required. A great many subscribe
 with neither, and refusing them a subscription over a field their jurisdiction does not ask for would
 be a billing rule invented here.
 
-The profile is also **where a billing account gets its contact** when `CreateSubscriptionRequest`
-names none. `BillingName` and `BillingEmail` stay on the request for an integration that keeps its own
+The profile is also **where a billing account gets its contact**, on every subscribe, when
+`CreateSubscriptionRequest` names none. `BillingName` and `BillingEmail` stay on the request for an integration that keeps its own
 record of a customer, and each falls back on its own field: a caller that sends an address and no name
 keeps the profile's name, because it meant the address and blanking the name would lose the only one
 there is. That decides where renewal and usage-threshold mail is sent and nothing else — what a
@@ -1209,6 +1209,19 @@ exists: the profile is one organization's answer to "who do we bill", and two se
 ways is how they come to disagree. Unlike the completeness check it is *not* gated on
 `RequireBillingProfile` — a free metered plan is never asked for a profile and still sends
 usage-threshold mail, so the address is worth having wherever there is one.
+
+`GetOrCreateAndReconcileAsync` applies it to an **existing** account too, and not only to a new one.
+A billing account is one per organization and provider and outlives every subscription on it, so an
+organization that subscribed before filling its profile in used to keep the blank contact for good:
+correcting the profile and subscribing again returned the old account untouched, and renewal and
+threshold mail went on going nowhere. Creating it correctly was never enough.
+
+The reconciliation is a single upsert keyed on the unique index, so there is no read-then-write window
+and concurrent signups converge on one document. A null leaves what is stored alone rather than
+blanking it — a caller naming only an address cannot erase a name — but a value that *is* supplied
+overwrites, which is what makes a corrected profile take effect. The consequence worth knowing: an
+integration that sets a contact once and later subscribes without naming it will see the profile's
+value take over, so send it on every request if you keep your own record of the customer.
 
 Contacts are recorded per user id as people act, and under **that person's own name and address**,
 taken from the authenticated context. Not the organization's billing contact: those two are the same

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1197,6 +1197,19 @@ The address and the tax id are deliberately not required. A great many subscribe
 with neither, and refusing them a subscription over a field their jurisdiction does not ask for would
 be a billing rule invented here.
 
+The profile is also **where a billing account gets its contact** when `CreateSubscriptionRequest`
+names none. `BillingName` and `BillingEmail` stay on the request for an integration that keeps its own
+record of a customer, and each falls back on its own field: a caller that sends an address and no name
+keeps the profile's name, because it meant the address and blanking the name would lose the only one
+there is. That decides where renewal and usage-threshold mail is sent and nothing else — what a
+document states about its recipient is snapshotted at issue, never read from here.
+
+Read through the guard rather than by injecting the repository a second time, for the reason the guard
+exists: the profile is one organization's answer to "who do we bill", and two services reading it two
+ways is how they come to disagree. Unlike the completeness check it is *not* gated on
+`RequireBillingProfile` — a free metered plan is never asked for a profile and still sends
+usage-threshold mail, so the address is worth having wherever there is one.
+
 Contacts are recorded per user id as people act, and under **that person's own name and address**,
 taken from the authenticated context. Not the organization's billing contact: those two are the same
 person only by coincidence, and copying the second — which this used to do — made every document say

--- a/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using Blocks.Genesis;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
@@ -10,6 +11,14 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
 {
     /// <summary>Mongo's duplicate-key code, as it arrives on a losing upsert.</summary>
     private const int DuplicateKeyErrorCode = 11000;
+
+    // Stored element names, which this entity maps from its property names. Only the id is renamed,
+    // and nothing here touches it. Were that to change, the update below would name a field twice
+    // and Mongo would refuse it outright rather than write something surprising.
+    private const string BillingEmailField = nameof(BillingAccount.BillingEmail);
+    private const string BillingNameField = nameof(BillingAccount.BillingName);
+    private const string LastUpdatedField = nameof(BillingAccount.LastUpdatedDateUtc);
+    private const string VersionField = nameof(BillingAccount.Version);
 
     private readonly IDbContextProvider _dbContextProvider;
     private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
@@ -118,46 +127,50 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
     /// </remarks>
     private static UpdateDefinition<BillingAccount> Reconciliation(BillingAccount account)
     {
-        var update = Builders<BillingAccount>.Update
-            .SetOnInsert(stored => stored.ItemId, account.ItemId)
-            .SetOnInsert(stored => stored.TenantId, account.TenantId)
-            .SetOnInsert(stored => stored.OrganizationId, account.OrganizationId)
-            .SetOnInsert(stored => stored.ProviderName, account.ProviderName)
-            .SetOnInsert(stored => stored.CreatedAtUtc, account.CreatedAtUtc);
-
-        var contact = new List<UpdateDefinition<BillingAccount>>(2);
+        // The whole argument under $setOnInsert, rather than a hand-written list of its fields.
+        // Listing them by hand is what the first version of this did, and it silently dropped the
+        // provider customer id and the saved card on insert — which surfaces as a renewal with no
+        // card to present, a long way from the cause. Serialising the entity means a field added to
+        // it later is inserted without anybody having to remember this method exists.
+        var insert = account.ToBsonDocument();
+        var reconciled = new BsonDocument();
 
         if (!string.IsNullOrWhiteSpace(account.BillingEmail))
         {
-            contact.Add(Builders<BillingAccount>.Update.Set(
-                stored => stored.BillingEmail,
-                account.BillingEmail));
+            reconciled[BillingEmailField] = account.BillingEmail;
         }
 
         if (!string.IsNullOrWhiteSpace(account.BillingName))
         {
-            contact.Add(Builders<BillingAccount>.Update.Set(
-                stored => stored.BillingName,
-                account.BillingName));
+            reconciled[BillingNameField] = account.BillingName;
         }
 
-        if (contact.Count == 0)
+        if (reconciled.ElementCount == 0)
         {
-            return Builders<BillingAccount>.Update.Combine(
-                update,
-                Builders<BillingAccount>.Update.SetOnInsert(
-                    stored => stored.LastUpdatedDateUtc,
-                    account.LastUpdatedDateUtc),
-                Builders<BillingAccount>.Update.SetOnInsert(stored => stored.Version, 1));
+            // Nothing to bring up to date, so an existing account is left exactly as it stands,
+            // timestamp included: recording that nothing changed would be a lie a support
+            // conversation later has to unpick.
+            return new BsonDocument("$setOnInsert", insert);
         }
 
-        return Builders<BillingAccount>.Update.Combine(
-            update,
-            Builders<BillingAccount>.Update.Combine(contact),
-            Builders<BillingAccount>.Update.Set(
-                stored => stored.LastUpdatedDateUtc,
-                DateTime.UtcNow),
-            Builders<BillingAccount>.Update.Inc(stored => stored.Version, 1));
+        reconciled[LastUpdatedField] = DateTime.UtcNow;
+
+        // Mongo refuses a field named by two operators, so whatever is being written now comes out
+        // of the insert-only half — it is being written on both paths anyway. $inc creates a
+        // missing field, so a freshly inserted document still lands on version 1.
+        foreach (var name in reconciled.Names.ToList())
+        {
+            insert.Remove(name);
+        }
+
+        insert.Remove(VersionField);
+
+        return new BsonDocument
+        {
+            { "$setOnInsert", insert },
+            { "$set", reconciled },
+            { "$inc", new BsonDocument(VersionField, 1) }
+        };
     }
 
     public async Task<BillingAccount?> GetAsync(

--- a/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Blocks.Genesis;
 using MongoDB.Driver;
 using Subscription.DomainService.Entities;
@@ -8,6 +8,9 @@ namespace Subscription.DomainService.Repositories;
 
 public sealed class BillingAccountRepository : IBillingAccountRepository
 {
+    /// <summary>Mongo's duplicate-key code, as it arrives on a losing upsert.</summary>
+    private const int DuplicateKeyErrorCode = 11000;
+
     private readonly IDbContextProvider _dbContextProvider;
     private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
 
@@ -30,7 +33,7 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
         _indexedTenants.TryAdd(tenantId, 0);
     }
 
-    public async Task<BillingAccount> GetOrCreateAsync(
+    public async Task<BillingAccount> GetOrCreateAndReconcileAsync(
         BillingAccount account,
         CancellationToken cancellationToken)
     {
@@ -38,29 +41,33 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
 
         await EnsureIndexesAsync(account.TenantId, cancellationToken);
 
-        var existing = await FindAsync(
-            account.TenantId,
-            account.OrganizationId,
-            account.ProviderName,
-            cancellationToken);
-
-        if (existing is not null)
-        {
-            return existing;
-        }
+        var identity = Builders<BillingAccount>.Filter.And(
+            Builders<BillingAccount>.Filter.Eq(stored => stored.TenantId, account.TenantId),
+            Builders<BillingAccount>.Filter.Eq(
+                stored => stored.OrganizationId,
+                account.OrganizationId),
+            Builders<BillingAccount>.Filter.Eq(
+                stored => stored.ProviderName,
+                account.ProviderName));
 
         try
         {
-            await Accounts(account.TenantId)
-                .InsertOneAsync(account, cancellationToken: cancellationToken);
-
-            return account;
+            return await Accounts(account.TenantId).FindOneAndUpdateAsync(
+                identity,
+                Reconciliation(account),
+                new FindOneAndUpdateOptions<BillingAccount>
+                {
+                    IsUpsert = true,
+                    ReturnDocument = ReturnDocument.After
+                },
+                cancellationToken);
         }
-        catch (MongoWriteException exception)
-            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        catch (MongoCommandException exception)
+            when (exception.Code == DuplicateKeyErrorCode)
         {
-            // Another request created it between the read and the insert. Its document is as
-            // good as the one this call would have written.
+            // Two upserts raced and both decided to insert; one lost on the unique index. Its own
+            // reconciliation is gone, but the winner was reconciling to the same values, so reading
+            // what it wrote is the same answer this call would have given.
             return await FindAsync(
                        account.TenantId,
                        account.OrganizationId,
@@ -68,6 +75,68 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
                        cancellationToken)
                    ?? account;
         }
+    }
+
+    /// <summary>
+    /// The update that creates the account, or brings an existing one up to date.
+    /// </summary>
+    /// <remarks>
+    /// Identity and the creation stamp go under <c>$setOnInsert</c>, so a second signup cannot
+    /// rewrite the id a subscription already points at or move the creation date.
+    /// <para>
+    /// A contact field is set only when there is a value, which is what makes a null mean "leave it
+    /// alone" rather than "blank it". Mongo refuses a field named by both operators, so anything
+    /// reconciled here is deliberately absent from the insert-only list — and <c>$inc</c> on a
+    /// missing field creates it, so a freshly inserted document still comes out at version 1.
+    /// </para>
+    /// <para>
+    /// With nothing to reconcile the whole update is insert-only and an existing account is left
+    /// exactly as it was: touching its timestamp to record that nothing changed would be a lie a
+    /// support conversation later has to unpick.
+    /// </para>
+    /// </remarks>
+    private static UpdateDefinition<BillingAccount> Reconciliation(BillingAccount account)
+    {
+        var update = Builders<BillingAccount>.Update
+            .SetOnInsert(stored => stored.ItemId, account.ItemId)
+            .SetOnInsert(stored => stored.TenantId, account.TenantId)
+            .SetOnInsert(stored => stored.OrganizationId, account.OrganizationId)
+            .SetOnInsert(stored => stored.ProviderName, account.ProviderName)
+            .SetOnInsert(stored => stored.CreatedAtUtc, account.CreatedAtUtc);
+
+        var contact = new List<UpdateDefinition<BillingAccount>>(2);
+
+        if (!string.IsNullOrWhiteSpace(account.BillingEmail))
+        {
+            contact.Add(Builders<BillingAccount>.Update.Set(
+                stored => stored.BillingEmail,
+                account.BillingEmail));
+        }
+
+        if (!string.IsNullOrWhiteSpace(account.BillingName))
+        {
+            contact.Add(Builders<BillingAccount>.Update.Set(
+                stored => stored.BillingName,
+                account.BillingName));
+        }
+
+        if (contact.Count == 0)
+        {
+            return Builders<BillingAccount>.Update.Combine(
+                update,
+                Builders<BillingAccount>.Update.SetOnInsert(
+                    stored => stored.LastUpdatedDateUtc,
+                    account.LastUpdatedDateUtc),
+                Builders<BillingAccount>.Update.SetOnInsert(stored => stored.Version, 1));
+        }
+
+        return Builders<BillingAccount>.Update.Combine(
+            update,
+            Builders<BillingAccount>.Update.Combine(contact),
+            Builders<BillingAccount>.Update.Set(
+                stored => stored.LastUpdatedDateUtc,
+                DateTime.UtcNow),
+            Builders<BillingAccount>.Update.Inc(stored => stored.Version, 1));
     }
 
     public async Task<BillingAccount?> GetAsync(

--- a/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
@@ -62,8 +62,7 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
                 },
                 cancellationToken);
         }
-        catch (MongoCommandException exception)
-            when (exception.Code == DuplicateKeyErrorCode)
+        catch (Exception exception) when (IsDuplicateKey(exception))
         {
             // Two upserts raced and both decided to insert; one lost on the unique index. Its own
             // reconciliation is gone, but the winner was reconciling to the same values, so reading
@@ -76,6 +75,28 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
                    ?? account;
         }
     }
+
+    /// <summary>
+    /// Whether a failed upsert lost a race on the unique index, rather than failing for real.
+    /// </summary>
+    /// <remarks>
+    /// Both driver shapes are accepted deliberately. A duplicate key reaches an ordinary write as a
+    /// <see cref="MongoWriteException"/> and a <c>findAndModify</c> as a
+    /// <see cref="MongoCommandException"/>, and which one an upsert produces has moved between driver
+    /// versions. Recognising only one would turn a lost race - the ordinary outcome of two people
+    /// subscribing at once, and the case the retry below exists for - into an unhandled exception on
+    /// a signup, on an upgrade nobody linked to it.
+    /// </remarks>
+    private static bool IsDuplicateKey(Exception exception) =>
+        exception switch
+        {
+            MongoWriteException write =>
+                write.WriteError?.Category == ServerErrorCategory.DuplicateKey,
+            MongoCommandException command => command.Code == DuplicateKeyErrorCode,
+            MongoBulkWriteException bulk =>
+                bulk.WriteErrors.Any(error => error.Code == DuplicateKeyErrorCode),
+            _ => false
+        };
 
     /// <summary>
     /// The update that creates the account, or brings an existing one up to date.

--- a/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/IBillingAccountRepository.cs
@@ -1,4 +1,4 @@
-using Subscription.DomainService.Enums;
+﻿using Subscription.DomainService.Enums;
 using Subscription.DomainService.Entities;
 
 namespace Subscription.DomainService.Repositories;
@@ -8,13 +8,36 @@ public interface IBillingAccountRepository
     Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Returns the organization's account with this provider, creating it if there is none.
+    /// Returns the organization's account with this provider, creating it if there is none, and
+    /// bringing its contact details up to date either way.
     /// </summary>
     /// <remarks>
-    /// Idempotent by way of the unique index: two concurrent signups both attempt the insert,
-    /// one loses on the duplicate key and reads what the other wrote.
+    /// Named for the reconciling half because leaving it out was a bug. This used to return an
+    /// existing account untouched, so an organization that fixed a blank or wrong billing profile
+    /// and subscribed again kept the old contact on the account — and renewal and usage-threshold
+    /// mail went on going nowhere, or to the previous address, with the corrected profile sitting
+    /// right there. An account is one per organization and provider and outlives every subscription
+    /// on it, so "create it correctly" was never enough.
+    /// <para>
+    /// <see cref="BillingAccount.BillingEmail"/> and <see cref="BillingAccount.BillingName"/> on the
+    /// argument are the values to reconcile <em>to</em>, already resolved by the caller: an explicit
+    /// request value takes precedence over the organization's billing profile, per field. A null
+    /// leaves whatever is stored alone rather than blanking it, so a caller that knows only an
+    /// address cannot erase a name.
+    /// </para>
+    /// <para>
+    /// A profile-derived value does overwrite a stored one. That is the point — a stale address is
+    /// the reported failure — and it means an integration that sets a contact once and then
+    /// subscribes again without naming it will see the profile's value take over. Send the value on
+    /// every request if you keep your own record of the customer.
+    /// </para>
+    /// <para>
+    /// One round trip, and safe under concurrency without a read-then-write window: an upsert keyed
+    /// on the unique index, whose creation-only fields are written under <c>$setOnInsert</c>. Two
+    /// concurrent signups converge on one document, and both were reconciling to the same values.
+    /// </para>
     /// </remarks>
-    Task<BillingAccount> GetOrCreateAsync(
+    Task<BillingAccount> GetOrCreateAndReconcileAsync(
         BillingAccount account,
         CancellationToken cancellationToken);
 

--- a/server/Subscription.DomainService/Services/ISubscriptionBillingProfileGuard.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionBillingProfileGuard.cs
@@ -49,4 +49,31 @@ public interface ISubscriptionBillingProfileGuard
         string? name,
         string? email,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The organization's saved billing contact, for a caller that was not given one.
+    /// </summary>
+    /// <remarks>
+    /// Read here rather than by injecting the repository a second time, for the reason this
+    /// collaborator exists at all: the profile is one organization's answer to "who do we bill", and
+    /// two services reading it two ways is how they come to disagree.
+    /// <para>
+    /// Not gated on whether the profile is required. A free metered plan is never asked for a
+    /// profile and still sends usage-threshold email, so the address is worth having whenever there
+    /// is one — and an organization with no profile simply has none to give.
+    /// </para>
+    /// </remarks>
+    Task<BillingContactDefaults> ContactDefaultsAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken);
 }
+
+/// <summary>
+/// A billing account's contact details, as the organization's own profile states them.
+/// </summary>
+/// <remarks>
+/// Both nullable: an organization that has never filled in a profile has neither, and a billing
+/// account with no address is the state the module already handles by not sending the mail.
+/// </remarks>
+public readonly record struct BillingContactDefaults(string? Name, string? Email);

--- a/server/Subscription.DomainService/Services/SubscriptionBillingProfileGuard.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionBillingProfileGuard.cs
@@ -55,6 +55,25 @@ public sealed class SubscriptionBillingProfileGuard : ISubscriptionBillingProfil
         ];
     }
 
+    public async Task<BillingContactDefaults> ContactDefaultsAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken)
+    {
+        var profile = await _profiles.GetAsync(tenantId, organizationId, cancellationToken);
+
+        if (profile is null)
+        {
+            return default;
+        }
+
+        // The billing contact, not the legal name: this fills a mail recipient, and an invoice's
+        // addressee is the person who reads it rather than the company that owes it.
+        return new BillingContactDefaults(
+            Trimmed(profile.BillingContactName),
+            Trimmed(profile.BillingContactEmail));
+    }
+
     public async Task RememberInitiatorAsync(
         string tenantId,
         string organizationId,
@@ -104,4 +123,7 @@ public sealed class SubscriptionBillingProfileGuard : ISubscriptionBillingProfil
                 PaymentLogValue.Hash(organizationId));
         }
     }
+
+    private static string? Trimmed(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -172,14 +172,16 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 correlationId);
         }
 
+        var contact = await BillingContactAsync(request, context, cancellationToken);
+
         var account = await _billingAccounts.GetOrCreateAsync(
             new BillingAccount
             {
                 TenantId = context.TenantId,
                 OrganizationId = context.OrganizationId,
                 ProviderName = StripeProvider,
-                BillingEmail = request.BillingEmail,
-                BillingName = request.BillingName
+                BillingEmail = contact.Email,
+                BillingName = contact.Name
             },
             cancellationToken);
 
@@ -670,4 +672,48 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         return missing;
     }
+
+    /// <summary>
+    /// Who the billing account should mail, when the caller did not say.
+    /// </summary>
+    /// <remarks>
+    /// The request wins where it carries a value, because an integration with its own record of a
+    /// customer is naming somebody this module cannot know about. Where it does not, the
+    /// organization's saved billing profile answers — which is the same profile a paid subscription
+    /// is refused for the want of, so a subscriber who has filled it in has already said this once.
+    /// <para>
+    /// Filled in per field rather than per request. A caller that sends an address and no name meant
+    /// the address, and blanking the name it did not mention would lose the only one there is.
+    /// </para>
+    /// <para>
+    /// Not a substitute for the profile snapshot on a document. This only decides where renewal and
+    /// usage-threshold mail is sent; what an invoice states about its recipient is copied from the
+    /// profile when the document is issued, and never from here.
+    /// </para>
+    /// </remarks>
+    private async Task<BillingContactDefaults> BillingContactAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        CancellationToken cancellationToken)
+    {
+        var requestedName = Trimmed(request.BillingName);
+        var requestedEmail = Trimmed(request.BillingEmail);
+
+        if (_billingProfile is null || (requestedName is not null && requestedEmail is not null))
+        {
+            return new BillingContactDefaults(requestedName, requestedEmail);
+        }
+
+        var saved = await _billingProfile.ContactDefaultsAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        return new BillingContactDefaults(
+            requestedName ?? saved.Name,
+            requestedEmail ?? saved.Email);
+    }
+
+    private static string? Trimmed(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -174,7 +174,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         var contact = await BillingContactAsync(request, context, cancellationToken);
 
-        var account = await _billingAccounts.GetOrCreateAsync(
+        var account = await _billingAccounts.GetOrCreateAndReconcileAsync(
             new BillingAccount
             {
                 TenantId = context.TenantId,

--- a/server/XUnitTest/Integration/SubscriptionRenewalCrashRecoveryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRenewalCrashRecoveryIntegrationTests.cs
@@ -69,7 +69,7 @@ public sealed class SubscriptionRenewalCrashRecoveryIntegrationTests
         var accounts = new BillingAccountRepository(_fixture.DbContextProvider);
         var queue = Queue();
 
-        await accounts.GetOrCreateAsync(NewAccount(), default);
+        await accounts.GetOrCreateAndReconcileAsync(NewAccount(), default);
 
         // Reserved, which is what makes the first attempt's transition fail after its charge — the
         // state a worker leaves behind when it dies between the provider and the write.
@@ -170,7 +170,7 @@ public sealed class SubscriptionRenewalCrashRecoveryIntegrationTests
         var subscriptions = new SubscriptionRepository(_fixture.DbContextProvider);
         var accounts = new BillingAccountRepository(_fixture.DbContextProvider);
 
-        await accounts.GetOrCreateAsync(NewAccount(), default);
+        await accounts.GetOrCreateAndReconcileAsync(NewAccount(), default);
 
         var subscription = NewSubscription();
         subscription.SettlementReservation = new SettlementReservation

--- a/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
@@ -257,15 +257,138 @@ public sealed class SubscriptionRepositoryIntegrationTests
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
-        var first = await _accounts.GetOrCreateAsync(
+        var first = await _accounts.GetOrCreateAndReconcileAsync(
             NewAccount(tenantId, "org-9"),
             CancellationToken.None);
 
-        var second = await _accounts.GetOrCreateAsync(
+        var second = await _accounts.GetOrCreateAndReconcileAsync(
             NewAccount(tenantId, "org-9"),
             CancellationToken.None);
 
         second.ItemId.Should().Be(first.ItemId);
+    }
+
+    /// <summary>
+    /// The reason this operation reconciles rather than merely creating.
+    /// </summary>
+    /// <remarks>
+    /// An account is one per organization and provider and outlives every subscription on it, so an
+    /// organization that subscribed before filling its billing profile in had a blank contact stored
+    /// for good. Fixing the profile and subscribing again returned the old account untouched, and
+    /// renewal and usage-threshold mail went on going nowhere.
+    /// <para>
+    /// Only a real collection shows it. A mock returning the account it was handed reports success
+    /// for the very write that never happened, which is exactly what the unit tests did.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task A_billing_account_takes_up_a_contact_it_was_created_without()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var created = await _accounts.GetOrCreateAndReconcileAsync(
+            NewAccount(tenantId, "org-contact-1"),
+            CancellationToken.None);
+
+        created.BillingEmail.Should().BeNull();
+
+        var account = NewAccount(tenantId, "org-contact-1");
+        account.BillingEmail = "billing@northwind.example";
+        account.BillingName = "Ada Byron";
+
+        var reconciled = await _accounts.GetOrCreateAndReconcileAsync(
+            account,
+            CancellationToken.None);
+
+        // The same account, now reachable. A new one would strand the subscriptions pointing at the
+        // first, so the id has to survive the reconciliation.
+        reconciled.ItemId.Should().Be(created.ItemId);
+        reconciled.BillingEmail.Should().Be("billing@northwind.example");
+        reconciled.BillingName.Should().Be("Ada Byron");
+        reconciled.CreatedAtUtc.Should().Be(created.CreatedAtUtc);
+    }
+
+    [Fact]
+    public async Task A_billing_account_follows_a_contact_that_changed()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var first = NewAccount(tenantId, "org-contact-2");
+        first.BillingEmail = "old@northwind.example";
+        first.BillingName = "Ada Byron";
+        await _accounts.GetOrCreateAndReconcileAsync(first, CancellationToken.None);
+
+        var second = NewAccount(tenantId, "org-contact-2");
+        second.BillingEmail = "new@northwind.example";
+        second.BillingName = "Grace Hopper";
+
+        var reconciled = await _accounts.GetOrCreateAndReconcileAsync(
+            second,
+            CancellationToken.None);
+
+        // A stale address is the failure this exists for: mail kept going to whoever the profile
+        // used to name, months after somebody corrected it.
+        reconciled.BillingEmail.Should().Be("new@northwind.example");
+        reconciled.BillingName.Should().Be("Grace Hopper");
+        reconciled.Version.Should().BeGreaterThan(1, "a reconciliation is a change to the account");
+    }
+
+    [Fact]
+    public async Task A_contact_this_caller_does_not_know_is_left_alone_rather_than_blanked()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var first = NewAccount(tenantId, "org-contact-3");
+        first.BillingEmail = "billing@northwind.example";
+        first.BillingName = "Ada Byron";
+        var created = await _accounts.GetOrCreateAndReconcileAsync(first, CancellationToken.None);
+
+        // Knows an address and no name, which is what a caller sending one field looks like.
+        var second = NewAccount(tenantId, "org-contact-3");
+        second.BillingEmail = "later@northwind.example";
+
+        var reconciled = await _accounts.GetOrCreateAndReconcileAsync(
+            second,
+            CancellationToken.None);
+
+        reconciled.BillingEmail.Should().Be("later@northwind.example");
+        reconciled.BillingName.Should().Be(
+            "Ada Byron",
+            "a caller that named no name meant the address, and blanking it would lose the only " +
+            "name there is");
+
+        // And a call that knows neither leaves the account exactly as it stands, timestamp included.
+        var untouched = await _accounts.GetOrCreateAndReconcileAsync(
+            NewAccount(tenantId, "org-contact-3"),
+            CancellationToken.None);
+
+        untouched.BillingEmail.Should().Be("later@northwind.example");
+        untouched.BillingName.Should().Be("Ada Byron");
+        untouched.CreatedAtUtc.Should().Be(created.CreatedAtUtc);
+    }
+
+    [Fact]
+    public async Task Concurrent_signups_converge_on_one_account_and_one_contact()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        // Sixteen at once, all reconciling to the same values, which is what a real signup burst
+        // looks like: the profile is one answer and every request read it.
+        var accounts = await Task.WhenAll(Enumerable.Range(0, 16).Select(_ =>
+        {
+            var account = NewAccount(tenantId, "org-contact-4");
+            account.BillingEmail = "billing@northwind.example";
+            account.BillingName = "Ada Byron";
+
+            return _accounts.GetOrCreateAndReconcileAsync(account, CancellationToken.None);
+        }));
+
+        // One document, not sixteen. The upsert is keyed on the unique index, so a loser reads the
+        // winner rather than inserting a second account the next renewal would have to choose
+        // between.
+        accounts.Select(account => account.ItemId).Distinct().Should().HaveCount(1);
+        accounts.Should().OnlyContain(
+            account => account.BillingEmail == "billing@northwind.example");
     }
 
     [Fact]
@@ -273,7 +396,7 @@ public sealed class SubscriptionRepositoryIntegrationTests
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
-        var account = await _accounts.GetOrCreateAsync(
+        var account = await _accounts.GetOrCreateAndReconcileAsync(
             NewAccount(tenantId, "org-10"),
             CancellationToken.None);
 

--- a/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
@@ -308,6 +308,79 @@ public sealed class SubscriptionRepositoryIntegrationTests
         reconciled.CreatedAtUtc.Should().Be(created.CreatedAtUtc);
     }
 
+    /// <summary>
+    /// Everything else on the account survives being created through the reconciling upsert.
+    /// </summary>
+    /// <remarks>
+    /// The upsert first written for this named its inserted fields by hand and left these two out, so
+    /// an account created with a customer and a saved card arrived with neither. Nothing near the
+    /// billing profile noticed: it surfaced two suites away, as a renewal that reached the provider
+    /// with no card to present and never charged. Pinned here so the next field added to the entity
+    /// cannot go the same way.
+    /// </remarks>
+    [Fact]
+    public async Task Creating_an_account_keeps_the_fields_this_operation_does_not_reconcile()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var account = NewAccount(tenantId, "org-contact-5");
+        account.ProviderCustomerId = "cus_123";
+        account.DefaultPaymentMethodId = "pm-1";
+        account.ProviderOrganizationId = "default";
+        account.BillingEmail = "billing@northwind.example";
+
+        var created = await _accounts.GetOrCreateAndReconcileAsync(
+            account,
+            CancellationToken.None);
+
+        created.ProviderCustomerId.Should().Be("cus_123");
+        created.DefaultPaymentMethodId.Should().Be("pm-1");
+        created.ProviderOrganizationId.Should().Be("default");
+        created.BillingEmail.Should().Be("billing@northwind.example");
+        created.Version.Should().Be(1);
+
+        // And read back from the collection, not just returned: an upsert that answers correctly
+        // while storing less than it should is the failure this is about.
+        var reloaded = await _accounts.GetAsync(
+            tenantId,
+            created.ItemId,
+            CancellationToken.None);
+
+        reloaded!.ProviderCustomerId.Should().Be("cus_123");
+        reloaded.DefaultPaymentMethodId.Should().Be("pm-1");
+        reloaded.ProviderOrganizationId.Should().Be("default");
+    }
+
+    [Fact]
+    public async Task Reconciling_a_contact_leaves_the_provider_details_alone()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var account = NewAccount(tenantId, "org-contact-6");
+        account.ProviderCustomerId = "cus_123";
+        account.DefaultPaymentMethodId = "pm-1";
+        var created = await _accounts.GetOrCreateAndReconcileAsync(
+            account,
+            CancellationToken.None);
+
+        // A later signup knows the contact and nothing about the provider, which is exactly what the
+        // creation service hands over: it builds an account from the billing profile alone.
+        var later = NewAccount(tenantId, "org-contact-6");
+        later.BillingEmail = "billing@northwind.example";
+
+        var reconciled = await _accounts.GetOrCreateAndReconcileAsync(
+            later,
+            CancellationToken.None);
+
+        reconciled.BillingEmail.Should().Be("billing@northwind.example");
+
+        // The card and the customer are the account's standing with the provider and no business of
+        // a contact update. Blanking them would leave a renewal unable to charge.
+        reconciled.ItemId.Should().Be(created.ItemId);
+        reconciled.ProviderCustomerId.Should().Be("cus_123");
+        reconciled.DefaultPaymentMethodId.Should().Be("pm-1");
+    }
+
     [Fact]
     public async Task A_billing_account_follows_a_contact_that_changed()
     {

--- a/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
@@ -54,7 +54,7 @@ public sealed class CalendarAlignedSubscriptionTests
             .ReturnsAsync(() => _price);
 
         _accounts
-            .Setup(repository => repository.GetOrCreateAsync(
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
                 It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
 

--- a/server/XUnitTest/Subscription/CalendarAlignedYearlyTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedYearlyTests.cs
@@ -60,7 +60,7 @@ public sealed class CalendarAlignedYearlyTests
             .ReturnsAsync(() => _price);
 
         _accounts
-            .Setup(repository => repository.GetOrCreateAsync(
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
                 It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
 

--- a/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
@@ -62,7 +62,7 @@ public sealed class CalendarAnnualChargeTimingTests
             .ReturnsAsync(() => _price);
 
         _accounts
-            .Setup(repository => repository.GetOrCreateAsync(
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
                 It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
 

--- a/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualTrialAndCancellationTests.cs
@@ -68,7 +68,7 @@ public sealed class CalendarAnnualTrialAndCancellationTests
             .ReturnsAsync(() => YearlyPrice(_timing));
 
         _accounts
-            .Setup(repository => repository.GetOrCreateAsync(
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
                 It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
 

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -32,6 +32,7 @@ public sealed class SubscriptionCreationServiceTests
 
     private Plan _plan = NewPlan();
     private SubscriptionDetail? _created;
+    private BillingAccount? _account;
 
     public SubscriptionCreationServiceTests()
     {
@@ -55,7 +56,17 @@ public sealed class SubscriptionCreationServiceTests
         _accounts
             .Setup(repository => repository.GetOrCreateAsync(
                 It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .Callback<BillingAccount, CancellationToken>((account, _) => _account = account)
             .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        // Moq would answer this with a default struct, which reads as "the organization has no
+        // profile" — a plausible state, and the wrong default for a fixture whose subscriber is
+        // otherwise complete. Named so the fallback tests below are testing the fallback rather
+        // than the absence of one.
+        _billingProfile
+            .Setup(guard => guard.ContactDefaultsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingContactDefaults("Ada Byron", "billing@northwind.example"));
 
         _subscriptions
             .Setup(repository => repository.TryCreateAsync(
@@ -606,6 +617,70 @@ public sealed class SubscriptionCreationServiceTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Where renewal and usage-threshold mail goes when the caller never said.
+    /// </summary>
+    /// <remarks>
+    /// The subscribe form used to ask for these separately, which meant a subscriber typed a billing
+    /// address twice and the two copies were free to disagree — and the one the invoice used was not
+    /// the one the form collected.
+    /// </remarks>
+    [Fact]
+    public async Task A_billing_account_takes_its_contact_from_the_organizations_profile()
+    {
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _account!.BillingName.Should().Be("Ada Byron");
+        _account.BillingEmail.Should().Be("billing@northwind.example");
+    }
+
+    [Fact]
+    public async Task An_integration_that_names_its_own_contact_keeps_it()
+    {
+        var request = NewRequest();
+        request.BillingName = "Grace Hopper";
+        request.BillingEmail = "grace@contoso.example";
+
+        await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        // The caller knows a customer this module does not, so it wins. The fields stay on the
+        // request for exactly this reason, even though no screen sends them any more.
+        _account!.BillingName.Should().Be("Grace Hopper");
+        _account.BillingEmail.Should().Be("grace@contoso.example");
+    }
+
+    [Fact]
+    public async Task A_request_naming_only_an_address_still_gets_the_saved_name()
+    {
+        var request = NewRequest();
+        request.BillingEmail = "grace@contoso.example";
+
+        await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        // Filled per field rather than per request: a caller that sent an address and no name meant
+        // the address, and blanking the name would lose the only one there is.
+        _account!.BillingEmail.Should().Be("grace@contoso.example");
+        _account.BillingName.Should().Be("Ada Byron");
+    }
+
+    [Fact]
+    public async Task An_organization_with_no_profile_leaves_the_contact_empty()
+    {
+        _billingProfile
+            .Setup(guard => guard.ContactDefaultsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(default(BillingContactDefaults));
+
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        // Empty rather than refused. A free plan is never asked for a profile at all, and the
+        // module already handles an account with no address by not sending the mail.
+        _account!.BillingName.Should().BeNull();
+        _account.BillingEmail.Should().BeNull();
     }
 
     private SubscriptionCreationService Service() => new(

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -53,8 +53,13 @@ public sealed class SubscriptionCreationServiceTests
                 TenantId, "price-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(NewPrice);
 
+        // Returns what it was handed, which is what an insert does. Note what that hides: a real
+        // repository given an account for an organization that already has one returns the *stored*
+        // document, so a mock echoing the argument back reports success for a reconciliation that
+        // never happened. That is why the reconciling behaviour is pinned against a real collection
+        // in SubscriptionRepositoryIntegrationTests rather than here.
         _accounts
-            .Setup(repository => repository.GetOrCreateAsync(
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
                 It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
             .Callback<BillingAccount, CancellationToken>((account, _) => _account = account)
             .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
@@ -681,6 +686,34 @@ public sealed class SubscriptionCreationServiceTests
         // module already handles an account with no address by not sending the mail.
         _account!.BillingName.Should().BeNull();
         _account.BillingEmail.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_subscription_is_linked_to_the_account_the_repository_returned()
+    {
+        // An organization subscribing for a second time already has an account, and the repository
+        // answers with that one rather than the freshly built argument.
+        _accounts
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .Callback<BillingAccount, CancellationToken>((account, _) => _account = account)
+            .ReturnsAsync(new BillingAccount
+            {
+                ItemId = "account-already-there",
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                ProviderName = "STRIPE"
+            });
+
+        await Service().CreateAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        // The stored one, not the proposed one. Linking to an id that was never inserted would
+        // leave the subscription pointing at nothing, and a renewal with no card to present.
+        _created!.BillingAccountId.Should().Be("account-already-there");
+
+        // And the contact still travelled, which is what the repository reconciles onto it.
+        _account!.BillingEmail.Should().Be("billing@northwind.example");
     }
 
     private SubscriptionCreationService Service() => new(


### PR DESCRIPTION
## Summary

Picking an organization on the plan list and then clicking through the sidebar silently dropped it. Billing profile went on to edit whichever organization the server resolved for an unscoped request — usually the console's own — and nothing on the screen said so, which is what made it confusing rather than merely wrong.

The scope now survives navigation, every screen says which organization it is showing, and a refusal points at the page that fixes it. The duplicate billing-contact inputs on the subscribe dialog are gone, and the organization's saved profile supplies the billing account's contact instead.

No migration. Existing billing accounts are brought up to date the next time the organization subscribes, rather than by a backfill — see **Reconciling an existing account** below.

## Navigation

- A shared subscription-link helper in two parts: one for menu entries, one for links built inside a page. Only paths under `/app/subscription` are touched — the scope is this module's idea and means nothing to Payment or IAM, so putting it on their links would advertise a filter they do not apply.
- `ScopedDashboardRoute` carries it onto the shell's sidebar. The sidebar renders above every page, so no page can reach the links that navigate away from it; this is the one place the menu tree and the current URL are both in hand. It covers desktop and mobile at once, since both render from the same menu tree.
- **The entry the page is already inside is left clean.** The shell marks an entry active with `pathname.startsWith(menu.path)`, and a query string appended there matches nothing — the active item would quietly stop being highlighted. Nothing is lost by it: the link left clean is the one that navigates nowhere.
- Three back links pointed at `/dashboard/subscription/plans`, **which is not a route in this app** — the real one is `/app/:itemId/subscription/plans`. Fixed through the helper, which gets the project segment and the organization right in one place.

## Billing profile

- Names the organization being edited and always shows the resolved id, derived from the response rather than the URL.
- Warns, and **withholds "Ready to be invoiced"**, when the server answered about a different organization than the link asked for. Naming another organization is honoured for the platform console alone; for anybody else the request is *ignored* rather than refused, so the page has to state what it loaded. A green light under the wrong company's name is how somebody fills in a form for the wrong organization.
- Caching was already keyed per organization, so it is unchanged — the defect was the derivation, not the cache.

## Failure handling

- The API's error `code` and `fields` now survive to the UI instead of being flattened to a message. A 400 arrives as an `HttpError` whose `errors` is the parsed body, so the envelope sits a level down; both shapes are read in one place rather than at each call site.
- `subscription_billing_profile_incomplete` renders as the page that fixes it, for that organization, rather than as JSON.
- **The field list is split in two.** The server folds `merchantLegalName` into the same list, and that one is the tenant's own seller identity. Sending a subscriber to add a legal name, when the missing name is the platform's own, sends them to correct something that was never theirs.

## Duplicate contact inputs

- Removed "Billing email" and "Billing name" from the subscribe dialog. They looked like the details an invoice needs and satisfied none of them: the server reads the organization's billing profile, while these went to the billing account. Two forms for one answer, free to disagree, and the one on screen was not the one that counted.
- The request fields stay for integrations that keep their own record of a customer. The server fills each **per field** from the profile's billing contact — a caller that sends an address and no name keeps the profile's name, because it meant the address and blanking the name would lose the only one there is.
- This decides where renewal and usage-threshold mail is sent and nothing else. What a document states about its recipient is still snapshotted when the document is issued, never read from here.
- Read through `ISubscriptionBillingProfileGuard` rather than injecting the repository a second time, for the reason that collaborator exists: the profile is one organization's answer to "who do we bill", and two services reading it two ways is how they come to disagree. Deliberately **not** gated on `RequireBillingProfile` — a free metered plan is never asked for a profile and still sends threshold mail, so the address is worth having wherever there is one.

## Reconciling an existing account

Added in `b0020dd`, from review feedback on this PR. Resolving the contact in the creation service was only half the job: `GetOrCreateAsync` returned an existing account **untouched**, so an organization that subscribed before filling its billing profile in kept the blank contact for good. Correcting the profile and subscribing again changed nothing, and renewal and usage-threshold mail went on going nowhere — or to the address the profile used to name. A billing account is one per organization and provider and outlives every subscription on it, so "create it correctly" was never enough.

- The operation is now `GetOrCreateAndReconcileAsync`, and does that. The old name described the half that worked, which is how the missing half went unnoticed; leaving a pure get-or-create beside it would have left the same footgun for the next caller, so it is renamed rather than supplemented.
- **One atomic upsert** keyed on the unique index, replacing a read-then-insert with a window between the two. Creation-only fields go under `$setOnInsert`, so a second signup cannot rewrite the id a subscription already points at or move the creation date.
- A null contact field **leaves what is stored alone rather than blanking it**, so a caller naming only an address cannot erase a name. A supplied value overwrites — that is what lets a corrected profile take effect. Explicit request values still take precedence over profile defaults, per field, resolved before the repository sees them.
- With nothing to reconcile the update is insert-only and an existing account is left exactly as it stands, timestamp included. Recording that nothing changed would be a lie a support conversation later has to unpick.

**One consequence worth a reviewer's agreement:** a profile-derived value now overwrites a stored one, so an integration that sets a contact once and later subscribes *without* naming it will see the profile's value take over. That is the direction the finding asked for — a stale address is the reported failure — and distinguishing "stored by an integration" from "stored by an older profile" would need provenance state nobody asked for. Documented in the interface, the README and the API docs: send the value on every request if you keep your own record of the customer.

**Why the tests missed it.** The repository was mocked to return the account it was handed — which is what an insert does, and not what an existing account does. The mock reported success for the write that never happened. That assumption is now named in the fixture, and the behaviour is pinned against a real collection instead.

## Verification

- **Server:** 2920 passing on this branch. 4 failures, all `SubscriptionSimulation*` permission-guard tests — verified failing identically on untouched `origin/dev`, so pre-existing. Build clean.
- **The four new reconcile tests are integration tests** and need a real MongoDB, so they run in CI's `mongo-integration` job rather than locally. Verified here that they compile and are discovered by the runner.
- **Client:** typecheck clean, lint clean on all 17 touched files, 337 subscription and layout tests passing, full suite 2136 passing. Five client test *files* fail to load on an SVG asset import in the devops/create-project area; none of them imports anything this PR touches.
- Both were re-run against the commit in an isolated worktree, not just the working tree.

New tests worth naming: the scope reaches subscription links and no others; the entry the page is inside stays clean so the sidebar keeps highlighting it; an organization id is escaped so it cannot forge a second parameter; the profile page withholds "ready to be invoiced" when the server answered about another organization; the envelope is read out of both a failing status and a 200; a missing seller identity links to the tenant's page and lists none of the subscriber's fields; the billing account takes the profile's contact, an integration's own values win, and a request naming only an address keeps the profile's name.

From the review finding: an account created without a contact takes one up while keeping its id and creation date; a contact that changed is followed; a field the caller does not know is left alone rather than blanked, and a call knowing neither touches nothing; sixteen concurrent signups converge on one account and one contact; and a subscription links to the account the repository *returned* rather than the one proposed — linking to an id that was never inserted would leave a renewal with no card to present.

## Two decisions worth a reviewer's eye

- **After saving, the page offers "Continue to plans" rather than redirecting.** Auto-navigating would stop somebody reviewing what they just saved and is hostile to anyone merely editing the profile. Easy to change if you would rather it were automatic.
- **Every subscription menu entry carries the scope, including merchant profile,** which ignores it. A menu rule with named exceptions is how the next entry added comes to be forgotten, and the benefit is that a detour through merchant profile does not silently reset the organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
