### PR TITLE
fix(subscription): move predecessorPlanId to the request type that's actually sent

### DIFF
--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -311,6 +311,8 @@ export interface CreateSubscriptionPlanRequest {
   usageIntervalCount: number;
   familyCode?: string;
   familyRank?: number;
+  /** The plan this one replaces, for display only — see {@link SubscriptionPlan.predecessorPlanId}. */
+  predecessorPlanId?: string;
   quantityItems: CreatePlanQuantityItemRequest[];
   meters: CreatePlanMeterRequest[];
   entitlements: CreatePlanEntitlementRequest[];
@@ -346,8 +348,6 @@ export interface UpdateSubscriptionPlanRequest {
   usageIntervalCount: number;
   familyCode?: string;
   familyRank?: number;
-  /** The plan this one replaces, for display only — see {@link SubscriptionPlan.predecessorPlanId}. */
-  predecessorPlanId?: string;
   quantityItems: CreatePlanQuantityItemRequest[];
   meters: CreatePlanMeterRequest[];
   entitlements: CreatePlanEntitlementRequest[];


### PR DESCRIPTION
Fixes the same client build break as #332, but on `main` — #330 merged this identical mistake before the correction that plan-history work should target `dev` first arrived, so `main`'s build is currently broken independent of that process question.

`CreateSubscriptionPlanRequest` and `UpdateSubscriptionPlanRequest` have near-identical bodies. My earlier edit's trailing-context anchor matched the tail shared by both and landed on the wrong one — `predecessorPlanId` went onto `UpdateSubscriptionPlanRequest`, which nothing populates it through. `create-subscription-plan-page.tsx` writes to `CreateSubscriptionPlanRequest`, which didn't have the field:

```
error TS2339: Property 'predecessorPlanId' does not exist on type 'CreateSubscriptionPlanRequest'.
```

Moved the field to the correct interface — the only change in this PR.

## Verified

- `npm run build` (the exact command CI runs) — succeeds on this branch
- Identical fix already merged to `dev` via #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)