### PR TITLE
feat(subscription): add a purchase preview that cannot disagree with the charge

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
@@ -1,0 +1,244 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import type {
+  SimulatedSubscription,
+  SubscriptionPurchasePreview,
+} from "../models/subscription-simulation.model";
+
+const toast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({ toast: (...args: unknown[]) => toast(...args) }));
+
+const previewSubscription = vi.fn();
+const subscribe = vi.fn();
+
+vi.mock("../services/subscription-simulation.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../services/subscription-simulation.service")
+  >("../services/subscription-simulation.service");
+
+  return {
+    ...actual,
+    subscriptionSimulationService: {
+      previewSubscription: (...args: unknown[]) => previewSubscription(...args),
+      subscribe: (...args: unknown[]) => subscribe(...args),
+    },
+  };
+});
+
+import { SubscribeDialog } from "./subscribe-dialog";
+
+const plan = {
+  code: "professional",
+  displayName: "Professional",
+  quantityItems: [
+    { itemKey: "seat", unitLabel: "seat", minQuantity: 1, maxQuantity: null, defaultQuantity: 1 },
+  ],
+  prices: [
+    {
+      priceId: "price-1",
+      currencyCode: "CHF",
+      unitAmountMinor: 8_900,
+      interval: "Month",
+      intervalCount: 1,
+      quantityItemKey: "seat",
+      displayPriceNote: null,
+    },
+  ],
+} as unknown as SubscriptionPlan;
+
+const quote: SubscriptionPurchasePreview = {
+  currencyCode: "CHF",
+  subtotalMinor: 8_900,
+  discountMinor: 0,
+  builtInDiscountMinor: 0,
+  promotionalDiscountMinor: 0,
+  taxMinor: 0,
+  totalDueNowMinor: 8_900,
+  prorated: false,
+  coveredDays: null,
+  totalDays: null,
+  periodStartUtc: "2026-08-16T00:00:00Z",
+  periodEndUtc: "2026-09-16T00:00:00Z",
+  nextRenewalAtUtc: "2026-09-16T00:00:00Z",
+  nextRenewalAmountMinor: 8_900,
+  trialEndsAtUtc: null,
+  requiresCardSetup: false,
+  pendingAnnualPeriod: null,
+  blockers: [],
+  quotedAtUtc: "2026-08-16T00:00:00Z",
+  quoteValidUntilUtc: null,
+};
+
+const subscription: SimulatedSubscription = {
+  subscriptionId: "sub-1",
+  status: "Incomplete",
+  planCode: "professional",
+  planName: "Professional",
+  currencyCode: "CHF",
+  unitAmountMinor: 8_900,
+  interval: "Month",
+  intervalCount: 1,
+  displayPriceNote: null,
+  quantities: [{ itemKey: "seat", quantity: 1, unitLabel: "seat" }],
+  currentPeriodStartUtc: "2026-08-16T00:00:00Z",
+  currentPeriodEndUtc: "2026-09-16T00:00:00Z",
+  nextPaymentAtUtc: "2026-09-16T00:00:00Z",
+  trialEndsAtUtc: null,
+  cancelAtPeriodEnd: false,
+  canceledAtUtc: null,
+  pendingQuantityChange: null,
+  currentTier: null,
+  recurringAmountMinor: 8_900,
+  checkoutUrl: "https://checkout.example/session",
+  version: 1,
+};
+
+const onSubscribed = vi.fn();
+
+const renderDialog = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <SubscribeDialog
+        plan={plan}
+        organizationId="org-1"
+        open
+        onOpenChange={() => {}}
+        onSubscribed={onSubscribed}
+      />
+    </QueryClientProvider>,
+  );
+};
+
+const click = (name: RegExp) => fireEvent.click(screen.getByRole("button", { name }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SubscribeDialog", () => {
+  it("cannot be confirmed before a preview is taken", () => {
+    renderDialog();
+
+    expect(screen.getByRole("button", { name: /^Subscribe$/ })).toBeDisabled();
+  });
+
+  it("previews the total due now before enabling confirm", async () => {
+    previewSubscription.mockResolvedValue(quote);
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscribe-quote")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId("subscribe-quote").textContent,
+    ).toContain("89.00");
+    expect(screen.getByRole("button", { name: /^Subscribe$/ })).toBeEnabled();
+    // The preview writes nothing.
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("discards the quote when the quantity is edited after previewing", async () => {
+    previewSubscription.mockResolvedValue(quote);
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscribe-quote")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/seat/), { target: { value: "2" } });
+
+    expect(screen.queryByTestId("subscribe-quote")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Subscribe$/ })).toBeDisabled();
+  });
+
+  it("discards the quote when the discount code is edited after previewing", async () => {
+    previewSubscription.mockResolvedValue(quote);
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscribe-quote")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/Discount code/), { target: { value: "LAUNCH20" } });
+
+    expect(screen.queryByTestId("subscribe-quote")).not.toBeInTheDocument();
+  });
+
+  it("sends exactly what was previewed when confirmed", async () => {
+    previewSubscription.mockResolvedValue(quote);
+    subscribe.mockResolvedValue(subscription);
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => screen.getByTestId("subscribe-quote"));
+
+    click(/^Subscribe$/);
+
+    await waitFor(() => {
+      expect(subscribe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          planCode: "professional",
+          priceId: "price-1",
+          quantities: [{ itemKey: "seat", quantity: 1 }],
+          organizationId: "org-1",
+        }),
+      );
+    });
+
+    expect(onSubscribed).toHaveBeenCalledWith(subscription.checkoutUrl);
+  });
+
+  it("shows a blocker without disabling the preview, but keeps confirm disabled", async () => {
+    previewSubscription.mockResolvedValue({
+      ...quote,
+      blockers: [
+        {
+          code: "subscription_billing_profile_incomplete",
+          message: "This organization's billing profile is missing details an invoice must carry.",
+          fields: { BillingProfile: ["LegalName"] },
+        },
+      ],
+    });
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/billing profile is missing details/),
+      ).toBeInTheDocument();
+    });
+
+    // The price was shown, but confirming it would be refused.
+    expect(screen.getByRole("button", { name: /^Subscribe$/ })).toBeDisabled();
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("reports a card requirement even when nothing is due now", async () => {
+    previewSubscription.mockResolvedValue({
+      ...quote,
+      totalDueNowMinor: 0,
+      trialEndsAtUtc: "2026-08-30T00:00:00Z",
+      requiresCardSetup: true,
+    });
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/a card is required to start this subscription/)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
@@ -1,5 +1,6 @@
-import { Loader2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui-kits/badge/badge";
 import { Button } from "@/components/ui-kits/button/button";
 import {
   Dialog,
@@ -20,11 +21,23 @@ import {
 } from "@/components/ui-kits/select/select";
 import { toast } from "@/hooks/use-toast";
 import { detectBrowserTimeZone } from "../constants/subscription-simulation.constants";
+import { usePreviewSubscription } from "../hooks/use-preview-subscription";
 import { useSubscribeToPlan } from "../hooks/use-subscribe-to-plan";
-import type { SubscriptionQuantity } from "../models/subscription-simulation.model";
+import type {
+  SubscribeToPlanRequest,
+  SubscriptionPurchasePreview,
+  SubscriptionQuantity,
+} from "../models/subscription-simulation.model";
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
-import { formatPrice } from "../../subscription/utilities/subscription-format";
+import { formatMoney, formatPrice } from "../../subscription/utilities/subscription-format";
 
+/**
+ * Subscribing to a plan.
+ *
+ * Nothing is charged from this screen without a preview first, and any edit — the price, a
+ * quantity, the discount code — discards the quote it produced: a confirmation sent after its
+ * figures stopped applying would be a confirmation of numbers the subscriber never saw.
+ */
 export const SubscribeDialog = ({
   plan,
   organizationId,
@@ -38,7 +51,8 @@ export const SubscribeDialog = ({
   onOpenChange: (open: boolean) => void;
   onSubscribed: (checkoutUrl: string | null) => void;
 }) => {
-  const { mutateAsync, isPending } = useSubscribeToPlan();
+  const preview = usePreviewSubscription();
+  const subscribe = useSubscribeToPlan();
 
   const [priceId, setPriceId] = useState(plan.prices[0]?.priceId ?? "");
   const [quantities, setQuantities] = useState<Record<string, string>>(() =>
@@ -49,19 +63,31 @@ export const SubscribeDialog = ({
   const [discountCode, setDiscountCode] = useState("");
   const [billingEmail, setBillingEmail] = useState("");
   const [billingName, setBillingName] = useState("");
+  const [quote, setQuote] = useState<SubscriptionPurchasePreview | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
 
-  const selectedPrice = useMemo(
-    () => plan.prices.find((price) => price.priceId === priceId),
-    [plan.prices, priceId],
-  );
+  const busy = preview.isPending || subscribe.isPending;
 
-  const submit = async () => {
-    setFormError(null);
+  const editPrice = (value: string) => {
+    setPriceId(value);
+    setQuote(null);
+  };
 
+  const editQuantity = (itemKey: string, value: string) => {
+    setQuantities((current) => ({ ...current, [itemKey]: value }));
+    setQuote(null);
+  };
+
+  const editDiscount = (value: string) => {
+    setDiscountCode(value);
+    setQuote(null);
+  };
+
+  const requested = ():
+    | { valid: true; request: SubscribeToPlanRequest }
+    | { valid: false; error: string } => {
     if (!priceId) {
-      setFormError("Choose a price to subscribe on.");
-      return;
+      return { valid: false, error: "Choose a price to subscribe on." };
     }
 
     const parsedQuantities: SubscriptionQuantity[] = [];
@@ -70,20 +96,25 @@ export const SubscribeDialog = ({
       const quantity = Number(raw);
 
       if (!raw || !Number.isFinite(quantity) || quantity < item.minQuantity) {
-        setFormError(`${item.unitLabel} must be at least ${item.minQuantity}.`);
-        return;
+        return {
+          valid: false,
+          error: `${item.unitLabel} must be at least ${item.minQuantity}.`,
+        };
       }
 
       if (item.maxQuantity != null && quantity > item.maxQuantity) {
-        setFormError(`${item.unitLabel} can be at most ${item.maxQuantity}.`);
-        return;
+        return {
+          valid: false,
+          error: `${item.unitLabel} can be at most ${item.maxQuantity}.`,
+        };
       }
 
       parsedQuantities.push({ itemKey: item.itemKey, quantity });
     }
 
-    try {
-      const subscription = await mutateAsync({
+    return {
+      valid: true,
+      request: {
         planCode: plan.code,
         priceId,
         quantities: parsedQuantities,
@@ -92,7 +123,42 @@ export const SubscribeDialog = ({
         billingEmail: billingEmail.trim() || undefined,
         billingName: billingName.trim() || undefined,
         organizationId,
-      });
+      },
+    };
+  };
+
+  const runPreview = async () => {
+    const parsed = requested();
+
+    if (!parsed.valid) {
+      setFormError(parsed.error);
+      return;
+    }
+
+    setFormError(null);
+
+    try {
+      setQuote(await preview.mutateAsync(parsed.request));
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "The subscription could not be previewed.",
+      );
+      setQuote(null);
+    }
+  };
+
+  const submit = async () => {
+    const parsed = requested();
+
+    if (!parsed.valid) {
+      setFormError(parsed.error);
+      return;
+    }
+
+    setFormError(null);
+
+    try {
+      const subscription = await subscribe.mutateAsync(parsed.request);
 
       toast({
         variant: "success",
@@ -108,14 +174,19 @@ export const SubscribeDialog = ({
       setFormError(
         error instanceof Error ? error.message : "The subscription could not be started.",
       );
+      // What was shown no longer describes what a retry would charge — the failed attempt may
+      // itself have changed something a fresh quote needs to account for.
+      setQuote(null);
     }
   };
+
+  const blocked = (quote?.blockers.length ?? 0) > 0;
 
   return (
     <Dialog
       open={open}
       onOpenChange={(next) => {
-        if (!isPending) {
+        if (!busy) {
           onOpenChange(next);
         }
       }}
@@ -132,7 +203,7 @@ export const SubscribeDialog = ({
         <div className="space-y-4">
           <div className="space-y-1.5">
             <Label htmlFor="subscribe-price">Price</Label>
-            <Select value={priceId} onValueChange={setPriceId}>
+            <Select value={priceId} onValueChange={editPrice}>
               <SelectTrigger id="subscribe-price">
                 <SelectValue placeholder="Choose a price" />
               </SelectTrigger>
@@ -150,7 +221,10 @@ export const SubscribeDialog = ({
             <div className="space-y-1.5" key={item.itemKey}>
               <Label htmlFor={`quantity-${item.itemKey}`}>
                 {item.unitLabel}
-                {selectedPrice?.quantityItemKey === item.itemKey && " (price multiplier)"}
+                {plan.prices.find((price) => price.priceId === priceId)?.quantityItemKey ===
+                item.itemKey
+                  ? " (price multiplier)"
+                  : ""}
               </Label>
               <Input
                 id={`quantity-${item.itemKey}`}
@@ -158,12 +232,7 @@ export const SubscribeDialog = ({
                 min={item.minQuantity}
                 max={item.maxQuantity ?? undefined}
                 value={quantities[item.itemKey] ?? ""}
-                onChange={(event) =>
-                  setQuantities((current) => ({
-                    ...current,
-                    [item.itemKey]: event.target.value,
-                  }))
-                }
+                onChange={(event) => editQuantity(item.itemKey, event.target.value)}
               />
             </div>
           ))}
@@ -173,7 +242,7 @@ export const SubscribeDialog = ({
             <Input
               id="subscribe-discount"
               value={discountCode}
-              onChange={(event) => setDiscountCode(event.target.value)}
+              onChange={(event) => editDiscount(event.target.value)}
               placeholder="e.g. LAUNCH20"
             />
           </div>
@@ -198,15 +267,84 @@ export const SubscribeDialog = ({
             </div>
           </div>
 
+          {quote ? (
+            <div className="space-y-2 rounded-md border p-3 text-sm" data-testid="subscribe-quote">
+              <div className="flex items-center justify-between">
+                <p className="font-medium">
+                  {quote.totalDueNowMinor > 0 ? "Due now" : "Nothing due now"}
+                </p>
+                <Badge variant={quote.prorated ? "secondary" : "default"}>
+                  {quote.prorated ? `${quote.coveredDays}/${quote.totalDays} days` : "Full period"}
+                </Badge>
+              </div>
+
+              <Row
+                label="Total due now"
+                value={formatMoney(quote.totalDueNowMinor, quote.currencyCode)}
+              />
+              {quote.discountMinor > 0 ? (
+                <Row
+                  label="Discount"
+                  value={`-${formatMoney(quote.discountMinor, quote.currencyCode)}`}
+                />
+              ) : null}
+              {quote.taxMinor > 0 ? (
+                <Row label="of which tax" value={formatMoney(quote.taxMinor, quote.currencyCode)} />
+              ) : null}
+              <Row
+                label={quote.trialEndsAtUtc ? "First renewal" : "Next renewal"}
+                value={`${formatMoney(quote.nextRenewalAmountMinor, quote.currencyCode)}${
+                  quote.nextRenewalAtUtc ? ` on ${formatDate(quote.nextRenewalAtUtc)}` : ""
+                }`}
+              />
+              {quote.requiresCardSetup && quote.totalDueNowMinor === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  Nothing is charged now, but a card is required to start this subscription.
+                </p>
+              ) : null}
+              {quote.pendingAnnualPeriod ? (
+                <p className="text-xs text-muted-foreground">
+                  Also buys the year starting {formatDate(quote.pendingAnnualPeriod.startUtc)}
+                  {quote.pendingAnnualPeriod.collectedWithCheckout
+                    ? " — included in the total above."
+                    : ", collected separately when it starts."}
+                </p>
+              ) : null}
+              {quote.quoteValidUntilUtc ? (
+                <p className="text-xs text-muted-foreground">
+                  This price holds until {formatDate(quote.quoteValidUntilUtc)}.
+                </p>
+              ) : null}
+
+              {quote.blockers.map((blocker) => (
+                <div
+                  key={blocker.code}
+                  className="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 p-2 text-warning-900"
+                >
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>{blocker.message}</p>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
           {formError && <p className="text-sm text-destructive">{formError}</p>}
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button onClick={submit} disabled={isPending}>
-            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          <Button variant="outline" onClick={runPreview} disabled={busy}>
+            {preview.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Preview
+          </Button>
+          {/* Nothing is charged without a quote on screen, and the quote is discarded the moment
+              anything that would change the price is edited — so this button can only ever send
+              the figures just shown. Still disabled on a blocker: the price was shown, but
+              confirming it would be refused. */}
+          <Button onClick={submit} disabled={busy || quote === null || blocked}>
+            {subscribe.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             Subscribe
           </Button>
         </DialogFooter>
@@ -214,3 +352,12 @@ export const SubscribeDialog = ({
     </Dialog>
   );
 };
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-baseline justify-between gap-4">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="text-right font-medium">{value}</span>
+  </div>
+);
+
+const formatDate = (isoDate: string) => new Date(isoDate).toLocaleString();

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-preview-subscription.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-preview-subscription.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import type { SubscribeToPlanRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/**
+ * What subscribing would cost right now. Writes nothing, so it invalidates nothing.
+ */
+export const usePreviewSubscription = () =>
+  useMutation({
+    mutationFn: (request: SubscribeToPlanRequest) =>
+      subscriptionSimulationService.previewSubscription(request),
+  });

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -127,6 +127,68 @@ export interface QuantityChangeQuote {
   pendingQuantityChange: PendingQuantityChange | null;
 }
 
+/**
+ * What confirming would refuse, seen alongside the price rather than instead of it.
+ *
+ * The same error codes a failed subscribe returns, so a screen already handling those learns no
+ * second vocabulary for the preview.
+ */
+export interface SubscriptionPreviewBlocker {
+  code: string;
+  message: string;
+  /** Set only for `subscription_billing_profile_incomplete`. */
+  fields?: Record<string, string[]> | null;
+}
+
+export interface SubscriptionPreviewAnnualPeriod {
+  startUtc: string;
+  endUtc: string;
+  amountMinor: number;
+  netAmountMinor: number;
+  taxAmountMinor: number;
+  /** Whether the year's amount is already included in `totalDueNowMinor`. */
+  collectedWithCheckout: boolean;
+}
+
+/**
+ * What subscribing would cost right now, and what would stand in the way — without subscribing.
+ *
+ * `totalDueNowMinor` is the exact figure a confirming subscribe call then charges: both read the
+ * same frozen amount on the server, so this cannot quote one number and charge another.
+ */
+export interface SubscriptionPurchasePreview {
+  currencyCode: string;
+  subtotalMinor: number;
+  /** Every reduction combined. */
+  discountMinor: number;
+  builtInDiscountMinor: number;
+  promotionalDiscountMinor: number;
+  taxMinor: number;
+  /** What confirming this preview would actually charge. Zero for a card-free trial. */
+  totalDueNowMinor: number;
+  prorated: boolean;
+  coveredDays: number | null;
+  totalDays: number | null;
+  periodStartUtc: string;
+  periodEndUtc: string;
+  nextRenewalAtUtc: string | null;
+  nextRenewalAmountMinor: number;
+  /** Set only for a subscription that opens on a trial. */
+  trialEndsAtUtc: string | null;
+  /** Whether confirming will ask for a card even though nothing is due now. */
+  requiresCardSetup: boolean;
+  pendingAnnualPeriod: SubscriptionPreviewAnnualPeriod | null;
+  /** Empty when nothing stands in the way of confirming. */
+  blockers: SubscriptionPreviewBlocker[];
+  /** The instant these figures were derived from. */
+  quotedAtUtc: string;
+  /**
+   * The earliest instant this quote's proration could no longer hold. Null when nothing here is
+   * prorated, because then no boundary changes the answer.
+   */
+  quoteValidUntilUtc: string | null;
+}
+
 export interface SubscribeToPlanRequest {
   /** The plan's stable code, not its planId — sending the id reads as "plan not found". */
   planCode: string;

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -19,6 +19,7 @@ import type {
   SimulatedSubscription,
   SubscribeToPlanRequest,
   SubscriptionAuditEvent,
+  SubscriptionPurchasePreview,
 } from "../models/subscription-simulation.model";
 
 interface SimulationApiError {
@@ -72,6 +73,48 @@ class SubscriptionSimulationService {
       if (error instanceof HttpError && error.status === 404) {
         return null;
       }
+      throw error;
+    }
+  }
+
+  /**
+   * What subscribing would cost right now, and what would stand in the way, without starting
+   * anything.
+   *
+   * A blocker in the response — an existing subscription, an incomplete billing profile — is not
+   * an error: the price is returned alongside it, because the point of a preview is to show both
+   * together. Only a genuine input problem (an unknown plan, price or discount code) throws here,
+   * with the same code {@link subscribe} would then fail with.
+   */
+  async previewSubscription(
+    request: SubscribeToPlanRequest,
+  ): Promise<SubscriptionPurchasePreview> {
+    try {
+      const response = await serviceInstances.utitlitiesService.post<
+        SimulationApiResponse<SubscriptionPurchasePreview>
+      >(`${SUBSCRIPTIONS_ENDPOINT}/preview`, request);
+
+      if (!response.success || !response.data) {
+        throw new SubscriptionOperationError(
+          response.error?.message || "The subscription could not be previewed.",
+          response.error?.code ?? "unknown",
+        );
+      }
+
+      return response.data;
+    } catch (error) {
+      if (error instanceof SubscriptionOperationError) {
+        throw error;
+      }
+
+      if (error instanceof HttpError) {
+        throw new SubscriptionOperationError(
+          messageFrom(error, "The subscription could not be previewed."),
+          subscribeErrorCode(error),
+          error.status,
+        );
+      }
+
       throw error;
     }
   }
@@ -292,7 +335,7 @@ class SubscriptionSimulationService {
       // outcome into "unknown" and every retry into a guess.
       if (error instanceof HttpError) {
         throw new SubscriptionOperationError(
-          messageFrom(error),
+          messageFrom(error, "The quantity could not be changed."),
           quantityErrorCode(error),
           error.status,
         );
@@ -356,13 +399,38 @@ const serialize = (error: unknown): string => {
   }
 };
 
-const quantityErrorCode = (error: unknown): string => {
+/**
+ * The outcomes {@link SubscriptionSimulationService.subscribe} and
+ * {@link SubscriptionSimulationService.previewSubscription} both refuse for — genuine input
+ * problems, as opposed to the billing-profile and already-active conditions a preview reports as
+ * a blocker rather than an error.
+ */
+const SUBSCRIBE_ERROR_CODES = [
+  "subscription_plan_not_found",
+  "subscription_price_not_found",
+  "subscription_quantity_invalid",
+  "subscription_schedule_invalid",
+  "subscription_discount_not_found",
+  "subscription_discount_expired",
+  "subscription_discount_not_applicable",
+  "subscription_discount_currency_mismatch",
+  "subscription_request_invalid",
+] as const;
+
+const codeFrom = (
+  error: unknown,
+  candidates: readonly string[],
+): string => {
   const haystack = `${serialize(error)} ${error instanceof Error ? error.message : ""}`;
 
-  return QUANTITY_ERROR_CODES.find((code) => haystack.includes(code)) ?? "unknown";
+  return candidates.find((code) => haystack.includes(code)) ?? "unknown";
 };
 
-const messageFrom = (error: unknown): string => {
+const quantityErrorCode = (error: unknown): string => codeFrom(error, QUANTITY_ERROR_CODES);
+
+const subscribeErrorCode = (error: unknown): string => codeFrom(error, SUBSCRIBE_ERROR_CODES);
+
+const messageFrom = (error: unknown, fallback: string): string => {
   if (error instanceof HttpError) {
     const values = Object.values(error.errors ?? {}).flat();
     const first = values.find((value) => typeof value === "string" && value.trim().length > 0);
@@ -372,9 +440,7 @@ const messageFrom = (error: unknown): string => {
     }
   }
 
-  return error instanceof Error && error.message
-    ? error.message
-    : "The quantity could not be changed.";
+  return error instanceof Error && error.message ? error.message : fallback;
 };
 
 export const subscriptionSimulationService = new SubscriptionSimulationService();

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -662,6 +662,24 @@
             something anyone can change.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.PreviewSubscription(Subscription.DomainService.Requests.CreateSubscriptionRequest,System.Threading.CancellationToken)">
+            <summary>
+            What subscribing would cost right now, and what would stand in the way, without creating
+            anything.
+            </summary>
+            <remarks>
+            Runs the same plan and price resolution, the same discount validation, and the same
+            schedule and proration arithmetic <see cref="M:Api.Controllers.SubscriptionsController.Subscribe(Subscription.DomainService.Requests.CreateSubscriptionRequest,System.Threading.CancellationToken)"/> does — stopped one step short of
+            storing a subscription or opening a checkout session. <c>totalDueNowMinor</c> is the exact
+            figure a confirming <see cref="M:Api.Controllers.SubscriptionsController.Subscribe(Subscription.DomainService.Requests.CreateSubscriptionRequest,System.Threading.CancellationToken)"/> call would then charge.
+            <para>
+            A condition that would refuse the confirm — an existing subscription, an incomplete
+            billing profile — is reported in <c>blockers</c> rather than as a failure, so a client can
+            show the price and the obstacle together. Genuine input errors (an unknown plan, price or
+            discount code) still fail with the same codes <see cref="M:Api.Controllers.SubscriptionsController.Subscribe(Subscription.DomainService.Requests.CreateSubscriptionRequest,System.Threading.CancellationToken)"/> returns.
+            </para>
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.SubscriptionsController.GetCurrent(System.String,System.Threading.CancellationToken)">
             <summary>
             The caller's own subscription.

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -27,6 +27,7 @@ namespace Api.Controllers;
 public sealed class SubscriptionsController : ControllerBase
 {
     private readonly ISubscriptionCheckoutService _checkout;
+    private readonly ISubscriptionCreationService _creation;
     private readonly ISubscriptionCancellationService _cancellation;
     private readonly ISubscriptionPlanChangeService _planChange;
     private readonly ISubscriptionInvoiceDocumentService _invoiceDocuments;
@@ -38,6 +39,7 @@ public sealed class SubscriptionsController : ControllerBase
 
     public SubscriptionsController(
         ISubscriptionCheckoutService checkout,
+        ISubscriptionCreationService creation,
         ISubscriptionCancellationService cancellation,
         ISubscriptionPlanChangeService planChange,
         ISubscriptionInvoiceDocumentService invoiceDocuments,
@@ -48,6 +50,7 @@ public sealed class SubscriptionsController : ControllerBase
         ISubscriptionAuditRepository auditRepository)
     {
         _checkout = checkout;
+        _creation = creation;
         _cancellation = cancellation;
         _planChange = planChange;
         _invoiceDocuments = invoiceDocuments;
@@ -56,6 +59,55 @@ public sealed class SubscriptionsController : ControllerBase
         _contextResolver = contextResolver;
         _audit = audit;
         _auditRepository = auditRepository;
+    }
+
+    /// <summary>
+    /// What subscribing would cost right now, and what would stand in the way, without creating
+    /// anything.
+    /// </summary>
+    /// <remarks>
+    /// Runs the same plan and price resolution, the same discount validation, and the same
+    /// schedule and proration arithmetic <see cref="Subscribe"/> does — stopped one step short of
+    /// storing a subscription or opening a checkout session. <c>totalDueNowMinor</c> is the exact
+    /// figure a confirming <see cref="Subscribe"/> call would then charge.
+    /// <para>
+    /// A condition that would refuse the confirm — an existing subscription, an incomplete
+    /// billing profile — is reported in <c>blockers</c> rather than as a failure, so a client can
+    /// show the price and the obstacle together. Genuine input errors (an unknown plan, price or
+    /// discount code) still fail with the same codes <see cref="Subscribe"/> returns.
+    /// </para>
+    /// </remarks>
+    [HttpPost("preview")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionPreviewResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionPreviewResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionPreviewResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> PreviewSubscription(
+        [FromBody] CreateSubscriptionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, request.OrganizationId, cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            var failure = resolution.ToFailure<SubscriptionPreviewResponse>(correlationId);
+            return failure.ToActionResult(correlationId);
+        }
+
+        var result = await _creation.PreviewAsync(
+            request,
+            resolution.Context!,
+            correlationId,
+            cancellationToken);
+
+        await AuditAsync("PreviewSubscription", request.OrganizationId, null,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            result.Value?.TotalDueNowMinor, result.Value?.CurrencyCode, cancellationToken);
+
+        return result.ToActionResult(correlationId);
     }
 
     [HttpPost]

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1501,9 +1501,12 @@ Content-Type: application/json
         </table>
       </div>
       <p>
-        The API currently has no separate proration-preview endpoint. If the product needs an
-        exact amount before confirmation, add a preview operation rather than estimating it in
-        the browser with a second copy of the billing rules.
+        There is no separate proration-preview endpoint for a plan change specifically — that
+        would answer a different question from
+        <a href="#api-subs"><code>POST /api/subscriptions/preview</code></a>, which quotes a new
+        subscription rather than a move between prices on an existing one. If the product needs
+        an exact amount before confirming a plan change, add a preview operation for it rather
+        than estimating one in the browser with a second copy of the billing rules.
       </p>
     </section>
 
@@ -2061,9 +2064,94 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       <h3 id="api-subs">Subscriptions</h3>
 
       <div class="endpoint">
+        <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscriptions/preview</span></div>
+        <div class="endpoint-body">
+          <p>
+            What subscribing would cost right now, and what would stand in the way, without
+            creating anything.
+          </p>
+          <h4>Body</h4>
+          <p class="prose">The same shape <code>POST /api/subscriptions</code> takes.</p>
+          <pre><code>{
+  "planCode": "pro",
+  "priceId": "price-monthly",
+  "quantities": [
+    { "itemKey": "user", "quantity": 1 }
+  ],
+  "timeZoneId": "Europe/Zurich",
+  "discountCode": null
+}</code></pre>
+          <h4>Sample response</h4>
+          <pre><code>{
+  "success": true,
+  "data": {
+    "currencyCode": "CHF",
+    "subtotalMinor": 2806,
+    "discountMinor": 0,
+    "builtInDiscountMinor": 0,
+    "promotionalDiscountMinor": 0,
+    "taxMinor": 0,
+    "totalDueNowMinor": 2806,
+    "prorated": true,
+    "coveredDays": 6,
+    "totalDays": 31,
+    "periodStartUtc": "2026-08-25T09:30:00Z",
+    "periodEndUtc": "2026-08-31T22:00:00Z",
+    "nextRenewalAtUtc": "2026-08-31T22:00:00Z",
+    "nextRenewalAmountMinor": 14500,
+    "trialEndsAtUtc": null,
+    "requiresCardSetup": false,
+    "pendingAnnualPeriod": null,
+    "blockers": [],
+    "quotedAtUtc": "2026-08-25T09:30:00Z",
+    "quoteValidUntilUtc": "2026-08-26T22:00:00Z"
+  },
+  "error": null,
+  "meta": { "correlationId": "0HN…", "timestampUtc": "…", "replayed": false }
+}</code></pre>
+          <p class="prose">
+            Runs the same plan and price resolution, the same discount validation, and the same
+            schedule and proration arithmetic <code>POST /api/subscriptions</code> does, stopped
+            one step short of storing a subscription or opening a checkout session.
+            <code>totalDueNowMinor</code> is the exact figure a confirming call would then charge
+            — both read the one frozen amount on the server, so the two cannot quote a different
+            number.
+          </p>
+          <p class="prose">
+            <code>quoteValidUntilUtc</code> is the earliest instant this quote's proration could
+            no longer hold — the next local midnight in the request's own <code>timeZoneId</code>,
+            since a day fraction is the only figure here that moves with the clock. It is
+            <code>null</code> when nothing is prorated, because then no boundary changes the
+            answer: a flat monthly price quoted today prices the same tomorrow. Re-preview once
+            that instant passes rather than trust a held quote past it.
+          </p>
+          <p class="prose">
+            A condition that would refuse the confirm — an existing subscription, an incomplete
+            billing profile — is reported in <code>blockers</code> rather than as a failure, so a
+            client can show the price and the obstacle together. Each blocker carries the same
+            <code>code</code> a failed <code>POST /api/subscriptions</code> would return, and
+            <code>subscription_billing_profile_incomplete</code> also carries <code>fields</code>,
+            naming which ones are missing. An empty <code>blockers</code> array means confirming
+            would succeed as quoted.
+          </p>
+          <h4>Returns</h4>
+          <p>
+            <code>200</code> · <code>400</code> invalid, unknown time zone, or a discount code
+            problem · <code>404</code> plan or price not found.
+          </p>
+        </div>
+      </div>
+
+      <div class="endpoint">
         <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscriptions</span></div>
         <div class="endpoint-body">
           <p>Starts a subscription and raises the first charge.</p>
+          <p class="prose">
+            The UI should require a fresh <code>POST /api/subscriptions/preview</code> before
+            letting the subscriber confirm, and discard it the moment anything that would change
+            the price is edited — the plan, the price, a quantity, or the discount code. A stale
+            quote confirmed after editing is a confirmation of numbers the subscriber never saw.
+          </p>
           <h4>Body</h4>
           <pre><code>{
   "planCode": "personal",         // the CODE, not the planId

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -339,6 +339,33 @@ They are exposed on the subscription response, and kept after activation for tra
 `recurringAmountMinor` is unaffected throughout — it is what the next *full* month costs, which is
 a different question from what the opening stub cost.
 
+### The purchase preview is the same build, stopped one step short
+
+`POST /api/subscriptions/preview` answers "what would this cost right now" without creating
+anything. It is not a second implementation of the pricing — `SubscriptionCreationService` splits
+its old `CreateAsync` into a shared `BuildSubscriptionAsync` that resolves the plan, price and
+discount, builds the schedules, and runs `ApplyPeriods` to freeze the opening charge onto an
+in-memory subscription; `CreateAsync` then persists it, and `PreviewAsync` reads the same fields
+back out and never writes. `SubscriptionAmountCalculator.InitialChargeAmountMinor` — the exact
+expression `SubscriptionCheckoutService` charges — is what both the confirm and the preview call,
+so the two cannot quote a different figure from the same inputs.
+
+Only one write is skipped on a preview: `IBillingAccountRepository.GetOrCreateAsync`, which
+inserts a durable billing account nobody has confirmed subscribing yet. An unsaved stand-in serves
+just as well — its id plays no part in the price, only in the record `CreateAsync` would go on to
+store.
+
+A condition that would refuse the confirm is reported as a **blocker** rather than a failure, so a
+client sees the price and the obstacle together: an incomplete billing profile, or an existing live
+or incomplete subscription for the organization (read via `GetLiveAsync` and `GetIncompleteAsync`
+— the same two states the reservation index refuses a second insert for). A genuine input problem
+— an unknown plan, price or discount code — still fails with the same code the confirm would.
+
+`quoteValidUntilUtc` names the boundary rather than leaving the client to guess one: proration is
+quantized per calendar day, so a quote is only exact until the next local midnight in the
+request's own time zone — not until the period boundary, which can be weeks away. Null when
+nothing is prorated, because then no boundary changes the answer.
+
 ### What the fraction applies to, and in what order
 
 The gross is scaled once, at the front, and everything downstream applies to a prorated gross:

--- a/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
@@ -1,0 +1,122 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// What a subscription would cost if bought right now, without buying it.
+/// </summary>
+/// <remarks>
+/// Every figure here is read from a subscription built exactly as <c>POST /subscriptions</c>
+/// builds one, stopped one step short of being saved — the same plan and price resolution, the
+/// same discount validation, the same schedule and proration arithmetic. There is one pricing
+/// path, not two, so this cannot state an amount the confirm then charges something else for.
+/// <para>
+/// <see cref="TotalDueNowMinor"/> is that subscription's own frozen initial charge — the exact
+/// expression <c>SubscriptionCheckoutService</c> reads when it actually takes payment.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionPreviewResponse
+{
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    /// <summary>The undiscounted amount for the period covered, before tax.</summary>
+    public long SubtotalMinor { get; init; }
+
+    /// <summary>Every reduction combined — the figure the specified contract asks for.</summary>
+    public long DiscountMinor { get; init; }
+
+    /// <summary>What the price's own automatic discount and volume band took off.</summary>
+    public long BuiltInDiscountMinor { get; init; }
+
+    /// <summary>What a promotional code took off, if one was supplied and applied.</summary>
+    public long PromotionalDiscountMinor { get; init; }
+
+    public long TaxMinor { get; init; }
+
+    /// <summary>
+    /// What confirming this preview would actually charge. Zero for a card-free trial, and for
+    /// any subscription discounted to nothing.
+    /// </summary>
+    public long TotalDueNowMinor { get; init; }
+
+    /// <summary>Whether the opening period is a fraction of a full one.</summary>
+    public bool Prorated { get; init; }
+
+    public int? CoveredDays { get; init; }
+
+    public int? TotalDays { get; init; }
+
+    public DateTime PeriodStartUtc { get; init; }
+
+    public DateTime PeriodEndUtc { get; init; }
+
+    /// <summary>
+    /// When the next charge falls — the trial's end for a card-free trial, otherwise this
+    /// period's own end.
+    /// </summary>
+    public DateTime? NextRenewalAtUtc { get; init; }
+
+    /// <summary>What a full period costs once proration and the trial no longer apply.</summary>
+    public long NextRenewalAmountMinor { get; init; }
+
+    /// <summary>Set only for a subscription that opens on a trial.</summary>
+    public DateTime? TrialEndsAtUtc { get; init; }
+
+    /// <summary>
+    /// Whether confirming this preview will ask for a card even though nothing is due now.
+    /// </summary>
+    public bool RequiresCardSetup { get; init; }
+
+    /// <summary>
+    /// The year a calendar-aligned yearly signup has also bought, mid-month, in addition to its
+    /// stub. Null for every other case.
+    /// </summary>
+    public SubscriptionPreviewAnnualPeriodResponse? PendingAnnualPeriod { get; init; }
+
+    /// <summary>
+    /// What would stop the confirm from succeeding, named rather than hidden behind a price the
+    /// customer is then refused. Empty when nothing stands in the way.
+    /// </summary>
+    public List<SubscriptionPreviewBlockerResponse> Blockers { get; init; } = [];
+
+    /// <summary>The instant these figures were derived from.</summary>
+    public DateTime QuotedAtUtc { get; init; }
+
+    /// <summary>
+    /// The earliest instant at which this quote's proration could no longer hold — the next local
+    /// midnight in the request's own time zone. Null when nothing here is prorated, because then
+    /// no boundary changes the answer.
+    /// </summary>
+    public DateTime? QuoteValidUntilUtc { get; init; }
+}
+
+public sealed class SubscriptionPreviewAnnualPeriodResponse
+{
+    public DateTime StartUtc { get; init; }
+
+    public DateTime EndUtc { get; init; }
+
+    public long AmountMinor { get; init; }
+
+    public long NetAmountMinor { get; init; }
+
+    public long TaxAmountMinor { get; init; }
+
+    /// <summary>Whether the year's amount is already included in <c>totalDueNowMinor</c>.</summary>
+    public bool CollectedWithCheckout { get; init; }
+}
+
+/// <summary>
+/// One reason confirming this preview would be refused.
+/// </summary>
+/// <remarks>
+/// The same error codes <c>POST /subscriptions</c> itself returns, so a client already handling
+/// those does not learn a second vocabulary for the preview.
+/// </remarks>
+public sealed class SubscriptionPreviewBlockerResponse
+{
+    public string Code { get; init; } = string.Empty;
+
+    public string Message { get; init; } = string.Empty;
+
+    /// <summary>Set only for <c>subscription_billing_profile_incomplete</c>.</summary>
+    public IReadOnlyDictionary<string, string[]>? Fields { get; init; }
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCreationService.cs
@@ -1,5 +1,6 @@
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
 
 namespace Subscription.DomainService.Services;
 
@@ -14,6 +15,23 @@ public interface ISubscriptionCreationService
     /// durable record.
     /// </remarks>
     Task<SubscriptionOperationResult<SubscriptionDetail>> CreateAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// What <see cref="CreateAsync"/> would charge and when it would renew, without storing
+    /// anything.
+    /// </summary>
+    /// <remarks>
+    /// Runs the same resolution and the same arithmetic as <see cref="CreateAsync"/>, stopped
+    /// short of every write — so a caller that confirms what it was quoted gets what it was
+    /// quoted. A condition that would refuse the confirm (an existing subscription, an
+    /// incomplete billing profile) is reported as a blocker here rather than as a failure, so
+    /// the price and the obstacle are seen together.
+    /// </remarks>
+    Task<SubscriptionOperationResult<SubscriptionPreviewResponse>> PreviewAsync(
         CreateSubscriptionRequest request,
         SubscriptionContext context,
         string correlationId,

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -19,6 +19,49 @@ public static class SubscriptionAmountCalculator
         FirstPeriodAmountMinor(subscription, default, DateTime.UtcNow);
 
     /// <summary>
+    /// What checkout actually charges when a subscription is first created.
+    /// </summary>
+    /// <remarks>
+    /// A card-free trial is charged nothing regardless of what a period would otherwise cost —
+    /// the money path cannot hold a card without charging it, so taking payment here would defeat
+    /// the entire point of a trial that starts free. Every other subscription reads its own frozen
+    /// figure, falling back only for one written before that was frozen at signup.
+    /// <para>
+    /// Shared between the checkout charge and the purchase preview so the two read one expression
+    /// rather than risk computing a different figure from the same subscription.
+    /// </para>
+    /// </remarks>
+    public static long InitialChargeAmountMinor(SubscriptionDetail subscription)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        if (subscription.Trial is { RequiresPaymentMethod: false })
+        {
+            return 0;
+        }
+
+        return subscription.InitialChargeAmountMinor ?? PeriodAmountMinor(subscription);
+    }
+
+    /// <summary>
+    /// Whether a card must be on file before this subscription grants anything, given that
+    /// nothing is payable today.
+    /// </summary>
+    /// <remarks>
+    /// Two separate reasons, either sufficient. The plan may require a card outright — a fully
+    /// discounted first period should not mean an unbillable second one. Or the subscription may
+    /// start on a trial the plan said needs a card, which until now could only be honoured by
+    /// charging for the first period at signup.
+    /// <para>
+    /// Shared between checkout and the purchase preview, so a quote cannot promise "no card
+    /// needed" for a subscription checkout would then refuse to start without one.
+    /// </para>
+    /// </remarks>
+    public static bool RequiresCardSetup(SubscriptionDetail subscription) =>
+        subscription.Plan.RequirePaymentMethodUpfront ||
+        subscription.Trial is { RequiresPaymentMethod: true };
+
+    /// <summary>
     /// What the opening period costs, when that period may be a fraction of a month.
     /// </summary>
     /// <remarks>

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -118,12 +118,11 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         var subscription = created.Value!;
 
         // The figure fixed when the subscription was built, so the charge raised here is the one
-        // the customer was quoted. Falls back for the paths that never priced a first period —
-        // a card-free trial, and any subscription written before the amount was frozen.
-        var amountMinor = subscription.InitialChargeAmountMinor
-            ?? SubscriptionAmountCalculator.PeriodAmountMinor(subscription);
+        // the customer was quoted — and the same expression the purchase preview reports, so the
+        // two cannot disagree.
+        var amountMinor = SubscriptionAmountCalculator.InitialChargeAmountMinor(subscription);
 
-        if (RequiresPayment(subscription, amountMinor))
+        if (RequiresPayment(amountMinor))
         {
             return await ChargeAsync(subscription, amountMinor, correlationId, cancellationToken);
         }
@@ -132,7 +131,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         // what the plan asked for: a card can be a condition of activation without being a
         // charge, and the two questions were conflated for as long as the only way to hold a
         // card was to take money with it.
-        return RequiresCardSetup(subscription)
+        return SubscriptionAmountCalculator.RequiresCardSetup(subscription)
             ? await StartCardSetupAsync(subscription, correlationId, cancellationToken)
             : await StartWithoutPaymentAsync(
                 subscription,
@@ -424,36 +423,13 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     /// a zero-amount charge is not something the money path accepts — the currency resolver
     /// refuses anything at or below zero. So these start directly rather than being sent to a
     /// checkout that would decline them.
-    /// </remarks>
-    private static bool RequiresPayment(SubscriptionDetail subscription, long amountMinor)
-    {
-        if (subscription.Trial is { RequiresPaymentMethod: false })
-        {
-            return false;
-        }
-
-        return amountMinor > 0;
-    }
-
-    /// <summary>
-    /// Whether a card must be on file before this subscription grants anything, given that
-    /// nothing is payable today.
-    /// </summary>
-    /// <remarks>
-    /// Two separate reasons, either sufficient. The plan may require a card outright — a fully
-    /// discounted first period should not mean an unbillable second one. Or the subscription may
-    /// start on a trial the plan said needs a card, which until now could only be honoured by
-    /// charging for the first period at signup.
     /// <para>
-    /// A card-free trial can still land here, when the plan asks for a card up front regardless.
-    /// That combination is deliberate and is the one this setting was asked for: genuinely free
-    /// until the trial ends, and with a card on file so the charge that ends it has something to
-    /// bill.
+    /// <paramref name="amountMinor"/> is already trial-aware — see
+    /// <see cref="SubscriptionAmountCalculator.InitialChargeAmountMinor"/> — so the only question
+    /// left here is whether it came to anything.
     /// </para>
     /// </remarks>
-    private static bool RequiresCardSetup(SubscriptionDetail subscription) =>
-        subscription.Plan.RequirePaymentMethodUpfront ||
-        subscription.Trial is { RequiresPaymentMethod: true };
+    private static bool RequiresPayment(long amountMinor) => amountMinor > 0;
 
     /// <summary>
     /// Opens a hosted session that stores a card and charges nothing.

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using Microsoft.Extensions.Logging;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Utilities;
@@ -7,6 +7,7 @@ using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Scheduling;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
 using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
@@ -94,6 +95,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             context,
             plan,
             price,
+            preview: false,
             cancellationToken);
 
         if (profileMissing.Count > 0)
@@ -113,96 +115,15 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 });
         }
 
-        var discount = await ResolveDiscountAsync(request, context, plan, price, correlationId, cancellationToken);
-        if (!discount.IsSuccess) return discount.ToFailure<SubscriptionDetail>();
-        var quantities = SubscriptionQuantityBuilder.Build(request.Quantities, plan, price);
+        var built = await BuildSubscriptionAsync(
+            request, context, plan, price, preview: false, correlationId, cancellationToken);
 
-        if (quantities is null)
+        if (!built.Result.IsSuccess)
         {
-            return Failure(
-                PaymentFailureKind.Validation,
-                "subscription_quantity_invalid",
-                "The quantities do not match the plan's items or fall outside their bounds.",
-                correlationId);
+            return built.Result;
         }
 
-        var now = _time.GetUtcNow().UtcDateTime;
-
-        // A calendar-aligned price anchors on the first of the month rather than on this instant;
-        // every later boundary then derives from that anchor exactly as an anniversary one does.
-        // The usage schedule is never realigned — metering keeps the plan's own independent
-        // cadence, which is the whole reason it is a separate schedule.
-        var calendarAligned = CalendarBillingAlignment.IsCalendarAligned(
-            price.BillingAlignment,
-            price.Interval,
-            price.IntervalCount,
-            price.CalendarStubBaseUnitAmountMinor);
-
-        // A card-free trial defers the first paid period to the day it ends, and for a yearly
-        // price that day decides the whole annual cycle: a 25 August signup on a trial running to
-        // 20 September starts its year on 1 October, not 1 September. The trial's end is known
-        // here, so the schedule is anchored on it rather than corrected later — every boundary
-        // derives from the anchor, and one anchored a month early stays a month early forever.
-        var scheduleAnchorUtc = plan.TrialDays is { } trialDays && !plan.TrialRequiresPaymentMethod
-            ? now.AddDays(trialDays)
-            : now;
-
-        var feeScheduleBuilt = calendarAligned
-            ? CalendarBillingAlignment.TryCreateSchedule(
-                price.Interval, scheduleAnchorUtc, request.TimeZoneId, out var feeSchedule)
-            : BillingPeriodCalculator.TryCreateSchedule(
-                price.Interval,
-                price.IntervalCount,
-                now,
-                request.TimeZoneId,
-                out feeSchedule);
-
-        if (!feeScheduleBuilt ||
-            !BillingPeriodCalculator.TryCreateSchedule(
-                plan.UsageInterval,
-                plan.UsageIntervalCount,
-                now,
-                request.TimeZoneId,
-                out var usageSchedule))
-        {
-            return Failure(
-                PaymentFailureKind.Validation,
-                "subscription_schedule_invalid",
-                "The billing schedule could not be derived from this time zone.",
-                correlationId);
-        }
-
-        var account = await _billingAccounts.GetOrCreateAsync(
-            new BillingAccount
-            {
-                TenantId = context.TenantId,
-                OrganizationId = context.OrganizationId,
-                ProviderName = StripeProvider,
-                BillingEmail = request.BillingEmail,
-                BillingName = request.BillingName
-            },
-            cancellationToken);
-
-        var subscription = BuildSubscription(
-            context,
-            plan,
-            price,
-            quantities,
-            account,
-            feeSchedule,
-            usageSchedule,
-            discount.Value,
-            now,
-            correlationId);
-
-        if (!ApplyPeriods(subscription, now, calendarAligned))
-        {
-            return Failure(
-                PaymentFailureKind.Validation,
-                "subscription_schedule_invalid",
-                "The billing periods could not be computed for this schedule.",
-                correlationId);
-        }
+        var subscription = built.Result.Value!;
 
         if (!await _subscriptions.TryCreateAsync(subscription, cancellationToken))
         {
@@ -235,6 +156,97 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         return SubscriptionOperationResult<SubscriptionDetail>.Success(
             subscription,
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionPreviewResponse>> PreviewAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var invalid = await SubscriptionValidation
+            .CheckAsync<CreateSubscriptionRequest, SubscriptionPreviewResponse>(
+                _validator,
+                request,
+                "subscription_request_invalid",
+                "The subscription request is invalid.",
+                correlationId,
+                cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var terms = await ResolveTermsAsync(request, context, correlationId, cancellationToken);
+
+        if (!terms.IsSuccess)
+        {
+            return terms.ToFailure<SubscriptionPreviewResponse>();
+        }
+
+        var (plan, price) = terms.Value;
+
+        // Not a failure here, unlike CreateAsync: the price is worth showing even to an
+        // organization that still owes its profile, so the missing fields become a blocker
+        // alongside the figures rather than the only thing reported.
+        var profileMissing = await MissingBillingProfileFieldsAsync(
+            context,
+            plan,
+            price,
+            preview: true,
+            cancellationToken);
+
+        var built = await BuildSubscriptionAsync(
+            request, context, plan, price, preview: true, correlationId, cancellationToken);
+
+        if (!built.Result.IsSuccess)
+        {
+            return built.Result.ToFailure<SubscriptionPreviewResponse>();
+        }
+
+        var subscription = built.Result.Value!;
+        var blockers = new List<SubscriptionPreviewBlockerResponse>();
+
+        if (profileMissing.Count > 0)
+        {
+            blockers.Add(new SubscriptionPreviewBlockerResponse
+            {
+                Code = "subscription_billing_profile_incomplete",
+                Message = "This organization's billing profile is missing details an invoice must " +
+                    "carry. Complete it before starting a paid subscription.",
+                Fields = new Dictionary<string, string[]>
+                {
+                    ["BillingProfile"] = [.. profileMissing]
+                }
+            });
+        }
+
+        // The same condition TryCreateAsync's unique index would refuse a real signup for — read
+        // rather than attempted, since a preview writes nothing to conflict on. Both reservation
+        // statuses matter: an Incomplete checkout left over from an abandoned attempt blocks a new
+        // one exactly as a Live subscription does.
+        var liveTask = _subscriptions.GetLiveAsync(context.TenantId, context.OrganizationId, cancellationToken);
+        var incompleteTask = _subscriptions.GetIncompleteAsync(
+            context.TenantId, context.OrganizationId, cancellationToken);
+
+        await Task.WhenAll(liveTask, incompleteTask);
+
+        if (liveTask.Result is not null || incompleteTask.Result is not null)
+        {
+            blockers.Add(new SubscriptionPreviewBlockerResponse
+            {
+                Code = "subscription_already_active",
+                Message = "This organization already has a live subscription."
+            });
+        }
+
+        return SubscriptionOperationResult<SubscriptionPreviewResponse>.Success(
+            BuildPreviewResponse(subscription, built.StubCharge, blockers, request.TimeZoneId),
             correlationId);
     }
 
@@ -278,6 +290,143 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         return SubscriptionOperationResult<(Plan, Price)>.Success(
             (plan, price),
             correlationId);
+    }
+
+    /// <summary>
+    /// Everything <see cref="CreateAsync"/> and <see cref="PreviewAsync"/> share: resolving the
+    /// discount, building the quantities and schedules, and freezing the opening charge onto an
+    /// in-memory subscription. Neither caller may diverge here — a branch in this method is a
+    /// chance for the two to price the same request differently.
+    /// </summary>
+    /// <remarks>
+    /// The only place <paramref name="preview"/> changes anything is the billing account: a real
+    /// signup gets or creates the durable one, a preview builds an unsaved stand-in whose id is
+    /// never read for anything but the field it fills on the built subscription. Everything that
+    /// decides the price runs identically either way.
+    /// </remarks>
+    private async Task<SubscriptionBuildOutcome> BuildSubscriptionAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        Plan plan,
+        Price price,
+        bool preview,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var discount = await ResolveDiscountAsync(request, context, plan, price, correlationId, cancellationToken);
+        if (!discount.IsSuccess)
+        {
+            return new SubscriptionBuildOutcome(discount.ToFailure<SubscriptionDetail>(), null);
+        }
+
+        var quantities = SubscriptionQuantityBuilder.Build(request.Quantities, plan, price);
+
+        if (quantities is null)
+        {
+            return new SubscriptionBuildOutcome(
+                Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_quantity_invalid",
+                    "The quantities do not match the plan's items or fall outside their bounds.",
+                    correlationId),
+                null);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        // A calendar-aligned price anchors on the first of the month rather than on this instant;
+        // every later boundary then derives from that anchor exactly as an anniversary one does.
+        // The usage schedule is never realigned — metering keeps the plan's own independent
+        // cadence, which is the whole reason it is a separate schedule.
+        var calendarAligned = CalendarBillingAlignment.IsCalendarAligned(
+            price.BillingAlignment,
+            price.Interval,
+            price.IntervalCount,
+            price.CalendarStubBaseUnitAmountMinor);
+
+        // A card-free trial defers the first paid period to the day it ends, and for a yearly
+        // price that day decides the whole annual cycle: a 25 August signup on a trial running to
+        // 20 September starts its year on 1 October, not 1 September. The trial's end is known
+        // here, so the schedule is anchored on it rather than corrected later — every boundary
+        // derives from the anchor, and one anchored a month early stays a month early forever.
+        var scheduleAnchorUtc = plan.TrialDays is { } trialDays && !plan.TrialRequiresPaymentMethod
+            ? now.AddDays(trialDays)
+            : now;
+
+        var feeScheduleBuilt = calendarAligned
+            ? CalendarBillingAlignment.TryCreateSchedule(
+                price.Interval, scheduleAnchorUtc, request.TimeZoneId, out var feeSchedule)
+            : BillingPeriodCalculator.TryCreateSchedule(
+                price.Interval,
+                price.IntervalCount,
+                now,
+                request.TimeZoneId,
+                out feeSchedule);
+
+        if (!feeScheduleBuilt ||
+            !BillingPeriodCalculator.TryCreateSchedule(
+                plan.UsageInterval,
+                plan.UsageIntervalCount,
+                now,
+                request.TimeZoneId,
+                out var usageSchedule))
+        {
+            return new SubscriptionBuildOutcome(
+                Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_schedule_invalid",
+                    "The billing schedule could not be derived from this time zone.",
+                    correlationId),
+                null);
+        }
+
+        // A preview writes nothing: GetOrCreateAsync inserts a durable billing account, which a
+        // quote nobody has confirmed must not leave behind. Only the id is read from it below, and
+        // it plays no part in the price — an unsaved stand-in serves exactly as well.
+        var account = preview
+            ? new BillingAccount
+            {
+                TenantId = context.TenantId,
+                OrganizationId = context.OrganizationId,
+                ProviderName = StripeProvider
+            }
+            : await _billingAccounts.GetOrCreateAsync(
+                new BillingAccount
+                {
+                    TenantId = context.TenantId,
+                    OrganizationId = context.OrganizationId,
+                    ProviderName = StripeProvider,
+                    BillingEmail = request.BillingEmail,
+                    BillingName = request.BillingName
+                },
+                cancellationToken);
+
+        var subscription = BuildSubscription(
+            context,
+            plan,
+            price,
+            quantities,
+            account,
+            feeSchedule,
+            usageSchedule,
+            discount.Value,
+            now,
+            correlationId);
+
+        if (!ApplyPeriods(subscription, now, calendarAligned, out var stubCharge))
+        {
+            return new SubscriptionBuildOutcome(
+                Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_schedule_invalid",
+                    "The billing periods could not be computed for this schedule.",
+                    correlationId),
+                null);
+        }
+
+        return new SubscriptionBuildOutcome(
+            SubscriptionOperationResult<SubscriptionDetail>.Success(subscription, correlationId),
+            stubCharge);
     }
 
     private async Task<SubscriptionOperationResult<DiscountTerms?>> ResolveDiscountAsync(
@@ -446,11 +595,24 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                     .ToList()
             };
 
+    /// <summary>
+    /// Freezes the opening period's dates and charge onto the subscription.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="stubCharge"/> is the exact <see cref="PeriodCharge"/> the opening-period
+    /// branch below computed to fill <see cref="SubscriptionDetail.InitialChargeAmountMinor"/> —
+    /// null when that branch never ran, which is only the card-free trial. The purchase preview
+    /// reads it back out rather than recomputing anything, so its subtotal and tax cannot drift
+    /// from the figure this method actually froze.
+    /// </remarks>
     private static bool ApplyPeriods(
         SubscriptionDetail subscription,
         DateTime now,
-        bool calendarAligned)
+        bool calendarAligned,
+        out PeriodCharge? stubCharge)
     {
+        stubCharge = null;
+
         if (!BillingPeriodCalculator.TryGetPeriod(
                 subscription.FeeSchedule,
                 now,
@@ -529,6 +691,8 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 fraction,
                 now,
                 includePromotionalDiscount: annual is null);
+
+            stubCharge = charge;
 
             subscription.InitialChargeAmountMinor = annual is { CollectedWithCheckout: true }
                 ? charge.AmountMinor + annual.AmountMinor
@@ -613,6 +777,103 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         };
     }
 
+    /// <summary>
+    /// Turns a built-but-unsaved subscription into the figures a customer is shown.
+    /// </summary>
+    /// <remarks>
+    /// Every money field here is read from what <see cref="ApplyPeriods"/> already froze onto
+    /// <paramref name="subscription"/>, or from <paramref name="stubCharge"/> — the exact
+    /// <see cref="PeriodCharge"/> that froze it. Nothing is recomputed, so nothing here can
+    /// disagree with what <see cref="CreateAsync"/> would have stored or what
+    /// <see cref="SubscriptionAmountCalculator.InitialChargeAmountMinor"/> would then charge.
+    /// </remarks>
+    private static SubscriptionPreviewResponse BuildPreviewResponse(
+        SubscriptionDetail subscription,
+        PeriodCharge? stubCharge,
+        List<SubscriptionPreviewBlockerResponse> blockers,
+        string timeZoneId)
+    {
+        var annual = subscription.PendingAnnualPeriod;
+        var annualBundled = annual is { CollectedWithCheckout: true };
+
+        var subtotalMinor = (stubCharge?.GrossAmountMinor ?? 0)
+            + (annualBundled ? annual!.GrossAmountMinor : 0);
+        var builtInDiscountMinor = (stubCharge?.BuiltInDiscountMinor ?? 0)
+            + (annualBundled ? annual!.BuiltInDiscountMinor : 0);
+        var promotionalDiscountMinor = (stubCharge?.PromotionalDiscountMinor ?? 0)
+            + (annualBundled ? annual!.PromotionalDiscountMinor : 0);
+        var taxMinor = (stubCharge?.TaxAmountMinor ?? 0)
+            + (annualBundled ? annual!.TaxAmountMinor : 0);
+
+        return new SubscriptionPreviewResponse
+        {
+            CurrencyCode = subscription.CurrencyCode,
+            SubtotalMinor = subtotalMinor,
+            DiscountMinor = builtInDiscountMinor + promotionalDiscountMinor,
+            BuiltInDiscountMinor = builtInDiscountMinor,
+            PromotionalDiscountMinor = promotionalDiscountMinor,
+            TaxMinor = taxMinor,
+            // The exact expression SubscriptionCheckoutService charges — see its own call to the
+            // same method — so this figure and the one actually taken cannot diverge.
+            TotalDueNowMinor = SubscriptionAmountCalculator.InitialChargeAmountMinor(subscription),
+            Prorated = subscription.InitialChargeProrated,
+            CoveredDays = subscription.ProrationDays,
+            TotalDays = subscription.ProrationTotalDays,
+            PeriodStartUtc = subscription.CurrentPeriodStartUtc,
+            PeriodEndUtc = subscription.CurrentPeriodEndUtc,
+            NextRenewalAtUtc = subscription.NextFeeBillingAtUtc,
+            // The same call SubscriptionResponseMapper uses for an existing subscription's
+            // RecurringAmountMinor, so a quote and a live subscription describe a renewal
+            // identically.
+            NextRenewalAmountMinor = SubscriptionAmountCalculator
+                .PeriodAmountMinor(subscription, subscription.CreatedAtUtc)
+                .AmountMinor,
+            TrialEndsAtUtc = subscription.Trial?.EndsAtUtc,
+            RequiresCardSetup = SubscriptionAmountCalculator.RequiresCardSetup(subscription),
+            PendingAnnualPeriod = annual is null
+                ? null
+                : new SubscriptionPreviewAnnualPeriodResponse
+                {
+                    StartUtc = annual.StartUtc,
+                    EndUtc = annual.EndUtc,
+                    AmountMinor = annual.AmountMinor,
+                    NetAmountMinor = annual.NetAmountMinor,
+                    TaxAmountMinor = annual.TaxAmountMinor,
+                    CollectedWithCheckout = annual.CollectedWithCheckout
+                },
+            Blockers = blockers,
+            QuotedAtUtc = subscription.CreatedAtUtc,
+            QuoteValidUntilUtc = QuoteValidUntilUtc(subscription, timeZoneId)
+        };
+    }
+
+    /// <summary>
+    /// The earliest instant this quote's proration could no longer hold: the next local midnight
+    /// in the request's own time zone, since a day fraction is the only thing here that moves
+    /// with the clock. Null when nothing is prorated, because then no boundary changes the
+    /// answer — a flat monthly price quoted today prices the same tomorrow.
+    /// </summary>
+    private static DateTime? QuoteValidUntilUtc(SubscriptionDetail subscription, string timeZoneId)
+    {
+        if (!subscription.InitialChargeProrated)
+        {
+            return null;
+        }
+
+        // Already validated by CreateSubscriptionRequestValidator before either method runs, so
+        // this only fails for a caller that bypassed validation — fail closed with no boundary
+        // rather than guess one.
+        if (!BillingLocalTime.TryFindTimeZone(timeZoneId, out var timeZone))
+        {
+            return null;
+        }
+
+        var local = BillingLocalTime.ToLocal(subscription.CreatedAtUtc, timeZone);
+        var nextLocalMidnight = local.Date.AddDays(1);
+
+        return BillingLocalTime.ToUtc(nextLocalMidnight, timeZone);
+    }
+
     private static SubscriptionOperationResult<SubscriptionDetail> Failure(
         PaymentFailureKind kind,
         string errorCode,
@@ -639,10 +900,16 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
     /// and asking then means asking in the middle of an upgrade.
     /// </para>
     /// </remarks>
+    /// <param name="preview">
+    /// True to leave <see cref="ISubscriptionBillingProfileGuard.RememberInitiatorAsync"/> unread.
+    /// A preview has not started anything, and recording an initiator for a quote that may never
+    /// be confirmed would misname who actually began the subscription.
+    /// </param>
     private async Task<IReadOnlyList<string>> MissingBillingProfileFieldsAsync(
         SubscriptionContext context,
         Plan plan,
         Price price,
+        bool preview,
         CancellationToken cancellationToken)
     {
         if (_billingProfile is null ||
@@ -656,7 +923,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             context.OrganizationId,
             cancellationToken);
 
-        if (missing.Count == 0)
+        if (missing.Count == 0 && !preview)
         {
             // Whoever starts a subscription is, by acting, somebody an invoice may have to name.
             await _billingProfile.RememberInitiatorAsync(
@@ -670,4 +937,14 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         return missing;
     }
+
+    /// <summary>What building an unsaved subscription produced.</summary>
+    /// <param name="StubCharge">
+    /// The opening period's own charge, as computed inside <see cref="ApplyPeriods"/> — null when
+    /// <see cref="Result"/> failed, and also null for a card-free trial, which never prices an
+    /// opening period at all.
+    /// </param>
+    private readonly record struct SubscriptionBuildOutcome(
+        SubscriptionOperationResult<SubscriptionDetail> Result,
+        PeriodCharge? StubCharge);
 }

--- a/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
@@ -63,6 +63,52 @@ public sealed class CalendarAlignedSubscriptionTests
                 It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
             .Callback<SubscriptionDetail, CancellationToken>((subscription, _) => _created = subscription)
             .ReturnsAsync(true);
+
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+    }
+
+    /// <summary>
+    /// The stub this fixture's headline case buys — a 25 August signup, 7 of 31 days — previewed
+    /// exactly as confirmed, and the boundary at which the quote stops holding.
+    /// </summary>
+    [Fact]
+    public async Task A_preview_of_the_stub_quotes_the_same_fraction_and_states_its_boundary()
+    {
+        var request = new CreateSubscriptionRequest
+        {
+            PlanCode = "professional",
+            PriceId = "price-1",
+            TimeZoneId = Zurich,
+            Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 1 }]
+        };
+
+        var preview = await Service().PreviewAsync(
+            request,
+            new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1"),
+            "corr-preview",
+            CancellationToken.None);
+
+        await Subscribe();
+
+        preview.IsSuccess.Should().BeTrue();
+        preview.Value!.Prorated.Should().BeTrue();
+        preview.Value.CoveredDays.Should().Be(7);
+        preview.Value.TotalDays.Should().Be(31);
+        preview.Value.TotalDueNowMinor.Should().Be(_created!.InitialChargeAmountMinor);
+
+        // The fraction is quantized per calendar day — 7/31 today, 6/31 tomorrow — so it moves at
+        // the very next local midnight, not at the period boundary a week later. This fixture's
+        // clock sits on 25 August, 09:30 UTC = 11:30 in Zurich, so the boundary is 26 August,
+        // 00:00 Zurich.
+        preview.Value.QuoteValidUntilUtc.Should().Be(LocalMidnight(2026, 8, 26));
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -63,6 +63,20 @@ public sealed class SubscriptionCreationServiceTests
             .Callback<SubscriptionDetail, CancellationToken>(
                 (subscription, _) => _created = subscription)
             .ReturnsAsync(true);
+
+        // No reservation unless a test says otherwise. Moq's unconfigured default for a
+        // Task<SubscriptionDetail?> method is a null Task, not a completed one — awaiting it
+        // throws, so every preview test would fail for a reason that has nothing to do with what
+        // it is testing without this.
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
     }
 
     [Fact]
@@ -606,6 +620,216 @@ public sealed class SubscriptionCreationServiceTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    /// <summary>
+    /// The identity the preview endpoint exists to guarantee: whatever it quotes is what a
+    /// confirming <c>CreateAsync</c> then charges. Run on the same clock, since a real gap between
+    /// the two calls is exactly what <c>quoteValidUntilUtc</c> exists to flag rather than what this
+    /// test is about.
+    /// </summary>
+    [Fact]
+    public async Task A_preview_quotes_exactly_what_the_confirm_then_charges()
+    {
+        var service = Service();
+
+        var preview = await service.PreviewAsync(
+            NewRequest(), Context(), "corr-preview", CancellationToken.None);
+        var created = await service.CreateAsync(
+            NewRequest(), Context(), "corr-create", CancellationToken.None);
+
+        preview.IsSuccess.Should().BeTrue();
+        created.IsSuccess.Should().BeTrue();
+
+        preview.Value!.TotalDueNowMinor.Should().Be(
+            SubscriptionAmountCalculator.InitialChargeAmountMinor(created.Value!));
+        preview.Value.CurrencyCode.Should().Be(created.Value!.CurrencyCode);
+        preview.Value.PeriodStartUtc.Should().Be(created.Value.CurrentPeriodStartUtc);
+        preview.Value.PeriodEndUtc.Should().Be(created.Value.CurrentPeriodEndUtc);
+        preview.Value.NextRenewalAtUtc.Should().Be(created.Value.NextFeeBillingAtUtc);
+    }
+
+    /// <summary>The same identity, holding under a promotional discount.</summary>
+    [Fact]
+    public async Task A_preview_with_a_discount_still_quotes_exactly_what_is_charged()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "thisone";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "thisone", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ApplicablePlanCodes = ["professional"],
+                ApplicablePriceIds = ["price-1"],
+                Terms = new DiscountTerms
+                {
+                    Code = "thisone",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 800
+                }
+            });
+
+        var service = Service();
+
+        var preview = await service.PreviewAsync(
+            request, Context(), "corr-preview", CancellationToken.None);
+        var created = await service.CreateAsync(
+            request, Context(), "corr-create", CancellationToken.None);
+
+        preview.Value!.TotalDueNowMinor.Should().Be(
+            SubscriptionAmountCalculator.InitialChargeAmountMinor(created.Value!));
+        preview.Value.SubtotalMinor.Should().Be(created.Value!.Price.UnitAmountMinor * 12);
+        preview.Value.PromotionalDiscountMinor.Should().BeGreaterThan(0);
+        (preview.Value.SubtotalMinor - preview.Value.DiscountMinor + preview.Value.TaxMinor)
+            .Should().Be(preview.Value.TotalDueNowMinor,
+                "subtotal, less every discount, plus tax has to reconcile to the same total the " +
+                "customer is actually charged");
+    }
+
+    [Fact]
+    public async Task A_preview_writes_nothing()
+    {
+        await Service().PreviewAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        _accounts.Verify(
+            repository => repository.GetOrCreateAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a quote nobody has confirmed must not leave a durable billing account behind");
+        _subscriptions.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _billingProfile.Verify(
+            guard => guard.RememberInitiatorAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "nobody has acted yet, so a preview must not record an initiator");
+        _created.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_card_free_trial_previews_nothing_due_now()
+    {
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        var result = await Service().PreviewAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.TotalDueNowMinor.Should().Be(0);
+        result.Value.TrialEndsAtUtc.Should().NotBeNull();
+        result.Value.NextRenewalAtUtc.Should().Be(result.Value.TrialEndsAtUtc);
+    }
+
+    [Fact]
+    public async Task A_plan_requiring_a_card_up_front_previews_that_requirement()
+    {
+        _plan.RequirePaymentMethodUpfront = true;
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = false;
+
+        var result = await Service().PreviewAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.Value!.RequiresCardSetup.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_organization_that_already_has_a_live_subscription_is_quoted_with_a_blocker()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionDetail { ItemId = "existing" });
+
+        var result = await Service().PreviewAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        // A price, not a failure: the customer learns both the amount and what stands in the way,
+        // rather than only being told no.
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.TotalDueNowMinor.Should().BeGreaterThan(0);
+        result.Value.Blockers.Should().ContainSingle()
+            .Which.Code.Should().Be("subscription_already_active");
+    }
+
+    [Fact]
+    public async Task An_incomplete_checkout_left_over_is_also_a_blocker()
+    {
+        // The same condition the unique index refuses a real signup for — an abandoned checkout,
+        // not yet live, still occupies the one reservation an organization gets.
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionDetail { ItemId = "abandoned" });
+
+        var result = await Service().PreviewAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.Value!.Blockers.Should().ContainSingle()
+            .Which.Code.Should().Be("subscription_already_active");
+    }
+
+    [Fact]
+    public async Task An_incomplete_billing_profile_is_a_blocker_not_a_failure_on_preview()
+    {
+        _billingProfile
+            .Setup(guard => guard.MissingFieldsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([nameof(SubscriptionBillingProfile.LegalName)]);
+
+        var result = await Service().PreviewAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.TotalDueNowMinor.Should().BeGreaterThan(0);
+
+        var blocker = result.Value.Blockers.Should().ContainSingle().Which;
+        blocker.Code.Should().Be("subscription_billing_profile_incomplete");
+        blocker.Fields!["BillingProfile"]
+            .Should().Contain(nameof(SubscriptionBillingProfile.LegalName));
+    }
+
+    [Fact]
+    public async Task An_unknown_plan_fails_the_preview_exactly_as_it_fails_the_confirm()
+    {
+        var request = NewRequest();
+        request.PlanCode = "not-a-plan";
+
+        var result = await Service().PreviewAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_plan_not_found");
+    }
+
+    [Fact]
+    public async Task An_unknown_discount_code_fails_the_preview_too()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "missing";
+
+        var result = await Service().PreviewAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_not_found");
+    }
+
+    [Fact]
+    public async Task A_prorated_quote_states_when_it_stops_holding()
+    {
+        // Mid-month against a monthly price with no calendar alignment: whole-period pricing, not
+        // a stub, so nothing here is prorated and there is no boundary to name.
+        var result = await Service().PreviewAsync(
+            NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.Value!.Prorated.Should().BeFalse();
+        result.Value.QuoteValidUntilUtc.Should().BeNull(
+            "a flat price quoted today prices the same tomorrow");
     }
 
     private SubscriptionCreationService Service() => new(


### PR DESCRIPTION
## Summary

A customer could not learn what they would pay until `POST /api/subscriptions` had already created the pending subscription and opened a checkout session. To see a price they had to first commit to buying, and backing out left an `Incomplete` subscription behind for the recovery sweep to tidy.

Adds `POST /api/subscriptions/preview`, which returns the exact payable amount, the period it covers, and what renews later — without creating anything. The UI now requires a preview before confirming, and the confirm charges exactly what the preview quoted.

```
POST /api/subscriptions/preview
{
  "planCode": "pro", "priceId": "price-monthly",
  "quantities": [{ "itemKey": "user", "quantity": 1 }],
  "timeZoneId": "Europe/Zurich", "discountCode": null
}
```
```
{
  "currencyCode": "CHF", "subtotalMinor": 2806, "discountMinor": 0, "taxMinor": 0,
  "totalDueNowMinor": 2806, "prorated": true, "coveredDays": 6, "totalDays": 31,
  "periodEndUtc": "2026-08-31T22:00:00Z", "nextRenewalAtUtc": "2026-08-31T22:00:00Z",
  "nextRenewalAmountMinor": 14500, "blockers": [], "quoteValidUntilUtc": "…"
}
```

## Design

**The preview is the existing creation path stopped one step early, not a second implementation of the pricing.** `SubscriptionCreationService.CreateAsync` freezes `InitialChargeAmountMinor` and the proration fields onto the subscription *before* persisting it, and `SubscriptionCheckoutService` charges exactly that frozen figure. So the fix is architectural: split `CreateAsync` into a shared `BuildSubscriptionAsync` — plan/price resolution, discount validation, quantity build, schedules, and `ApplyPeriods` freezing the opening charge onto an in-memory subscription — and a persist half only `CreateAsync` runs. `PreviewAsync` calls the same builder and reads the frozen fields back out; nothing is recomputed.

`SubscriptionAmountCalculator.InitialChargeAmountMinor` is now the one expression both the preview and the real charge call (`SubscriptionCheckoutService.cs`), so the two structurally cannot quote a different figure from the same inputs — the "must reproduce the same amount exactly" requirement is a property of the design, not something asserted after the fact.

**Only one write is skipped on a preview:** `GetOrCreateAsync`, which would insert a durable billing account nobody has confirmed subscribing yet. An unsaved stand-in serves as well — its id plays no part in the price.

**Blockers, not refusals.** A condition that would refuse the confirm — an existing subscription (live *or* an abandoned incomplete checkout — both matter, since the reservation index refuses a second insert for either), an incomplete billing profile — is reported in `blockers` alongside the price, so a client shows both together rather than a price the confirm then refuses. A genuine input problem (unknown plan, price, or discount code) still fails with the same code the confirm returns.

**`quoteValidUntilUtc` states its own boundary rather than leaving the client to guess one.** Proration is quantized per calendar day, so a quote is exact only until the *next local midnight* in the request's own time zone — not the period boundary, which can be weeks away. Null when nothing is prorated.

## A real bug caught along the way

Writing an identity test (preview a subscription, then create it, assert the two amounts match) surfaced that `InitialChargeAmountMinor`'s null-fallback (`?? PeriodAmountMinor(subscription)`) doesn't account for a card-free trial, which is charged nothing regardless of what a period would otherwise cost. Checkout was only correct today because `RequiresPayment` separately short-circuited on the trial *before* that wrong number was ever used — so the bug was latent, masked by a second check downstream. Fixed at the source (`InitialChargeAmountMinor` now returns 0 for a card-free trial), and `RequiresPayment` simplified now that the figure it receives is already trial-aware. Caught by `A_card_free_trial_previews_nothing_due_now`.

## Client

`SubscribeDialog` now requires a preview before confirming, mirroring `ChangeQuantityDialog`'s existing preview/apply split. Editing the price, a quantity, or the discount code discards the quote. Blockers render inline; confirm stays disabled while any are present, and separately while nothing has been previewed yet.

## Verification

- **Server:** 2919 passing. 4 failures, all `SubscriptionSimulation*` permission-guard tests — confirmed failing identically on untouched `origin/dev` in an isolated worktree, so pre-existing.
- New tests worth naming: `A_preview_quotes_exactly_what_the_confirm_then_charges` and its discounted variant (the identity guarantee itself); `A_preview_writes_nothing`; `A_card_free_trial_previews_nothing_due_now`; `An_organization_that_already_has_a_live_subscription_is_quoted_with_a_blocker` / `An_incomplete_checkout_left_over_is_also_a_blocker`; `An_incomplete_billing_profile_is_a_blocker_not_a_failure_on_preview`; a calendar-aligned stub case (`A_preview_of_the_stub_quotes_the_same_fraction_and_states_its_boundary`) proving `quoteValidUntilUtc` lands on the next local midnight, not the period boundary a week later.
- **Client:** typecheck and lint clean on all touched files, 310 test files / 2112 tests passing. 7 pre-existing failures are unrelated — SVG asset imports in the devops/create-project area and one environment-card test — none touch subscriptions.

## One thing worth a reviewer's eye

The doc's existing note about plan-change proration having no dedicated preview endpoint is still true and left as-is — this PR answers "what would a *new* subscription cost", not "what would moving an *existing* one to another price cost". I added one sentence distinguishing the two so the note doesn't read as contradicted by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
