### PR TITLE
ci(subscription): run the repository integration tests that were running nowhere

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -37,9 +37,17 @@ jobs:
           dotnet-version: 10.0.x
       - name: Restore
         run: dotnet restore server/XUnitTest/XUnitTest.csproj
+      # SubscriptionRepositoryIntegrationTests is named here because its guarantees are enforced by
+      # MongoDB and not by our code: a unique index, an atomic upsert, a compare-and-set. They can
+      # only be demonstrated against a real collection, and a filter that leaves the class out means
+      # they are demonstrated nowhere — the suite passes, and nothing has been tried.
+      #
+      # Several integration classes are still outside this filter and so run nowhere. Widening it
+      # belongs in its own change, since whatever it turns up would arrive as unrelated failures on
+      # whichever pull request happened to widen it.
       - name: Run subscription Mongo integration suite
         run: >-
           dotnet test server/XUnitTest/XUnitTest.csproj
           --no-restore
-          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests"
+          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests"
           --verbosity minimal


### PR DESCRIPTION
## Summary

`SubscriptionRepositoryIntegrationTests` runs in no workflow. This adds it to the `mongo-integration` filter, so its **21 tests execute** instead of merely existing.

It was meant to go in with #317 and missed the merge, so it needs its own pull request. The six billing-account reconcile tests that #317 added to that class are in `dev` right now, and nothing runs them.

## Why this matters more than a one-line filter usually would

There is no `mongod` on a developer machine, so `--filter "FullyQualifiedName!~Integration"` is the local default. That makes CI the *only* place an integration test ever runs. A class outside the filter is therefore not "covered less" — it is never executed at all, while still reading as coverage in a diff and in a review.

This is not hypothetical. Two things on #317 turned on it:

- I added six tests for a repository fix, reported them as verification, and none of them had run.
- A bug in that same fix — an upsert whose `$setOnInsert` dropped `ProviderCustomerId` and `DefaultPaymentMethodId`, leaving a renewal with no card to charge — was caught by a **renewal** test that happens to be inside the filter, two suites away from the change. None of the tests written for the fix could have caught it, because none of them ran.

## What this does not do

**Eleven of the fifteen integration classes are still outside every filter**, including `FinancialDocumentLedgerIntegrationTests`, `SubscriptionDocumentSourceIntegrationTests`, `SubscriptionSchedulerCoordinatorIntegrationTests` and every Payment repository class except the work queue.

Worth knowing: that means the concurrency tests added in #314 — the sixteen-concurrent-reopening collapse test among them — have also never executed, though they were reported as green at the time. That was my error in reading a passing check as covering them.

Widening the filter further deliberately stays out of this PR. Whatever it turns up would arrive as unrelated failures on whichever pull request happened to widen it, and the right way to find out is a change that has nothing else in it. Recommended as the next step, one workflow at a time.

## Risk

CI-only; no production code. Two ways it can go:

- The 21 tests pass, and a real guarantee starts being checked on every relevant PR.
- Some fail — in which case they were failing all along and nobody could see it, and this PR is where we find out. That is the point, and it is why this is worth landing on its own rather than inside a feature branch.

The job already provisions MongoDB 8.0 and the class needs nothing else; it shares the `MongoIntegrationFixture` with the two classes the filter already names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
