### PR TITLE
feat(subscription): add a plan-change preview, priced fresh not frozen

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
@@ -1,0 +1,252 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
+import type {
+  SimulatedSubscription,
+  SubscriptionPlanChangePreview,
+} from "../models/subscription-simulation.model";
+
+const toast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({ toast: (...args: unknown[]) => toast(...args) }));
+
+const previewPlanChange = vi.fn();
+const changePlan = vi.fn();
+
+vi.mock("../services/subscription-simulation.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../services/subscription-simulation.service")
+  >("../services/subscription-simulation.service");
+
+  return {
+    ...actual,
+    subscriptionSimulationService: {
+      previewPlanChange: (...args: unknown[]) => previewPlanChange(...args),
+      changePlan: (...args: unknown[]) => changePlan(...args),
+    },
+  };
+});
+
+import { ChangePlanDialog } from "./change-plan-dialog";
+
+const currentPlan = {
+  planId: "plan-basic",
+  code: "basic",
+  displayName: "Basic",
+  quantityItems: [],
+  prices: [
+    {
+      priceId: "price-basic",
+      currencyCode: "CHF",
+      unitAmountMinor: 10_000,
+      interval: "Month",
+      intervalCount: 1,
+      quantityItemKey: null,
+      displayPriceNote: null,
+    },
+  ],
+} as unknown as SubscriptionPlan;
+
+const premiumPlan = {
+  planId: "plan-premium",
+  code: "premium",
+  displayName: "Premium",
+  quantityItems: [],
+  prices: [
+    {
+      priceId: "price-premium",
+      currencyCode: "CHF",
+      unitAmountMinor: 20_000,
+      interval: "Month",
+      intervalCount: 1,
+      quantityItemKey: null,
+      displayPriceNote: null,
+    },
+    {
+      priceId: "price-premium-annual",
+      currencyCode: "CHF",
+      unitAmountMinor: 200_000,
+      interval: "Year",
+      intervalCount: 1,
+      quantityItemKey: null,
+      displayPriceNote: null,
+    },
+  ],
+} as unknown as SubscriptionPlan;
+
+const subscription: SimulatedSubscription = {
+  subscriptionId: "sub-1",
+  status: "Active",
+  planCode: "basic",
+  planName: "Basic",
+  currencyCode: "CHF",
+  unitAmountMinor: 10_000,
+  interval: "Month",
+  intervalCount: 1,
+  displayPriceNote: null,
+  quantities: [],
+  currentPeriodStartUtc: "2026-08-01T00:00:00Z",
+  currentPeriodEndUtc: "2026-09-01T00:00:00Z",
+  nextPaymentAtUtc: "2026-09-01T00:00:00Z",
+  trialEndsAtUtc: null,
+  cancelAtPeriodEnd: false,
+  canceledAtUtc: null,
+  pendingQuantityChange: null,
+  currentTier: null,
+  recurringAmountMinor: 10_000,
+  checkoutUrl: null,
+  version: 1,
+};
+
+const quote: SubscriptionPlanChangePreview = {
+  currencyCode: "CHF",
+  targetPlanCode: "premium",
+  targetPlanName: "Premium",
+  targetPriceId: "price-premium",
+  interval: "Month",
+  intervalCount: 1,
+  quantities: [],
+  chargeMinor: 5_000,
+  creditBankedMinor: 0,
+  settlement: {
+    outgoing: {
+      grossAmountMinor: 10_000,
+      builtInDiscountMinor: 0,
+      promotionalDiscountMinor: 0,
+      taxAmountMinor: 0,
+      periodTotalMinor: 10_000,
+      proratedValueMinor: 5_000,
+    },
+    target: {
+      grossAmountMinor: 20_000,
+      builtInDiscountMinor: 0,
+      promotionalDiscountMinor: 0,
+      taxAmountMinor: 0,
+      periodTotalMinor: 20_000,
+      proratedValueMinor: 10_000,
+    },
+    creditConsumedMinor: 0,
+    netSettlementMinor: 5_000,
+  },
+  newPeriodStartUtc: "2026-08-01T00:00:00Z",
+  newPeriodEndUtc: "2026-09-01T00:00:00Z",
+  nextRenewalAmountMinor: 20_000,
+  blockers: [],
+  quotedAtUtc: "2026-08-16T00:00:00Z",
+};
+
+const renderDialog = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <ChangePlanDialog
+        subscription={subscription}
+        currentPlan={currentPlan}
+        plans={[currentPlan, premiumPlan]}
+        organizationId="org-1"
+        open
+        onOpenChange={() => {}}
+      />
+    </QueryClientProvider>,
+  );
+};
+
+const click = (name: RegExp) => fireEvent.click(screen.getByRole("button", { name }));
+
+const selectTargetPlan = () => {
+  const target = screen.getByRole("combobox", { name: /Target plan/ });
+  fireEvent.click(target);
+  fireEvent.click(screen.getByText("Premium"));
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ChangePlanDialog", () => {
+  it("cannot be confirmed before a preview is taken", () => {
+    renderDialog();
+
+    expect(screen.getByRole("button", { name: /^Confirm change$/ })).toBeDisabled();
+  });
+
+  it("previews the settlement before enabling confirm", async () => {
+    previewPlanChange.mockResolvedValue(quote);
+
+    renderDialog();
+    selectTargetPlan();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-change-quote")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("plan-change-quote").textContent).toContain("50.00");
+    expect(screen.getByRole("button", { name: /^Confirm change$/ })).toBeEnabled();
+    expect(changePlan).not.toHaveBeenCalled();
+  });
+
+  it("discards the quote when the target price is edited after previewing", async () => {
+    previewPlanChange.mockResolvedValue(quote);
+
+    renderDialog();
+    selectTargetPlan();
+    click(/^Preview$/);
+
+    await waitFor(() => screen.getByTestId("plan-change-quote"));
+
+    const priceSelect = screen.getByRole("combobox", { name: /Target price/ });
+    fireEvent.click(priceSelect);
+    fireEvent.click(screen.getByText(/every year/));
+
+    expect(screen.queryByTestId("plan-change-quote")).not.toBeInTheDocument();
+  });
+
+  it("sends exactly what was previewed when confirmed", async () => {
+    previewPlanChange.mockResolvedValue(quote);
+    changePlan.mockResolvedValue({ ...subscription, planCode: "premium" });
+
+    renderDialog();
+    selectTargetPlan();
+    click(/^Preview$/);
+
+    await waitFor(() => screen.getByTestId("plan-change-quote"));
+
+    click(/^Confirm change$/);
+
+    await waitFor(() => {
+      expect(changePlan).toHaveBeenCalledWith(
+        "sub-1",
+        expect.objectContaining({
+          planCode: "premium",
+          priceId: "price-premium",
+          organizationId: "org-1",
+        }),
+      );
+    });
+  });
+
+  it("shows a blocker and keeps confirm disabled even though the price is quoted", async () => {
+    previewPlanChange.mockResolvedValue({
+      ...quote,
+      blockers: [
+        {
+          code: "subscription_plan_change_no_payment_method",
+          message: "This upgrade cannot be charged without a saved payment method.",
+        },
+      ],
+    });
+
+    renderDialog();
+    selectTargetPlan();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByText(/saved payment method/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: /^Confirm change$/ })).toBeDisabled();
+    expect(changePlan).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui-kits/badge/badge";
 import { Button } from "@/components/ui-kits/button/button";
@@ -21,14 +21,25 @@ import {
 } from "@/components/ui-kits/select/select";
 import { toast } from "@/hooks/use-toast";
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
-import { formatPrice } from "../../subscription/utilities/subscription-format";
+import { formatMoney, formatPrice } from "../../subscription/utilities/subscription-format";
 import { useChangeSubscriptionPlan } from "../hooks/use-change-subscription-plan";
+import { usePreviewPlanChange } from "../hooks/use-preview-plan-change";
 import type {
+  ChangeSubscriptionPlanRequest,
   SimulatedSubscription,
+  SubscriptionPlanChangePreview,
   SubscriptionQuantity,
 } from "../models/subscription-simulation.model";
 import { labelPlanChange } from "../utilities/plan-change-label";
 
+/**
+ * Moving a subscription to another plan or price.
+ *
+ * Nothing is confirmed from this screen without a preview first, and any edit that would change
+ * the price — the target plan, the target price, a quantity — discards the quote. Unlike the
+ * subscribe dialog's, this quote is never frozen server-side: re-preview if more than a moment
+ * has passed before confirming.
+ */
 export const ChangePlanDialog = ({
   subscription,
   currentPlan,
@@ -44,12 +55,16 @@ export const ChangePlanDialog = ({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) => {
-  const { mutateAsync, isPending } = useChangeSubscriptionPlan();
+  const preview = usePreviewPlanChange();
+  const apply = useChangeSubscriptionPlan();
 
   const [targetPlanId, setTargetPlanId] = useState(currentPlan?.planId ?? "");
   const [priceId, setPriceId] = useState("");
   const [quantities, setQuantities] = useState<Record<string, string>>({});
+  const [quote, setQuote] = useState<SubscriptionPlanChangePreview | null>(null);
   const [formError, setFormError] = useState<string | null>(null);
+
+  const busy = preview.isPending || apply.isPending;
 
   const targetPlan = useMemo(
     () => plans.find((plan) => plan.planId === targetPlanId),
@@ -76,21 +91,32 @@ export const ChangePlanDialog = ({
       ),
     );
     setFormError(null);
+    setQuote(null);
   };
 
-  const submit = async () => {
-    setFormError(null);
+  const selectPrice = (value: string) => {
+    setPriceId(value);
+    setQuote(null);
+  };
 
+  const editQuantity = (itemKey: string, value: string) => {
+    setQuantities((current) => ({ ...current, [itemKey]: value }));
+    setQuote(null);
+  };
+
+  const requested = ():
+    | { valid: true; request: ChangeSubscriptionPlanRequest }
+    | { valid: false; error: string } => {
     if (!targetPlan || !priceId) {
-      setFormError("Choose a target plan and price.");
-      return;
+      return { valid: false, error: "Choose a target plan and price." };
     }
 
     if (currencyMismatch) {
-      setFormError(
-        "This price is in a different currency. A currency change needs a cancel and a fresh subscription, not a plan change.",
-      );
-      return;
+      return {
+        valid: false,
+        error: "This price is in a different currency. A currency change needs a cancel and a " +
+          "fresh subscription, not a plan change.",
+      };
     }
 
     const parsedQuantities: SubscriptionQuantity[] = [];
@@ -99,46 +125,89 @@ export const ChangePlanDialog = ({
       const quantity = Number(raw);
 
       if (!raw || !Number.isFinite(quantity) || quantity < item.minQuantity) {
-        setFormError(`${item.unitLabel} must be at least ${item.minQuantity}.`);
-        return;
+        return { valid: false, error: `${item.unitLabel} must be at least ${item.minQuantity}.` };
       }
 
       if (item.maxQuantity != null && quantity > item.maxQuantity) {
-        setFormError(`${item.unitLabel} can be at most ${item.maxQuantity}.`);
-        return;
+        return { valid: false, error: `${item.unitLabel} can be at most ${item.maxQuantity}.` };
       }
 
       parsedQuantities.push({ itemKey: item.itemKey, quantity });
     }
 
+    return {
+      valid: true,
+      request: {
+        planCode: targetPlan.code,
+        priceId,
+        quantities: parsedQuantities,
+        organizationId,
+      },
+    };
+  };
+
+  const runPreview = async () => {
+    const parsed = requested();
+
+    if (!parsed.valid) {
+      setFormError(parsed.error);
+      return;
+    }
+
+    setFormError(null);
+
     try {
-      await mutateAsync({
+      setQuote(
+        await preview.mutateAsync({
+          subscriptionId: subscription.subscriptionId,
+          request: parsed.request,
+        }),
+      );
+    } catch (error) {
+      setFormError(
+        error instanceof Error ? error.message : "The plan change could not be previewed.",
+      );
+      setQuote(null);
+    }
+  };
+
+  const submit = async () => {
+    const parsed = requested();
+
+    if (!parsed.valid) {
+      setFormError(parsed.error);
+      return;
+    }
+
+    setFormError(null);
+
+    try {
+      await apply.mutateAsync({
         subscriptionId: subscription.subscriptionId,
-        request: {
-          planCode: targetPlan.code,
-          priceId,
-          quantities: parsedQuantities,
-          organizationId,
-        },
+        request: parsed.request,
       });
 
       toast({
         variant: "success",
         title: `${moveLabel ?? "Plan changed"}`,
-        description: `Now on ${targetPlan.displayName}.`,
+        description: `Now on ${targetPlan!.displayName}.`,
       });
 
       onOpenChange(false);
     } catch (error) {
       setFormError(error instanceof Error ? error.message : "The plan could not be changed.");
+      // The quote may no longer describe what a retry would charge.
+      setQuote(null);
     }
   };
+
+  const blocked = (quote?.blockers.length ?? 0) > 0;
 
   return (
     <Dialog
       open={open}
       onOpenChange={(next) => {
-        if (!isPending) {
+        if (!busy) {
           onOpenChange(next);
         }
       }}
@@ -173,7 +242,7 @@ export const ChangePlanDialog = ({
           {targetPlan && (
             <div className="space-y-1.5">
               <Label htmlFor="change-plan-price">Target price</Label>
-              <Select value={priceId} onValueChange={setPriceId}>
+              <Select value={priceId} onValueChange={selectPrice}>
                 <SelectTrigger id="change-plan-price">
                   <SelectValue placeholder="Choose a price" />
                 </SelectTrigger>
@@ -211,12 +280,7 @@ export const ChangePlanDialog = ({
                 min={item.minQuantity}
                 max={item.maxQuantity ?? undefined}
                 value={quantities[item.itemKey] ?? ""}
-                onChange={(event) =>
-                  setQuantities((current) => ({
-                    ...current,
-                    [item.itemKey]: event.target.value,
-                  }))
-                }
+                onChange={(event) => editQuantity(item.itemKey, event.target.value)}
               />
             </div>
           ))}
@@ -226,15 +290,60 @@ export const ChangePlanDialog = ({
             upgrade may charge immediately, a downgrade becomes credit toward future renewals.
           </p>
 
+          {quote ? (
+            <div className="space-y-2 rounded-md border p-3 text-sm" data-testid="plan-change-quote">
+              <div className="flex items-center justify-between">
+                <p className="font-medium">
+                  {quote.chargeMinor > 0 ? "Charged now" : "Credited, nothing charged"}
+                </p>
+                <Badge variant={quote.chargeMinor > 0 ? "default" : "secondary"}>
+                  {quote.chargeMinor > 0
+                    ? formatMoney(quote.chargeMinor, quote.currencyCode)
+                    : formatMoney(quote.creditBankedMinor, quote.currencyCode)}
+                </Badge>
+              </div>
+
+              <Row
+                label="Next full period"
+                value={formatMoney(quote.nextRenewalAmountMinor, quote.currencyCode)}
+              />
+              {quote.settlement.netSettlementMinor !== 0 ? (
+                <Row
+                  label="Net settlement"
+                  value={formatMoney(quote.settlement.netSettlementMinor, quote.currencyCode)}
+                />
+              ) : null}
+
+              <p className="text-xs text-muted-foreground">
+                Priced against the current clock — a plan change is never frozen ahead of
+                confirming, so re-preview if this has sat open for a while.
+              </p>
+
+              {quote.blockers.map((blocker) => (
+                <div
+                  key={blocker.code}
+                  className="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 p-2 text-warning-900"
+                >
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <p>{blocker.message}</p>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
           {formError && <p className="text-sm text-destructive">{formError}</p>}
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button onClick={submit} disabled={isPending}>
-            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          <Button variant="outline" onClick={runPreview} disabled={busy}>
+            {preview.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            Preview
+          </Button>
+          <Button onClick={submit} disabled={busy || quote === null || blocked}>
+            {apply.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             Confirm change
           </Button>
         </DialogFooter>
@@ -242,3 +351,10 @@ export const ChangePlanDialog = ({
     </Dialog>
   );
 };
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-baseline justify-between gap-4">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="text-right font-medium">{value}</span>
+  </div>
+);

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-preview-plan-change.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-preview-plan-change.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "@tanstack/react-query";
+import type { ChangeSubscriptionPlanRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/**
+ * What moving to another plan or price would cost. Writes nothing, so it invalidates nothing.
+ */
+export const usePreviewPlanChange = () =>
+  useMutation({
+    mutationFn: ({
+      subscriptionId,
+      request,
+    }: {
+      subscriptionId: string;
+      request: ChangeSubscriptionPlanRequest;
+    }) => subscriptionSimulationService.previewPlanChange(subscriptionId, request),
+  });

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -229,6 +229,52 @@ export interface ChangeSubscriptionPlanRequest {
   organizationId?: string;
 }
 
+/** One side of a plan-change settlement — what a period costs, and how much of it this counts. */
+export interface PlanChangeSettlementSide {
+  grossAmountMinor: number;
+  builtInDiscountMinor: number;
+  promotionalDiscountMinor: number;
+  taxAmountMinor: number;
+  /** The whole period, tax included — undiminished by proration. */
+  periodTotalMinor: number;
+  /** The part of the period this settlement actually counts. */
+  proratedValueMinor: number;
+}
+
+export interface PlanChangeSettlement {
+  outgoing: PlanChangeSettlementSide;
+  target: PlanChangeSettlementSide;
+  creditConsumedMinor: number;
+  netSettlementMinor: number;
+}
+
+/**
+ * What moving to another plan or price would cost or credit right now, without applying anything.
+ *
+ * Unlike {@link SubscriptionPurchasePreview}, nothing here is frozen ahead of time — a plan
+ * change is priced fresh, immediately before it is applied, every time it runs. So this quote
+ * holds only up to the clock: re-fetch it immediately before confirming rather than holding it.
+ */
+export interface SubscriptionPlanChangePreview {
+  currencyCode: string;
+  targetPlanCode: string;
+  targetPlanName: string;
+  targetPriceId: string;
+  interval: string;
+  intervalCount: number;
+  quantities: SubscriptionQuantity[];
+  /** What confirming this preview would charge now. Zero for a downgrade. */
+  chargeMinor: number;
+  /** What confirming this preview would bank as credit. Zero for an upgrade. */
+  creditBankedMinor: number;
+  settlement: PlanChangeSettlement;
+  newPeriodStartUtc: string;
+  newPeriodEndUtc: string;
+  nextRenewalAmountMinor: number;
+  blockers: SubscriptionPreviewBlocker[];
+  quotedAtUtc: string;
+}
+
 export type PlanChangeLabel =
   | "Upgrade"
   | "Downgrade"

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -19,6 +19,7 @@ import type {
   SimulatedSubscription,
   SubscribeToPlanRequest,
   SubscriptionAuditEvent,
+  SubscriptionPlanChangePreview,
   SubscriptionPurchasePreview,
 } from "../models/subscription-simulation.model";
 
@@ -160,6 +161,51 @@ class SubscriptionSimulationService {
    * (`[FromBody]` on the server), so — unlike the GET/DELETE endpoints — `organizationId` has to
    * travel as a field on `request`, not as a query parameter.
    */
+  /**
+   * What moving to another plan or price would cost or credit right now, without applying
+   * anything.
+   *
+   * Unlike {@link previewSubscription}, nothing here is frozen — a plan change is priced fresh,
+   * immediately before it is applied, every time it runs, so this quote holds only up to the
+   * clock. A blocker in the response — an incomplete billing profile, no saved payment method for
+   * an upgrade — is not an error: the price is returned alongside it. A condition that leaves no
+   * coherent price to quote (an unsurvivable discount, an unknown target) still throws, with the
+   * same code {@link changePlan} would then fail with.
+   */
+  async previewPlanChange(
+    subscriptionId: string,
+    request: ChangeSubscriptionPlanRequest,
+  ): Promise<SubscriptionPlanChangePreview> {
+    try {
+      const response = await serviceInstances.utitlitiesService.post<
+        SimulationApiResponse<SubscriptionPlanChangePreview>
+      >(`${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/plan/preview`, request);
+
+      if (!response.success || !response.data) {
+        throw new SubscriptionOperationError(
+          response.error?.message || "The plan change could not be previewed.",
+          response.error?.code ?? "unknown",
+        );
+      }
+
+      return response.data;
+    } catch (error) {
+      if (error instanceof SubscriptionOperationError) {
+        throw error;
+      }
+
+      if (error instanceof HttpError) {
+        throw new SubscriptionOperationError(
+          messageFrom(error, "The plan change could not be previewed."),
+          planChangeErrorCode(error),
+          error.status,
+        );
+      }
+
+      throw error;
+    }
+  }
+
   async changePlan(
     subscriptionId: string,
     request: ChangeSubscriptionPlanRequest,
@@ -417,6 +463,25 @@ const SUBSCRIBE_ERROR_CODES = [
   "subscription_request_invalid",
 ] as const;
 
+/**
+ * The outcomes {@link SubscriptionSimulationService.changePlan} and
+ * {@link SubscriptionSimulationService.previewPlanChange} both refuse for outright — as opposed
+ * to the billing-profile and no-payment-method conditions a preview reports as a blocker.
+ */
+const PLAN_CHANGE_ERROR_CODES = [
+  "subscription_plan_change_invalid",
+  "subscription_not_found",
+  "subscription_plan_change_not_eligible",
+  "subscription_quantity_change_in_flight",
+  "subscription_initial_annual_period_pending",
+  "subscription_plan_not_found",
+  "subscription_price_not_found",
+  "subscription_plan_change_currency_mismatch",
+  "subscription_discount_not_applicable",
+  "subscription_quantity_invalid",
+  "subscription_schedule_invalid",
+] as const;
+
 const codeFrom = (
   error: unknown,
   candidates: readonly string[],
@@ -429,6 +494,8 @@ const codeFrom = (
 const quantityErrorCode = (error: unknown): string => codeFrom(error, QUANTITY_ERROR_CODES);
 
 const subscribeErrorCode = (error: unknown): string => codeFrom(error, SUBSCRIBE_ERROR_CODES);
+
+const planChangeErrorCode = (error: unknown): string => codeFrom(error, PLAN_CHANGE_ERROR_CODES);
 
 const messageFrom = (error: unknown, fallback: string): string => {
   if (error instanceof HttpError) {

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -702,6 +702,24 @@
             and releases the organization to subscribe again.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.PreviewPlanChange(System.String,Subscription.DomainService.Requests.ChangeSubscriptionPlanRequest,System.Threading.CancellationToken)">
+            <summary>
+            What moving the subscription to a different price would cost or credit right now, without
+            applying anything.
+            </summary>
+            <remarks>
+            Priced by the same calculator <see cref="M:Api.Controllers.SubscriptionsController.ChangePlan(System.String,Subscription.DomainService.Requests.ChangeSubscriptionPlanRequest,System.Threading.CancellationToken)"/> uses, evaluated fresh — a plan
+            change is never frozen ahead of confirming, so this quote holds only up to the clock, not
+            indefinitely. Re-fetch it immediately before confirming rather than holding it.
+            <para>
+            A condition that would refuse the confirm without changing the price — an incomplete
+            billing profile, no saved payment method for an upgrade — is reported in
+            <c>blockers</c> rather than as a failure. A condition that leaves no coherent price to
+            show — an unsurvivable discount, an unknown target — still fails outright, with the same
+            code <see cref="M:Api.Controllers.SubscriptionsController.ChangePlan(System.String,Subscription.DomainService.Requests.ChangeSubscriptionPlanRequest,System.Threading.CancellationToken)"/> would return.
+            </para>
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.SubscriptionsController.ChangePlan(System.String,Subscription.DomainService.Requests.ChangeSubscriptionPlanRequest,System.Threading.CancellationToken)">
             <summary>
             Moves the subscription to a different price, mid-period.

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -200,6 +200,48 @@ public sealed class SubscriptionsController : ControllerBase
     }
 
     /// <summary>
+    /// What moving the subscription to a different price would cost or credit right now, without
+    /// applying anything.
+    /// </summary>
+    /// <remarks>
+    /// Priced by the same calculator <see cref="ChangePlan"/> uses, evaluated fresh — a plan
+    /// change is never frozen ahead of confirming, so this quote holds only up to the clock, not
+    /// indefinitely. Re-fetch it immediately before confirming rather than holding it.
+    /// <para>
+    /// A condition that would refuse the confirm without changing the price — an incomplete
+    /// billing profile, no saved payment method for an upgrade — is reported in
+    /// <c>blockers</c> rather than as a failure. A condition that leaves no coherent price to
+    /// show — an unsurvivable discount, an unknown target — still fails outright, with the same
+    /// code <see cref="ChangePlan"/> would return.
+    /// </para>
+    /// </remarks>
+    [HttpPost("{subscriptionId}/plan/preview")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionPlanChangePreviewResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionPlanChangePreviewResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionPlanChangePreviewResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionPlanChangePreviewResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> PreviewPlanChange(
+        string subscriptionId,
+        [FromBody] ChangeSubscriptionPlanRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _planChange.PreviewPlanChangeAsync(
+            subscriptionId,
+            request,
+            correlationId,
+            cancellationToken);
+
+        await AuditAsync("PreviewPlanChange", request.OrganizationId, subscriptionId,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            result.Value?.ChargeMinor, result.Value?.CurrencyCode, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
     /// Moves the subscription to a different price, mid-period.
     /// </summary>
     /// <remarks>

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1463,6 +1463,67 @@ stateDiagram-v2
           </p>
         </li>
         <li>
+          <p class="step-title">Preview what it would cost</p>
+          <pre><code>POST /api/subscriptions/{subscriptionId}/plan/preview
+Content-Type: application/json
+
+{
+  "priceId": "target-price-id",
+  "quantities": []
+}</code></pre>
+          <p class="prose">
+            The same body <code>PUT</code> takes, priced through the identical calculator and
+            stopped short of applying anything. Unlike
+            <a href="#api-subs"><code>POST /api/subscriptions/preview</code></a>, nothing here is
+            frozen ahead of time: a plan change is priced fresh, immediately before it is applied,
+            every time it runs — so this quote holds only up to the clock, not indefinitely.
+            Re-fetch it immediately before the user confirms rather than holding it while they
+            decide.
+          </p>
+          <h4>Sample response</h4>
+          <pre><code>{
+  "success": true,
+  "data": {
+    "currencyCode": "CHF",
+    "targetPlanCode": "premium",
+    "targetPlanName": "Premium",
+    "targetPriceId": "target-price-id",
+    "interval": "Month",
+    "intervalCount": 1,
+    "quantities": [],
+    "chargeMinor": 5000,
+    "creditBankedMinor": 0,
+    "settlement": {
+      "outgoing": { "grossAmountMinor": 10000, "periodTotalMinor": 10000, "proratedValueMinor": 5000, "…": "…" },
+      "target": { "grossAmountMinor": 20000, "periodTotalMinor": 20000, "proratedValueMinor": 10000, "…": "…" },
+      "creditConsumedMinor": 0,
+      "netSettlementMinor": 5000
+    },
+    "newPeriodStartUtc": "2026-08-16T16:29:00Z",
+    "newPeriodEndUtc": "2026-09-16T16:29:00Z",
+    "nextRenewalAmountMinor": 20000,
+    "blockers": [],
+    "quotedAtUtc": "2026-08-16T16:29:00Z"
+  },
+  "error": null
+}</code></pre>
+          <p class="prose">
+            <code>chargeMinor</code> is zero for a downgrade; <code>creditBankedMinor</code> is
+            zero for an upgrade. <code>nextRenewalAmountMinor</code> is already the whole target
+            period, tax included, undiminished by proration.
+          </p>
+          <p class="prose">
+            A condition that would refuse the confirm without changing the price — an incomplete
+            billing profile, no saved payment method for an upgrade — is reported in
+            <code>blockers</code> rather than as a failure, so a client can show the price and the
+            obstacle together. A condition that leaves no coherent price to quote — an
+            unsurvivable discount, an unknown target plan or price — still fails outright, with the
+            same code the real change would return.
+          </p>
+          <h4>Returns</h4>
+          <p><code>200</code> · <code>400</code> · <code>404</code> · <code>409</code> ineligible status.</p>
+        </li>
+        <li>
           <p class="step-title">Submit the plan change</p>
           <pre><code>PUT /api/subscriptions/{subscriptionId}/plan
 Content-Type: application/json
@@ -1500,13 +1561,15 @@ Content-Type: application/json
           </tbody>
         </table>
       </div>
-      <p>
-        There is no separate proration-preview endpoint for a plan change specifically — that
-        would answer a different question from
+      <p class="prose">
+        <code>POST /api/subscriptions/{subscriptionId}/plan/preview</code> (above) answers exactly
+        this — the exact amount before confirming a plan change — and is a different question from
         <a href="#api-subs"><code>POST /api/subscriptions/preview</code></a>, which quotes a new
-        subscription rather than a move between prices on an existing one. If the product needs
-        an exact amount before confirming a plan change, add a preview operation for it rather
-        than estimating one in the browser with a second copy of the billing rules.
+        subscription rather than a move between prices on an existing one. The two differ in one
+        load-bearing way: the purchase preview freezes its figure on the subscription it builds,
+        so it holds exactly until the next local midnight; a plan-change preview freezes nothing
+        and is priced fresh every time it runs, so it holds only up to the clock. Re-fetch it
+        immediately before confirming rather than treating it as a held quote.
       </p>
     </section>
 

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -730,6 +730,32 @@ Two restrictions keep this a contained piece of work rather than a rewrite of th
 > does not have an equivalent sweep yet; the case is rare (a genuine concurrent write to the same
 > subscription, not a network failure) and is called out here rather than left to be discovered.
 
+### The preview is priced fresh, not frozen
+
+`POST /api/subscriptions/{id}/plan/preview` answers what a plan change would cost or credit,
+without applying anything. Unlike the purchase preview
+(`SubscriptionCreationService.PreviewAsync`), nothing here is frozen ahead of time —
+`ChangePlanAsync` has never worked that way: it calls `SubscriptionProrationCalculator.Calculate`
+fresh, immediately before charging, every time it runs. So the preview makes the same promise
+this module's quantity-change preview already makes (`SubscriptionQuantityChangeService`'s own
+`PreviewAsync`/`ChangeAsync` share one `RunAsync`, and price fresh on both paths) — the same
+math, evaluated a moment later — rather than a stronger one this service has never provided.
+
+`SubscriptionPlanChangeService` splits `ResolveAsync(preview)` from pricing: everything through
+building the target schedule is shared, but pricing itself is not — `ChargeAndApplyAsync` still
+calls the calculator itself on the real path, and the preview calls it separately, because the
+calculator is a pure function of already-resolved inputs and cannot diverge by being called
+twice.
+
+Two conditions are collected as blockers on a preview instead of failing it outright — an
+incomplete billing profile, and no saved payment method for a genuine upgrade — because neither
+changes what the change would cost, only whether the confirm can go through. Everything else,
+including an unsurvivable discount, still fails the preview exactly as it fails the confirm: the
+real change never charges a price with the discount silently dropped, so there is no honest
+number to quote alongside that refusal. `SettlementReservation` and `PendingAnnualPeriod` are
+checked only on the real change — a preview is read-only and does not need either clear to quote
+a price, mirroring the quantity-change preview's own treatment of the same two conditions.
+
 ## Entitlement is advisory; recording is enforcement
 
 `GET /api/entitlements` reads only our own database — the subscription, then one counter per

--- a/server/Subscription.DomainService/Responses/SubscriptionPlanChangePreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionPlanChangePreviewResponse.cs
@@ -1,0 +1,61 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// What moving a live subscription to another plan or price would cost right now, without
+/// applying anything.
+/// </summary>
+/// <remarks>
+/// Every figure here comes from the exact same call to
+/// <c>SubscriptionProrationCalculator.Calculate</c> that <c>ChargeAndApplyAsync</c> makes when the
+/// change is actually confirmed — there is one arithmetic, evaluated a moment later. Unlike
+/// <see cref="SubscriptionPreviewResponse"/>, nothing here is frozen ahead of time: a plan change
+/// is priced fresh, immediately before it is applied, every time it runs, so this quote holds only
+/// up to the clock — the same guarantee the quantity-change preview already makes. There is no
+/// <c>quoteValidUntilUtc</c> because there is no discrete boundary to name: the proration is
+/// continuous (ticks remaining over the period, not whole calendar days), so the figure drifts by
+/// a small amount every instant that passes rather than jumping at a fixed point.
+/// </remarks>
+public sealed class SubscriptionPlanChangePreviewResponse
+{
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public string TargetPlanCode { get; init; } = string.Empty;
+
+    public string TargetPlanName { get; init; } = string.Empty;
+
+    public string TargetPriceId { get; init; } = string.Empty;
+
+    public string Interval { get; init; } = string.Empty;
+
+    public int IntervalCount { get; init; }
+
+    public List<SubscriptionQuantityResponse> Quantities { get; init; } = [];
+
+    /// <summary>What confirming this preview would charge now. Zero for a downgrade.</summary>
+    public long ChargeMinor { get; init; }
+
+    /// <summary>
+    /// What confirming this preview would bank as credit toward future renewals. Zero for an
+    /// upgrade — a downgrade is never refunded, only credited.
+    /// </summary>
+    public long CreditBankedMinor { get; init; }
+
+    /// <summary>The two priced sides — what is left of the old plan, what is bought of the new one.</summary>
+    public FinancialDocumentSettlementResponse Settlement { get; init; } = new();
+
+    public DateTime NewPeriodStartUtc { get; init; }
+
+    public DateTime NewPeriodEndUtc { get; init; }
+
+    /// <summary>What a full period costs at the target plan and price, once this change has settled.</summary>
+    public long NextRenewalAmountMinor { get; init; }
+
+    /// <summary>
+    /// What would stop the confirm from succeeding, named rather than hidden behind a price the
+    /// customer is then refused. Empty when nothing stands in the way.
+    /// </summary>
+    public List<SubscriptionPreviewBlockerResponse> Blockers { get; init; } = [];
+
+    /// <summary>The instant these figures were derived from.</summary>
+    public DateTime QuotedAtUtc { get; init; }
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionPlanChangeService.cs
@@ -11,4 +11,22 @@ public interface ISubscriptionPlanChangeService
         ChangeSubscriptionPlanRequest request,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// What <see cref="ChangePlanAsync"/> would charge or credit right now, without applying
+    /// anything.
+    /// </summary>
+    /// <remarks>
+    /// Priced by the same calculator <see cref="ChangePlanAsync"/> uses, evaluated fresh — a plan
+    /// change is never frozen ahead of confirming, so this quote holds only up to the clock, the
+    /// same promise the quantity-change preview already makes. A condition that would refuse the
+    /// confirm without changing the price (an incomplete billing profile, no saved payment
+    /// method) is reported as a blocker here rather than as a failure; a condition that leaves no
+    /// coherent price to show — an unsurvivable discount, an unknown target — still fails outright.
+    /// </remarks>
+    Task<SubscriptionOperationResult<SubscriptionPlanChangePreviewResponse>> PreviewPlanChangeAsync(
+        string subscriptionId,
+        ChangeSubscriptionPlanRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -129,10 +129,135 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         string correlationId,
         CancellationToken cancellationToken)
     {
+        var resolved = await ResolveAsync(
+            subscriptionId, request, preview: false, correlationId, cancellationToken);
+
+        if (!resolved.IsSuccess)
+        {
+            return resolved.ToFailure<SubscriptionResponse>();
+        }
+
+        var r = resolved.Value!;
+
+        return r.Subscription.Status == SubscriptionStatus.Trialing
+            ? await ApplyAsync(
+                r.Subscription, r.NewPlan, r.NewPrice, r.Quantities, r.NewSchedule,
+                r.Subscription.CreditBalanceMinor, null, null, correlationId, cancellationToken,
+                initiatedByUserId: r.RequestedByUserId)
+            : await ChargeAndApplyAsync(
+                r.Subscription, r.NewPlan, r.NewPrice, r.Quantities, r.NewSchedule, r.Now,
+                r.RequestedByUserId, correlationId, cancellationToken);
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionPlanChangePreviewResponse>>
+        PreviewPlanChangeAsync(
+            string subscriptionId,
+            ChangeSubscriptionPlanRequest request,
+            string correlationId,
+            CancellationToken cancellationToken)
+    {
+        var resolved = await ResolveAsync(
+            subscriptionId, request, preview: true, correlationId, cancellationToken);
+
+        if (!resolved.IsSuccess)
+        {
+            return resolved.ToFailure<SubscriptionPlanChangePreviewResponse>();
+        }
+
+        var r = resolved.Value!;
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            r.Subscription,
+            r.NewPlan,
+            r.NewPrice,
+            r.Quantities,
+            r.Now,
+            r.NewSchedule.CurrentPeriodStartUtc,
+            r.NewSchedule.CurrentPeriodEndUtc,
+            r.NewSchedule.FeePeriodFraction);
+
+        var blockers = new List<SubscriptionPreviewBlockerResponse>(r.Blockers);
+
+        // Only a real upgrade needs a card, and the amount owed is unaffected by whether one is
+        // on file — so this is an obstacle to name alongside the price, not a reason to withhold
+        // it. A downgrade never reaches here: it banks credit and charges nothing.
+        if (outcome.ChargeMinor > 0)
+        {
+            var account = await _billingAccounts.GetAsync(
+                r.Subscription.TenantId,
+                r.Subscription.BillingAccountId,
+                cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(account?.DefaultPaymentMethodId))
+            {
+                blockers.Add(new SubscriptionPreviewBlockerResponse
+                {
+                    Code = "subscription_plan_change_no_payment_method",
+                    Message = "This upgrade cannot be charged without a saved payment method."
+                });
+            }
+        }
+
+        return SubscriptionOperationResult<SubscriptionPlanChangePreviewResponse>.Success(
+            new SubscriptionPlanChangePreviewResponse
+            {
+                CurrencyCode = r.Subscription.CurrencyCode,
+                TargetPlanCode = r.NewPlan.Code,
+                TargetPlanName = r.NewPlan.DisplayName,
+                TargetPriceId = r.NewPrice.PriceId,
+                Interval = r.NewPrice.Interval.ToString(),
+                IntervalCount = r.NewPrice.IntervalCount,
+                Quantities = [.. r.Quantities.Select(item => new SubscriptionQuantityResponse
+                {
+                    ItemKey = item.ItemKey,
+                    UnitLabel = item.UnitLabel,
+                    Quantity = item.Quantity
+                })],
+                ChargeMinor = outcome.ChargeMinor,
+                // Nonzero only for a downgrade, and only the part the change itself banked — see
+                // ApplyAsync, which treats NewCreditBalanceMinor as the balance to *write*, not the
+                // amount this change adds. ChargeMinor is zero exactly when this is what was banked.
+                CreditBankedMinor = outcome.ChargeMinor <= 0 ? outcome.NewCreditBalanceMinor : 0,
+                Settlement = SettlementResponseOf(outcome.Breakdown),
+                NewPeriodStartUtc = r.NewSchedule.CurrentPeriodStartUtc,
+                NewPeriodEndUtc = r.NewSchedule.CurrentPeriodEndUtc,
+                // Already the whole target period, tax included, undiminished by proration — see
+                // ProrationSide.PeriodTotalMinor — so there is nothing left to compute here.
+                NextRenewalAmountMinor = outcome.Breakdown.Target.PeriodTotalMinor,
+                Blockers = blockers,
+                QuotedAtUtc = r.Now
+            },
+            correlationId);
+    }
+
+    /// <summary>
+    /// Everything <see cref="ChangePlanAsync"/> and <see cref="PreviewPlanChangeAsync"/> share:
+    /// resolving the caller, the subscription, the target plan and price, and the schedule it
+    /// would move onto. Stops short of pricing, because pricing is the one step the two callers
+    /// do not share — <see cref="ChargeAndApplyAsync"/> still calls
+    /// <see cref="SubscriptionProrationCalculator.Calculate"/> itself.
+    /// </summary>
+    /// <remarks>
+    /// A condition that would refuse <see cref="ChangePlanAsync"/> without changing what a change
+    /// would cost — an incomplete billing profile — is collected into <c>Blockers</c> on a preview
+    /// instead of failing outright. A condition that leaves no coherent price to quote — an
+    /// unsurvivable discount, an unknown target, an unbuildable schedule — fails either way, since
+    /// a preview with nothing to price has nothing to show. <see cref="SettlementReservation"/> and
+    /// <see cref="SubscriptionDetail.PendingAnnualPeriod"/> are checked only on the real change,
+    /// mirroring <see cref="SubscriptionQuantityChangeService"/>'s own preview exactly — a quote is
+    /// read-only and does not need the state that would block a write.
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<PlanChangeResolution>> ResolveAsync(
+        string subscriptionId,
+        ChangeSubscriptionPlanRequest request,
+        bool preview,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(request);
 
         var invalid = await SubscriptionValidation
-            .CheckAsync<ChangeSubscriptionPlanRequest, SubscriptionResponse>(
+            .CheckAsync<ChangeSubscriptionPlanRequest, PlanChangeResolution>(
                 _validator,
                 request,
                 "subscription_plan_change_invalid",
@@ -152,7 +277,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         if (!resolution.IsSuccess)
         {
-            return resolution.ToFailure<SubscriptionResponse>(correlationId);
+            return resolution.ToFailure<PlanChangeResolution>(correlationId);
         }
 
         var context = resolution.Context!;
@@ -165,7 +290,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         if (subscription is null)
         {
-            return Failure(
+            return Failure<PlanChangeResolution>(
                 PaymentFailureKind.NotFound,
                 "subscription_not_found",
                 "The subscription does not exist.",
@@ -174,7 +299,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         if (!EligibleStatuses.Contains(subscription.Status))
         {
-            return Failure(
+            return Failure<PlanChangeResolution>(
                 PaymentFailureKind.Conflict,
                 "subscription_plan_change_not_eligible",
                 "This subscription cannot change plan in its current state.",
@@ -183,25 +308,26 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         // A quantity increase is holding units priced against the plan being left. Refused by name
         // rather than by the repository's filter alone, so the caller knows to re-read and retry
-        // rather than reading it as a stale version.
-        if (subscription.SettlementReservation is not null)
+        // rather than reading it as a stale version. Only enforced on the real change: a preview
+        // is read-only and does not need the reservation to be clear to quote a price against the
+        // subscription as it stands.
+        if (!preview && subscription.SettlementReservation is not null)
         {
-            return Failure(
+            return Failure<PlanChangeResolution>(
                 PaymentFailureKind.Conflict,
                 "subscription_quantity_change_in_flight",
                 "A quantity change is being settled on this subscription.",
                 correlationId);
         }
 
-
         // A calendar-aligned yearly subscription inside its opening stub has a year already priced
         // and, on a prepaid price, already paid for. Repricing it now would have to unpick a
         // settled annual charge or silently discard one that is about to be collected, and neither
         // is something a caller can be told about after the fact. Refused until the boundary
-        // settles it, which is at most a month away.
-        if (subscription.PendingAnnualPeriod is not null)
+        // settles it, which is at most a month away — again, only on the real change.
+        if (!preview && subscription.PendingAnnualPeriod is not null)
         {
-            return Failure(
+            return Failure<PlanChangeResolution>(
                 PaymentFailureKind.Conflict,
                 "subscription_initial_annual_period_pending",
                 "This subscription is in its opening period and its first year is not yet " +
@@ -213,14 +339,17 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         if (!terms.IsSuccess)
         {
-            return terms.ToFailure<SubscriptionResponse>();
+            return terms.ToFailure<PlanChangeResolution>();
         }
 
         var (plan, price) = terms.Value;
 
         if (!DiscountSurvives(subscription, plan, price))
         {
-            return Failure(
+            // Not a blocker: the real change never charges a price with the discount silently
+            // dropped, it only ever refuses, so there is no honest number to show alongside this
+            // one. A preview with nothing achievable to price has nothing to quote.
+            return Failure<PlanChangeResolution>(
                 PaymentFailureKind.Validation,
                 "subscription_discount_not_applicable",
                 "The discount on this subscription does not apply to the plan or price being "
@@ -229,25 +358,40 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 correlationId);
         }
 
-        if (await MissingBillingProfileFieldsAsync(context, cancellationToken) is { Count: > 0 } missing)
+        var blockers = new List<SubscriptionPreviewBlockerResponse>();
+
+        if (await MissingBillingProfileFieldsAsync(context, preview, cancellationToken) is
+            { Count: > 0 } missing)
         {
             // A plan change prorates two periods and usually charges the difference, so it is a
-            // money-moving change and needs somebody to invoice. Refused here rather than after the
-            // card is charged, which is the only point at which refusing is free.
-            return SubscriptionOperationResult<SubscriptionResponse>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_billing_profile_incomplete",
-                "This organization's billing profile is missing details an invoice must carry. " +
-                    "Complete it before changing plan.",
-                correlationId,
-                new Dictionary<string, string[]> { ["BillingProfile"] = [.. missing] });
+            // money-moving change and needs somebody to invoice. On the real change this is
+            // refused here, which is the only point at which refusing is free. A preview shows the
+            // price anyway — filling in the profile does not change what the change would cost.
+            if (!preview)
+            {
+                return SubscriptionOperationResult<PlanChangeResolution>.Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_billing_profile_incomplete",
+                    "This organization's billing profile is missing details an invoice must " +
+                        "carry. Complete it before changing plan.",
+                    correlationId,
+                    new Dictionary<string, string[]> { ["BillingProfile"] = [.. missing] });
+            }
+
+            blockers.Add(new SubscriptionPreviewBlockerResponse
+            {
+                Code = "subscription_billing_profile_incomplete",
+                Message = "This organization's billing profile is missing details an invoice " +
+                    "must carry. Complete it before changing plan.",
+                Fields = new Dictionary<string, string[]> { ["BillingProfile"] = [.. missing] }
+            });
         }
 
         var quantities = SubscriptionQuantityBuilder.Build(request.Quantities, plan, price);
 
         if (quantities is null)
         {
-            return Failure(
+            return Failure<PlanChangeResolution>(
                 PaymentFailureKind.Validation,
                 "subscription_quantity_invalid",
                 "The quantities do not match the plan's items or fall outside their bounds.",
@@ -260,21 +404,18 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         if (!TryBuildSchedule(subscription, newPlan, newPrice, now, out var newSchedule))
         {
-            return Failure(
+            return Failure<PlanChangeResolution>(
                 PaymentFailureKind.Validation,
                 "subscription_schedule_invalid",
                 "The target plan's schedules could not be derived.",
                 correlationId);
         }
 
-        return subscription.Status == SubscriptionStatus.Trialing
-            ? await ApplyAsync(
-                subscription, newPlan, newPrice, quantities, newSchedule,
-                subscription.CreditBalanceMinor, null, null, correlationId, cancellationToken,
-                initiatedByUserId: context.UserId)
-            : await ChargeAndApplyAsync(
+        return SubscriptionOperationResult<PlanChangeResolution>.Success(
+            new PlanChangeResolution(
                 subscription, newPlan, newPrice, quantities, newSchedule, now,
-                context.UserId, correlationId, cancellationToken);
+                context.UserId, blockers),
+            correlationId);
     }
 
     /// <summary>
@@ -652,8 +793,14 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
     /// What the organization's billing profile still needs, and remembers who is asking when it is
     /// complete.
     /// </summary>
+    /// <param name="preview">
+    /// True to leave <see cref="ISubscriptionBillingProfileGuard.RememberInitiatorAsync"/> unread.
+    /// A preview has not changed anything, and recording an initiator for a quote that may never
+    /// be confirmed would misname who actually asked for the change.
+    /// </param>
     private async Task<IReadOnlyList<string>> MissingBillingProfileFieldsAsync(
         SubscriptionContext context,
+        bool preview,
         CancellationToken cancellationToken)
     {
         if (_billingProfile is null)
@@ -666,7 +813,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             context.OrganizationId,
             cancellationToken);
 
-        if (missing.Count == 0)
+        if (missing.Count == 0 && !preview)
         {
             await _billingProfile.RememberInitiatorAsync(
                 context.TenantId,
@@ -820,4 +967,59 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             errorCode,
             errorMessage,
             correlationId);
+
+    private static SubscriptionOperationResult<TValue> Failure<TValue>(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId) =>
+        SubscriptionOperationResult<TValue>.Failure(
+            kind,
+            errorCode,
+            errorMessage,
+            correlationId);
+
+    /// <summary>
+    /// The two priced sides of a settlement, in the shape a client already knows how to render —
+    /// the same one an issued document's settlement carries.
+    /// </summary>
+    /// <remarks>
+    /// Converts directly from the calculator's own <see cref="ProrationBreakdown"/> rather than
+    /// from the persisted <see cref="Payment.DomainService.Entities.SubscriptionSettlementBreakdown"/>
+    /// that <see cref="SettlementCharge.BreakdownOf"/> builds for a real reservation — a preview
+    /// persists nothing, so there is no reservation to convert from.
+    /// </remarks>
+    private static FinancialDocumentSettlementResponse SettlementResponseOf(ProrationBreakdown breakdown) =>
+        new()
+        {
+            Outgoing = SettlementSideResponseOf(breakdown.Outgoing),
+            Target = SettlementSideResponseOf(breakdown.Target),
+            CreditConsumedMinor = breakdown.CreditConsumedMinor,
+            NetSettlementMinor = breakdown.NetSettlementMinor
+        };
+
+    private static FinancialDocumentSettlementSideResponse SettlementSideResponseOf(ProrationSide side) =>
+        new()
+        {
+            GrossAmountMinor = side.GrossAmountMinor,
+            BuiltInDiscountMinor = side.BuiltInDiscountMinor,
+            PromotionalDiscountMinor = side.PromotionalDiscountMinor,
+            TaxAmountMinor = side.TaxAmountMinor,
+            PeriodTotalMinor = side.PeriodTotalMinor,
+            ProratedValueMinor = side.ProratedValueMinor
+        };
+
+    /// <summary>
+    /// What <see cref="ResolveAsync"/> resolved, before either caller decides what to do with it:
+    /// price it, or spend it.
+    /// </summary>
+    private readonly record struct PlanChangeResolution(
+        SubscriptionDetail Subscription,
+        PlanSnapshot NewPlan,
+        PriceSnapshot NewPrice,
+        List<SubscriptionQuantityItem> Quantities,
+        SubscriptionPlanSchedule NewSchedule,
+        DateTime Now,
+        string? RequestedByUserId,
+        List<SubscriptionPreviewBlockerResponse> Blockers);
 }

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -26,6 +26,7 @@ public sealed class SubscriptionPlanChangeServiceTests
     private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
     private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
     private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private readonly Mock<ISubscriptionBillingProfileGuard> _billingProfile = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero));
 
@@ -107,6 +108,13 @@ public sealed class SubscriptionPlanChangeServiceTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(SubscriptionOperationResult<string>.Success("in_1", "corr-1"));
+
+        // Complete unless a test says otherwise: the gate is not what most of these are about, and
+        // a default of "incomplete" would make every unrelated test fail for the wrong reason.
+        _billingProfile
+            .Setup(guard => guard.MissingFieldsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
     }
 
     [Fact]
@@ -804,6 +812,237 @@ public sealed class SubscriptionPlanChangeServiceTests
             "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
+    /// <summary>
+    /// The identity a plan-change preview promises: the same math the confirm evaluates, on the
+    /// same clock. Unlike the purchase preview, nothing here is frozen — this only holds because
+    /// both calls share one <see cref="ControlledTimeProvider"/> reading, exactly as it would hold
+    /// for two calls made in the same instant in production.
+    /// </summary>
+    [Fact]
+    public async Task A_preview_quotes_exactly_what_the_change_then_charges()
+    {
+        var service = Service();
+
+        var preview = await service.PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-preview", CancellationToken.None);
+        var applied = await service.ChangePlanAsync(
+            "sub-1", Request(), "corr-apply", CancellationToken.None);
+
+        preview.IsSuccess.Should().BeTrue();
+        applied.IsSuccess.Should().BeTrue();
+
+        preview.Value!.ChargeMinor.Should().Be(1_000);
+        _reserved!.ChargeAmountMinor.Should().Be(preview.Value.ChargeMinor);
+        preview.Value.CreditBankedMinor.Should().Be(0);
+        preview.Value.CurrencyCode.Should().Be("CHF");
+        preview.Value.TargetPlanCode.Should().Be("premium");
+    }
+
+    [Fact]
+    public async Task A_preview_of_a_downgrade_reports_the_credit_it_would_bank()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Active, 2_000);
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice(1_000));
+
+        var service = Service();
+
+        var preview = await service.PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-preview", CancellationToken.None);
+        var applied = await service.ChangePlanAsync(
+            "sub-1", Request(), "corr-apply", CancellationToken.None);
+
+        preview.Value!.ChargeMinor.Should().Be(0);
+        preview.Value.CreditBankedMinor.Should().BeGreaterThan(0);
+        applied.Value!.CurrencyCode.Should().Be("CHF");
+    }
+
+    [Fact]
+    public async Task A_preview_writes_nothing()
+    {
+        await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        _subscriptions.Verify(
+            repository => repository.TryReserveSettlementAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<SettlementReservation>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _subscriptions.Verify(
+            repository => repository.TryChangePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(),
+                It.IsAny<PendingUsagePeriod>(), It.IsAny<long>(), It.IsAny<string?>(),
+                It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>(),
+                It.IsAny<SubscriptionDocumentSource?>()),
+            Times.Never);
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _billingProfile.Verify(
+            guard => guard.RememberInitiatorAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "nobody has acted yet, so a preview must not record an initiator");
+    }
+
+    [Fact]
+    public async Task An_in_flight_settlement_reservation_does_not_block_a_preview()
+    {
+        // The check that refuses ChangePlanAsync here (A_quantity_increase_mid_settlement_blocks_a_
+        // plan_change) is read-only-safe to skip on a preview, which writes nothing and does not
+        // need the reservation clear to quote a price.
+        _subscription.SettlementReservation = new SettlementReservation
+        {
+            ReservationId = "reservation-1",
+            Kind = SettlementReservationKind.QuantityIncrease,
+            QuantityChange = new ReservedQuantityChange { RequestedQuantities = [] },
+            ChargeAmountMinor = 5_437,
+            ReservedAtUtc = new DateTime(2026, 8, 16, 11, 0, 0, DateTimeKind.Utc)
+        };
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ChargeMinor.Should().Be(1_000);
+    }
+
+    [Fact]
+    public async Task A_pending_annual_period_does_not_block_a_preview()
+    {
+        _subscription.PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The one refusal that stays a hard failure on preview rather than becoming a blocker: the
+    /// real change never charges a price with the discount silently dropped, so there is no
+    /// honest number to show alongside the refusal.
+    /// </summary>
+    [Fact]
+    public async Task An_unsurvivable_discount_fails_the_preview_exactly_as_it_fails_the_change()
+    {
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "loyal",
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 1_000,
+            ApplicablePlanCodes = ["basic"]
+        };
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_not_applicable");
+    }
+
+    [Fact]
+    public async Task An_incomplete_billing_profile_is_a_blocker_not_a_failure_on_preview()
+    {
+        _billingProfile
+            .Setup(guard => guard.MissingFieldsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([nameof(SubscriptionBillingProfile.LegalName)]);
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.ChargeMinor.Should().Be(1_000);
+
+        var blocker = result.Value.Blockers.Should().ContainSingle().Which;
+        blocker.Code.Should().Be("subscription_billing_profile_incomplete");
+        blocker.Fields!["BillingProfile"].Should().Contain(nameof(SubscriptionBillingProfile.LegalName));
+    }
+
+    [Fact]
+    public async Task An_incomplete_billing_profile_still_fails_the_real_change()
+    {
+        _billingProfile
+            .Setup(guard => guard.MissingFieldsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([nameof(SubscriptionBillingProfile.LegalName)]);
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_billing_profile_incomplete");
+    }
+
+    [Fact]
+    public async Task No_saved_payment_method_is_a_blocker_only_when_an_upgrade_would_be_charged()
+    {
+        _account = new BillingAccount { ItemId = "acct-1", ProviderName = "STRIPE" };
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.Value!.ChargeMinor.Should().Be(1_000);
+        result.Value.Blockers.Should().ContainSingle()
+            .Which.Code.Should().Be("subscription_plan_change_no_payment_method");
+    }
+
+    [Fact]
+    public async Task No_saved_payment_method_previews_cleanly_for_a_downgrade()
+    {
+        _account = new BillingAccount { ItemId = "acct-1", ProviderName = "STRIPE" };
+        _subscription = NewSubscription(SubscriptionStatus.Active, 2_000);
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice(1_000));
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        // Nothing is owed, so there is nothing a missing card would stop.
+        result.Value!.ChargeMinor.Should().Be(0);
+        result.Value.Blockers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task An_unknown_target_plan_fails_the_preview_exactly_as_it_fails_the_change()
+    {
+        var request = Request();
+        request.PlanCode = "not-a-plan";
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_plan_not_found");
+    }
+
+    /// <summary>
+    /// Already the whole target period, tax included, undiminished by proration — pinned here so
+    /// nothing quietly starts recomputing it.
+    /// </summary>
+    [Fact]
+    public async Task NextRenewalAmountMinor_is_the_targets_own_full_period_total()
+    {
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.Value!.NextRenewalAmountMinor.Should().Be(2_000);
+    }
+
     private SubscriptionPlanChangeService Service() => new(
         _contextResolver.Object,
         _subscriptions.Object,
@@ -815,7 +1054,8 @@ public sealed class SubscriptionPlanChangeServiceTests
         new SubscriptionResponseMapper(),
         new ChangeSubscriptionPlanRequestValidator(),
         NullLogger<SubscriptionPlanChangeService>.Instance,
-        _time);
+        _time,
+        billingProfile: _billingProfile.Object);
 
     private static ChangeSubscriptionPlanRequest Request() => new()
     {


### PR DESCRIPTION
## Summary

`POST /api/subscriptions/preview` ([PR #319](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/319)) quotes a new subscription, but explicitly does not cover an existing subscriber moving to another plan — `PUT /api/subscriptions/{subscriptionId}/plan` refuses that case outright (`subscription_already_active`). The docs already flagged the gap:

> There is no separate proration-preview endpoint for a plan change specifically... If the product needs an exact amount before confirming a plan change, add a preview operation for it.

Adds `POST /api/subscriptions/{subscriptionId}/plan/preview`: what moving to another plan or price would cost or credit right now, without applying anything.

```
POST /api/subscriptions/{subscriptionId}/plan/preview
{ "priceId": "target-price-id", "quantities": [] }
```
```
{
  "chargeMinor": 5000, "creditBankedMinor": 0,
  "settlement": { "outgoing": {...}, "target": {...}, "netSettlementMinor": 5000 },
  "nextRenewalAmountMinor": 20000, "blockers": [], "quotedAtUtc": "..."
}
```

## A different guarantee than the purchase preview, on purpose

The purchase preview (#319) freezes its figure on the subscription it builds, so it's exact until the next local midnight. **`ChangePlanAsync` has never worked that way** — it calls `SubscriptionProrationCalculator.Calculate` fresh, immediately before charging, every single time it runs. There is nothing to freeze.

So this preview makes the same promise this module's *own* quantity-change preview already ships with: `SubscriptionQuantityChangeService.PreviewAsync`/`ChangeAsync` share one `RunAsync`, pricing fresh on both paths — the same math, evaluated a moment later. Rather than invent a stronger guarantee (a frozen quote token, a validity window) that this service has never provided anywhere else, the response has **no `quoteValidUntilUtc`** and says so plainly: plan-change proration is continuous (ticks remaining over the period), not quantized per calendar day, so there's no discrete boundary to name — the client is told to re-fetch immediately before confirming instead.

## Design

`SubscriptionPlanChangeService` splits `ResolveAsync(preview)` from pricing — narrower than the purchase preview's split, because the two callers here return genuinely different shapes (`SubscriptionResponse` for the applied change, a new preview response for the quote). Everything through building the target schedule is shared: context resolution, subscription load, target plan/price resolution, discount survival, billing profile, quantities, schedule build. `ChargeAndApplyAsync` is otherwise **untouched** — it still calls the calculator itself on the real path rather than being threaded a pre-computed outcome, because the calculator is a pure function of already-resolved inputs and cannot diverge by being called twice. Smaller diff, lower risk to the money-moving path.

**Two conditions become blockers instead of failures on preview** — an incomplete billing profile, and no saved payment method (checked only when the computed charge is positive, i.e. only for a genuine upgrade). Neither changes what the change would cost, only whether the confirm can go through, so the price is shown alongside the obstacle.

**Everything else, including an unsurvivable discount, still fails the preview exactly as it fails the confirm.** This is a real judgment call worth a reviewer's eye: unlike an incomplete profile, a discount that doesn't survive the move *changes what number could even be shown* — the real confirm never charges a stripped-discount price, it only ever refuses outright (the existing code's own comment: *"Refusing puts the consequence in front of them first"*). There is no honest price to quote alongside that refusal, so it stays a hard failure rather than becoming a third kind of blocker.

**`SettlementReservation` and `PendingAnnualPeriod` are checked only on the real change**, silently skipped on preview — mirroring `SubscriptionQuantityChangeService`'s own treatment of the identical two conditions exactly. A preview is read-only and doesn't need either clear to quote a price.

Response reuses two existing types rather than duplicating them: `FinancialDocumentSettlementResponse`/`...SideResponse` (already field-identical to the calculator's own `ProrationBreakdown`/`ProrationSide`) and `SubscriptionPreviewBlockerResponse` from #319.

## Client

`ChangePlanDialog` now requires a preview before confirming, mirroring `SubscribeDialog`'s pattern from #319: editing the target plan, price, or a quantity discards the quote; blockers render inline; confirm stays disabled while any are present or before a quote exists.

## Verification

- **Server:** 2945 total. 4 pre-existing `SubscriptionSimulation*` permission-guard failures, unchanged baseline. All **40 pre-existing plan-change tests still pass** after the refactor — the split preserved behavior exactly. **12 new tests**, including the identity guarantee itself (preview then apply on one clock, asserting the reservation's actual charge equals what was quoted), the discount-vs-billing-profile classification, and a pin on `nextRenewalAmountMinor` reusing `ProrationSide.PeriodTotalMinor` rather than recomputing it.
- **Client:** typecheck and lint clean on all touched files. Both new dialog test files pass in full isolation (`subscribe-dialog.test.tsx` 7/7 from #319, `change-plan-dialog.test.tsx` 5/5 new). The full client suite (2945+ tests) was still running in the background well past its usual ~9.5-minute baseline at the time of this PR — worker processes were confirmed alive and progressing (not hung) each time checked, but it hadn't completed. Given the small, self-contained change surface and the isolated verification already gathered, I opened this PR without waiting further; happy to report the full-suite result as a follow-up comment once it lands, or hold merge until CI's own client suite confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
