### PR TITLE
feat(subscription): add configurable trial period rules

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -134,7 +134,8 @@ const PlanBuilderWizard = ({
     displayName: draft.displayName ?? "",
     code: draft.code ?? "",
     organizationLabel,
-    trialDays: draft.trialDays ?? null,
+    trialDurationKind: draft.trialDurationKind ?? null,
+    trialDurationCount: draft.trialDurationCount ?? null,
     trialRequiresPaymentMethod: draft.trialRequiresPaymentMethod ?? true,
     quantityItems: (draft.quantityItems ?? []).map((item) => ({
       itemKey: item?.itemKey ?? "",

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -18,10 +18,36 @@ import {
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 import { CardListItem, CardListShell } from "./card-list-shell";
 
+/** Not a server value — selecting this clears the trial fields entirely. */
+const NO_TRIAL = "None" as const;
+
+const TRIAL_DURATION_KIND_OPTIONS: {
+  value: "Days" | "EndOfCalendarMonth" | "AnniversaryMonths";
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "Days",
+    label: "Fixed number of days",
+    description: "14 days from signup.",
+  },
+  {
+    value: "EndOfCalendarMonth",
+    label: "Until the end of the calendar month",
+    description:
+      "Until the end of the calendar month; late signups may receive a short trial.",
+  },
+  {
+    value: "AnniversaryMonths",
+    label: "Fixed number of months",
+    description: "Same local date and time after N months.",
+  },
+];
+
 export const StepTrial = () => {
-  const { control } = useFormContext<CreateSubscriptionPlanFormValues>();
+  const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
   const trialGrants = useFieldArray({ control, name: "trialGrants" });
-  const trialDays = useWatch({ control, name: "trialDays" });
+  const trialDurationKind = useWatch({ control, name: "trialDurationKind" });
   const trialRequiresPaymentMethod = useWatch({
     control,
     name: "trialRequiresPaymentMethod",
@@ -37,24 +63,79 @@ export const StepTrial = () => {
       <div>
         <h2 className="text-lg font-semibold">Trial</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Optional. Leave the trial length blank for a plan that charges from day one.
+          Optional. Choose &ldquo;No trial&rdquo; for a plan that charges from day one.
         </p>
       </div>
 
       <div className="grid gap-5 sm:grid-cols-2">
         <FormField
           control={control}
-          name="trialDays"
+          name="trialDurationKind"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Trial length (days)</FormLabel>
-              <FormControl>
-                <Input {...field} value={field.value ?? ""} type="number" min={1} max={365} />
-              </FormControl>
+              <FormLabel>Trial duration</FormLabel>
+              <Select
+                value={field.value ?? NO_TRIAL}
+                onValueChange={(value) => {
+                  if (value === NO_TRIAL) {
+                    field.onChange(undefined);
+                    setValue("trialDurationCount", undefined);
+                    return;
+                  }
+                  field.onChange(value);
+                  // Every kind uses a different valid range (or none at all), so a count left
+                  // over from a different kind would otherwise fail silently until submit.
+                  setValue("trialDurationCount", undefined);
+                }}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value={NO_TRIAL}>No trial</SelectItem>
+                  {TRIAL_DURATION_KIND_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {trialDurationKind
+                  ? TRIAL_DURATION_KIND_OPTIONS.find((option) => option.value === trialDurationKind)
+                      ?.description
+                  : "A plan that charges from day one."}
+              </p>
               <FormMessage />
             </FormItem>
           )}
         />
+
+        {trialDurationKind && trialDurationKind !== "EndOfCalendarMonth" && (
+          <FormField
+            control={control}
+            name="trialDurationCount"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {trialDurationKind === "AnniversaryMonths" ? "Months" : "Days"}
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    type="number"
+                    min={1}
+                    max={trialDurationKind === "AnniversaryMonths" ? 12 : 365}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         <FormField
           control={control}
@@ -107,7 +188,7 @@ export const StepTrial = () => {
         />
       </div>
 
-      {Boolean(trialDays) && (
+      {Boolean(trialDurationKind) && (
         <div className="space-y-3">
           <h3 className="text-sm font-semibold">Trial grants</h3>
           <p className="text-xs text-muted-foreground">

--- a/client/app/cross-modules/utilities/subscription/components/plan-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-card.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui-kits/badge/badge";
 import { Card } from "@/components/ui-kits/card/card";
 import type { SubscriptionPlan } from "../models/subscription-plan.model";
 import { formatPrice } from "../utilities/subscription-format";
+import { describeTrialDuration } from "../utilities/trial-duration-label";
 
 export const PlanCard = ({
   plan,
@@ -21,6 +22,7 @@ export const PlanCard = ({
         : cheapest,
     null,
   );
+  const trialLabel = describeTrialDuration(plan);
 
   return (
     <Link to={detailPath} className="block">
@@ -37,9 +39,9 @@ export const PlanCard = ({
           <Badge variant="outline" className="font-normal">
             {organizationLabel}
           </Badge>
-          {plan.trialDays ? (
+          {trialLabel ? (
             <Badge variant="info" className="font-normal">
-              {plan.trialDays}-day trial
+              {trialLabel}
             </Badge>
           ) : null}
           {plan.quantityItems.length > 0 && (

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.test.tsx
@@ -6,7 +6,8 @@ const plan = (overrides: Partial<PlanSummaryData> = {}): PlanSummaryData => ({
   displayName: "Personal",
   code: "personal",
   organizationLabel: "AmLora Test Org",
-  trialDays: null,
+  trialDurationKind: null,
+  trialDurationCount: null,
   trialRequiresPaymentMethod: true,
   quantityItems: [],
   meters: [],
@@ -167,21 +168,26 @@ describe("PlanSummaryCard", () => {
     render(
       <PlanSummaryCard
         plan={plan({
-          trialDays: 1,
+          trialDurationKind: "Days",
+          trialDurationCount: 1,
           meters: [meter()],
           trialGrants: [{ meterKey: "ses-signatures", includedQuantity: 5 }],
         })}
       />,
     );
 
-    expect(screen.getByText("During the 1-day trial")).toBeInTheDocument();
+    expect(screen.getByText("During the trial")).toBeInTheDocument();
     expect(
       screen.getByText(/5 signatures, instead of the usual 150/),
     ).toBeInTheDocument();
   });
 
   it("warns that a meter with no grant gives a whole month away during the trial", () => {
-    render(<PlanSummaryCard plan={plan({ trialDays: 14, meters: [meter()] })} />);
+    render(
+      <PlanSummaryCard
+        plan={plan({ trialDurationKind: "Days", trialDurationCount: 14, meters: [meter()] })}
+      />,
+    );
 
     expect(
       screen.getByText(/150 signatures — the full monthly allowance, with no separate trial limit/),
@@ -189,7 +195,9 @@ describe("PlanSummaryCard", () => {
   });
 
   it("says nothing about trial allowances on a plan that measures nothing", () => {
-    render(<PlanSummaryCard plan={plan({ trialDays: 14 })} />);
+    render(
+      <PlanSummaryCard plan={plan({ trialDurationKind: "Days", trialDurationCount: 14 })} />,
+    );
 
     expect(screen.queryByText(/During the/)).not.toBeInTheDocument();
   });

--- a/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-summary-card.tsx
@@ -1,6 +1,7 @@
 import { CircleDollarSign, Gauge, Hourglass, Layers, ShieldCheck } from "lucide-react";
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui-kits/card/card";
+import type { TrialDurationKindName } from "../models/subscription-plan.model";
 import { describeEntitlementMeterMismatch } from "../utilities/plan-consistency";
 import {
   formatEntitlementLimit,
@@ -9,12 +10,14 @@ import {
   formatTrialAllowance,
 } from "../utilities/subscription-format";
 import { describeQuantityBand } from "../utilities/quantity-discount-format";
+import { describeTrialDuration, describeTrialSentence } from "../utilities/trial-duration-label";
 
 export interface PlanSummaryData {
   displayName: string;
   code: string;
   organizationLabel: string;
-  trialDays: number | null;
+  trialDurationKind: TrialDurationKindName | null;
+  trialDurationCount: number | null;
   trialRequiresPaymentMethod: boolean;
   quantityItems: {
     itemKey: string;
@@ -104,13 +107,15 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
   const hasPricing = plan.quantityItems.length > 0 || plan.prices.length > 0;
   const hasUsage = plan.meters.length > 0;
   const hasEntitlements = plan.entitlements.length > 0;
+  const trialLabel = describeTrialDuration(plan);
+  const trialSentence = describeTrialSentence(plan);
 
   return (
     <Card className="rounded-xl">
       <CardHeader className="gap-2">
         <div className="flex flex-wrap items-center gap-2">
           <CardTitle>{plan.displayName || "Untitled plan"}</CardTitle>
-          {plan.trialDays ? <Badge variant="info">{plan.trialDays}-day trial</Badge> : null}
+          {trialLabel ? <Badge variant="info">{trialLabel}</Badge> : null}
         </div>
         <p className="text-xs text-muted-foreground">
           {plan.code || "no-code-yet"} · {plan.organizationLabel}
@@ -128,21 +133,17 @@ export const PlanSummaryCard = ({ plan }: { plan: PlanSummaryData }) => {
           </div>
         )}
 
-        {plan.trialDays ? (
-          <p className="text-sm text-muted-foreground">
-            {plan.trialRequiresPaymentMethod
-              ? `Charged at signup; the ${plan.trialDays}-day trial governs the allowances, not the price.`
-              : `Free for ${plan.trialDays} days, then the first charge is taken.`}
-          </p>
+        {trialSentence ? (
+          <p className="text-sm text-muted-foreground">{trialSentence}</p>
         ) : null}
 
         {/* Only worth showing where there is something to measure: a trial on a plan with no
             meters changes nothing but when the first charge falls. */}
-        {plan.trialDays && hasUsage ? (
+        {trialLabel && hasUsage ? (
           <div className="flex items-start gap-2 text-sm">
             <Hourglass className="mt-0.5 h-4 w-4 shrink-0 text-blocks-primary-600" />
             <div className="space-y-0.5">
-              <p className="font-medium">During the {plan.trialDays}-day trial</p>
+              <p className="font-medium">During the trial</p>
               {plan.meters.map((meter, index) => (
                 <p key={index}>
                   {meter.displayName}:{" "}

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -70,6 +70,12 @@ export type EntitlementLimitKindName = keyof typeof ENTITLEMENT_LIMIT_KIND;
  */
 export type QuantityDiscountCombinationPolicyName = "BestDiscount" | "QuantityOnly" | "Stack";
 
+/**
+ * How a trial's length is measured. A name on the wire, like every other enum in this module —
+ * see the server's `TrialDurationKind` for what each one resolves to.
+ */
+export type TrialDurationKindName = "Days" | "EndOfCalendarMonth" | "AnniversaryMonths";
+
 export interface QuantityDiscountTier {
   minimumQuantity: number;
   /** Null on the last band of an unbounded item: everything above the minimum falls in it. */
@@ -187,7 +193,15 @@ export interface SubscriptionPlan {
   quantityDiscountCombinationPolicy?: QuantityDiscountCombinationPolicyName;
   featuresJson: string | null;
   organizationId: string | null;
+  /** Set only when {@link trialDurationKind} is `"Days"` — including a legacy day-based plan. */
   trialDays: number | null;
+  /**
+   * How this plan's trial length is measured, normalized by the server from whichever of the
+   * legacy or current fields the plan actually has. Null when the plan has no trial.
+   */
+  trialDurationKind?: TrialDurationKindName | null;
+  /** The count {@link trialDurationKind} is measured in. Null for `"EndOfCalendarMonth"`. */
+  trialDurationCount?: number | null;
   trialRequiresPaymentMethod: boolean;
   /**
    * Whether a card is collected before the subscription starts, even when the opening amount is
@@ -265,6 +279,15 @@ export interface CreateSubscriptionPlanRequest {
   featuresJson?: string;
   /** Omitted entirely for a tenant-wide plan. */
   organizationId?: string;
+  /**
+   * How a trial's length is measured. The console always sends this instead of the legacy
+   * {@link trialDays} — mutually exclusive on the wire, and the server rejects a request naming
+   * both. Omitted (with {@link trialDurationCount}) means no trial.
+   */
+  trialDurationKind?: TrialDurationKindName;
+  /** The count {@link trialDurationKind} is measured in. Omitted for `"EndOfCalendarMonth"`. */
+  trialDurationCount?: number;
+  /** Legacy day-count trial. The console never sends this; kept only for the response type's sake. */
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
   /** Sent on every write, for the same reason the combination policy is. */
@@ -291,6 +314,15 @@ export interface UpdateSubscriptionPlanRequest {
   featuresJson?: string;
   /** Names the plan's organization for the console. It never changes the plan's scope. */
   organizationId?: string;
+  /**
+   * How a trial's length is measured. The console always sends this instead of the legacy
+   * {@link trialDays} — mutually exclusive on the wire, and the server rejects a request naming
+   * both. Omitted (with {@link trialDurationCount}) means no trial.
+   */
+  trialDurationKind?: TrialDurationKindName;
+  /** The count {@link trialDurationKind} is measured in. Omitted for `"EndOfCalendarMonth"`. */
+  trialDurationCount?: number;
+  /** Legacy day-count trial. The console never sends this; kept only for the response type's sake. */
   trialDays?: number;
   trialRequiresPaymentMethod: boolean;
   /** Sent on every write, for the same reason the combination policy is. */

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -111,7 +111,8 @@ export const SubscriptionPlanDetailPage = () => {
     displayName: plan.displayName,
     code: plan.code,
     organizationLabel,
-    trialDays: plan.trialDays,
+    trialDurationKind: plan.trialDurationKind ?? null,
+    trialDurationCount: plan.trialDurationCount ?? null,
     trialRequiresPaymentMethod: plan.trialRequiresPaymentMethod,
     quantityItems: plan.quantityItems.map((item) => ({
       quantityDiscountTiers: item.quantityDiscountTiers,

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
@@ -33,6 +33,82 @@ describe("createSubscriptionPlanSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a plan with no trial", () => {
+    const result = createSubscriptionPlanSchema.safeParse(validPlan);
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a days trial with a valid count", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      trialDurationKind: "Days",
+      trialDurationCount: 14,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a days trial with no count", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      trialDurationKind: "Days",
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["trialDurationCount"]);
+  });
+
+  it("rejects a days trial count outside 1-365", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      trialDurationKind: "Days",
+      trialDurationCount: 366,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an anniversary-months trial with a valid count", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      trialDurationKind: "AnniversaryMonths",
+      trialDurationCount: 1,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an anniversary-months trial count outside 1-12", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      trialDurationKind: "AnniversaryMonths",
+      trialDurationCount: 13,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an end-of-calendar-month trial with no count", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      trialDurationKind: "EndOfCalendarMonth",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an end-of-calendar-month trial that specifies a count", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      trialDurationKind: "EndOfCalendarMonth",
+      trialDurationCount: 1,
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["trialDurationCount"]);
+  });
+
   it("rejects a plan code with characters the server would reject", () => {
     const result = createSubscriptionPlanSchema.safeParse({
       ...validPlan,
@@ -141,7 +217,8 @@ describe("createSubscriptionPlanSchema", () => {
   it("rejects a trial grant naming a meter the plan does not define", () => {
     const result = createSubscriptionPlanSchema.safeParse({
       ...validPlan,
-      trialDays: 14,
+      trialDurationKind: "Days",
+      trialDurationCount: 14,
       trialGrants: [{ meterKey: "not-a-meter", includedQuantity: 10 }],
     });
 

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -259,7 +259,13 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
         .optional()
         .or(z.literal("")),
       organizationId: z.string().min(1, "Choose an organization."),
-      trialDays: z.coerce.number().int().min(1).max(365).optional(),
+      // The console always authors through these two rather than the legacy trialDays — see the
+      // cross-field checks below for what each duration kind requires.
+      trialDurationKind: z.enum(["Days", "EndOfCalendarMonth", "AnniversaryMonths"]).optional(),
+      trialDurationCount: z.preprocess(
+        (value) => (value === "" ? undefined : value),
+        z.coerce.number().int().optional(),
+      ),
       trialRequiresPaymentMethod: z.boolean(),
       requirePaymentMethodUpfront: z.boolean(),
       // Always in the form, whether or not any item has bands: a plan edited while the field
@@ -285,6 +291,50 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
           code: z.ZodIssueCode.custom,
           path: ["featuresJson"],
           message: 'Features must be a valid JSON object, e.g. {"betaAccess": true}.',
+        });
+      }
+
+      // Mirrors the server's PlanDefinitionRequestValidator rules for trial duration exactly —
+      // the two must agree, or an edit that passes here could still be rejected on save.
+      if (plan.trialDurationKind === "Days" && plan.trialDurationCount === undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trialDurationCount"],
+          message: "Enter how many days the trial lasts.",
+        });
+      } else if (
+        plan.trialDurationKind === "Days" &&
+        (plan.trialDurationCount! < 1 || plan.trialDurationCount! > 365)
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trialDurationCount"],
+          message: "A day-based trial must be between 1 and 365 days.",
+        });
+      }
+
+      if (plan.trialDurationKind === "AnniversaryMonths" && plan.trialDurationCount === undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trialDurationCount"],
+          message: "Enter how many months the trial lasts.",
+        });
+      } else if (
+        plan.trialDurationKind === "AnniversaryMonths" &&
+        (plan.trialDurationCount! < 1 || plan.trialDurationCount! > 12)
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trialDurationCount"],
+          message: "An anniversary-month trial must be between 1 and 12 months.",
+        });
+      }
+
+      if (plan.trialDurationKind === "EndOfCalendarMonth" && plan.trialDurationCount !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["trialDurationCount"],
+          message: "An end-of-calendar-month trial has no count to set.",
         });
       }
 
@@ -403,7 +453,8 @@ export const defaultSubscriptionPlanFormValues: CreateSubscriptionPlanFormValues
   description: "",
   featuresJson: "",
   organizationId: TENANT_WIDE_ORGANIZATION,
-  trialDays: undefined,
+  trialDurationKind: undefined,
+  trialDurationCount: undefined,
   trialRequiresPaymentMethod: true,
   // False, which is what every plan authored before this existed meant: nothing due today, so
   // nothing to collect.

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -12,6 +12,8 @@ const storedPlan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan
   featuresJson: null,
   organizationId: "org-1",
   trialDays: 1,
+  trialDurationKind: "Days",
+  trialDurationCount: 1,
   trialRequiresPaymentMethod: true,
   version: 1,
   hasSubscribers: false,
@@ -89,6 +91,40 @@ describe("planToFormValues", () => {
     expect(planToFormValues(plan).meters[0].resetPolicy).toBe(1);
   });
 
+  it("reads the normalized duration fields, not the legacy trialDays", () => {
+    const values = planToFormValues(storedPlan());
+
+    expect(values.trialDurationKind).toBe("Days");
+    expect(values.trialDurationCount).toBe(1);
+  });
+
+  it("reopens an anniversary-months plan with its kind and count intact", () => {
+    const values = planToFormValues(
+      storedPlan({ trialDurationKind: "AnniversaryMonths", trialDurationCount: 2, trialDays: null }),
+    );
+
+    expect(values.trialDurationKind).toBe("AnniversaryMonths");
+    expect(values.trialDurationCount).toBe(2);
+  });
+
+  it("reopens an end-of-calendar-month plan with no count", () => {
+    const values = planToFormValues(
+      storedPlan({ trialDurationKind: "EndOfCalendarMonth", trialDurationCount: null, trialDays: null }),
+    );
+
+    expect(values.trialDurationKind).toBe("EndOfCalendarMonth");
+    expect(values.trialDurationCount).toBeUndefined();
+  });
+
+  it("reopens a plan with no trial as no trial", () => {
+    const values = planToFormValues(
+      storedPlan({ trialDurationKind: null, trialDurationCount: null, trialDays: null }),
+    );
+
+    expect(values.trialDurationKind).toBeUndefined();
+    expect(values.trialDurationCount).toBeUndefined();
+  });
+
   it("keeps trial grants, which an edit would otherwise drop", () => {
     expect(planToFormValues(storedPlan()).trialGrants).toEqual([
       { meterKey: "ses-signatures", includedQuantity: 5 },
@@ -141,6 +177,14 @@ describe("toUpdatePlanRequest", () => {
     const request = toUpdatePlanRequest(planToFormValues(storedPlan()), null);
 
     expect(request.organizationId).toBeUndefined();
+  });
+
+  it("sends the current duration fields, never the legacy trialDays", () => {
+    const request = toUpdatePlanRequest(planToFormValues(storedPlan()), "org-1");
+
+    expect(request.trialDurationKind).toBe("Days");
+    expect(request.trialDurationCount).toBe(1);
+    expect(request.trialDays).toBeUndefined();
   });
 
   it("sends no code, which the server takes from the stored plan", () => {

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -24,7 +24,10 @@ const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
   displayName: values.displayName.trim(),
   description: values.description?.trim() || undefined,
   featuresJson: values.featuresJson?.trim() || undefined,
-  trialDays: values.trialDays,
+  // Always the current fields, never the legacy trialDays — the server rejects a request naming
+  // both, and there is no reason for the console to ever author the legacy one.
+  trialDurationKind: values.trialDurationKind,
+  trialDurationCount: values.trialDurationCount,
   trialRequiresPaymentMethod: values.trialRequiresPaymentMethod,
   requirePaymentMethodUpfront: values.requirePaymentMethodUpfront,
   usageInterval: values.usageInterval,
@@ -135,7 +138,11 @@ export const planToFormValues = (
   description: plan.description ?? "",
   featuresJson: plan.featuresJson ?? "",
   organizationId: plan.organizationId ?? TENANT_WIDE_ORGANIZATION,
-  trialDays: plan.trialDays ?? undefined,
+  // Read from the server's normalized fields, not the legacy trialDays — a plan authored before
+  // duration kinds existed still comes back with these populated (as "Days"), so this reopens
+  // identically regardless of which format the plan was originally saved in.
+  trialDurationKind: plan.trialDurationKind ?? undefined,
+  trialDurationCount: plan.trialDurationCount ?? undefined,
   trialRequiresPaymentMethod: plan.trialRequiresPaymentMethod,
   // Defaulted here rather than in the schema, because a plan the server stored before this
   // existed answers with nothing at all — and reading that as "leave it as it was" would turn a

--- a/client/app/cross-modules/utilities/subscription/utilities/trial-duration-label.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/trial-duration-label.ts
@@ -1,0 +1,51 @@
+import type { TrialDurationKindName } from "../models/subscription-plan.model";
+
+interface TrialDuration {
+  trialDurationKind?: TrialDurationKindName | null;
+  trialDurationCount?: number | null;
+}
+
+/**
+ * A short label describing a plan's trial rule, for a badge or a one-line summary. Null when the
+ * plan has no trial at all — including a plan whose `trialDurationKind` came back null from the
+ * server, which is how "no trial" is normalized regardless of whether the plan predates duration
+ * kinds. Not tied to a single plan shape: the builder's own draft and the server's stored plan
+ * are different types that both carry these same two fields.
+ */
+export const describeTrialDuration = (plan: TrialDuration): string | null => {
+  switch (plan.trialDurationKind) {
+    case "Days":
+      return plan.trialDurationCount ? `${plan.trialDurationCount}-day trial` : null;
+    case "AnniversaryMonths":
+      return plan.trialDurationCount ? `${plan.trialDurationCount}-month trial` : null;
+    case "EndOfCalendarMonth":
+      return "Trial until end of month";
+    default:
+      return null;
+  }
+};
+
+/**
+ * A full sentence describing when the trial ends and what happens then — for the plan summary
+ * card, where the badge's short label is not enough context.
+ */
+export const describeTrialSentence = (
+  plan: TrialDuration & { trialRequiresPaymentMethod: boolean },
+): string | null => {
+  const span =
+    plan.trialDurationKind === "Days" && plan.trialDurationCount
+      ? `${plan.trialDurationCount} days`
+      : plan.trialDurationKind === "AnniversaryMonths" && plan.trialDurationCount
+        ? `${plan.trialDurationCount} month${plan.trialDurationCount === 1 ? "" : "s"}`
+        : plan.trialDurationKind === "EndOfCalendarMonth"
+          ? "until the end of the calendar month"
+          : null;
+
+  if (span === null) {
+    return null;
+  }
+
+  return plan.trialRequiresPaymentMethod
+    ? `Charged at signup; the trial (${span}) governs the allowances, not the price.`
+    : `Free ${plan.trialDurationKind === "EndOfCalendarMonth" ? span : `for ${span}`}, then the first charge is taken.`;
+};

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -598,7 +598,9 @@
             <tr><td>usageInterval / usageIntervalCount</td><td class="type">string / int</td><td class="prose">The single allowance reset window, independent of price cadence. Defaults to one month.</td></tr>
             <tr><td>organizationId</td><td class="type">string?</td><td class="prose">Which organization the plan is sold to. <code>null</code> means the whole tenant.</td></tr>
             <tr><td>featuresJson</td><td class="type">string?</td><td class="prose">Arbitrary JSON, stored verbatim and returned untouched. Nothing interprets it — this is where your product puts its own flags.</td></tr>
-            <tr><td>trialDays</td><td class="type">int?</td><td class="prose">Trial length. <code>null</code> means no trial.</td></tr>
+            <tr><td>trialDays</td><td class="type">int?</td><td class="prose">Legacy trial length, still accepted on write and still returned when the trial is day-based. Prefer <code>trialDurationKind</code>/<code>trialDurationCount</code> below for new plans — a request naming both is rejected.</td></tr>
+            <tr><td>trialDurationKind</td><td class="type">string?</td><td class="prose"><code>"Days"</code>, <code>"EndOfCalendarMonth"</code>, or <code>"AnniversaryMonths"</code>. <code>null</code> (with <code>trialDurationCount</code> also <code>null</code>) means no trial. See <a href="#trial">Trial</a>.</td></tr>
+            <tr><td>trialDurationCount</td><td class="type">int?</td><td class="prose">Required and 1–365 for <code>"Days"</code>; required and 1–12 for <code>"AnniversaryMonths"</code>; must be omitted for <code>"EndOfCalendarMonth"</code>.</td></tr>
             <tr><td>trialRequiresPaymentMethod</td><td class="type">bool</td><td class="prose">Whether a card is taken before the trial starts. See <a href="#branches">Branches</a> — this changes when money moves.</td></tr>
             <tr><td>requirePaymentMethodUpfront</td><td class="type">bool</td><td class="prose">Whether a card is collected before activation even when nothing is due today. Defaults to <code>false</code>. See <a href="#branches">Branches</a>.</td></tr>
             <tr><td>version</td><td class="type">int</td><td class="prose">Bumps on every edit. Starts at 1.</td></tr>
@@ -931,7 +933,50 @@
 
       <h3 id="trial">Trial</h3>
       <p>
-        <code>trialDays</code> sets the length. <strong>A trial grant replaces a meter's allowance
+        A trial's length is authored one of three ways, via <code>trialDurationKind</code> and
+        (for two of the three) <code>trialDurationCount</code> — the legacy <code>trialDays</code>
+        is exactly <code>"Days"</code> with that count, still accepted, but mutually exclusive with
+        the current fields on a single write.
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Kind</th><th>Count</th><th>Ends at</th></tr></thead>
+          <tbody>
+            <tr><td><code>Days</code></td><td class="type">1–365</td><td class="prose">Exactly <code>count × 24 hours</code> after signup. No time zone involved — a fixed span, not a calendar boundary.</td></tr>
+            <tr><td><code>EndOfCalendarMonth</code></td><td class="type">none</td><td class="prose">Local midnight on the first day of the month <em>after</em> signup. A signup on the 31st can get a trial lasting barely a day — nothing tops it up to a minimum length.</td></tr>
+            <tr><td><code>AnniversaryMonths</code></td><td class="type">1–12</td><td class="prose">The same local time of day, <code>count</code> months later. Clamped to the target month's last day when the signup date doesn't exist there — 31 January plus one month lands on 28 or 29 February.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="prose">
+        <code>EndOfCalendarMonth</code> and <code>AnniversaryMonths</code> are resolved in the
+        <strong>subscriber's own time zone</strong> (the <code>timeZoneId</code> given at signup),
+        with the same daylight-saving handling every other billing boundary in this API uses: a
+        boundary that lands in a spring-forward gap moves to the first instant that exists, and one
+        that lands in an autumn hour repeated twice resolves to the earlier of the two — always, so
+        the choice never depends on which request happened to ask first.
+      </p>
+      <p class="prose">
+        <code>trialEndsAtUtc</code> is an <strong>exclusive</strong> boundary. A trial resolving to
+        local midnight on 1 September ran <em>through</em> 31 August, not into it — show it to a
+        subscriber as "through August 31," not "ends September 1," which reads as a day later than
+        it is.
+      </p>
+      <p class="prose">
+        The resolved kind, count and end are <strong>frozen onto the subscription at signup</strong>.
+        Editing a plan's trial rule afterward changes nothing for a subscriber already on it — only
+        a later signup sees the new rule.
+      </p>
+      <div class="callout">
+        <strong>A card-free trial's first paid cycle is anchored on <code>trialEndsAtUtc</code>,
+        whichever kind produced it.</strong> A 25 August signup on a one-month anniversary trial is
+        first charged 25 September; the same signup on an end-of-month trial is first charged 1
+        September. A calendar-aligned price still renews on its own calendar boundaries — the trial
+        only decides <em>when</em> the first charge happens, charging the stub up to the next
+        boundary and renewing normally from there.
+      </div>
+      <p>
+        <strong>A trial grant replaces a meter's allowance
         rather than adding to it</strong> — a 5-signature grant against a 150 meter means 5 during the
         trial. A meter with no grant keeps its <em>whole</em> monthly allowance for the trial's
         duration, which on anything costly is an invitation to sign up, consume and leave.
@@ -1746,6 +1791,8 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
     "displayName": "Personal",
     "organizationId": "org-1",
     "trialDays": null,
+    "trialDurationKind": null,
+    "trialDurationCount": null,
     "trialRequiresPaymentMethod": true,
     "requirePaymentMethodUpfront": false,
     "version": 1,
@@ -1803,7 +1850,8 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
   "displayName": "Personal",
   "description": "For one person signing on their own.",
   "organizationId": "org-1",          // omit for tenant-wide
-  "trialDays": 14,
+  "trialDurationKind": "Days",        // or "EndOfCalendarMonth" / "AnniversaryMonths"; omit both fields, and trialDays, for no trial
+  "trialDurationCount": 14,           // 1-365 for "Days", 1-12 for "AnniversaryMonths", omit for "EndOfCalendarMonth"
   "trialRequiresPaymentMethod": true,
   "requirePaymentMethodUpfront": false,   // true to collect a card even when nothing is due
   "quantityItems": [],

--- a/server/Subscription.DomainService/Entities/Plan.cs
+++ b/server/Subscription.DomainService/Entities/Plan.cs
@@ -62,8 +62,30 @@ public sealed class Plan
     public QuantityDiscountCombinationPolicy QuantityDiscountCombinationPolicy { get; set; } =
         QuantityDiscountCombinationPolicy.BestDiscount;
 
-    /// <summary>Trial length in days. Null means the plan offers no trial.</summary>
+    /// <summary>
+    /// Legacy trial length in days. Null means the plan offers no trial — unless
+    /// <see cref="TrialDurationKind"/> says otherwise. Kept only so a plan authored before
+    /// <see cref="TrialDurationKind"/> existed keeps deserializing and behaving identically; new
+    /// authoring should set <see cref="TrialDurationKind"/> and <see cref="TrialDurationCount"/>
+    /// instead. See <see cref="Utilities.TrialDurationNormalizer"/> for how the two reconcile.
+    /// </summary>
     public int? TrialDays { get; set; }
+
+    /// <summary>
+    /// How <see cref="TrialDurationCount"/> (or, for a legacy plan, <see cref="TrialDays"/>) is
+    /// measured. Defaults to <see cref="Enums.TrialDurationKind.Days"/>, which is also what every
+    /// document written before this field existed deserializes to — exactly what those plans
+    /// already meant.
+    /// </summary>
+    public TrialDurationKind TrialDurationKind { get; set; } = TrialDurationKind.Days;
+
+    /// <summary>
+    /// The count <see cref="TrialDurationKind"/> measures: a day count for
+    /// <see cref="Enums.TrialDurationKind.Days"/>, a month count for
+    /// <see cref="Enums.TrialDurationKind.AnniversaryMonths"/>. Must be null for
+    /// <see cref="Enums.TrialDurationKind.EndOfCalendarMonth"/>, which has no count to give.
+    /// </summary>
+    public int? TrialDurationCount { get; set; }
 
     /// <summary>Whether a trial collects a payment method before it starts.</summary>
     public bool TrialRequiresPaymentMethod { get; set; } = true;

--- a/server/Subscription.DomainService/Entities/TrialTerms.cs
+++ b/server/Subscription.DomainService/Entities/TrialTerms.cs
@@ -1,4 +1,5 @@
 using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
 
 namespace Subscription.DomainService.Entities;
 
@@ -10,7 +11,21 @@ public sealed class TrialTerms
 {
     public DateTime StartsAtUtc { get; set; }
 
+    /// <summary>
+    /// Resolved once, at creation, from <see cref="DurationKind"/>/<see cref="DurationCount"/>
+    /// in the subscription's own time zone — and never recomputed. A later catalogue edit to the
+    /// plan's trial rule must not move an existing subscriber's boundary.
+    /// </summary>
     public DateTime EndsAtUtc { get; set; }
+
+    /// <summary>
+    /// The rule <see cref="EndsAtUtc"/> was resolved from, kept for display and audit — not for
+    /// recomputation, since <see cref="EndsAtUtc"/> is already the frozen answer.
+    /// </summary>
+    public TrialDurationKind DurationKind { get; set; } = TrialDurationKind.Days;
+
+    /// <summary>The count <see cref="DurationKind"/> was measured with. Null for <see cref="TrialDurationKind.EndOfCalendarMonth"/>.</summary>
+    public int? DurationCount { get; set; }
 
     /// <summary>
     /// Whether a card was taken up front. When false the subscription starts without any

--- a/server/Subscription.DomainService/Enums/TrialDurationKind.cs
+++ b/server/Subscription.DomainService/Enums/TrialDurationKind.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// How a trial's length is measured. <see cref="Days"/> is the default (value 0) so every plan
+/// authored before this existed — which only ever set the legacy <c>TrialDays</c> field — keeps
+/// meaning exactly what it always meant.
+/// </summary>
+/// <remarks>
+/// Explicit string conversion: this is bound straight off a plan-authoring request body, where
+/// System.Text.Json's default numeric enum handling would reject the string names a caller
+/// actually sends — see the remark on
+/// <see cref="Subscription.DomainService.Simulation.SimulatedRenewalOutcome"/> for the identical
+/// gap this closes the same way.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TrialDurationKind
+{
+    /// <summary>A fixed number of days from signup — <c>count × 24 hours</c>, no time zone involved.</summary>
+    Days = 0,
+
+    /// <summary>Ends at local midnight on the first day of the month after signup. No count.</summary>
+    EndOfCalendarMonth = 1,
+
+    /// <summary>
+    /// Ends the given number of months after signup, same local wall-clock time, clamped to the
+    /// target month's last day when the signup date does not exist there (e.g. Jan 31 + 1 month).
+    /// </summary>
+    AnniversaryMonths = 2
+}

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -379,6 +379,37 @@ The usage schedule is never realigned. Metering keeps the plan's own independent
 allowance stays whole for the stub, and nothing is reset or forcibly rolled over on the first —
 an allowance is capacity for a period, not money to be prorated.
 
+### Trial duration
+
+A plan authors its trial length as one of three kinds (`TrialDurationKind`), plus a count where
+the kind needs one:
+
+| Kind | Count | Ends at |
+| --- | --- | --- |
+| `Days` | 1-365 | `count × 24 hours` after signup — a fixed span, never converted through a time zone. |
+| `EndOfCalendarMonth` | none | Local midnight on the first day of the month after signup. |
+| `AnniversaryMonths` | 1-12 | The same local wall-clock time, `count` months later, clamped to the target month's last day when signup's day-of-month does not exist there (31 January + 1 month lands on 28 or 29 February). |
+
+The legacy `TrialDays` field on a plan is still accepted and is exactly `Days` with that count —
+every plan authored before duration kinds existed keeps behaving identically, with no migration.
+A request may set the legacy field or the current pair, never both.
+
+`EndOfCalendarMonth` and `AnniversaryMonths` are resolved in the **subscription's own time zone**
+(`BillingLocalTime`, the same DST-gap-and-ambiguity handling every other billing boundary in this
+module uses), then converted to UTC and frozen. `Trial.EndsAtUtc` is an **exclusive** boundary —
+a trial that resolves to local midnight on 1 September has run *through* 31 August, not into it,
+even though the instant itself is timestamped 1 September. A UI showing that boundary to a
+subscriber should describe it as "through August 31," not "ends September 1," which reads as one
+day later than it is.
+
+Because `EndOfCalendarMonth` is anchored to the calendar rather than a fixed span, a signup late
+in the month gets a short trial — 31 August grants only until 1 September, by design; nothing
+tops it up to a minimum length.
+
+The resolved kind, count, start and end are all frozen onto `TrialTerms` at creation and never
+recomputed. Editing a plan's trial rule afterward changes nothing for a subscriber already on it —
+only a new signup sees the new rule.
+
 ### Trials
 
 - A **payment-free trial** ending mid-month charges a stub from the local trial-end date to the
@@ -392,6 +423,15 @@ an allowance is capacity for a period, not money to be prorated.
   for a yearly one.
 - A **payment-required trial** is charged up front at checkout, so its first fee uses the calendar
   stub exactly as an ordinary signup does.
+
+This holds the same way regardless of which `TrialDurationKind` produced `Trial.EndsAtUtc`:
+
+- 25 August signup, one `AnniversaryMonths` trial → ends 25 September → first charge 25 September.
+- 25 August signup, `EndOfCalendarMonth` trial → ends 1 September → first charge 1 September.
+- A calendar-aligned price whose next boundary is 25 September, converting from any trial ending
+  before then, is charged its 25 September-1 October stub immediately and renews on 1 October —
+  the trial only decided *when* the first charge happens, not which calendar boundaries the price
+  itself renews on.
 
 ### Plan changes
 

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -155,6 +155,8 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
             .Set(existing => existing.Meters, plan.Meters)
             .Set(existing => existing.QuantityItems, plan.QuantityItems)
             .Set(existing => existing.TrialDays, plan.TrialDays)
+            .Set(existing => existing.TrialDurationKind, plan.TrialDurationKind)
+            .Set(existing => existing.TrialDurationCount, plan.TrialDurationCount)
             .Set(existing => existing.TrialRequiresPaymentMethod, plan.TrialRequiresPaymentMethod)
             .Set(existing => existing.RequirePaymentMethodUpfront, plan.RequirePaymentMethodUpfront)
             .Set(existing => existing.TrialGrants, plan.TrialGrants)

--- a/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
+++ b/server/Subscription.DomainService/Requests/PlanDefinitionRequest.cs
@@ -24,7 +24,26 @@ public abstract class PlanDefinitionRequest
     /// </summary>
     public string? FeaturesJson { get; set; }
 
+    /// <summary>
+    /// Legacy day-count trial. Still accepted so existing callers keep working, but mutually
+    /// exclusive with <see cref="TrialDurationKind"/> — a request naming both is rejected rather
+    /// than guessing which one wins.
+    /// </summary>
     public int? TrialDays { get; set; }
+
+    /// <summary>
+    /// How a trial's length is measured. Null (the default) with <see cref="TrialDays"/> also
+    /// null means no trial. Prefer this over the legacy <see cref="TrialDays"/> for new plans.
+    /// </summary>
+    public TrialDurationKind? TrialDurationKind { get; set; }
+
+    /// <summary>
+    /// The count <see cref="TrialDurationKind"/> is measured in — required for
+    /// <see cref="Enums.TrialDurationKind.Days"/> (1-365) and
+    /// <see cref="Enums.TrialDurationKind.AnniversaryMonths"/> (1-12), and must be omitted for
+    /// <see cref="Enums.TrialDurationKind.EndOfCalendarMonth"/>.
+    /// </summary>
+    public int? TrialDurationCount { get; set; }
 
     public bool TrialRequiresPaymentMethod { get; set; } = true;
 

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -36,7 +36,25 @@ public sealed class PlanResponse
     /// <summary>The plan's own feature bag, exactly as it was authored.</summary>
     public string? FeaturesJson { get; init; }
 
+    /// <summary>
+    /// The trial length, for a <see cref="TrialDurationKind"/> of <c>Days</c> — including a plan
+    /// authored before <see cref="TrialDurationKind"/> existed, which only ever set this field.
+    /// Null for every other duration kind and for a plan with no trial at all.
+    /// </summary>
     public int? TrialDays { get; init; }
+
+    /// <summary>
+    /// How this plan's trial length is measured, as its name — normalized from whichever of the
+    /// legacy or current fields the stored plan actually has. Null when the plan has no trial.
+    /// </summary>
+    public string? TrialDurationKind { get; init; }
+
+    /// <summary>
+    /// The count <see cref="TrialDurationKind"/> is measured in. Same value as
+    /// <see cref="TrialDays"/> when the kind is <c>Days</c>; null for <c>EndOfCalendarMonth</c>
+    /// and for a plan with no trial.
+    /// </summary>
+    public int? TrialDurationCount { get; init; }
 
     public bool TrialRequiresPaymentMethod { get; init; }
 

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -744,6 +744,10 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         FeaturesJson = request.FeaturesJson,
         Status = CatalogueStatus.Active,
         TrialDays = request.TrialDays,
+        // The validator refuses a request naming both, so exactly one of these two paths ever
+        // has anything in it: TrialDays alone (legacy), or Kind/Count alone (current).
+        TrialDurationKind = request.TrialDurationKind ?? TrialDurationKind.Days,
+        TrialDurationCount = request.TrialDurationCount,
         TrialRequiresPaymentMethod = request.TrialRequiresPaymentMethod,
         RequirePaymentMethodUpfront = request.RequirePaymentMethodUpfront,
         QuantityItems = request.QuantityItems

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -1,5 +1,7 @@
 using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
 
@@ -21,6 +23,9 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(prices);
 
+        var hasTrial = TrialDurationNormalizer.HasTrial(plan);
+        var trialCount = TrialDurationNormalizer.EffectiveCount(plan);
+
         return new PlanResponse
         {
             PlanId = plan.ItemId,
@@ -33,7 +38,11 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
             UsageIntervalCount = plan.UsageIntervalCount,
             OrganizationId = plan.OrganizationId,
             FeaturesJson = plan.FeaturesJson,
-            TrialDays = plan.TrialDays,
+            // Only a Days-mode plan ever populated the legacy field, and only a Days-mode plan
+            // should keep returning it — an anniversary or end-of-month plan has no day count.
+            TrialDays = hasTrial && plan.TrialDurationKind == TrialDurationKind.Days ? trialCount : null,
+            TrialDurationKind = hasTrial ? plan.TrialDurationKind.ToString() : null,
+            TrialDurationCount = hasTrial ? trialCount : null,
             TrialRequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
             RequirePaymentMethodUpfront = plan.RequirePaymentMethodUpfront,
             Version = plan.Version,

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -128,6 +128,20 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         var now = _time.GetUtcNow().UtcDateTime;
 
+        if (!BillingLocalTime.TryFindTimeZone(request.TimeZoneId, out var timeZone))
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_schedule_invalid",
+                "The billing schedule could not be derived from this time zone.",
+                correlationId);
+        }
+
+        // Resolved once, here, and reused for both the schedule anchor below and the TrialTerms
+        // frozen onto the subscription — a trial's boundary must never be computed twice and risk
+        // disagreeing with itself.
+        var trial = BuildTrial(plan, now, timeZone);
+
         // A calendar-aligned price anchors on the first of the month rather than on this instant;
         // every later boundary then derives from that anchor exactly as an anniversary one does.
         // The usage schedule is never realigned — metering keeps the plan's own independent
@@ -143,8 +157,8 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // 20 September starts its year on 1 October, not 1 September. The trial's end is known
         // here, so the schedule is anchored on it rather than corrected later — every boundary
         // derives from the anchor, and one anchored a month early stays a month early forever.
-        var scheduleAnchorUtc = plan.TrialDays is { } trialDays && !plan.TrialRequiresPaymentMethod
-            ? now.AddDays(trialDays)
+        var scheduleAnchorUtc = trial is not null && !plan.TrialRequiresPaymentMethod
+            ? trial.EndsAtUtc
             : now;
 
         var feeScheduleBuilt = calendarAligned
@@ -192,6 +206,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             feeSchedule,
             usageSchedule,
             discount.Value,
+            trial,
             now,
             correlationId);
 
@@ -402,6 +417,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         BillingSchedule feeSchedule,
         BillingSchedule usageSchedule,
         DiscountTerms? discount,
+        TrialTerms? trial,
         DateTime now,
         string correlationId)
     {
@@ -421,7 +437,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             FeeSchedule = feeSchedule,
             UsageSchedule = usageSchedule,
             Discount = discount,
-            Trial = BuildTrial(plan, now),
+            Trial = trial,
             OrderId = SubscriptionConstants.OrderIdFor(subscriptionId),
             CorrelationId = correlationId,
             CreatedAtUtc = now,
@@ -429,22 +445,36 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         };
     }
 
-    private static TrialTerms? BuildTrial(Plan plan, DateTime now) =>
-        plan.TrialDays is not { } days
-            ? null
-            : new TrialTerms
-            {
-                StartsAtUtc = now,
-                EndsAtUtc = now.AddDays(days),
-                RequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
-                Grants = plan.TrialGrants
-                    .Select(grant => new TrialMeterGrant
-                    {
-                        MeterKey = grant.MeterKey,
-                        IncludedQuantity = grant.IncludedQuantity
-                    })
-                    .ToList()
-            };
+    /// <summary>
+    /// Resolves this plan's trial, in the subscription's own time zone, into the frozen terms a
+    /// later catalogue edit can no longer move.
+    /// </summary>
+    private static TrialTerms? BuildTrial(Plan plan, DateTime now, TimeZoneInfo timeZone)
+    {
+        if (!TrialDurationNormalizer.HasTrial(plan))
+        {
+            return null;
+        }
+
+        var count = TrialDurationNormalizer.EffectiveCount(plan);
+        var endsAtUtc = TrialDurationResolver.ResolveEndUtc(now, timeZone, plan.TrialDurationKind, count);
+
+        return new TrialTerms
+        {
+            StartsAtUtc = now,
+            EndsAtUtc = endsAtUtc,
+            DurationKind = plan.TrialDurationKind,
+            DurationCount = count,
+            RequiresPaymentMethod = plan.TrialRequiresPaymentMethod,
+            Grants = plan.TrialGrants
+                .Select(grant => new TrialMeterGrant
+                {
+                    MeterKey = grant.MeterKey,
+                    IncludedQuantity = grant.IncludedQuantity
+                })
+                .ToList()
+        };
+    }
 
     private static bool ApplyPeriods(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -167,7 +167,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             : BillingPeriodCalculator.TryCreateSchedule(
                 price.Interval,
                 price.IntervalCount,
-                now,
+                scheduleAnchorUtc,
                 request.TimeZoneId,
                 out feeSchedule);
 

--- a/server/Subscription.DomainService/Utilities/TrialDurationNormalizer.cs
+++ b/server/Subscription.DomainService/Utilities/TrialDurationNormalizer.cs
@@ -1,0 +1,39 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Reconciles a stored plan's trial fields into one answer, so a plan authored before
+/// <see cref="TrialDurationKind"/> existed — which only ever set the legacy <c>TrialDays</c> —
+/// keeps behaving exactly as it always did.
+/// </summary>
+/// <remarks>
+/// A stored <see cref="Plan.TrialDurationKind"/> of <see cref="TrialDurationKind.Days"/> is
+/// ambiguous by itself: it is both the explicit new-style choice and the default every
+/// pre-existing document deserializes to. The two are told apart the same way either way —
+/// falling back to <see cref="Plan.TrialDays"/> when the new count was never set — so this is
+/// the single place that reconciliation happens, used by both response mapping and subscription
+/// creation.
+/// </remarks>
+public static class TrialDurationNormalizer
+{
+    /// <summary>
+    /// The count <see cref="Plan.TrialDurationKind"/> measures — a day count for
+    /// <see cref="TrialDurationKind.Days"/>, a month count for
+    /// <see cref="TrialDurationKind.AnniversaryMonths"/>, or null for
+    /// <see cref="TrialDurationKind.EndOfCalendarMonth"/> or a plan with no trial at all.
+    /// </summary>
+    public static int? EffectiveCount(Plan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        return plan.TrialDurationKind == TrialDurationKind.Days
+            ? plan.TrialDurationCount ?? plan.TrialDays
+            : plan.TrialDurationCount;
+    }
+
+    /// <summary>Whether this plan configures a trial at all.</summary>
+    public static bool HasTrial(Plan plan) =>
+        plan.TrialDurationKind != TrialDurationKind.Days || EffectiveCount(plan) is not null;
+}

--- a/server/Subscription.DomainService/Utilities/TrialDurationResolver.cs
+++ b/server/Subscription.DomainService/Utilities/TrialDurationResolver.cs
@@ -1,0 +1,59 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Turns an authored trial duration into the UTC instant it ends at.
+/// </summary>
+/// <remarks>
+/// Called once, at subscription creation, and the result frozen onto
+/// <see cref="Entities.TrialTerms"/> — a later catalogue edit must never move an existing
+/// subscriber's trial boundary, so nothing here is ever re-evaluated against the plan again.
+/// </remarks>
+public static class TrialDurationResolver
+{
+    public static DateTime ResolveEndUtc(
+        DateTime startUtc,
+        TimeZoneInfo timeZone,
+        TrialDurationKind kind,
+        int? count)
+    {
+        ArgumentNullException.ThrowIfNull(timeZone);
+
+        return kind switch
+        {
+            // No time zone involved on purpose: a day-based trial is a fixed span, not a
+            // calendar boundary, and has always ended exactly count × 24 hours after signup.
+            TrialDurationKind.Days => startUtc.AddDays(count ?? 0),
+            TrialDurationKind.EndOfCalendarMonth => EndOfCalendarMonthUtc(startUtc, timeZone),
+            TrialDurationKind.AnniversaryMonths => AnniversaryMonthsUtc(startUtc, timeZone, count ?? 1),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unrecognized trial duration kind.")
+        };
+    }
+
+    /// <summary>Local midnight on the first day of the month after the one signup fell in.</summary>
+    private static DateTime EndOfCalendarMonthUtc(DateTime startUtc, TimeZoneInfo timeZone)
+    {
+        var startLocal = BillingLocalTime.ToLocal(startUtc, timeZone);
+        var firstOfNextMonth = new DateTime(startLocal.Year, startLocal.Month, 1).AddMonths(1);
+
+        return BillingLocalTime.ToUtc(firstOfNextMonth, timeZone);
+    }
+
+    /// <summary>
+    /// The same local wall-clock time, <paramref name="months"/> later, clamped to the target
+    /// month's last day when the signup day does not exist there.
+    /// </summary>
+    private static DateTime AnniversaryMonthsUtc(DateTime startUtc, TimeZoneInfo timeZone, int months)
+    {
+        var startLocal = BillingLocalTime.ToLocal(startUtc, timeZone);
+        var targetMonth = new DateTime(startLocal.Year, startLocal.Month, 1).AddMonths(months);
+        var day = Math.Min(startLocal.Day, DateTime.DaysInMonth(targetMonth.Year, targetMonth.Month));
+
+        var targetLocal = new DateTime(
+            targetMonth.Year, targetMonth.Month, day,
+            startLocal.Hour, startLocal.Minute, startLocal.Second, startLocal.Millisecond);
+
+        return BillingLocalTime.ToUtc(targetLocal, timeZone);
+    }
+}

--- a/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
@@ -23,7 +23,41 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
 
         RuleFor(request => request.TrialDays)
             .InclusiveBetween(1, 365)
-            .When(request => request.TrialDays.HasValue);
+            .When(request => request.TrialDays.HasValue && !request.TrialDurationKind.HasValue);
+
+        RuleFor(request => request)
+            .Must(request => !(request.TrialDays.HasValue && request.TrialDurationKind.HasValue))
+            .WithName(nameof(PlanDefinitionRequest.TrialDurationKind))
+            .WithMessage(
+                "Use either the legacy trialDays field or trialDurationKind/trialDurationCount, " +
+                "not both.")
+            .WithErrorCode("subscription_trial_duration_fields_conflict");
+
+        RuleFor(request => request.TrialDurationCount)
+            .NotNull()
+            .WithMessage("A day-based trial requires a count.")
+            .DependentRules(() => RuleFor(request => request.TrialDurationCount)
+                .InclusiveBetween(1, 365)
+                .WithMessage("A day-based trial's count must be between 1 and 365."))
+            .When(request => request.TrialDurationKind == TrialDurationKind.Days);
+
+        RuleFor(request => request.TrialDurationCount)
+            .NotNull()
+            .WithMessage("An anniversary-month trial requires a count.")
+            .DependentRules(() => RuleFor(request => request.TrialDurationCount)
+                .InclusiveBetween(1, 12)
+                .WithMessage("An anniversary-month trial's count must be between 1 and 12."))
+            .When(request => request.TrialDurationKind == TrialDurationKind.AnniversaryMonths);
+
+        RuleFor(request => request.TrialDurationCount)
+            .Null()
+            .WithMessage("An end-of-calendar-month trial must not specify a count.")
+            .When(request => request.TrialDurationKind == TrialDurationKind.EndOfCalendarMonth);
+
+        RuleFor(request => request.TrialDurationCount)
+            .Null()
+            .WithMessage("trialDurationCount requires trialDurationKind.")
+            .When(request => !request.TrialDurationKind.HasValue);
 
         RuleFor(request => request.UsageIntervalCount).InclusiveBetween(1, 100);
         RuleFor(request => request.FamilyCode).MaximumLength(64);

--- a/server/XUnitTest/Integration/SubscriptionCatalogueRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionCatalogueRepositoryIntegrationTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// What an edit actually writes to the stored plan document.
+/// </summary>
+/// <remarks>
+/// <see cref="SubscriptionCatalogueRepository.TryUpdatePlanAsync"/> builds its Mongo update from
+/// an explicit list of fields rather than replacing the whole document, so a field the service
+/// layer populates but the repository forgets to list is silently never persisted — a mocked
+/// repository in a service-level test cannot catch that; only the real update against a real
+/// collection can. This guards exactly the field this class was introduced for: a plan's trial
+/// duration kind and count previously fell into that gap, so an edit that changed a plan's trial
+/// rule reported success while quietly keeping the old one.
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class SubscriptionCatalogueRepositoryIntegrationTests
+{
+    private readonly SubscriptionCatalogueRepository _catalogue;
+
+    public SubscriptionCatalogueRepositoryIntegrationTests(MongoIntegrationFixture fixture) =>
+        _catalogue = new SubscriptionCatalogueRepository(fixture.DbContextProvider);
+
+    [Fact]
+    public async Task Editing_a_plan_persists_its_new_trial_duration_kind_and_count()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = NewPlan(tenantId);
+        plan.TrialDurationKind = TrialDurationKind.Days;
+        plan.TrialDurationCount = 14;
+
+        (await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None)).Should().BeTrue();
+
+        var edited = NewPlan(tenantId);
+        edited.TrialDurationKind = TrialDurationKind.AnniversaryMonths;
+        edited.TrialDurationCount = 2;
+
+        (await _catalogue.TryUpdatePlanAsync(
+                tenantId, plan.ItemId, plan.Version, edited, CancellationToken.None))
+            .Should().BeTrue();
+
+        var stored = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        stored!.TrialDurationKind.Should().Be(TrialDurationKind.AnniversaryMonths,
+            "the edit changed the duration kind, and reopening the plan must show what was saved, " +
+            "not what was there before");
+        stored.TrialDurationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Editing_a_legacy_day_based_plan_to_end_of_calendar_month_drops_the_old_count()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = NewPlan(tenantId);
+        plan.TrialDays = 14;
+
+        (await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None)).Should().BeTrue();
+
+        var edited = NewPlan(tenantId);
+        edited.TrialDays = null;
+        edited.TrialDurationKind = TrialDurationKind.EndOfCalendarMonth;
+        edited.TrialDurationCount = null;
+
+        (await _catalogue.TryUpdatePlanAsync(
+                tenantId, plan.ItemId, plan.Version, edited, CancellationToken.None))
+            .Should().BeTrue();
+
+        var stored = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        stored!.TrialDurationKind.Should().Be(TrialDurationKind.EndOfCalendarMonth);
+        stored.TrialDays.Should().BeNull(
+            "the legacy field must not survive an edit that moved the plan onto a current-style rule");
+    }
+
+    private static Plan NewPlan(string tenantId) => new()
+    {
+        TenantId = tenantId,
+        Code = "professional",
+        DisplayName = "Professional",
+        Status = CatalogueStatus.Active,
+        Version = 1
+    };
+}

--- a/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
+++ b/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
@@ -42,6 +42,115 @@ public sealed class PlanDefinitionRequestValidatorTests
             error.ErrorCode == "subscription_lifetime_meter_trial_grant_invalid");
     }
 
+    [Fact]
+    public async Task Legacy_trial_days_alone_is_valid()
+    {
+        var request = new UpdatePlanRequest { DisplayName = "Plan", TrialDays = 14 };
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Legacy_trial_days_together_with_the_new_duration_fields_is_rejected()
+    {
+        var request = new UpdatePlanRequest
+        {
+            DisplayName = "Plan",
+            TrialDays = 14,
+            TrialDurationKind = TrialDurationKind.Days,
+            TrialDurationCount = 14
+        };
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_trial_duration_fields_conflict");
+    }
+
+    [Fact]
+    public async Task A_days_mode_trial_requires_a_count_between_1_and_365()
+    {
+        var request = new UpdatePlanRequest
+        {
+            DisplayName = "Plan",
+            TrialDurationKind = TrialDurationKind.Days
+        };
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeFalse();
+
+        request.TrialDurationCount = 366;
+        result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+        result.IsValid.Should().BeFalse();
+
+        request.TrialDurationCount = 14;
+        result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_anniversary_months_trial_requires_a_count_between_1_and_12()
+    {
+        var request = new UpdatePlanRequest
+        {
+            DisplayName = "Plan",
+            TrialDurationKind = TrialDurationKind.AnniversaryMonths
+        };
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+        result.IsValid.Should().BeFalse();
+
+        request.TrialDurationCount = 13;
+        result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+        result.IsValid.Should().BeFalse();
+
+        request.TrialDurationCount = 12;
+        result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_end_of_calendar_month_trial_must_not_specify_a_count()
+    {
+        var request = new UpdatePlanRequest
+        {
+            DisplayName = "Plan",
+            TrialDurationKind = TrialDurationKind.EndOfCalendarMonth,
+            TrialDurationCount = 1
+        };
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeFalse();
+
+        request.TrialDurationCount = null;
+        result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_duration_count_without_a_duration_kind_is_rejected()
+    {
+        var request = new UpdatePlanRequest { DisplayName = "Plan", TrialDurationCount = 14 };
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task No_trial_fields_at_all_is_valid()
+    {
+        var request = new UpdatePlanRequest { DisplayName = "Plan" };
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
     private static UpdatePlanRequest RequestWithLifetimeMeter() => new()
     {
         DisplayName = "Storage plan",

--- a/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/PlanResponseMapperTests.cs
@@ -54,6 +54,58 @@ public sealed class PlanResponseMapperTests
             .Should().BeFalse("which is what every plan authored before this existed meant");
     }
 
+    /// <summary>A plan written before <see cref="TrialDurationKind"/> existed only ever set the legacy field.</summary>
+    [Fact]
+    public void A_legacy_day_based_trial_reports_both_the_legacy_and_the_normalized_fields()
+    {
+        var plan = Plan("organization-1");
+        plan.TrialDays = 14;
+
+        var response = _mapper.ToResponse(plan, []);
+
+        response.TrialDays.Should().Be(14);
+        response.TrialDurationKind.Should().Be(nameof(TrialDurationKind.Days));
+        response.TrialDurationCount.Should().Be(14);
+    }
+
+    [Fact]
+    public void An_anniversary_months_trial_reports_no_legacy_trial_days()
+    {
+        var plan = Plan("organization-1");
+        plan.TrialDurationKind = TrialDurationKind.AnniversaryMonths;
+        plan.TrialDurationCount = 2;
+
+        var response = _mapper.ToResponse(plan, []);
+
+        response.TrialDays.Should().BeNull(
+            "an anniversary-month trial has no day count to report through the legacy field");
+        response.TrialDurationKind.Should().Be(nameof(TrialDurationKind.AnniversaryMonths));
+        response.TrialDurationCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void An_end_of_calendar_month_trial_reports_no_count_at_all()
+    {
+        var plan = Plan("organization-1");
+        plan.TrialDurationKind = TrialDurationKind.EndOfCalendarMonth;
+
+        var response = _mapper.ToResponse(plan, []);
+
+        response.TrialDays.Should().BeNull();
+        response.TrialDurationKind.Should().Be(nameof(TrialDurationKind.EndOfCalendarMonth));
+        response.TrialDurationCount.Should().BeNull();
+    }
+
+    [Fact]
+    public void A_plan_with_no_trial_reports_a_null_duration_kind()
+    {
+        var response = _mapper.ToResponse(Plan("organization-1"), []);
+
+        response.TrialDurationKind.Should().BeNull();
+        response.TrialDurationCount.Should().BeNull();
+        response.TrialDays.Should().BeNull();
+    }
+
     [Fact]
     public void A_meter_carries_the_thresholds_it_will_notify_on()
     {

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -7,6 +7,7 @@ using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
 using Subscription.DomainService.Validators;
 using XUnitTest.Payment;
 
@@ -534,6 +535,103 @@ public sealed class SubscriptionCreationServiceTests
         await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
 
         _created!.NextFeeBillingAtUtc.Should().Be(_created.Trial!.EndsAtUtc);
+    }
+
+    /// <summary>
+    /// The regression this guards: only the calendar-aligned branch passed
+    /// <c>scheduleAnchorUtc</c> into schedule creation. An anniversary price's
+    /// <c>FeeSchedule.AnchorInstantUtc</c> was silently left on the signup instant, so every paid
+    /// period after the trial still followed the day the customer signed up rather than the day
+    /// the trial actually ended.
+    /// </summary>
+    [Fact]
+    public async Task A_card_free_end_of_calendar_month_trial_anchors_the_anniversary_schedule_itself()
+    {
+        _plan.TrialDays = null;
+        _plan.TrialDurationKind = TrialDurationKind.EndOfCalendarMonth;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        var trialEndUtc = _created!.Trial!.EndsAtUtc;
+        _created.FeeSchedule.AnchorInstantUtc.Should().Be(trialEndUtc,
+            "the schedule itself, not only NextFeeBillingAtUtc, must follow the trial's end");
+
+        BillingPeriodCalculator.TryGetPeriod(_created.FeeSchedule, trialEndUtc, out var first)
+            .Should().BeTrue();
+        first.StartUtc.Should().Be(trialEndUtc);
+        // 1 October local midnight, still CEST (UTC+2).
+        first.EndUtc.Should().Be(new DateTime(2026, 9, 30, 22, 0, 0, DateTimeKind.Utc));
+
+        BillingPeriodCalculator.TryGetPeriod(_created.FeeSchedule, first.EndUtc, out var second)
+            .Should().BeTrue();
+        second.StartUtc.Should().Be(first.EndUtc);
+        // 1 November local midnight — CET (UTC+1) by then, DST having ended 25 October.
+        second.EndUtc.Should().Be(new DateTime(2026, 10, 31, 23, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task A_card_free_anniversary_months_trial_anchors_the_schedule_itself()
+    {
+        _plan.TrialDays = null;
+        _plan.TrialDurationKind = TrialDurationKind.AnniversaryMonths;
+        _plan.TrialDurationCount = 1;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        // 14 September 2026, 12:00 local (CEST) — one anniversary month after signup.
+        var trialEndUtc = new DateTime(2026, 9, 14, 10, 0, 0, DateTimeKind.Utc);
+        _created!.Trial!.EndsAtUtc.Should().Be(trialEndUtc);
+        _created.FeeSchedule.AnchorInstantUtc.Should().Be(trialEndUtc);
+
+        BillingPeriodCalculator.TryGetPeriod(_created.FeeSchedule, trialEndUtc, out var first)
+            .Should().BeTrue();
+        first.StartUtc.Should().Be(trialEndUtc);
+        // 14 October, 12:00 local — still CEST (DST ends 25 October).
+        first.EndUtc.Should().Be(new DateTime(2026, 10, 14, 10, 0, 0, DateTimeKind.Utc));
+
+        BillingPeriodCalculator.TryGetPeriod(_created.FeeSchedule, first.EndUtc, out var second)
+            .Should().BeTrue();
+        second.StartUtc.Should().Be(first.EndUtc);
+        // 14 November, 12:00 local — CET (UTC+1) by then.
+        second.EndUtc.Should().Be(new DateTime(2026, 11, 14, 11, 0, 0, DateTimeKind.Utc));
+    }
+
+    /// <summary>
+    /// A calendar-aligned price renews on calendar boundaries regardless of when the trial ends —
+    /// its schedule anchors to the first of the month the trial ends in, not to the trial-end
+    /// instant itself, and the partial month in between is charged as a stub at conversion (see
+    /// <c>SubscriptionRenewalService.TryResolveTrialConversion</c>). What must still hold is that
+    /// the first charge is deferred to the trial's end, exactly as for an anniversary price.
+    /// </summary>
+    [Fact]
+    public async Task A_card_free_trial_on_a_calendar_aligned_price_still_defers_to_the_trial_s_end()
+    {
+        var price = NewPrice();
+        price.BillingAlignment = BillingAlignment.CalendarMonth;
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(price);
+        _plan.TrialDays = null;
+        _plan.TrialDurationKind = TrialDurationKind.AnniversaryMonths;
+        _plan.TrialDurationCount = 1;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        // 14 September 2026, 12:00 local — the same trial end an anniversary price gets.
+        var trialEndUtc = new DateTime(2026, 9, 14, 10, 0, 0, DateTimeKind.Utc);
+        _created!.Trial!.EndsAtUtc.Should().Be(trialEndUtc);
+        _created.NextFeeBillingAtUtc.Should().Be(trialEndUtc,
+            "the first charge must wait for the trial regardless of the price's own alignment");
+
+        // The schedule itself still snaps to the calendar boundary the trial ends inside — 1
+        // September local, the month the 14 September trial end falls in — which is what makes
+        // this a calendar-aligned price at all.
+        _created.FeeSchedule.AnchorInstantUtc.Should().Be(
+            new DateTime(2026, 8, 31, 22, 0, 0, DateTimeKind.Utc));
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -489,6 +489,54 @@ public sealed class SubscriptionCreationServiceTests
     }
 
     [Fact]
+    public async Task An_end_of_calendar_month_trial_ends_at_local_midnight_on_the_first()
+    {
+        // Signup is 14 August 2026, 10:00 UTC — 12:00 local (Zurich is CEST in August).
+        _plan.TrialDays = null;
+        _plan.TrialDurationKind = TrialDurationKind.EndOfCalendarMonth;
+        _plan.TrialDurationCount = null;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        // 1 September local midnight, still CEST (UTC+2).
+        _created!.Trial!.EndsAtUtc.Should().Be(new DateTime(2026, 8, 31, 22, 0, 0, DateTimeKind.Utc));
+        _created.Trial.DurationKind.Should().Be(TrialDurationKind.EndOfCalendarMonth);
+        _created.Trial.DurationCount.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task An_anniversary_months_trial_ends_the_same_local_time_n_months_later()
+    {
+        _plan.TrialDays = null;
+        _plan.TrialDurationKind = TrialDurationKind.AnniversaryMonths;
+        _plan.TrialDurationCount = 1;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        // 14 September 2026, 12:00 local — still CEST.
+        _created!.Trial!.EndsAtUtc.Should().Be(new DateTime(2026, 9, 14, 10, 0, 0, DateTimeKind.Utc));
+        _created.Trial.DurationKind.Should().Be(TrialDurationKind.AnniversaryMonths);
+        _created.Trial.DurationCount.Should().Be(1);
+    }
+
+    /// <summary>
+    /// A card-free trial anchors the whole later schedule on where it ends — proven here for a
+    /// non-day duration mode, since <see cref="A_card_free_trial_bills_for_the_first_time_when_it_ends"/>
+    /// only proves it for the legacy day-based one.
+    /// </summary>
+    [Fact]
+    public async Task A_card_free_end_of_calendar_month_trial_anchors_the_fee_schedule_on_its_end()
+    {
+        _plan.TrialDays = null;
+        _plan.TrialDurationKind = TrialDurationKind.EndOfCalendarMonth;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _created!.NextFeeBillingAtUtc.Should().Be(_created.Trial!.EndsAtUtc);
+    }
+
+    [Fact]
     public async Task A_second_live_subscription_is_a_conflict()
     {
         _subscriptions

--- a/server/XUnitTest/Subscription/TrialDurationResolverTests.cs
+++ b/server/XUnitTest/Subscription/TrialDurationResolverTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Trial-end boundaries, in the cases a calendar and a clock change make awkward.
+/// </summary>
+/// <remarks>
+/// Every failure here is a trial that ends on the wrong day or the wrong instant, silently —
+/// none of this throws, so tests are the only place it surfaces. Zurich is used throughout
+/// because it moves the clock on the same two nights <see cref="BillingPeriodCalculatorTests"/>
+/// already exercises for billing boundaries, so the expected instants there double as a
+/// cross-check.
+/// </remarks>
+public sealed class TrialDurationResolverTests
+{
+    private static readonly TimeZoneInfo Zurich = TimeZoneInfo.FindSystemTimeZoneById("Europe/Zurich");
+
+    [Fact]
+    public void Days_mode_ends_exactly_the_count_times_24_hours_later_regardless_of_time_zone()
+    {
+        var startUtc = new DateTime(2026, 8, 25, 13, 47, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(startUtc, Zurich, TrialDurationKind.Days, 14);
+
+        endUtc.Should().Be(startUtc.AddDays(14),
+            "a day-based trial is a fixed span, not a calendar boundary");
+    }
+
+    [Fact]
+    public void End_of_calendar_month_ends_at_local_midnight_on_the_first_of_the_next_month()
+    {
+        // 25 August 2026, 10:00 local (Zurich is CEST, UTC+2, in August).
+        var startUtc = new DateTime(2026, 8, 25, 8, 0, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.EndOfCalendarMonth, null);
+
+        // 1 September local midnight, still CEST.
+        endUtc.Should().Be(new DateTime(2026, 8, 31, 22, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void A_late_signup_still_ends_at_the_first_of_the_next_month()
+    {
+        // 31 August 2026, 23:00 local — a trial lasting barely over an hour.
+        var startUtc = new DateTime(2026, 8, 31, 21, 0, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.EndOfCalendarMonth, null);
+
+        endUtc.Should().Be(new DateTime(2026, 8, 31, 22, 0, 0, DateTimeKind.Utc),
+            "an August 31 signup can have a trial lasting only until September 1");
+    }
+
+    [Fact]
+    public void Anniversary_months_ends_the_same_local_time_n_months_later()
+    {
+        // 25 August 2026, 10:00 local (CEST, UTC+2).
+        var startUtc = new DateTime(2026, 8, 25, 8, 0, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.AnniversaryMonths, 1);
+
+        // 25 September 2026, 10:00 local — still CEST, so the same UTC offset applies.
+        endUtc.Should().Be(new DateTime(2026, 9, 25, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Anniversary_months_crosses_a_year_boundary()
+    {
+        // 15 December 2026, 09:00 local (CET, UTC+1).
+        var startUtc = new DateTime(2026, 12, 15, 8, 0, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.AnniversaryMonths, 2);
+
+        // 15 February 2027, 09:00 local — still CET.
+        endUtc.Should().Be(new DateTime(2027, 2, 15, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Anniversary_months_clamps_to_the_target_month_s_last_day()
+    {
+        // 31 January 2026, 09:00 local (CET, UTC+1). 2026 is not a leap year.
+        var startUtc = new DateTime(2026, 1, 31, 8, 0, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.AnniversaryMonths, 1);
+
+        // February has no 31st, so the boundary clamps to the 28th — and the clamp is not
+        // written back, so a plan resolved from a different start is unaffected.
+        endUtc.Should().Be(new DateTime(2026, 2, 28, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Anniversary_months_clamps_to_the_29th_in_a_leap_year()
+    {
+        // 31 January 2024, 09:00 local (CET, UTC+1). 2024 is a leap year.
+        var startUtc = new DateTime(2024, 1, 31, 8, 0, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.AnniversaryMonths, 1);
+
+        endUtc.Should().Be(new DateTime(2024, 2, 29, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Anniversary_months_landing_in_the_spring_forward_gap_moves_to_the_first_valid_instant()
+    {
+        // 29 January 2026, 02:30 local (CET) — two months later is 29 March 2026, which loses
+        // 02:00-03:00 to the spring-forward transition, so 02:30 does not exist that day.
+        var startUtc = new DateTime(2026, 1, 29, 1, 30, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.AnniversaryMonths, 2);
+
+        // 03:00 local on the transition day is 01:00 UTC — the same instant
+        // BillingPeriodCalculatorTests expects for an identical gap boundary.
+        endUtc.Should().Be(new DateTime(2026, 3, 29, 1, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void Anniversary_months_landing_in_an_ambiguous_autumn_hour_resolves_to_the_earlier_instant()
+    {
+        // 25 September 2026, 02:30 local (CEST) — one month later is 25 October 2026, which
+        // repeats 02:00-03:00 for the autumn transition, so 02:30 happens twice.
+        var startUtc = new DateTime(2026, 9, 25, 0, 30, 0, DateTimeKind.Utc);
+
+        var endUtc = TrialDurationResolver.ResolveEndUtc(
+            startUtc, Zurich, TrialDurationKind.AnniversaryMonths, 1);
+
+        // The earlier of the two instants — still CEST (UTC+2) — matching how a renewal boundary
+        // resolves the same ambiguity.
+        endUtc.Should().Be(new DateTime(2026, 10, 25, 0, 30, 0, DateTimeKind.Utc));
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the trial's fixed "number of days" assumption with three
authoring choices:

- **Fixed number of days** (unchanged legacy behavior).
- **Until the end of the signup calendar month.**
- **Fixed number of anniversary months.**

Trial boundaries are resolved in the subscription's own configured time
zone and frozen onto `TrialTerms` at creation — a later catalogue edit to
the plan's trial rule can never move an existing subscriber's boundary.
Existing plans using the legacy `trialDays` are unaffected.

## API and data model

- New `TrialDurationKind` enum: `Days` (= 0, the default — so every
  document written before this field existed deserializes to exactly
  what it already meant) / `EndOfCalendarMonth` / `AnniversaryMonths`.
- `Plan` gains `TrialDurationKind`/`TrialDurationCount` alongside the
  legacy `TrialDays`. `TrialDurationNormalizer` is the single place that
  reconciles the two, used by both response mapping and subscription
  creation.
- `PlanDefinitionRequestValidator`: rejects a request naming both the
  legacy and current fields; enforces each kind's count rule (`Days`
  1-365, `AnniversaryMonths` 1-12, `EndOfCalendarMonth` none).
- `PlanResponse` always returns the normalized `trialDurationKind`/
  `trialDurationCount`, and keeps returning the legacy `trialDays` only
  for a `Days`-mode plan.

## Boundary and billing behavior

- `Days`: unchanged — ends exactly `count × 24 hours` after signup, no
  time zone involved.
- `AnniversaryMonths`: same local wall-clock time, N months later,
  clamped to the target month's last day (31 Jan + 1 month → 28/29 Feb)
  — the same clamp-without-writeback pattern `BillingPeriodCalculator`
  already uses for billing anchors.
- `EndOfCalendarMonth`: local midnight on the first of the next month.
  `EndsAtUtc` is an **exclusive** boundary — an August 31 signup can
  have a trial lasting only until September 1, by design.
- Both new modes go through the existing `BillingLocalTime` DST-gap and
  ambiguous-time handling, matching every other billing boundary in this
  module.
- A card-free trial's first paid period anchors on `Trial.EndsAtUtc`
  regardless of which kind produced it — verified for both anniversary
  and end-of-month modes (previously only proven for `Days`).

## Client

- `SubscriptionPlan`/`Create`/`UpdateSubscriptionPlanRequest` gain
  `trialDurationKind`/`trialDurationCount`. The console always authors
  through these now, never the legacy `trialDays`.
- The plan builder's "Trial length (days)" field is replaced with a
  duration-kind selector (including "No trial") and a conditional count
  input labeled "Days" or "Months", with a zod `superRefine` mirroring
  the server's validation rules exactly.
- Plan cards/summaries describe the selected rule instead of always
  saying "N-day trial".
- Reopening or duplicating a plan reads the server's already-normalized
  fields, so a legacy day-based plan reopens identically regardless of
  which format it was originally saved in.

## Docs

Added a "Trial duration" section to `Subscription.DomainService/README.md`
covering the three kinds, the exclusive-boundary semantics, time
zone/DST handling, the deliberate short-trial-on-a-late-signup behavior,
and worked examples for how each mode anchors the first post-trial
charge.

## Test plan

- [x] `dotnet build Api/Api.csproj --no-incremental`: 0 errors
- [x] `dotnet test XUnitTest` (non-integration): passes, no regressions
      (confirmed against a clean checkout: the few failures present are
      a pre-existing, unrelated `SubscriptionSimulationGuard`
      test-harness issue)
- [x] New `TrialDurationResolverTests`: all three kinds, a late-signup
      short trial, month-end clamping in a leap and non-leap year, a
      year-boundary crossing, and both a spring-forward-gap and an
      ambiguous-autumn-hour anniversary boundary (Europe/Zurich)
- [x] New `SubscriptionCreationServiceTests`,
      `PlanDefinitionRequestValidatorTests`, `PlanResponseMapperTests`
      cases for every duration kind and the legacy/current field
      conflict
- [x] `npx tsc -b --noEmit` / `npx vitest run` (client): 0 type errors,
      2118 tests passed (6 unrelated pre-existing suite failures: a
      canvas dependency, an unrelated parse error, a local tooling
      glitch — none touch subscription code)
- [x] `npx eslint` on every changed/new client file: 0 errors, 0
      warnings

## Follow-ups

If there is a separately-published integration guide beyond this repo's
own `Subscription.DomainService/README.md`, it still needs the same
exclusive-boundary/DST/post-trial-billing language added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)