### PR TITLE
Move payment-method-upfront setting out of the Trial step

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -51,6 +51,10 @@ export const StepPricingModel = ({
 }) => {
   const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
 
+  const requirePaymentMethodUpfront = useWatch({
+    control,
+    name: "requirePaymentMethodUpfront",
+  });
   const quantityItems = useFieldArray({ control, name: "quantityItems" });
   const meters = useFieldArray({ control, name: "meters" });
   // Watched, not read from useFieldArray's snapshot, which only refreshes when the list
@@ -474,6 +478,36 @@ export const StepPricingModel = ({
         onUpdatePriceDiscount={onUpdatePriceDiscount}
         retiringPriceId={retiringPriceId}
       />
+
+      {/*
+        Governs activation, not any one price shape — including a plan with no trial and nothing
+        due today. It sits after the prices it applies to rather than beside the trial's own
+        card question, since a card requirement at signup is a billing decision, not a trial one.
+      */}
+      <div className="space-y-3 rounded-md border p-4">
+        <h3 className="text-sm font-semibold">Payment method</h3>
+        <FormField
+          control={control}
+          name="requirePaymentMethodUpfront"
+          render={({ field }) => (
+            <FormItem>
+              <div className="flex items-center gap-2">
+                <FormControl>
+                  <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                </FormControl>
+                <FormLabel className="!m-0">
+                  Require a payment method before activation, even when nothing is due today
+                </FormLabel>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {requirePaymentMethodUpfront
+                  ? "The subscriber is sent to a card form that charges nothing. Nothing is granted until the card is stored, so the next period has something to bill."
+                  : "A plan that costs nothing today starts straight away. Nothing has a card on file until the first charge, which is a problem only if there will be a later one."}
+              </p>
+            </FormItem>
+          )}
+        />
+      </div>
     </div>
   );
 };

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -52,10 +52,6 @@ export const StepTrial = () => {
     control,
     name: "trialRequiresPaymentMethod",
   });
-  const requirePaymentMethodUpfront = useWatch({
-    control,
-    name: "requirePaymentMethodUpfront",
-  });
   const meters = useWatch({ control, name: "meters" });
 
   return (
@@ -152,36 +148,6 @@ export const StepTrial = () => {
                 {trialRequiresPaymentMethod
                   ? "The first period is charged at signup — the payment path cannot hold a card without charging it. The trial then only governs the allowances below."
                   : "Genuinely free until the trial ends, when the first charge is taken. Your product must collect a card before then, or that charge has nothing to bill."}
-              </p>
-            </FormItem>
-          )}
-        />
-      </div>
-
-      {/*
-        Not a trial setting, but the same question — when is a card collected — so it belongs
-        beside the one above rather than a step away from it. It applies to a plan with no trial
-        at all, which is why it sits outside the block that appears only when there is one.
-      */}
-      <div className="space-y-3 rounded-md border p-4">
-        <h3 className="text-sm font-semibold">Payment method</h3>
-        <FormField
-          control={control}
-          name="requirePaymentMethodUpfront"
-          render={({ field }) => (
-            <FormItem>
-              <div className="flex items-center gap-2">
-                <FormControl>
-                  <Checkbox checked={field.value} onCheckedChange={field.onChange} />
-                </FormControl>
-                <FormLabel className="!m-0">
-                  Require a payment method before activation, even when nothing is due today
-                </FormLabel>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {requirePaymentMethodUpfront
-                  ? "The subscriber is sent to a card form that charges nothing. Nothing is granted until the card is stored, so the next period has something to bill."
-                  : "A plan that costs nothing today starts straight away. Nothing has a card on file until the first charge, which is a problem only if there will be a later one."}
               </p>
             </FormItem>
           )}


### PR DESCRIPTION
## Summary
- `requirePaymentMethodUpfront` governs whether a payment method is required before activation — this applies to any plan, including one with no trial and nothing due today. It was living inside `StepTrial`, right next to the trial-specific `trialRequiresPaymentMethod` checkbox, which reads as two redundant "require a card" controls stacked together.
- Relocated it to `StepPricingModel`, placed after the price fields it actually governs, since it's an activation/billing decision rather than a trial one. `trialRequiresPaymentMethod` stays in the Trial step, since that one only applies when a trial is configured.

## Test plan
- [x] `npm run type-check` passes with no errors
- [ ] Manually walk the plan-builder wizard (Pricing model step shows the "Payment method" card; Trial step no longer does) — not run in this session, worth a quick look before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)