### PR TITLE
fix(subscription): move predecessorPlanId to the request type that's actually sent

### DIFF
--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -311,6 +311,8 @@ export interface CreateSubscriptionPlanRequest {
   usageIntervalCount: number;
   familyCode?: string;
   familyRank?: number;
+  /** The plan this one replaces, for display only — see {@link SubscriptionPlan.predecessorPlanId}. */
+  predecessorPlanId?: string;
   quantityItems: CreatePlanQuantityItemRequest[];
   meters: CreatePlanMeterRequest[];
   entitlements: CreatePlanEntitlementRequest[];
@@ -346,8 +348,6 @@ export interface UpdateSubscriptionPlanRequest {
   usageIntervalCount: number;
   familyCode?: string;
   familyRank?: number;
-  /** The plan this one replaces, for display only — see {@link SubscriptionPlan.predecessorPlanId}. */
-  predecessorPlanId?: string;
   quantityItems: CreatePlanQuantityItemRequest[];
   meters: CreatePlanMeterRequest[];
   entitlements: CreatePlanEntitlementRequest[];


### PR DESCRIPTION
Fixes the build break from #331.

`CreateSubscriptionPlanRequest` and `UpdateSubscriptionPlanRequest` have near-identical bodies (same trailing fields, same `CreateSubscriptionPriceRequest` interface immediately after — but only after `UpdateSubscriptionPlanRequest`). My earlier edit's trailing-context anchor matched that shared tail and landed on the wrong one: `predecessorPlanId` went onto `UpdateSubscriptionPlanRequest`, which nothing ever populates it through. `create-subscription-plan-page.tsx` writes to `CreateSubscriptionPlanRequest`, which didn't have the field — hence:

```
error TS2339: Property 'predecessorPlanId' does not exist on type 'CreateSubscriptionPlanRequest'.
```

Moved the field to the correct interface. `predecessorPlanId` was already correctly excluded from `UpdateSubscriptionPlanRequest` per the plan (it's create-only, immutable, same as `Code`) — this just fixes which interface actually declares it.

## Verified

- `npm run type-check` — clean
- `npm run build` (the exact command CI runs) — succeeds
- `npx vitest run app/cross-modules/utilities/subscription` — 388/388 passed (one transient timeout on a re-run under full concurrent load was not reproducible in isolation or on a clean re-run — not caused by this change)

**Note on the same bug already merged to `main`:** #330 (merged to `main` before the dev-first correction) carries the identical mistake, so `main`'s build is currently broken too. Following up with a separate fix PR to `main` for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)