### PR TITLE
fix(subscription): restore client build after PR #317

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
@@ -201,7 +201,6 @@ export const SubscribeDialog = ({
     .map((blocker) =>
       billingProfileGapOf({
         code: blocker.code,
-        message: blocker.message,
         fields: blocker.fields ?? {},
       }),
     )


### PR DESCRIPTION
## Fix\n\nRemoves the unsupported message property passed to illingProfileGapOf by the PR #317 conflict resolution. The helper intentionally accepts only code and ields, which are all it uses to classify the billing-profile blocker.\n\n## Verification\n\n- 
px tsc -b --pretty false passes\n- The original TS2353 failure is no longer present