### PR TITLE
fix(subscription)!: answer GET /subscriptions/current with 200 and no data instead of 404

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -83,10 +83,14 @@ class SubscriptionSimulationService {
         SimulationApiResponse<SimulatedSubscription>
       >(`${SUBSCRIPTIONS_CURRENT_ENDPOINT}${query}`);
 
+      // Null data on a 200 is the answer for an organization with no subscription. Nothing here
+      // had to change for that: the endpoint stopped saying 404 and this already read the body.
       return response.success ? response.data : null;
     } catch (error) {
-      // No granting or pending subscription for this scope is an ordinary empty state for a
-      // simulation screen, not a failure worth reporting as one.
+      // Kept for a server that has not been deployed yet. During a rollout this client can be
+      // talking to the old endpoint, which answers the same question with a 404 — and treating
+      // that as a failure would empty the screen mid-deploy for subscribers who do have one.
+      // Safe to delete once no reachable server still returns it.
       if (error instanceof HttpError && error.status === 404) {
         return null;
       }

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -682,13 +682,20 @@
         </member>
         <member name="M:Api.Controllers.SubscriptionsController.GetCurrent(System.String,System.Threading.CancellationToken)">
             <summary>
-            The caller's own subscription.
+            The caller's own subscription, or nothing if they have none.
             </summary>
             <remarks>
+            Always <c>200</c>. An organization with no subscription gets
+            <c>{ "success": true, "data": null }</c> rather than a <c>404</c>: having no subscription yet
+            is one of this question's two ordinary answers, and a 404 says the endpoint is not there —
+            which a client cannot tell apart from a bad route or a revoked path. Check <c>data</c> for
+            null; there is no status code to special-case any more.
+            <para>
             Immediately after paying this may still report <c>Incomplete</c>: the shopper's browser
             usually returns before the provider's webhook lands, and only the webhook is treated as
             proof that money moved. Clients should expect a short pending state rather than assume
             something failed.
+            </para>
             </remarks>
         </member>
         <member name="M:Api.Controllers.SubscriptionsController.Cancel(System.String,System.Boolean,System.String,System.String,System.Threading.CancellationToken)">

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -135,17 +135,23 @@ public sealed class SubscriptionsController : ControllerBase
     }
 
     /// <summary>
-    /// The caller's own subscription.
+    /// The caller's own subscription, or nothing if they have none.
     /// </summary>
     /// <remarks>
+    /// Always <c>200</c>. An organization with no subscription gets
+    /// <c>{ "success": true, "data": null }</c> rather than a <c>404</c>: having no subscription yet
+    /// is one of this question's two ordinary answers, and a 404 says the endpoint is not there —
+    /// which a client cannot tell apart from a bad route or a revoked path. Check <c>data</c> for
+    /// null; there is no status code to special-case any more.
+    /// <para>
     /// Immediately after paying this may still report <c>Incomplete</c>: the shopper's browser
     /// usually returns before the provider's webhook lands, and only the webhook is treated as
     /// proof that money moved. Clients should expect a short pending state rather than assume
     /// something failed.
