### PR TITLE
feat(subscription): show which plan a new one replaces

### DIFF
--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -184,6 +184,19 @@ export interface SubscriptionPlan {
   description: string | null;
   familyCode?: string | null;
   familyRank?: number | null;
+  /**
+   * The plan this one was created to replace, for display only. Set once, at creation — naming
+   * one here never moved a subscriber and never changed either plan's editability.
+   */
+  predecessorPlanId?: string | null;
+  /** Resolved alongside {@link predecessorPlanId} so a link can render without another fetch. */
+  predecessorDisplayName?: string | null;
+  /**
+   * The plan that named this one as its predecessor, if any — the reverse link. Only present on
+   * a single plan fetched by id; a list of plans does not carry it.
+   */
+  successorPlanId?: string | null;
+  successorDisplayName?: string | null;
   usageInterval?: BillingIntervalName;
   usageIntervalCount?: number;
   /**
@@ -333,6 +346,8 @@ export interface UpdateSubscriptionPlanRequest {
   usageIntervalCount: number;
   familyCode?: string;
   familyRank?: number;
+  /** The plan this one replaces, for display only — see {@link SubscriptionPlan.predecessorPlanId}. */
+  predecessorPlanId?: string;
   quantityItems: CreatePlanQuantityItemRequest[];
   meters: CreatePlanMeterRequest[];
   entitlements: CreatePlanEntitlementRequest[];

--- a/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/create-subscription-plan-page.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { toast } from "@/hooks/use-toast";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import { PlanBuilder } from "../components/plan-builder/plan-builder";
 import { useCreateSubscriptionPlan } from "../hooks/use-create-subscription-plan";
 import { useCreateSubscriptionPrice } from "../hooks/use-create-subscription-price";
@@ -28,50 +29,71 @@ export const CreateSubscriptionPlanPage = () => {
         : defaultSubscriptionPlanFormValues,
     [duplicatePlan],
   );
+  // Checked by default, but not assumed: a duplicate can just as easily be a fresh plan started
+  // from a convenient template, so whether it replaces the one it came from is a choice, not an
+  // inference from clicking "Duplicate plan".
+  const [marksAsSuccessor, setMarksAsSuccessor] = useState(true);
 
   return (
-    <PlanBuilder
-      mode="create"
-      defaultValues={initialValues}
-      title={duplicatePlan ? `Duplicate ${duplicatePlan.displayName}` : "Create subscription plan"}
-      description="A guided walkthrough — nothing is created until you review and confirm at the end."
-      backTo={listPath}
-      submitLabel="Create plan"
-      submittingLabel="Creating plan…"
-      // One submission spans both calls, so the buttons stay locked through the price loop too.
-      isSubmitting={isPending || isPricing}
-      onSubmit={async (values) => {
-        const { plan, failures } = await submitPlanWithPrices({
-          planRequest: toCreatePlanRequest(values),
-          prices: values.prices,
-          createPlan,
-          createPrice,
-        });
+    <>
+      {duplicatePlan && (
+        <label className="flex items-center gap-2 px-4 pt-4 text-sm text-muted-foreground sm:px-6 lg:px-8">
+          <Checkbox
+            checked={marksAsSuccessor}
+            onCheckedChange={(checked) => setMarksAsSuccessor(checked === true)}
+          />
+          This plan replaces &ldquo;{duplicatePlan.displayName}&rdquo;
+        </label>
+      )}
+      <PlanBuilder
+        mode="create"
+        defaultValues={initialValues}
+        title={duplicatePlan ? `Duplicate ${duplicatePlan.displayName}` : "Create subscription plan"}
+        description="A guided walkthrough — nothing is created until you review and confirm at the end."
+        backTo={listPath}
+        submitLabel="Create plan"
+        submittingLabel="Creating plan…"
+        // One submission spans both calls, so the buttons stay locked through the price loop too.
+        isSubmitting={isPending || isPricing}
+        onSubmit={async (values) => {
+          const planRequest = toCreatePlanRequest(values);
 
-        if (failures.length > 0) {
-          toast({
-            variant: "destructive",
-            title: `${plan.displayName} was created, but ${failures.length} price${failures.length === 1 ? "" : "s"} was not`,
-            description: `${failures.join(" ")} Add the missing prices from the plan page.`,
-          });
-        } else {
-          toast({
-            variant: "success",
-            title: "Plan created",
-            description: `${plan.displayName} is ready to subscribe to.`,
-          });
-        }
+          if (duplicatePlan && marksAsSuccessor) {
+            planRequest.predecessorPlanId = duplicatePlan.planId;
+          }
 
-        // Carries the organization the plan was just scoped to. Without it the detail page
-        // resolves as the console organization, and a plan belonging to someone else reads as
-        // missing — the plan is created and then immediately unreachable.
-        navigate(
-          withOrganizationScope(
-            `${listPath}/${encodeURIComponent(plan.planId)}`,
-            plan.organizationId,
-          ),
-        );
-      }}
-    />
+          const { plan, failures } = await submitPlanWithPrices({
+            planRequest,
+            prices: values.prices,
+            createPlan,
+            createPrice,
+          });
+
+          if (failures.length > 0) {
+            toast({
+              variant: "destructive",
+              title: `${plan.displayName} was created, but ${failures.length} price${failures.length === 1 ? "" : "s"} was not`,
+              description: `${failures.join(" ")} Add the missing prices from the plan page.`,
+            });
+          } else {
+            toast({
+              variant: "success",
+              title: "Plan created",
+              description: `${plan.displayName} is ready to subscribe to.`,
+            });
+          }
+
+          // Carries the organization the plan was just scoped to. Without it the detail page
+          // resolves as the console organization, and a plan belonging to someone else reads as
+          // missing — the plan is created and then immediately unreachable.
+          navigate(
+            withOrganizationScope(
+              `${listPath}/${encodeURIComponent(plan.planId)}`,
+              plan.organizationId,
+            ),
+          );
+        }}
+      />
+    </>
   );
 };

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
@@ -137,3 +137,37 @@ describe("SubscriptionPlanDetailPage identifiers", () => {
     expect(screen.queryByText("Draws down")).not.toBeInTheDocument();
   });
 });