+    /// </para>
     /// </remarks>
     [HttpGet("current")]
     [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
-    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetCurrent(
         [FromQuery] string? organizationId,

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2419,10 +2419,32 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
 }</code></pre>
           <h4>Returns</h4>
           <p>
-            <code>200</code> with a granting or <code>Incomplete</code> subscription ·
-            <code>404 subscription_not_found</code> only when the organization has neither a
+            Always <code>200</code> · <code>data</code> is the granting or <code>Incomplete</code>
+            subscription, or <strong><code>null</code></strong> when the organization has neither a
             granting subscription nor an incomplete checkout · <code>401</code> unauthenticated.
           </p>
+          <pre><code>{
+  "success": true,
+  "data": null,
+  "error": null
+}</code></pre>
+          <div class="callout">
+            <strong>This no longer answers <code>404</code>.</strong> Having no subscription yet is
+            one of this question's two ordinary answers, and <code>404</code> says the endpoint is
+            not there — which a caller cannot tell apart from a bad route, a revoked path or a
+            typo. Test <code>data</code> for null; there is no status code to special-case.
+            <p class="prose">
+              Nothing else changed. A subscription that exists comes back in exactly the shape it
+              always did, so a client that reads <code>data</code> and copes with null needs no
+              edit — and one that treated <code>404</code> as "none" keeps working until the last
+              old server is gone, since it will simply stop seeing it.
+            </p>
+            <p class="prose">
+              The other <code>404 subscription_not_found</code> refusals in this API are unchanged:
+              asking to cancel or reprice a subscription that does not exist really is a request
+              about something absent.
+            </p>
+          </div>
         </div>
       </div>
 
@@ -2881,7 +2903,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <tr><td>subscription_already_active</td><td class="prose">This organization already has a live subscription. Cancel or change plan instead.</td></tr>
             <tr><td>subscription_checkout_pending</td><td class="prose">This organization has an unpaid checkout for different terms. The error fields contain its <code>subscriptionId</code> and, when recoverable, <code>checkoutUrl</code>; continue it or cancel it before subscribing again.</td></tr>
             <tr><td>subscription_already_ended</td><td class="prose">Cancelling something already cancelled.</td></tr>
-            <tr><td>subscription_not_found</td><td class="prose">No subscription for this organization.</td></tr>
+            <tr><td>subscription_not_found</td><td class="prose">The subscription this request names does not exist &mdash; raised by cancel, plan change, quantity change and usage recording. <strong>Not</strong> by <code>GET /subscriptions/current</code>, which answers <code>200</code> with <code>data: null</code> instead.</td></tr>
             <tr><td>subscription_time_zone_unknown</td><td class="prose">Not a valid IANA identifier. Refused here rather than at the first renewal.</td></tr>
             <tr><td>subscription_meter_not_found</td><td class="prose">The plan defines no such meter.</td></tr>
             <tr><td>subscription_usage_idempotency_key_required</td><td class="prose">Every usage call needs one.</td></tr>
@@ -2995,6 +3017,11 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       <p>
         A plan or subscription belonging to another organization reports as missing rather than
         forbidden, deliberately — a 403 would confirm the identifier exists somewhere else.
+      </p>
+      <p class="prose">
+        <code>GET /subscriptions/current</code> is not one of these. It names no identifier, so there
+        is nothing to confirm or conceal: it answers <code>200</code> either way, with
+        <code>data: null</code> for an organization that has no subscription.
       </p>
     </section>
 

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -408,11 +408,12 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                 correlationId);
         }
 
-        return SubscriptionOperationResult<SubscriptionResponse>.Failure(
-            PaymentFailureKind.NotFound,
-            "subscription_not_found",
-            "This organization has no current or pending subscription.",
-            correlationId);
+        // No subscription is an answer, not a failure. This used to be a 404, which says the
+        // endpoint is not there: a client cannot tell that from a bad route, a revoked path or a
+        // typo, so every caller had to special-case one status code to read an ordinary "not yet".
+        // The other not-found refusals in this module stay as they are - asking to cancel or reprice
+        // a subscription that does not exist really is a request about something absent.
+        return SubscriptionOperationResult<SubscriptionResponse>.Empty(correlationId);
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionOperationResult.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionOperationResult.cs
@@ -1,4 +1,4 @@
-using Payment.DomainService.Enums;
+﻿using Payment.DomainService.Enums;
 
 namespace Subscription.DomainService.Services;
 
@@ -43,6 +43,27 @@ public sealed class SubscriptionOperationResult<TValue>
         {
             IsSuccess = true,
             Value = value,
+            CorrelationId = correlationId
+        };
+
+    /// <summary>
+    /// Succeeded, and there is nothing to return.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Failure"/> with a not-found kind, which is what "no subscription"
+    /// used to be. Asking whether an organization has a subscription is a question with two ordinary
+    /// answers, and "no" is one of them — a 404 says the endpoint is not there, which is a
+    /// different sentence entirely and one a client cannot tell from a routing mistake, a revoked
+    /// path or a typo.
+    /// <para>
+    /// Renders as <c>{ "success": true, "data": null }</c>. Reserved for reads: an operation that was
+    /// asked to change something and changed nothing has an outcome to report, not an absence.
+    /// </para>
+    /// </remarks>
+    public static SubscriptionOperationResult<TValue> Empty(string correlationId) =>
+        new()
+        {
+            IsSuccess = true,
             CorrelationId = correlationId
         };
 

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -55,6 +55,27 @@ public sealed class SubscriptionCancellationServiceTests
             .Callback<string, string, SubscriptionTransition, CancellationToken>(
                 (_, _, transition, _) => _transition = transition)
             .ReturnsAsync(true);