+
+/**
+ * Purely a label, in both directions: naming a predecessor never migrated a subscriber and
+ * never changed either plan's editability, so these only check that the link itself renders —
+ * not that anything about purchasability changed.
+ */
+describe("SubscriptionPlanDetailPage plan history", () => {
+  it("links to the plan this one replaces", () => {
+    renderPage(
+      plan({ predecessorPlanId: "plan-0", predecessorDisplayName: "Legacy professional" }),
+    );
+
+    const link = screen.getByRole("link", { name: "Replaces Legacy professional →" });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toContain("plan-0");
+  });
+
+  it("links to the plan that replaced this one", () => {
+    renderPage(
+      plan({ successorPlanId: "plan-2", successorDisplayName: "Professional (2026)" }),
+    );
+
+    const link = screen.getByRole("link", { name: "Replaced by Professional (2026) →" });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toContain("plan-2");
+  });
+
+  it("shows neither link for a plan with no history", () => {
+    renderPage(plan());
+
+    expect(screen.queryByText(/^Replaces /)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Replaced by /)).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -184,6 +184,35 @@ export const SubscriptionPlanDetailPage = () => {
         }
       />
 
+      {/* Display only, both directions: naming a predecessor never migrated a subscriber and
+          never touched either plan's editability — see Plan.PredecessorPlanId server-side. */}
+      {(plan.predecessorPlanId || plan.successorPlanId) && (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+          {plan.predecessorPlanId && (
+            <Link
+              to={withOrganizationScope(
+                `${basePath}/${encodeURIComponent(plan.predecessorPlanId)}`,
+                plan.organizationId,
+              )}
+              className="underline-offset-4 hover:underline"
+            >
+              Replaces {plan.predecessorDisplayName ?? "a retired plan"} →
+            </Link>
+          )}
+          {plan.successorPlanId && (
+            <Link
+              to={withOrganizationScope(
+                `${basePath}/${encodeURIComponent(plan.successorPlanId)}`,
+                plan.organizationId,
+              )}
+              className="underline-offset-4 hover:underline"
+            >
+              Replaced by {plan.successorDisplayName ?? "a newer plan"} →
+            </Link>
+          )}
+        </div>
+      )}
+
       <div className="grid items-start gap-5 xl:grid-cols-[1fr_22rem]">
         <div className="space-y-5">
           {plan.quantityItems.length > 0 && (

--- a/server/Subscription.DomainService/Entities/Plan.cs
+++ b/server/Subscription.DomainService/Entities/Plan.cs
@@ -26,6 +26,16 @@ public sealed class Plan
     /// <summary>A stable key configuration points at. The display name may change; this may not.</summary>
     public string Code { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The plan this one was created to replace, if any. Set once, at creation, and never
+    /// resolved by anything that sells, prices, or migrates a subscriber — purely a label for
+    /// "what came before this" on a detail page. A plan that has subscribers still cannot be
+    /// edited in place; naming a predecessor here does not change that, and does not migrate
+    /// anyone off it. See <c>ChangePlanAsync</c> for the operation that actually moves a
+    /// subscriber between plans.
+    /// </summary>
+    public string? PredecessorPlanId { get; set; }
+
     public string DisplayName { get; set; } = string.Empty;
 
     public string? Description { get; set; }

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -146,6 +146,18 @@ why editing is closed before offering it.
 editing include it — an edit that could store what a create would have refused is a hole, and one
 rule is the only way to be sure the two agree.
 
+### Naming a predecessor is a label, not a migration
+
+`CreatePlanRequest.PredecessorPlanId` lets a new plan say which one it was created to replace.
+It is set once, at creation, checked only for existing (and visible) at that moment, and never
+read by anything that sells, prices, or migrates a subscriber. `GetPlanAsync`/`ListPlansAsync`
+resolve the predecessor's display name so a caller can render a link without a second fetch; a
+single-plan read also resolves the reverse — the plan, if any, that named *this* one as its
+predecessor — via an unindexed scan scoped to the tenant, the same scale assumption
+`ListPlansAsync` already makes for its own full scan. Naming one changes nothing about either
+plan's `hasSubscribers`, editability, or purchasability: it is purely something a detail page can
+show.
+
 ## Periods are derived, never advanced
 
 `BillingPeriodCalculator` is pure and static, and the instant is always a parameter. Asking

--- a/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
@@ -33,6 +33,17 @@ public interface ISubscriptionCatalogueRepository
         string? organizationId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Finds the plan that named <paramref name="predecessorPlanId"/> as its own predecessor, if
+    /// one exists — the reverse of <see cref="Plan.PredecessorPlanId"/>. Unindexed: plan counts
+    /// per tenant are small, the same assumption <see cref="ListPlansAsync"/> already makes for
+    /// its own full scan, and this is only ever called once per single-plan read.
+    /// </summary>
+    Task<Plan?> FindSuccessorPlanAsync(
+        string tenantId,
+        string predecessorPlanId,
+        CancellationToken cancellationToken);
+
     Task<bool> TryUpdatePlanAsync(
         string tenantId,
         string planId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -132,6 +132,16 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
             .ToList();
     }
 
+    public async Task<Plan?> FindSuccessorPlanAsync(
+        string tenantId,
+        string predecessorPlanId,
+        CancellationToken cancellationToken) =>
+        await Plans(tenantId)
+            .Find(Builders<Plan>.Filter.And(
+                Builders<Plan>.Filter.Eq(plan => plan.TenantId, tenantId),
+                Builders<Plan>.Filter.Eq(plan => plan.PredecessorPlanId, predecessorPlanId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
     public async Task<bool> TryUpdatePlanAsync(
         string tenantId,
         string planId,

--- a/server/Subscription.DomainService/Requests/CreatePlanRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreatePlanRequest.cs
@@ -9,4 +9,11 @@ public sealed class CreatePlanRequest : PlanDefinitionRequest
     /// case where the tenant sells the same plan to everyone.
     /// </summary>
     public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// The plan this one replaces, for display only. Naming one here does not migrate any
+    /// subscriber and does not affect either plan's editability or purchasability — see
+    /// <see cref="Subscription.DomainService.Entities.Plan.PredecessorPlanId"/>.
+    /// </summary>
+    public string? PredecessorPlanId { get; set; }
 }

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -22,6 +22,25 @@ public sealed class PlanResponse
 
     public int? FamilyRank { get; init; }
 
+    /// <summary>
+    /// The plan this one was created to replace, for display only — naming it never migrated a
+    /// subscriber and never changed either plan's editability or purchasability.
+    /// </summary>
+    public string? PredecessorPlanId { get; init; }
+
+    /// <summary>Resolved alongside <see cref="PredecessorPlanId"/> so a caller can link to it
+    /// without a second lookup. Null when the predecessor is not named, or itself no longer resolves.</summary>
+    public string? PredecessorDisplayName { get; init; }
+
+    /// <summary>
+    /// The plan that named this one as its predecessor, if any — the reverse of
+    /// <see cref="PredecessorPlanId"/>. Resolved only where a single plan is being read; a list
+    /// of plans does not carry it, to avoid one extra lookup per row.
+    /// </summary>
+    public string? SuccessorPlanId { get; init; }
+
+    public string? SuccessorDisplayName { get; init; }
+
     public string UsageInterval { get; init; } = string.Empty;
 
     public int UsageIntervalCount { get; init; }

--- a/server/Subscription.DomainService/Services/IPlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/IPlanResponseMapper.cs
@@ -10,8 +10,21 @@ public interface IPlanResponseMapper
     /// still be edited. Defaulted for the paths that have not asked — a plan just created has no
     /// subscriber by definition.
     /// </param>
+    /// <param name="predecessorDisplayName">
+    /// The resolved name of <see cref="Plan.PredecessorPlanId"/>, so the mapper does not have to
+    /// look it up itself. Null when there is no predecessor, or it no longer resolves.
+    /// </param>
+    /// <param name="successorPlanId">
+    /// The plan that named this one as its predecessor, if the caller resolved one. Left null by
+    /// every path that has not looked (e.g. building a list) — absence here does not mean no
+    /// successor exists, only that nobody checked.
+    /// </param>
+    /// <param name="successorDisplayName">The resolved name of <paramref name="successorPlanId"/>.</param>
     PlanResponse ToResponse(
         Plan plan,
         IReadOnlyList<Price> prices,
-        bool hasSubscribers = false);
+        bool hasSubscribers = false,
+        string? predecessorDisplayName = null,
+        string? successorPlanId = null,
+        string? successorDisplayName = null);
 }

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -82,6 +82,32 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             ? null
             : request.OrganizationId;
 
+        string? predecessorDisplayName = null;
+
+        if (!string.IsNullOrWhiteSpace(request.PredecessorPlanId))
+        {
+            var predecessor = await _catalogue.GetPlanAsync(
+                context.TenantId,
+                request.PredecessorPlanId,
+                cancellationToken);
+
+            // Checked once, here, so a stray or foreign id can never be stored — this is the
+            // only validation the link ever gets. Not found and not visible are reported the
+            // same way, for the same reason a plan lookup is elsewhere in this file: an
+            // organization boundary must not be discoverable through what error comes back.
+            if (predecessor is null || !IsVisibleTo(predecessor, context.OrganizationId))
+            {
+                return SubscriptionOperationResult<PlanResponse>.Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_plan_predecessor_not_found",
+                    "The plan named as a predecessor does not exist, or is not visible here.",
+                    correlationId);
+            }
+
+            plan.PredecessorPlanId = predecessor.ItemId;
+            predecessorDisplayName = predecessor.DisplayName;
+        }
+
         if (!await _catalogue.TryCreatePlanAsync(plan, cancellationToken))
         {
             return SubscriptionOperationResult<PlanResponse>.Failure(
@@ -99,7 +125,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             correlationId);
 
         return SubscriptionOperationResult<PlanResponse>.Success(
-            _mapper.ToResponse(plan, []),
+            _mapper.ToResponse(plan, [], predecessorDisplayName: predecessorDisplayName),
             correlationId);
     }
 
@@ -656,7 +682,14 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
                 plan.ItemId,
                 cancellationToken);
 
-            responses.Add(_mapper.ToResponse(plan, prices, hasSubscribers));
+            var predecessorName = await ResolvePredecessorDisplayNameAsync(
+                context.TenantId, plan.PredecessorPlanId, cancellationToken);
+
+            // The reverse link is deliberately not resolved here: it would mean one extra
+            // lookup per row just to render a list, for a fact each plan's own detail page
+            // already reports.
+            responses.Add(_mapper.ToResponse(
+                plan, prices, hasSubscribers, predecessorDisplayName: predecessorName));
         }
 
         return SubscriptionOperationResult<IReadOnlyList<PlanResponse>>.Success(
@@ -701,9 +734,40 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             plan.ItemId,
             cancellationToken);
 
+        var predecessorName = await ResolvePredecessorDisplayNameAsync(
+            context.TenantId, plan.PredecessorPlanId, cancellationToken);
+
+        var successor = await _catalogue.FindSuccessorPlanAsync(
+            context.TenantId, plan.ItemId, cancellationToken);
+
         return SubscriptionOperationResult<PlanResponse>.Success(
-            _mapper.ToResponse(plan, prices, hasSubscribers),
+            _mapper.ToResponse(
+                plan,
+                prices,
+                hasSubscribers,
+                predecessorDisplayName: predecessorName,
+                successorPlanId: successor?.ItemId,
+                successorDisplayName: successor?.DisplayName),
             correlationId);
+    }
+
+    /// <summary>
+    /// Looks up a predecessor purely for display. No visibility check: the link was already
+    /// validated as visible when it was created, and a predecessor's organization scope cannot
+    /// change afterward, so re-checking here would only ever refuse something that was fine.
+    /// </summary>
+    private async Task<string?> ResolvePredecessorDisplayNameAsync(
+        string tenantId, string? predecessorPlanId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(predecessorPlanId))
+        {
+            return null;
+        }
+
+        var predecessor = await _catalogue.GetPlanAsync(
+            tenantId, predecessorPlanId, cancellationToken);
+
+        return predecessor?.DisplayName;
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -18,7 +18,10 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
     public PlanResponse ToResponse(
         Plan plan,
         IReadOnlyList<Price> prices,
-        bool hasSubscribers = false)
+        bool hasSubscribers = false,
+        string? predecessorDisplayName = null,
+        string? successorPlanId = null,
+        string? successorDisplayName = null)
     {
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(prices);
@@ -34,6 +37,10 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
             Description = plan.Description,
             FamilyCode = plan.FamilyCode,
             FamilyRank = plan.FamilyRank,
+            PredecessorPlanId = plan.PredecessorPlanId,
+            PredecessorDisplayName = predecessorDisplayName,
+            SuccessorPlanId = successorPlanId,
+            SuccessorDisplayName = successorDisplayName,
             UsageInterval = plan.UsageInterval.ToString(),
             UsageIntervalCount = plan.UsageIntervalCount,
             OrganizationId = plan.OrganizationId,

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -956,6 +956,107 @@ public sealed class PlanCatalogueServiceTests
             "the portal has to be able to say why editing is closed before offering it");
     }
 
+    /// <summary>
+    /// Purely a label: naming a predecessor neither migrates anyone nor touches either plan's
+    /// editability or purchasability, so this only checks that the link and its resolved name
+    /// come back — not that anything about the plans themselves changed.
+    /// </summary>
+    [Fact]
+    public async Task A_plan_can_name_a_predecessor_for_display()
+    {
+        var predecessor = StoredPlan();
+        predecessor.ItemId = "plan-0";
+        predecessor.DisplayName = "Legacy professional";
+        StorePlan(predecessor);
+
+        var request = NewPlan();
+        request.PredecessorPlanId = "plan-0";
+
+        var result = await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.PredecessorPlanId.Should().Be("plan-0");
+        result.Value!.PredecessorDisplayName.Should().Be("Legacy professional",
+            "the caller should not need a second lookup to render a link");
+    }
+
+    [Fact]
+    public async Task A_predecessor_that_does_not_exist_is_refused()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, "missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Plan?)null);
+
+        var request = NewPlan();
+        request.PredecessorPlanId = "missing";
+
+        var result = await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_plan_predecessor_not_found");
+        _catalogue.Verify(
+            repository => repository.TryCreatePlanAsync(It.IsAny<Plan>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a stray or foreign id must never be stored, even as a label");
+    }
+
+    [Fact]
+    public async Task A_predecessor_scoped_to_another_organization_is_refused()
+    {
+        var predecessor = StoredPlan();
+        predecessor.ItemId = "plan-9";
+        predecessor.OrganizationId = "org-9";
+        StorePlan(predecessor);
+
+        var request = NewPlan();
+        request.PredecessorPlanId = "plan-9";
+
+        var result = await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_plan_predecessor_not_found",
+            "not found and not visible are reported the same way, so an organization boundary " +
+            "cannot be discovered through what error comes back");
+    }
+
+    [Fact]
+    public async Task A_plan_reports_the_successor_that_named_it_as_a_predecessor()
+    {
+        var stored = StoredPlan();
+        StorePlan(stored);
+
+        var successor = StoredPlan();
+        successor.ItemId = "plan-2";
+        successor.DisplayName = "Professional (2026)";
+        successor.PredecessorPlanId = stored.ItemId;
+
+        _catalogue
+            .Setup(repository => repository.FindSuccessorPlanAsync(
+                TenantId, stored.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(successor);
+
+        var result = await Service().GetPlanAsync(stored.ItemId, null, "corr-1", CancellationToken.None);
+
+        result.Value!.SuccessorPlanId.Should().Be("plan-2");
+        result.Value.SuccessorDisplayName.Should().Be("Professional (2026)");
+    }
+
+    [Fact]
+    public async Task A_plan_with_no_successor_reports_none()
+    {
+        StorePlan(StoredPlan());
+        _catalogue
+            .Setup(repository => repository.FindSuccessorPlanAsync(
+                TenantId, "plan-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Plan?)null);
+
+        var result = await Service().GetPlanAsync("plan-1", null, "corr-1", CancellationToken.None);
+
+        result.Value!.SuccessorPlanId.Should().BeNull();
+        result.Value.SuccessorDisplayName.Should().BeNull();
+    }
+
     [Fact]
     public async Task Archiving_a_price_takes_it_off_the_menu()
     {


### PR DESCRIPTION
Replaces #330, retargeted to `dev` — same commit, cherry-picked cleanly onto current `dev` (one auto-merge in README.md, no conflicts).

## What

A plan cannot be edited in place once it has a subscriber — the catalogue document is also the historical record every past invoice was computed from ([README.md](server/Subscription.DomainService/README.md), "Editing a plan ends when the first subscriber arrives"). The sanctioned path for changing sold terms is `ChangePlanAsync`: create a new plan, migrate subscribers.

What was missing was any visible link between the old plan and its replacement. This adds one — purely a display label, never read by anything that sells, prices, or migrates a subscriber.

## Changes

**Server**
- `Plan.PredecessorPlanId` — set once at creation, validated to exist and be visible to the caller (`subscription_plan_predecessor_not_found` otherwise), never touched afterward.
- `CreatePlanAsync` resolves and stores it; `GetPlanAsync`/`ListPlansAsync` resolve the predecessor's display name so a caller can link without a second fetch.
- `GetPlanAsync` also resolves the reverse — the plan, if any, that named *this* one as predecessor — via `FindSuccessorPlanAsync`, a tenant-scoped scan (no new index, same scale assumption `ListPlansAsync` already makes for its own full scan).
- `PlanResponse` gains `PredecessorPlanId`/`PredecessorDisplayName`/`SuccessorPlanId`/`SuccessorDisplayName`.

**Client**
- Duplicating a plan now offers a checked-by-default "This plan replaces '{name}'" checkbox rather than assuming it — a duplicate can just as easily be a fresh plan started from a template.
- The plan detail page shows "Replaces X →" / "Replaced by Y →" links in both directions when set.

**Explicitly unchanged:** `hasSubscribers`, plan editability, plan purchasability, `ChangePlanAsync`. No schema/identity redefinition of `Plan.Code` or `PlanId` — a fuller "plan versioning" design was considered and rejected because it would require redefining `Code` from "one live plan" to "a family of plans," touching every `Code`-scoped lookup (`ChangePlanAsync`'s `FindPlanByCodeAsync`, discount/promo scoping) for a payoff that's mostly ergonomic.

## Testing

- Server: `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName!~Integration"` — 0 regressions against `dev`'s own baseline. 6 new tests in `PlanCatalogueServiceTests.cs`, re-run clean on this branch.
- Client: `type-check` and the touched test file re-run clean on this branch; full subscription-module suite (356 tests) was green on the equivalent `main`-based branch before the retarget.
- `eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)