+    }
+
+    /// <summary>
+    /// The boundary of the change that made "no subscription" a 200 on <c>GET /current</c>.
+    /// </summary>
+    /// <remarks>
+    /// That read asks whether there is a subscription, and "no" is one of its two ordinary answers.
+    /// This is a request <em>about</em> one, and a subscription that does not exist really is
+    /// something absent: answering 200 would let a caller believe it had cancelled something.
+    /// </remarks>
+    [Fact]
+    public async Task Cancelling_a_subscription_that_does_not_exist_is_still_not_found()
+    {
+        _subscription = null;
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        result.ErrorCode.Should().Be("subscription_not_found");
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Payment.DomainService.Entities;
@@ -414,6 +414,39 @@ public sealed class SubscriptionCheckoutServiceTests
             repository => repository.GetIncompleteAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// An organization with no subscription is answered, not refused.
+    /// </summary>
+    /// <remarks>
+    /// This used to be a 404, which says the endpoint is not there. A caller cannot tell that from a
+    /// bad route, a revoked path or a typo, so reading an ordinary "not yet" meant special-casing one
+    /// status code and hoping it never meant anything else.
+    /// </remarks>
+    [Fact]
+    public async Task Current_answers_no_subscription_with_an_empty_success_rather_than_a_404()
+    {
+        // Neither lookup finds anything, which is every organization that has not subscribed.
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var result = await Service().GetCurrentAsync(null, "corr-empty", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("having no subscription is an answer, not a failure");
+        result.Value.Should().BeNull("which is what renders as data: null");
+
+        // No code and no kind, so nothing downstream can map this onto a status other than 200.
+        result.ErrorCode.Should().BeNull();
+        result.ErrorMessage.Should().BeNull();
+        result.FailureKind.Should().Be(default(PaymentFailureKind));
+        result.CorrelationId.Should().Be("corr-empty");
     }
 
     private SubscriptionCheckoutService Service() => new(


### PR DESCRIPTION
## Summary

`GET /api/subscriptions/current` answered `404` when an organization had no subscription. That says *the endpoint is not there* — indistinguishable, to a caller, from a bad route, a revoked path or a typo. Reading an ordinary "not yet" meant special-casing one status code and trusting it never meant anything else.

It is now **always `200`**, with `data: null` when there is neither a granting subscription nor an incomplete checkout.

```json
{ "success": true, "data": null, "error": null }
```

## Compatibility

**The found case is byte-identical.** A subscription that exists comes back in exactly the shape it always did — same fields, same nesting. Nothing was wrapped and nothing was renamed.

So the migration for a caller is: read `data`, cope with `null`. A caller that already did that needs no change at all. A caller that treated `404` as "none" keeps working until the last old server is gone, at which point it simply stops seeing it.

*(I asked before building this — a `hasSubscription` wrapper would have been more explicit but would have moved the found case under `data.subscription`, breaking every existing integrator's happy path. `data: null` was chosen precisely to avoid that.)*

## Changes

- `SubscriptionOperationResult` gains `Empty`: succeeded, and there is nothing to return. Deliberately distinct from a not-found failure, and documented as **reserved for reads** — an operation that was asked to change something and changed nothing has an outcome to report, not an absence.
- `GetCurrentAsync` returns it in place of the not-found failure. Nothing else in the method moves.
- `404` comes off that endpoint's `ProducesResponseType`, since no path to it remains. `Api.xml` regenerated for the doc comment.

## What this deliberately does *not* change

Every other `subscription_not_found` refusal is untouched — cancel, plan change, quantity change, usage recording. Asking to cancel or reprice a subscription that does not exist really *is* a request about something absent, and answering those `200` would let a caller believe it had acted.

A test in the cancellation service now pins that boundary from the other side, so a future reader does not "finish the job" by applying this to all of them.

## Tests

- `Current_answers_no_subscription_with_an_empty_success_rather_than_a_404` — asserts success, null value, **and** that no error code, message or failure kind is set, so nothing downstream can map it onto a status other than 200.
- `Cancelling_a_subscription_that_does_not_exist_is_still_not_found` — the boundary above.

Existing `current` tests (live preferred over pending, incomplete-with-checkout-url, organization forwarding) are unchanged and still pass.

## Docs

The endpoint's **Returns** block, a callout explaining why `404` was wrong here and what to test instead, the error-code table row for `subscription_not_found` (now naming which endpoints still raise it), and a note in *A 404 may mean "not yours"* that `current` is not one of those cases — it names no identifier, so it has nothing to conceal.

## Verification

- Server **2970 passing**; 4 failures, all `SubscriptionSimulation*` permission-guard tests, verified pre-existing on untouched `origin/dev` earlier today. Build clean.
- The 51 tests across the three suites that touch this path pass.
- The client change is **comment-only** — every changed line is a comment, verified against the diff. Its 404 branch is kept on purpose: during a rollout the client can be talking to a server that still answers the old way, and treating that as a failure would blank the screen mid-deploy for subscribers who *do* have a subscription. It can go once no reachable server returns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
