### PR TITLE
Add server-owned metered overage preview endpoint

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
@@ -2,6 +2,8 @@ export const SUBSCRIPTIONS_ENDPOINT = "/api/subscriptions";
 export const SUBSCRIPTIONS_CURRENT_ENDPOINT = "/api/subscriptions/current";
 export const ENTITLEMENTS_ENDPOINT = "/api/entitlements";
 export const SUBSCRIPTION_USAGE_ENDPOINT = "/api/subscription-usage";
+export const SUBSCRIPTION_USAGE_OVERAGE_PREVIEW_ENDPOINT =
+  "/api/subscription-usage/overage/preview";
 
 /**
  * The test-harness controller, distinct from the integrator-facing API above: it forces payment

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-preview-usage-overage.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-preview-usage-overage.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+import type { PreviewUsageOverageRequest } from "../models/subscription-simulation.model";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/**
+ * What additional metered usage would cost. Writes nothing, so it invalidates nothing — the
+ * server computes every price; this hook only carries the request and hands back the response.
+ */
+export const usePreviewUsageOverage = () =>
+  useMutation({
+    mutationFn: (request: PreviewUsageOverageRequest) =>
+      subscriptionSimulationService.previewUsageOverage(request),
+  });

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -359,3 +359,81 @@ export interface RecordUsageResult {
   overage: number;
   replayed: boolean;
 }
+
+/**
+ * A hypothetical slice of additional metered usage to price. Writes nothing and charges nothing —
+ * see {@link UsageOveragePreviewResult}.
+ */
+export interface PreviewUsageOverageRequest {
+  meterKey: string;
+  /** Cannot be zero or negative — a preview of no additional usage answers nothing. */
+  additionalQuantity: number;
+  /** Honoured only for this portal acting as the platform console; see SubscribeToPlanRequest. */
+  organizationId?: string;
+}
+
+/** One charge, split the way an invoice line would be. All amounts are minor units. */
+export interface UsageChargeAmounts {
+  grossMinor: number;
+  automaticDiscountMinor: number;
+  netMinor: number;
+  taxMinor: number;
+  totalMinor: number;
+}
+
+/** One graduated tier band's slice of the additional usage. */
+export interface UsageOverageTierAllocation {
+  /**
+   * The first overage unit this band covers, counted from the first overage unit of the whole
+   * period — not from wherever the additional usage itself begins.
+   */
+  fromOverageQuantity: number;
+  toOverageQuantity: number;
+  units: number;
+  unitAmountMinor: number;
+  amountMinor: number;
+}
+
+export interface UsageOveragePreviewDiscount {
+  automaticBasisPoints: number;
+  /** Always false — a promotional discount code never reduces metered overage. */
+  promotionalCodeApplied: boolean;
+}
+
+export interface UsageOveragePreviewTax {
+  rateBasisPoints: number | null;
+  mode: string;
+}
+
+/**
+ * What a hypothetical slice of additional metered usage would cost, rated with the subscription's
+ * own snapshotted terms and the same order of operations period-end usage rating uses — but
+ * nothing here is recorded and nothing here is charged. Server-computed throughout; nothing here
+ * should be recalculated in the browser.
+ */
+export interface UsageOveragePreviewResult {
+  meterKey: string;
+  unitLabel: string;
+  currencyCode: string;
+  periodKey: string;
+  periodStartUtc: string;
+  periodEndUtc: string;
+  /** When this preview was computed. Usage recorded afterward can change the eventual invoice. */
+  calculatedAtUtc: string;
+  includedQuantity: number;
+  currentUsage: number;
+  currentOverage: number;
+  additionalQuantity: number;
+  projectedUsage: number;
+  projectedOverage: number;
+  currentCharge: UsageChargeAmounts;
+  /** The difference between the projected and current charges — never rated on its own. */
+  additionalCharge: UsageChargeAmounts;
+  projectedPeriodCharge: UsageChargeAmounts;
+  additionalTierBreakdown: UsageOverageTierAllocation[];
+  discount: UsageOveragePreviewDiscount;
+  tax: UsageOveragePreviewTax;
+  writesUsage: boolean;
+  chargesPayment: boolean;
+  finalChargeDependsOnActualPeriodEndUsage: boolean;
+}

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -4,6 +4,7 @@ import {
   AUDIT_TRAIL_DEFAULT_LIMIT,
   ENTITLEMENTS_ENDPOINT,
   SUBSCRIPTION_USAGE_ENDPOINT,
+  SUBSCRIPTION_USAGE_OVERAGE_PREVIEW_ENDPOINT,
   SUBSCRIPTIONS_CURRENT_ENDPOINT,
   SUBSCRIPTIONS_ENDPOINT,
 } from "../constants/subscription-simulation.constants";
@@ -15,6 +16,7 @@ import type {
   QuantityChangeQuote,
   EntitlementDecision,
   EntitlementsSnapshot,
+  PreviewUsageOverageRequest,
   RecordUsageRequest,
   RecordUsageResult,
   SimulatedSubscription,
@@ -22,6 +24,7 @@ import type {
   SubscriptionAuditEvent,
   SubscriptionPlanChangePreview,
   SubscriptionPurchasePreview,
+  UsageOveragePreviewResult,
 } from "../models/subscription-simulation.model";
 
 interface SimulationApiError {
@@ -427,6 +430,28 @@ class SubscriptionSimulationService {
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "The usage could not be recorded.");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * Estimates the cost of additional metered usage against the caller's current subscription.
+   * Advisory only: the server neither records the usage nor charges anything, and every price in
+   * the response is server-computed — this is a thin fetch wrapper, not a place to recalculate.
+   */
+  async previewUsageOverage(
+    request: PreviewUsageOverageRequest,
+  ): Promise<UsageOveragePreviewResult> {
+    const response = await serviceInstances.utitlitiesService.post<
+      SimulationApiResponse<UsageOveragePreviewResult>
+    >(SUBSCRIPTION_USAGE_OVERAGE_PREVIEW_ENDPOINT, request);
+
+    if (!response.success || !response.data) {
+      throw new SubscriptionOperationError(
+        response.error?.message || "The overage could not be previewed.",
+        response.error?.code ?? "unknown",
+      );
     }
 
     return response.data;

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -914,6 +914,17 @@
             must not exceed its allowance should set <c>enforce</c> and act on <c>allowed</c>.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionUsageController.PreviewOverage(Subscription.DomainService.Requests.PreviewUsageOverageRequest,System.Threading.CancellationToken)">
+            <summary>
+            Estimates the cost of additional metered usage, using the active subscription's own
+            snapshotted terms and the same rating, discount and tax logic as the final usage invoice.
+            </summary>
+            <remarks>
+            Advisory only: nothing here is recorded against the usage ledger and nothing here is
+            charged. Usage recorded after <c>calculatedAtUtc</c> can change the eventual invoice — see
+            <c>finalChargeDependsOnActualPeriodEndUsage</c> on the response.
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.TemplateEngineController">
             <summary>
             API Controller for managing template engine operations

--- a/server/Api/Controllers/SubscriptionUsageController.cs
+++ b/server/Api/Controllers/SubscriptionUsageController.cs
@@ -18,8 +18,15 @@ namespace Api.Controllers;
 public sealed class SubscriptionUsageController : ControllerBase
 {
     private readonly IUsageRecordingService _usage;
+    private readonly ISubscriptionUsageOveragePreviewService _overagePreview;
 
-    public SubscriptionUsageController(IUsageRecordingService usage) => _usage = usage;
+    public SubscriptionUsageController(
+        IUsageRecordingService usage,
+        ISubscriptionUsageOveragePreviewService overagePreview)
+    {
+        _usage = usage;
+        _overagePreview = overagePreview;
+    }
 
     /// <summary>
     /// Records usage and reports where that leaves the allowance.
@@ -59,6 +66,39 @@ public sealed class SubscriptionUsageController : ControllerBase
             organizationId,
             correlationId,
             cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Estimates the cost of additional metered usage, using the active subscription's own
+    /// snapshotted terms and the same rating, discount and tax logic as the final usage invoice.
+    /// </summary>
+    /// <remarks>
+    /// Advisory only: nothing here is recorded against the usage ledger and nothing here is
+    /// charged. Usage recorded after <c>calculatedAtUtc</c> can change the eventual invoice — see
+    /// <c>finalChargeDependsOnActualPeriodEndUsage</c> on the response.
+    /// </remarks>
+    [HttpPost("overage/preview")]
+    [ProducesResponseType(
+        typeof(ApiResponse<SubscriptionUsageOveragePreviewResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(
+        typeof(ApiResponse<SubscriptionUsageOveragePreviewResponse>), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(
+        typeof(ApiResponse<SubscriptionUsageOveragePreviewResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(
+        typeof(ApiResponse<SubscriptionUsageOveragePreviewResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(
+        typeof(ApiResponse<SubscriptionUsageOveragePreviewResponse>),
+        StatusCodes.Status503ServiceUnavailable)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> PreviewOverage(
+        [FromBody] PreviewUsageOverageRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _overagePreview.PreviewAsync(request, correlationId, cancellationToken);
 
         return result.ToActionResult(correlationId);
     }

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2885,6 +2885,70 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         </div>
       </div>
 
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscription-usage/overage/preview</span></div>
+        <div class="endpoint-body">
+          <p>Estimates what a hypothetical slice of additional metered usage would cost, using the active subscription's own snapshotted terms and the same rating, discount and tax logic period-end usage rating uses to charge the final invoice. Subscription resolution and the platform console's organization override follow the same rule <code>GET /subscription-usage/current</code> already applies.</p>
+          <div class="callout">
+            <strong>Advisory and read-only.</strong> Nothing here is recorded against the usage ledger and nothing here is charged — <code>writesUsage</code> and <code>chargesPayment</code> are always <code>false</code>. <code>finalChargeDependsOnActualPeriodEndUsage</code> is always <code>true</code>: usage recorded after <code>calculatedAtUtc</code> can still change what period-end rating eventually charges.
+          </div>
+          <h4>Body</h4>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Field</th><th>Type</th><th>Meaning</th></tr></thead>
+              <tbody>
+                <tr><td>organizationId</td><td class="type">string?</td><td class="prose">Platform console only — omit to use the caller's own organization.</td></tr>
+                <tr><td>meterKey</td><td class="type">string</td><td class="prose">Required.</td></tr>
+                <tr><td>additionalQuantity</td><td class="type">long</td><td class="prose">How much more usage to price, on top of what has already been recorded this period. Must be positive.</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <h4>Sample response</h4>
+          <pre><code>{
+  "success": true,
+  "data": {
+    "meterKey": "screening",
+    "unitLabel": "screenings",
+    "currencyCode": "CHF",
+    "periodKey": "M20260801T000000Z",
+    "periodStartUtc": "2026-08-01T00:00:00Z",
+    "periodEndUtc": "2026-09-01T00:00:00Z",
+    "calculatedAtUtc": "2026-08-25T10:00:00Z",
+    "includedQuantity": 150,
+    "currentUsage": 170,
+    "currentOverage": 20,
+    "additionalQuantity": 100,
+    "projectedUsage": 270,
+    "projectedOverage": 120,
+    "currentCharge": { "grossMinor": 2000, "automaticDiscountMinor": 0, "netMinor": 2000, "taxMinor": 154, "totalMinor": 2154 },
+    "additionalCharge": { "grossMinor": 10000, "automaticDiscountMinor": 0, "netMinor": 10000, "taxMinor": 770, "totalMinor": 10770 },
+    "projectedPeriodCharge": { "grossMinor": 12000, "automaticDiscountMinor": 0, "netMinor": 12000, "taxMinor": 924, "totalMinor": 12924 },
+    "additionalTierBreakdown": [
+      { "fromOverageQuantity": 21, "toOverageQuantity": 120, "units": 100, "unitAmountMinor": 100, "amountMinor": 10000 }
+    ],
+    "discount": { "automaticBasisPoints": 0, "promotionalCodeApplied": false },
+    "tax": { "rateBasisPoints": 770, "mode": "Exclusive" },
+    "writesUsage": false,
+    "chargesPayment": false,
+    "finalChargeDependsOnActualPeriodEndUsage": true
+  },
+  "error": null,
+  "meta": { "correlationId": "0HN…", "timestampUtc": "…", "replayed": false }
+}</code></pre>
+          <p class="prose">
+            <code>includedQuantity</code> is the <em>effective</em> allowance for this window — a trial grant or a carried-forward allowance included, resolved the same way enforcement and the entitlement read resolve it, never the plan's bare included quantity on its own.
+          </p>
+          <p class="prose">
+            <code>currentCharge</code> and <code>projectedPeriodCharge</code> are rated across <strong>every</strong> billable meter on the subscription, not only the one named in the request — the same aggregate a period-end invoice totals before its automatic discount and tax are applied once, across the whole invoice. <code>additionalCharge</code> is the difference of those two fully-discounted, fully-taxed aggregate totals, never rated on its own: a tier boundary the additional units cross, a rounding step at the discount or tax boundary, or overage already carried by another meter can each price the same units differently depending on what else the invoice already owes. <code>additionalTierBreakdown</code> stays scoped to the requested meter — it names which graduated tier bands the additional units fell into, for display only; it is not the source of truth for the charge, which is <code>additionalCharge</code>.
+          </p>
+          <p class="prose">
+            <strong>Promotional discounts do not apply here, on purpose.</strong> Metered overage has never been discountable by a promotional code — only the price's own automatic discount reaches it, exactly as in period-end rating — and <code>discount.promotionalCodeApplied</code> is always <code>false</code> rather than leaving a client to wonder whether a code was simply overlooked.
+          </p>
+          <h4>Returns</h4>
+          <p><code>200</code> · <code>400</code> <code>subscription_usage_preview_invalid</code> — missing <code>meterKey</code>, a non-positive <code>additionalQuantity</code>, or a projection outside the range this preview can compute · <code>404</code> <code>subscription_not_found</code>, <code>subscription_meter_not_found</code> · <code>409</code> <code>subscription_meter_overage_not_allowed</code>, <code>subscription_meter_rate_unavailable</code> · <code>503</code> <code>subscription_schedule_unavailable</code>.</p>
+        </div>
+      </div>
+
       <h3 id="api-ent">Entitlements</h3>
 
       <div class="endpoint">
@@ -3023,6 +3087,10 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <tr><td>subscription_document_resend_conflict</td><td class="prose">The document&#39;s delivery could not be reopened. Read it again and retry.</td></tr>
             <tr><td>subscription_document_pdf_unavailable</td><td class="prose">The stored PDF could not be fetched. An infrastructure problem, not a missing document.</td></tr>
             <tr><td>subscription_organization_missing</td><td class="prose">The caller's organization could not be resolved.</td></tr>
+            <tr><td>subscription_usage_preview_invalid</td><td class="prose">The overage preview request is missing <code>meterKey</code>, has a non-positive <code>additionalQuantity</code>, or the requested projection overflows the range this preview can compute.</td></tr>
+            <tr><td>subscription_meter_overage_not_allowed</td><td class="prose">The overage preview named a meter that does not allow usage beyond its included quantity.</td></tr>
+            <tr><td>subscription_meter_rate_unavailable</td><td class="prose">The overage preview named a meter with no rate table for the subscription's currency — a plan-authoring gap, reported rather than quoted as a silent zero.</td></tr>
+            <tr><td>subscription_schedule_unavailable</td><td class="prose">The overage preview could not place "now" in a usage period — the schedule's time zone may no longer be valid.</td></tr>
           </tbody>
         </table>
       </div>

--- a/server/Subscription.DomainService/Entities/PendingUsagePeriod.cs
+++ b/server/Subscription.DomainService/Entities/PendingUsagePeriod.cs
@@ -15,4 +15,19 @@ public sealed class PendingUsagePeriod
     public PriceSnapshot Price { get; set; } = new();
     public string CurrencyCode { get; set; } = string.Empty;
     public string CorrelationId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Each resetting meter's effective allowance, frozen via
+    /// <see cref="Services.IMeterAllowanceResolver.EffectiveAsync"/> against the subscription's
+    /// state at the moment this period was captured — before the status/schedule transition
+    /// (cancellation or plan change) that cut it short took effect. Keyed by
+    /// <see cref="PlanMeter.MeterKey"/>.
+    /// </summary>
+    /// <remarks>
+    /// Nullable for backward compatibility: a document queued before this field existed carries
+    /// no snapshot, and final rating falls back to resolving the allowance live against the
+    /// subscription's current (post-transition) state for those legacy documents — the same
+    /// behavior this type had before the snapshot was added.
+    /// </remarks>
+    public Dictionary<string, long>? MeterAllowances { get; set; }
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionCancellationEffectiveProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionCancellationEffectiveProcessor.cs
@@ -27,6 +27,8 @@ public sealed class SubscriptionCancellationEffectiveProcessor : ISubscriptionCa
     private readonly ILogger<SubscriptionCancellationEffectiveProcessor> _logger;
     private readonly TimeProvider _time;
     private readonly IUsagePeriodClosureRepository? _closures;
+    private readonly ISubscriptionUsageRepository? _usage;
+    private readonly IMeterAllowanceResolver? _allowances;
 
     public SubscriptionCancellationEffectiveProcessor(
         ISubscriptionRepository subscriptions,
@@ -35,7 +37,9 @@ public sealed class SubscriptionCancellationEffectiveProcessor : ISubscriptionCa
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<SubscriptionCancellationEffectiveProcessor> logger,
         TimeProvider? time = null,
-        IUsagePeriodClosureRepository? closures = null)
+        IUsagePeriodClosureRepository? closures = null,
+        ISubscriptionUsageRepository? usage = null,
+        IMeterAllowanceResolver? allowances = null)
     {
         _subscriptions = subscriptions;
         _events = events;
@@ -44,6 +48,8 @@ public sealed class SubscriptionCancellationEffectiveProcessor : ISubscriptionCa
         _logger = logger;
         _time = time ?? TimeProvider.System;
         _closures = closures;
+        _usage = usage;
+        _allowances = allowances;
     }
 
     public async Task<int> ProcessDueAsync(
@@ -151,7 +157,8 @@ public sealed class SubscriptionCancellationEffectiveProcessor : ISubscriptionCa
                 // one out of that set. Queuing it here, atomically with the status change, is
                 // what a plan change does with its own outgoing window — captured in the same
                 // compare-and-set that would otherwise let it be forgotten.
-                OutgoingUsagePeriod = OutgoingUsagePeriodOf(subscription, effectiveAtUtc),
+                OutgoingUsagePeriod = await OutgoingUsagePeriodOfAsync(
+                    subscription, effectiveAtUtc, cancellationToken),
                 Event = _events.Create(
                     subscription,
                     SubscriptionConstants.SubscriptionCanceled,
@@ -215,18 +222,35 @@ public sealed class SubscriptionCancellationEffectiveProcessor : ISubscriptionCa
     /// entitlement stopped there, and an invoice that priced usage through the later, uncut end
     /// would be claiming to cover service the subscriber never actually had.
     /// </remarks>
-    private static PendingUsagePeriod OutgoingUsagePeriodOf(
+    private async Task<PendingUsagePeriod> OutgoingUsagePeriodOfAsync(
         SubscriptionDetail subscription,
-        DateTime effectiveAtUtc) => new()
+        DateTime effectiveAtUtc,
+        CancellationToken cancellationToken)
     {
-        PeriodKey = PeriodKey.Create(
+        var periodKey = PeriodKey.Create(
             subscription.UsageSchedule.Interval,
-            subscription.CurrentUsagePeriodStartUtc),
-        PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
-        PeriodEndUtc = effectiveAtUtc,
-        Plan = subscription.Plan,
-        Price = subscription.Price,
-        CurrencyCode = subscription.CurrencyCode,
-        CorrelationId = subscription.CorrelationId
-    };
+            subscription.CurrentUsagePeriodStartUtc);
+
+        return new PendingUsagePeriod
+        {
+            PeriodKey = periodKey,
+            PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
+            PeriodEndUtc = effectiveAtUtc,
+            Plan = subscription.Plan,
+            Price = subscription.Price,
+            CurrencyCode = subscription.CurrencyCode,
+            CorrelationId = subscription.CorrelationId,
+            // Snapshotted here, before the status transition below installs Canceled — the
+            // subscription's trial and schedule are still the ones this window actually opened
+            // under. Null when the resolver/repository were not supplied (older call sites,
+            // tests); final rating falls back to resolving live for those, same as before this
+            // snapshot existed.
+            MeterAllowances = await MeterAllowanceSnapshot.CaptureAsync(
+                subscription,
+                new BillingPeriod(0, subscription.CurrentUsagePeriodStartUtc, effectiveAtUtc, periodKey),
+                _usage,
+                _allowances,
+                cancellationToken)
+        };
+    }
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -381,32 +381,11 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
 
         var overage = lines.Sum(line => line.AmountMinor);
 
-        // The price's automatic discount applies to what the price charges, and overage is one of
-        // the things it charges: a subscriber on an 8%-off yearly price is 8% off on this invoice
-        // too. On the aggregate, for the same reason tax is.
-        //
-        // Through the shared calculator with no band, rather than a percentage worked out here.
-        // A volume band prices seats and has no meaning for metered units, so the band is empty —
-        // and with no band both combination policies agree, which is why this needs no branch.
-        var builtIn = BuiltInDiscountCalculator.Resolve(
-            overage,
-            new QuantityDiscountOutcome(null, 0, overage, 0, overage),
-            subscription.Price.AutomaticDiscountBasisPoints,
-            subscription.Price.QuantityDiscountCombination);
+        // Discount and tax, through the calculator shared with the metered overage preview —
+        // see UsageChargeCalculator's own remarks for why the two must never drift apart.
+        var charge = UsageChargeCalculator.Charge(overage, subscription.Price);
 
-        // Tax is on the aggregate, not per meter — the same "one charge, not one per meter"
-        // scope this invoice already keeps for the charge itself, and the reason a meter that
-        // overages by half a cent cannot cost the subscriber a full one.
-        //
-        // The rate and mode are the subscription's snapshotted price, so overage is taxed the way
-        // the thing it is overage *on* was sold. After the discount, never before: tax is owed on
-        // what is actually charged.
-        var breakdown = SubscriptionAmountCalculator.TaxBreakdownFor(
-            builtIn.SubtotalMinor,
-            subscription.Price.TaxRateBasisPoints,
-            subscription.Price.TaxMode);
-
-        var total = breakdown.TotalAmountMinor;
+        var total = charge.TotalMinor;
         var now = _time.GetUtcNow().UtcDateTime;
 
         await _usageInvoices.TryCreateAsync(
@@ -418,13 +397,13 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 PeriodKey = periodKey,
                 CurrencyCode = subscription.CurrencyCode,
                 TotalAmountMinor = total,
-                NetAmountMinor = breakdown.NetAmountMinor,
-                TaxAmountMinor = breakdown.TaxAmountMinor,
+                NetAmountMinor = charge.NetMinor,
+                TaxAmountMinor = charge.TaxMinor,
                 TaxRateBasisPoints = subscription.Price.TaxRateBasisPoints,
                 TaxMode = subscription.Price.TaxMode,
                 AutomaticDiscountBasisPoints =
                     SubscriptionDiscountPresentation.RateOf(subscription.Price),
-                DiscountAmountMinor = builtIn.DiscountAmountMinor,
+                DiscountAmountMinor = charge.AutomaticDiscountMinor,
                 Lines = lines,
                 State = total > 0
                     ? SubscriptionUsageInvoiceState.Pending

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -214,11 +214,14 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 Price = pending.Price,
                 CurrencyCode = pending.CurrencyCode,
                 CorrelationId = pending.CorrelationId,
-                // Best-effort context for IMeterAllowanceResolver — a trial grant or a
-                // carry-forward window with a counter already resolves from the counter's own
-                // frozen LimitSnapshot regardless of these; only a carry-forward meter that
-                // recorded zero usage in this cut-short window would need the schedule that was
-                // in force *before* the change, which this snapshot does not carry.
+                // Best-effort context for IMeterAllowanceResolver, used only as a fallback: the
+                // window's own counter (its frozen LimitSnapshot) resolves correctly regardless
+                // of these, and pending.MeterAllowances — captured before the cancellation or
+                // plan-change transition that cut this window short — takes priority over a live
+                // resolve for the crash window where no counter was ever written. These
+                // current-not-original Status/Trial/UsageSchedule values are only reached for a
+                // legacy PendingUsagePeriod queued before that snapshot existed, or if a meter
+                // is somehow missing from the snapshot.
                 Status = subscription.Status,
                 Trial = subscription.Trial,
                 UsageSchedule = subscription.UsageSchedule
@@ -226,7 +229,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             var pendingPeriod = new BillingPeriod(
                 0, pending.PeriodStartUtc, pending.PeriodEndUtc, pending.PeriodKey);
 
-            await EnsureInvoiceAsync(ratingSubscription, pendingPeriod, cancellationToken);
+            await EnsureInvoiceAsync(
+                ratingSubscription, pendingPeriod, cancellationToken, pending.MeterAllowances);
 
             // The invoice exists now, so the charge is due now. Announced rather than left for the
             // next sweep: waiting only delays revenue and the subscriber's own record of what they
@@ -341,7 +345,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     private async Task EnsureInvoiceAsync(
         SubscriptionDetail subscription,
         BillingPeriod period,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, long>? frozenAllowances = null)
     {
         var periodKey = period.Key;
         var existing = await _usageInvoices.GetAsync(
@@ -390,12 +395,48 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             // included — never the plan's bare IncludedQuantity. The same resolver the overage
             // preview uses, so the two can never disagree about what "overage" means for this
             // window. See UsageChargePreviewParityTests for the coverage this guarantees.
-            var allowance = await _allowances.EffectiveAsync(
-                subscription, meter, period, counter, cancellationToken);
+            //
+            // For a cut-short (PendingUsagePeriod) window, frozenAllowances — captured before the
+            // cancellation/plan-change transition that cut the window short — takes priority over
+            // resolving live: the live resolver, given only the counter and a synthetic
+            // subscription carrying the *current* (post-transition) status/trial/schedule, cannot
+            // reconstruct the original terms for a window whose counter never made it to disk
+            // before the crash. A legacy PendingUsagePeriod queued before this snapshot existed
+            // carries no frozenAllowances entry, so it falls back to the live resolver exactly as
+            // before — same behavior, not a regression for documents already in flight.
+            var allowance = frozenAllowances is not null &&
+                             frozenAllowances.TryGetValue(meter.MeterKey, out var frozenAllowance)
+                ? frozenAllowance
+                : await _allowances.EffectiveAsync(
+                    subscription, meter, period, counter, cancellationToken);
             var overageQuantity = Math.Max(0, balance - allowance);
 
-            var allocations = SubscriptionUsageRater.OverageAllocations(
-                meter, overageQuantity, subscription.CurrencyCode);
+            UsageTierAllocationResult allocations;
+
+            try
+            {
+                allocations = SubscriptionUsageRater.OverageAllocations(
+                    meter, overageQuantity, subscription.CurrencyCode);
+            }
+            catch (OverflowException ex)
+            {
+                // A technically valid but very large balance or unit rate can make a tier total
+                // wrap a plain long — see SubscriptionUsageRater.WalkTierRange's own remarks.
+                // There is no HTTP response here to refuse with, the way the preview does, so the
+                // whole period is deferred instead: no invoice is created this pass, the same as
+                // BillingPeriodCalculator.TryGetPeriod failing above leaves a period for the next
+                // sweep rather than persisting a wrapped amount now.
+                _logger.LogError(
+                    ex,
+                    "Usage rating overflowed pricing a meter's overage and deferred the whole " +
+                    "period SubscriptionHash={SubscriptionHash} PeriodKey={PeriodKey} " +
+                    "MeterKey={MeterKey}",
+                    PaymentLogValue.Hash(subscription.ItemId),
+                    PaymentLogValue.Label(periodKey),
+                    PaymentLogValue.Label(meter.MeterKey));
+
+                return;
+            }
 
             if (allocations.TotalAmountMinor <= 0)
             {
@@ -410,11 +451,31 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             });
         }
 
-        var overage = lines.Sum(line => line.AmountMinor);
+        long overage;
+        UsageCharge charge;
 
-        // Discount and tax, through the calculator shared with the metered overage preview —
-        // see UsageChargeCalculator's own remarks for why the two must never drift apart.
-        var charge = UsageChargeCalculator.Charge(overage, subscription.Price);
+        try
+        {
+            // Enumerable.Sum(long) is itself checked and would throw OverflowException here on
+            // its own, but the aggregate is summed explicitly so the same overflow handling
+            // covers it and the calculator call together.
+            overage = lines.Sum(line => line.AmountMinor);
+
+            // Discount and tax, through the calculator shared with the metered overage preview —
+            // see UsageChargeCalculator's own remarks for why the two must never drift apart.
+            charge = UsageChargeCalculator.Charge(overage, subscription.Price);
+        }
+        catch (OverflowException ex)
+        {
+            _logger.LogError(
+                ex,
+                "Usage rating overflowed summing a period's overage lines and deferred the " +
+                "whole period SubscriptionHash={SubscriptionHash} PeriodKey={PeriodKey}",
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(periodKey));
+
+            return;
+        }
 
         var total = charge.TotalMinor;
         var now = _time.GetUtcNow().UtcDateTime;

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -15,6 +15,30 @@ namespace Subscription.DomainService.Outbox;
 /// <see cref="SubscriptionUsageInvoice"/> — the usage clock's own sweep, independent of the fee
 /// renewal sweep the way the two schedules themselves are independent.
 /// </summary>
+/// <summary>
+/// Whether <c>EnsureInvoiceAsync</c> left a period actually settled or had to leave it for the
+/// next sweep pass.
+/// </summary>
+/// <remarks>
+/// <see cref="Deferred"/> must never be treated as success by a caller: the pending-period
+/// snapshot, the closure record and the usage clock all have to stay exactly where they were so
+/// the next sweep picks the period up again, the same way it already does for any other
+/// not-yet-ready period (a claim still outstanding, a schedule whose time zone briefly failed to
+/// resolve). There is no separate retry queue to wire up — the periodic sweep is the retry.
+/// </remarks>
+public enum InvoiceReadiness
+{
+    /// <summary>The invoice already existed, or was created just now.</summary>
+    Ready,
+
+    /// <summary>
+    /// Pricing overflowed a <see cref="long"/> minor-unit amount. No invoice was created, and
+    /// nothing about the period was advanced or removed — it is exactly as due as before this
+    /// attempt.
+    /// </summary>
+    Deferred
+}
+
 public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingProcessor
 {
     /// <summary>
@@ -229,8 +253,17 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             var pendingPeriod = new BillingPeriod(
                 0, pending.PeriodStartUtc, pending.PeriodEndUtc, pending.PeriodKey);
 
-            await EnsureInvoiceAsync(
+            var readiness = await EnsureInvoiceAsync(
                 ratingSubscription, pendingPeriod, cancellationToken, pending.MeterAllowances);
+
+            if (readiness == InvoiceReadiness.Deferred)
+            {
+                // Pricing overflowed and EnsureInvoiceAsync already logged it. Leave the
+                // PendingUsagePeriods snapshot and the closure's Closing state exactly as they
+                // are — removing either here would make this period vanish with no invoice ever
+                // created. The next sweep pass finds this subscription due again and retries it.
+                continue;
+            }
 
             // The invoice exists now, so the charge is due now. Announced rather than left for the
             // next sweep: waiting only delays revenue and the subscriber's own record of what they
@@ -298,7 +331,16 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 subscription.CurrentUsagePeriodEndUtc,
                 periodKey);
 
-            await EnsureInvoiceAsync(subscription, currentPeriod, cancellationToken);
+            var readiness = await EnsureInvoiceAsync(subscription, currentPeriod, cancellationToken);
+
+            if (readiness == InvoiceReadiness.Deferred)
+            {
+                // Pricing overflowed and EnsureInvoiceAsync already logged it. Do not advance the
+                // usage clock — leave the period open so it is reprocessed rather than silently
+                // rolled forward past unbilled usage. The next sweep pass (this subscription is
+                // still due, since CurrentUsagePeriodEndUtc did not move) retries it.
+                break;
+            }
 
             if (!BillingPeriodCalculator.TryGetPeriod(
                     subscription.UsageSchedule,
@@ -342,7 +384,13 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     /// Prices the closed period's overage and records it, unless a crash already left one behind
     /// — <c>TryCreateAsync</c>'s uniqueness index is what makes this safe to call twice.
     /// </summary>
-    private async Task EnsureInvoiceAsync(
+    /// <returns>
+    /// <see cref="InvoiceReadiness.Ready"/> once an invoice exists for this period (already did,
+    /// or created just now); <see cref="InvoiceReadiness.Deferred"/> if pricing overflowed and no
+    /// invoice was created. Callers must treat <see cref="InvoiceReadiness.Deferred"/> as "not
+    /// done" — see the type's own remarks.
+    /// </returns>
+    private async Task<InvoiceReadiness> EnsureInvoiceAsync(
         SubscriptionDetail subscription,
         BillingPeriod period,
         CancellationToken cancellationToken,
@@ -357,7 +405,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
 
         if (existing is not null)
         {
-            return;
+            return InvoiceReadiness.Ready;
         }
 
         var lines = new List<UsageInvoiceLine>();
@@ -435,7 +483,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                     PaymentLogValue.Label(periodKey),
                     PaymentLogValue.Label(meter.MeterKey));
 
-                return;
+                return InvoiceReadiness.Deferred;
             }
 
             if (allocations.TotalAmountMinor <= 0)
@@ -462,19 +510,22 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             overage = lines.Sum(line => line.AmountMinor);
 
             // Discount and tax, through the calculator shared with the metered overage preview —
-            // see UsageChargeCalculator's own remarks for why the two must never drift apart.
+            // see UsageChargeCalculator's own remarks for why the two must never drift apart. A
+            // gross that fits a long can still overflow once exclusive tax is added on top inside
+            // SubscriptionAmountCalculator.TaxBreakdownFor, which is checked for exactly that —
+            // the OverflowException it throws is caught here the same as the sum above.
             charge = UsageChargeCalculator.Charge(overage, subscription.Price);
         }
         catch (OverflowException ex)
         {
             _logger.LogError(
                 ex,
-                "Usage rating overflowed summing a period's overage lines and deferred the " +
+                "Usage rating overflowed summing or taxing a period's overage and deferred the " +
                 "whole period SubscriptionHash={SubscriptionHash} PeriodKey={PeriodKey}",
                 PaymentLogValue.Hash(subscription.ItemId),
                 PaymentLogValue.Label(periodKey));
 
-            return;
+            return InvoiceReadiness.Deferred;
         }
 
         var total = charge.TotalMinor;
@@ -504,6 +555,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 CorrelationId = subscription.CorrelationId
             },
             cancellationToken);
+
+        return InvoiceReadiness.Ready;
     }
 
     public async Task<int> ChargeDueInvoicesAsync(

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -36,6 +36,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     private readonly TimeProvider _time;
     private readonly ISubscriptionAuditTrail? _audit;
     private readonly IUsagePeriodClosureRepository? _closures;
+    private readonly IMeterAllowanceResolver _allowances;
 
     public SubscriptionUsageRatingProcessor(
         ISubscriptionRepository subscriptions,
@@ -50,7 +51,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         ISubscriptionAuditTrail? audit = null,
         ISubscriptionWorkScheduler? scheduler = null,
         ISubscriptionFinancialDocumentAnnouncer? documents = null,
-        IUsagePeriodClosureRepository? closures = null)
+        IUsagePeriodClosureRepository? closures = null,
+        IMeterAllowanceResolver? allowances = null)
     {
         _scheduler = scheduler;
         _documents = documents;
@@ -65,6 +67,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         _time = time ?? TimeProvider.System;
         _audit = audit;
         _closures = closures;
+        _allowances = allowances ?? new MeterAllowanceResolver(usage);
     }
 
     /// <summary>Announces the overage invoice. Optional, like the scheduler beside it.</summary>
@@ -210,10 +213,20 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 Plan = pending.Plan,
                 Price = pending.Price,
                 CurrencyCode = pending.CurrencyCode,
-                CorrelationId = pending.CorrelationId
+                CorrelationId = pending.CorrelationId,
+                // Best-effort context for IMeterAllowanceResolver — a trial grant or a
+                // carry-forward window with a counter already resolves from the counter's own
+                // frozen LimitSnapshot regardless of these; only a carry-forward meter that
+                // recorded zero usage in this cut-short window would need the schedule that was
+                // in force *before* the change, which this snapshot does not carry.
+                Status = subscription.Status,
+                Trial = subscription.Trial,
+                UsageSchedule = subscription.UsageSchedule
             };
+            var pendingPeriod = new BillingPeriod(
+                0, pending.PeriodStartUtc, pending.PeriodEndUtc, pending.PeriodKey);
 
-            await EnsureInvoiceAsync(ratingSubscription, pending.PeriodKey, cancellationToken);
+            await EnsureInvoiceAsync(ratingSubscription, pendingPeriod, cancellationToken);
 
             // The invoice exists now, so the charge is due now. Announced rather than left for the
             // next sweep: waiting only delays revenue and the subscriber's own record of what they
@@ -275,8 +288,13 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             var periodKey = PeriodKey.Create(
                 subscription.UsageSchedule.Interval,
                 subscription.CurrentUsagePeriodStartUtc);
+            var currentPeriod = new BillingPeriod(
+                0,
+                subscription.CurrentUsagePeriodStartUtc,
+                subscription.CurrentUsagePeriodEndUtc,
+                periodKey);
 
-            await EnsureInvoiceAsync(subscription, periodKey, cancellationToken);
+            await EnsureInvoiceAsync(subscription, currentPeriod, cancellationToken);
 
             if (!BillingPeriodCalculator.TryGetPeriod(
                     subscription.UsageSchedule,
@@ -322,9 +340,10 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     /// </summary>
     private async Task EnsureInvoiceAsync(
         SubscriptionDetail subscription,
-        string periodKey,
+        BillingPeriod period,
         CancellationToken cancellationToken)
     {
+        var periodKey = period.Key;
         var existing = await _usageInvoices.GetAsync(
             subscription.TenantId,
             subscription.ItemId,
@@ -348,9 +367,15 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         // projection. A writer can crash after the ledger append but before moving that projection.
         // Final financial rating must therefore sum the durable ledger, not trust a counter which
         // recovery may still be repairing.
+        //
+        // Every resetting meter is rated here, not just Periodic — CarryForward still resets,
+        // rates and reports per window (see MeterResetPolicy.CarryForward's own remarks); only
+        // Never sits outside this per-period sweep entirely, since it holds one lifetime balance
+        // this processor never closes.
         foreach (var meter in subscription.Plan.Meters.Where(
-                     planMeter => planMeter.ResetPolicy == MeterResetPolicy.Periodic))
+                     planMeter => planMeter.ResetPolicy != MeterResetPolicy.Never))
         {
+            var counter = counters.GetValueOrDefault(meter.MeterKey);
             var ledger = await _usage.SummariseLedgerAsync(
                 subscription.TenantId,
                 subscription.ItemId,
@@ -359,14 +384,20 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 cancellationToken);
             var balance = ledger.RecordCount > 0
                 ? ledger.Balance
-                : counters.GetValueOrDefault(meter.MeterKey)?.Balance ?? 0;
+                : counter?.Balance ?? 0;
 
-            var amount = SubscriptionUsageRater.OverageAmountMinor(
-                meter,
-                balance,
-                subscription.CurrencyCode);
+            // The window's own frozen allowance — a trial grant or a carried-forward allowance
+            // included — never the plan's bare IncludedQuantity. The same resolver the overage
+            // preview uses, so the two can never disagree about what "overage" means for this
+            // window. See UsageChargePreviewParityTests for the coverage this guarantees.
+            var allowance = await _allowances.EffectiveAsync(
+                subscription, meter, period, counter, cancellationToken);
+            var overageQuantity = Math.Max(0, balance - allowance);
 
-            if (amount <= 0)
+            var allocations = SubscriptionUsageRater.OverageAllocations(
+                meter, overageQuantity, subscription.CurrencyCode);
+
+            if (allocations.TotalAmountMinor <= 0)
             {
                 continue;
             }
@@ -374,8 +405,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             lines.Add(new UsageInvoiceLine
             {
                 MeterKey = meter.MeterKey,
-                OverageQuantity = Math.Max(0, balance - meter.IncludedQuantity),
-                AmountMinor = amount
+                OverageQuantity = overageQuantity,
+                AmountMinor = allocations.TotalAmountMinor
             });
         }
 

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -891,6 +891,60 @@ double-billing guard.
   cancellation clears `NextUsageBillingAtUtc` the moment entitlement stops, so any usage recorded
   in that unrated final stretch has no billing path today.
 
+## Metered overage preview
+
+```http
+POST /api/subscription-usage/overage/preview
+```
+
+```json
+{ "organizationId": null, "meterKey": "screening", "additionalQuantity": 100 }
+```
+
+Estimates what a hypothetical slice of additional metered usage would cost, using the active
+subscription's own snapshotted terms and the same rating, discount and tax logic
+`SubscriptionUsageRatingProcessor` uses to charge the final usage invoice —
+`UsageChargeCalculator` and `SubscriptionUsageRater.OverageAllocations` are the two pieces shared
+between them, so the two can never quietly drift apart. Subscription resolution and the platform
+console's organization override follow the same rule `GET /subscription-usage/current` already
+applies (see "Console organization override" above).
+
+**Advisory, and read-only.** `SubscriptionUsageOveragePreviewService` takes only dependencies
+capable of reading — no usage ledger, no invoice repository, no billing gateway, no outbox, no
+audit trail — so there is nothing here that could write even by mistake. The response says so
+explicitly: `writesUsage` and `chargesPayment` are always `false`, and
+`finalChargeDependsOnActualPeriodEndUsage` is always `true` — usage recorded after
+`calculatedAtUtc` can still change what period-end rating eventually charges.
+
+The response reconciles three views of the period: `currentCharge` (rated from usage recorded so
+far), `projectedPeriodCharge` (rated as if the additional quantity had already happened), and
+`additionalCharge` — the **difference** of the two, never rated on its own. A tier boundary the
+additional units cross, or a rounding step at the discount or tax boundary, can price the same
+units differently depending on what came before them in the period; only the difference of two
+fully rated totals is guaranteed to match what the period-end invoice would actually add.
+`additionalTierBreakdown` names which graduated tier bands the additional units fell into and what
+each contributed, for display — it is informational only, since the authoritative additional
+charge is the difference described above, not a sum of independently-taxed bands.
+
+Included quantity is resolved through `IMeterAllowanceResolver`, so a trial grant or a
+carried-forward allowance changes the preview the same way it changes enforcement and the
+entitlement read. Everything is read from the subscription's own snapshot — `Plan`, `Price`,
+`UsageSchedule` — never from the mutable plan catalogue, for the same reason period-end rating
+reads its snapshot rather than the live plan.
+
+**Promotional discounts do not apply here, on purpose.** Metered overage has never been
+discountable by a promotional code — only the price's own `AutomaticDiscountBasisPoints` reaches
+it, exactly as in period-end rating — and the preview states that fact explicitly
+(`discount.promotionalCodeApplied` is always `false`) rather than leaving a client to wonder
+whether a code was simply overlooked.
+
+Named failures rather than a misleading zero price: `subscription_not_found`,
+`subscription_meter_not_found` (404); `subscription_usage_preview_invalid` (400, missing
+`meterKey` or a non-positive `additionalQuantity`); `subscription_meter_overage_not_allowed`,
+`subscription_meter_rate_unavailable` (409, a meter that refuses overage or has no rate table for
+the subscription's currency); `subscription_schedule_unavailable` (503, the usage schedule could
+not place "now" in a period).
+
 ## Events
 
 Appended in the same write as the state change that caused them, then published to

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -922,9 +922,16 @@ far), `projectedPeriodCharge` (rated as if the additional quantity had already h
 additional units cross, or a rounding step at the discount or tax boundary, can price the same
 units differently depending on what came before them in the period; only the difference of two
 fully rated totals is guaranteed to match what the period-end invoice would actually add.
-`additionalTierBreakdown` names which graduated tier bands the additional units fell into and what
-each contributed, for display — it is informational only, since the authoritative additional
-charge is the difference described above, not a sum of independently-taxed bands.
+
+Both `currentCharge` and `projectedPeriodCharge` are rated across **every** billable meter on the
+subscription, not only the one named in the request — the worker totals overage across every meter
+before it applies the automatic discount and tax once, across the whole invoice, and a preview that
+discounted and taxed only the requested meter in isolation could disagree with that total at a
+rounding boundary whenever another meter already carries overage. `additionalTierBreakdown` stays
+scoped to the requested meter — it names which graduated tier bands the additional units fell into
+and what each contributed, for display — it is informational only, since the authoritative
+additional charge is the aggregate difference described above, not a sum of independently-taxed
+bands.
 
 Included quantity is resolved through `IMeterAllowanceResolver`, so a trial grant or a
 carried-forward allowance changes the preview the same way it changes enforcement and the

--- a/server/Subscription.DomainService/Requests/PreviewUsageOverageRequest.cs
+++ b/server/Subscription.DomainService/Requests/PreviewUsageOverageRequest.cs
@@ -1,0 +1,27 @@
+namespace Subscription.DomainService.Requests;
+
+/// <summary>
+/// A hypothetical slice of extra metered usage to price, without recording anything.
+/// </summary>
+public sealed class PreviewUsageOverageRequest
+{
+    /// <summary>
+    /// Which organization's subscription to preview. Omit it to use the caller's own organization.
+    /// </summary>
+    /// <remarks>
+    /// Honoured only for the platform console — see
+    /// <see cref="Subscription.DomainService.Services.ISubscriptionContextResolver"/> for the full
+    /// rule, the same one <c>GET /subscription-usage/current</c> already applies.
+    /// </remarks>
+    public string? OrganizationId { get; set; }
+
+    /// <summary>The meter's key, in the calling product's own vocabulary.</summary>
+    public string MeterKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How much more usage to price, on top of what has already been recorded this period. Cannot
+    /// be zero or negative — a preview of no additional usage is not a question this endpoint
+    /// answers.
+    /// </summary>
+    public long AdditionalQuantity { get; set; }
+}

--- a/server/Subscription.DomainService/Responses/SubscriptionUsageOveragePreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionUsageOveragePreviewResponse.cs
@@ -1,0 +1,131 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// What a hypothetical slice of additional metered usage would cost, rated with the same terms
+/// and the same order of operations period-end usage rating would eventually charge — but
+/// nothing here is recorded, and nothing here is charged.
+/// </summary>
+public sealed class SubscriptionUsageOveragePreviewResponse
+{
+    public string MeterKey { get; init; } = string.Empty;
+
+    public string UnitLabel { get; init; } = string.Empty;
+
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public string PeriodKey { get; init; } = string.Empty;
+
+    public DateTime PeriodStartUtc { get; init; }
+
+    public DateTime PeriodEndUtc { get; init; }
+
+    /// <summary>
+    /// When this preview was computed. Usage recorded after this instant can change the eventual
+    /// invoice — this is an estimate, not a hold.
+    /// </summary>
+    public DateTime CalculatedAtUtc { get; init; }
+
+    /// <summary>
+    /// The effective allowance for this window, including a trial grant or carried-forward
+    /// allowance — see <c>IMeterAllowanceResolver</c>.
+    /// </summary>
+    public long IncludedQuantity { get; init; }
+
+    public long CurrentUsage { get; init; }
+
+    public long CurrentOverage { get; init; }
+
+    public long AdditionalQuantity { get; init; }
+
+    public long ProjectedUsage { get; init; }
+
+    public long ProjectedOverage { get; init; }
+
+    /// <summary>What the period would already owe, rated from usage recorded so far.</summary>
+    public UsageChargeAmountsResponse CurrentCharge { get; init; } = new();
+
+    /// <summary>
+    /// What the additional usage alone would add — the difference between the projected and
+    /// current charges, never rated on its own. See the endpoint documentation for why.
+    /// </summary>
+    public UsageChargeAmountsResponse AdditionalCharge { get; init; } = new();
+
+    /// <summary>What the whole period would owe if the additional usage happened right now.</summary>
+    public UsageChargeAmountsResponse ProjectedPeriodCharge { get; init; } = new();
+
+    /// <summary>
+    /// Which graduated tier bands the additional usage would fall into, and what each contributed.
+    /// Informational only — the amounts here are not independently taxed or discounted; the
+    /// authoritative additional charge is <see cref="AdditionalCharge"/>.
+    /// </summary>
+    public IReadOnlyList<UsageOverageTierAllocationResponse> AdditionalTierBreakdown { get; init; } = [];
+
+    public UsageOveragePreviewDiscountResponse Discount { get; init; } = new();
+
+    public UsageOveragePreviewTaxResponse Tax { get; init; } = new();
+
+    /// <summary>Always false. Nothing this call returns is recorded against the usage ledger.</summary>
+    public bool WritesUsage { get; init; }
+
+    /// <summary>Always false. This call never charges a payment method.</summary>
+    public bool ChargesPayment { get; init; }
+
+    /// <summary>
+    /// Always true. Usage recorded between now and period end changes the actual invoice; this
+    /// response is an estimate of what period-end rating would charge if nothing else changed.
+    /// </summary>
+    public bool FinalChargeDependsOnActualPeriodEndUsage { get; init; } = true;
+}
+
+/// <summary>One charge, split the way an invoice line would be.</summary>
+public sealed class UsageChargeAmountsResponse
+{
+    public long GrossMinor { get; init; }
+
+    public long AutomaticDiscountMinor { get; init; }
+
+    public long NetMinor { get; init; }
+
+    public long TaxMinor { get; init; }
+
+    public long TotalMinor { get; init; }
+}
+
+/// <summary>One graduated tier band's slice of the additional usage.</summary>
+public sealed class UsageOverageTierAllocationResponse
+{
+    /// <summary>
+    /// The first overage unit this band covers, counted from the first overage unit of the whole
+    /// period — not from wherever the additional usage itself begins.
+    /// </summary>
+    public long FromOverageQuantity { get; init; }
+
+    public long ToOverageQuantity { get; init; }
+
+    public long Units { get; init; }
+
+    public long UnitAmountMinor { get; init; }
+
+    public long AmountMinor { get; init; }
+}
+
+/// <summary>
+/// The reduction that reaches metered overage, and the one that explicitly does not.
+/// </summary>
+public sealed class UsageOveragePreviewDiscountResponse
+{
+    public int AutomaticBasisPoints { get; init; }
+
+    /// <summary>
+    /// Always false. A promotional discount code never reduces metered overage — stated
+    /// explicitly here rather than left for a client to wonder whether one was simply missed.
+    /// </summary>
+    public bool PromotionalCodeApplied { get; init; }
+}
+
+public sealed class UsageOveragePreviewTaxResponse
+{
+    public int? RateBasisPoints { get; init; }
+
+    public string Mode { get; init; } = string.Empty;
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionUsageOveragePreviewService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionUsageOveragePreviewService.cs
@@ -1,0 +1,16 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Prices a hypothetical slice of additional metered usage, without recording or charging
+/// anything.
+/// </summary>
+public interface ISubscriptionUsageOveragePreviewService
+{
+    Task<SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>> PreviewAsync(
+        PreviewUsageOverageRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/MeterAllowanceSnapshot.cs
+++ b/server/Subscription.DomainService/Services/MeterAllowanceSnapshot.cs
@@ -1,0 +1,69 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Freezes every resetting meter's effective allowance for a <see cref="PendingUsagePeriod"/>
+/// at the moment it is captured — before the status/schedule transition (cancellation or plan
+/// change) that cuts the window short takes effect.
+/// </summary>
+/// <remarks>
+/// Without this, final rating of a cut-short window has to fall back to resolving the allowance
+/// against whatever the subscription looks like by the time the rating sweep runs — which is
+/// after the transition, on the wrong side of it. A cancellation has already moved status to
+/// <see cref="SubscriptionStatus.Canceled"/> and a plan change has already re-anchored
+/// <see cref="Entities.BillingSchedule"/> by then, so a trial grant or a carried-forward
+/// allowance the outgoing window actually opened with would be lost, and the subscriber overbilled
+/// for usage that should have been covered. See <see cref="IMeterAllowanceResolver"/> for how a
+/// window's counter, once one exists, freezes the same figure on its own — this exists only to
+/// cover the crash window before that counter is written.
+/// </remarks>
+public static class MeterAllowanceSnapshot
+{
+    /// <summary>
+    /// Resolves the effective allowance of every resetting meter on <paramref name="subscription"/>'s
+    /// plan for <paramref name="period"/>, using whatever counter already exists for it.
+    /// </summary>
+    /// <returns>
+    /// Null when <paramref name="usage"/> or <paramref name="allowances"/> was not supplied — the
+    /// caller then queues a <see cref="PendingUsagePeriod"/> with no snapshot, and final rating
+    /// falls back to resolving live for it, exactly as it did before this snapshot existed.
+    /// </returns>
+    public static async Task<Dictionary<string, long>?> CaptureAsync(
+        SubscriptionDetail subscription,
+        BillingPeriod period,
+        ISubscriptionUsageRepository? usage,
+        IMeterAllowanceResolver? allowances,
+        CancellationToken cancellationToken)
+    {
+        if (usage is null || allowances is null)
+        {
+            return null;
+        }
+
+        var counters = (await usage.ListCountersAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                period.Key,
+                cancellationToken))
+            .ToDictionary(counter => counter.MeterKey, StringComparer.Ordinal);
+
+        var snapshot = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        // Every resetting meter, matching exactly the set SubscriptionUsageRatingProcessor rates
+        // for a closed window — Never sits outside per-period rating entirely and never needs an
+        // allowance snapshotted here either.
+        foreach (var meter in subscription.Plan.Meters.Where(
+                     planMeter => planMeter.ResetPolicy != MeterResetPolicy.Never))
+        {
+            var counter = counters.GetValueOrDefault(meter.MeterKey);
+            snapshot[meter.MeterKey] = await allowances.EffectiveAsync(
+                subscription, meter, period, counter, cancellationToken);
+        }
+
+        return snapshot;
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -470,14 +470,25 @@ public static class SubscriptionAmountCalculator
         // legacy calculation (integer truncation) so an existing renewal is never repriced by a
         // catalogue-presentation feature. Explicitly authored modes use the documented half-up
         // rule shared with inclusive prices.
-        var exclusiveTax = taxMode is null
-            ? (long)((Int128)discountedAmountMinor * basisPoints / 10_000)
-            : RoundedQuotient(discountedAmountMinor, basisPoints, 10_000);
+        //
+        // Checked throughout, including the final addition: a gross amount that comfortably fits
+        // a long on its own can still overflow once exclusive tax is added on top, and an
+        // unchecked addition here would silently wrap the total (possibly negative) instead of
+        // refusing it — see SubscriptionUsageRater.WalkTierRange's own remarks for why this
+        // module never lets that happen quietly. OverflowException propagates to the caller,
+        // which turns it into a refusal (the preview) or a deferral (period-end rating) rather
+        // than ever persisting a wrapped amount.
+        checked
+        {
+            var exclusiveTax = taxMode is null
+                ? (long)((Int128)discountedAmountMinor * basisPoints / 10_000)
+                : RoundedQuotient(discountedAmountMinor, basisPoints, 10_000);
 
-        return new TaxBreakdown(
-            discountedAmountMinor,
-            exclusiveTax,
-            discountedAmountMinor + exclusiveTax);
+            return new TaxBreakdown(
+                discountedAmountMinor,
+                exclusiveTax,
+                discountedAmountMinor + exclusiveTax);
+        }
     }
 
     /// <summary>
@@ -486,10 +497,12 @@ public static class SubscriptionAmountCalculator
     /// <remarks>
     /// Exact integer arithmetic, widened for the multiplication so a large amount times a rate
     /// cannot overflow, and never a floating-point ratio — the rest of this module's money
-    /// deliberately never touches one.
+    /// deliberately never touches one. The narrowing cast back down to <see cref="long"/> is
+    /// checked too: <c>checked</c>/<c>unchecked</c> context does not cross a method call, so this
+    /// has to guard its own cast rather than rely on a caller's <c>checked</c> block doing it.
     /// </remarks>
     private static long RoundedQuotient(long amountMinor, long numerator, long denominator) =>
-        (long)(((Int128)amountMinor * numerator + denominator / 2) / denominator);
+        checked((long)(((Int128)amountMinor * numerator + denominator / 2) / denominator));
 }
 
 /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -38,6 +38,8 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
     private readonly ISubscriptionWorkScheduler? _scheduler;
     private readonly IUsagePeriodClosureRepository? _closures;
     private readonly IOptionsMonitor<SubscriptionOptions>? _options;
+    private readonly ISubscriptionUsageRepository? _usage;
+    private readonly IMeterAllowanceResolver? _allowances;
 
     public SubscriptionCancellationService(
         ISubscriptionRepository subscriptions,
@@ -50,7 +52,9 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         TimeProvider? time = null,
         ISubscriptionWorkScheduler? scheduler = null,
         IUsagePeriodClosureRepository? closures = null,
-        IOptionsMonitor<SubscriptionOptions>? options = null)
+        IOptionsMonitor<SubscriptionOptions>? options = null,
+        ISubscriptionUsageRepository? usage = null,
+        IMeterAllowanceResolver? allowances = null)
     {
         _subscriptions = subscriptions;
         _links = links;
@@ -63,6 +67,8 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         _scheduler = scheduler;
         _closures = closures;
         _options = options;
+        _usage = usage;
+        _allowances = allowances;
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionResponse>> CancelAsync(
@@ -418,7 +424,7 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 // own outgoing window atomically with the schedule swap.
                 ClearNextUsageBillingAt = true,
                 OutgoingUsagePeriod = closure is { Reserved: true }
-                    ? OutgoingUsagePeriodOf(subscription, now)
+                    ? await OutgoingUsagePeriodOfAsync(subscription, now, cancellationToken)
                     : null,
                 Event = _events.Create(
                     subscription,
@@ -700,20 +706,36 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
     /// schedule — and an invoice that priced usage through the later, uncut end would be claiming
     /// to cover service the subscriber never actually had.
     /// </remarks>
-    private static PendingUsagePeriod OutgoingUsagePeriodOf(
+    private async Task<PendingUsagePeriod> OutgoingUsagePeriodOfAsync(
         SubscriptionDetail subscription,
-        DateTime effectiveAtUtc) => new()
+        DateTime effectiveAtUtc,
+        CancellationToken cancellationToken)
     {
-        PeriodKey = PeriodKey.Create(
+        var periodKey = PeriodKey.Create(
             subscription.UsageSchedule.Interval,
-            subscription.CurrentUsagePeriodStartUtc),
-        PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
-        PeriodEndUtc = effectiveAtUtc,
-        Plan = subscription.Plan,
-        Price = subscription.Price,
-        CurrencyCode = subscription.CurrencyCode,
-        CorrelationId = subscription.CorrelationId
-    };
+            subscription.CurrentUsagePeriodStartUtc);
+
+        return new PendingUsagePeriod
+        {
+            PeriodKey = periodKey,
+            PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
+            PeriodEndUtc = effectiveAtUtc,
+            Plan = subscription.Plan,
+            Price = subscription.Price,
+            CurrencyCode = subscription.CurrencyCode,
+            CorrelationId = subscription.CorrelationId,
+            // Snapshotted here, before the status transition below installs Canceled — the
+            // subscription's trial and schedule are still the ones this window actually opened
+            // under. Null (falling back to live resolution at rating time) when the
+            // resolver/repository were not supplied.
+            MeterAllowances = await MeterAllowanceSnapshot.CaptureAsync(
+                subscription,
+                new BillingPeriod(0, subscription.CurrentUsagePeriodStartUtc, effectiveAtUtc, periodKey),
+                _usage,
+                _allowances,
+                cancellationToken)
+        };
+    }
 
     /// <summary>
     /// Applies the transition to the copy being returned, so the caller sees what was written

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -66,6 +66,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
     private readonly IValidator<ChangeSubscriptionPlanRequest> _validator;
     private readonly ILogger<SubscriptionPlanChangeService> _logger;
     private readonly TimeProvider _time;
+    private readonly ISubscriptionUsageRepository? _usage;
+    private readonly IMeterAllowanceResolver? _allowances;
 
     public SubscriptionPlanChangeService(
         ISubscriptionContextResolver contextResolver,
@@ -82,7 +84,9 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         ISubscriptionWorkScheduler? scheduler = null,
         ISubscriptionFinancialDocumentAnnouncer? announcer = null,
         ISubscriptionFinancialDocumentIssuer? documents = null,
-        ISubscriptionBillingProfileGuard? billingProfile = null)
+        ISubscriptionBillingProfileGuard? billingProfile = null,
+        ISubscriptionUsageRepository? usage = null,
+        IMeterAllowanceResolver? allowances = null)
     {
         _contextResolver = contextResolver;
         _subscriptions = subscriptions;
@@ -99,6 +103,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         _announcer = announcer;
         _documents = documents;
         _billingProfile = billingProfile;
+        _usage = usage;
+        _allowances = allowances;
     }
 
     /// <summary>
@@ -511,7 +517,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 Price = newPrice,
                 QuantityItems = quantities,
                 Schedule = newSchedule,
-                OutgoingUsagePeriod = SnapshotOutgoingUsagePeriod(subscription, correlationId),
+                OutgoingUsagePeriod = await SnapshotOutgoingUsagePeriodAsync(
+                    subscription, correlationId, cancellationToken),
                 NewCreditBalanceMinor = outcome.NewCreditBalanceMinor
             },
             ChargeAmountMinor = outcome.ChargeMinor,
@@ -639,7 +646,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         var previousPlanCode = subscription.Plan.Code;
         var previousCreditMinor = subscription.CreditBalanceMinor;
         var expectedVersion = subscription.Version;
-        var outgoingUsagePeriod = SnapshotOutgoingUsagePeriod(subscription, correlationId);
+        var outgoingUsagePeriod = await SnapshotOutgoingUsagePeriodAsync(
+            subscription, correlationId, cancellationToken);
 
         // Composed here, before the plan is swapped, and carried by the write below. A downgrade
         // credits unused time on the plan being left, so this is the only moment that plan's name,
@@ -942,20 +950,40 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         return true;
     }
 
-    private static PendingUsagePeriod SnapshotOutgoingUsagePeriod(
+    private async Task<PendingUsagePeriod> SnapshotOutgoingUsagePeriodAsync(
         SubscriptionDetail subscription,
-        string correlationId) => new()
+        string correlationId,
+        CancellationToken cancellationToken)
     {
-        PeriodKey = PeriodKey.Create(
+        var periodKey = PeriodKey.Create(
             subscription.UsageSchedule.Interval,
-            subscription.CurrentUsagePeriodStartUtc),
-        PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
-        PeriodEndUtc = subscription.CurrentUsagePeriodEndUtc,
-        Plan = subscription.Plan,
-        Price = subscription.Price,
-        CurrencyCode = subscription.CurrencyCode,
-        CorrelationId = correlationId
-    };
+            subscription.CurrentUsagePeriodStartUtc);
+
+        return new PendingUsagePeriod
+        {
+            PeriodKey = periodKey,
+            PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
+            PeriodEndUtc = subscription.CurrentUsagePeriodEndUtc,
+            Plan = subscription.Plan,
+            Price = subscription.Price,
+            CurrencyCode = subscription.CurrencyCode,
+            CorrelationId = correlationId,
+            // Snapshotted here, before the schedule swap re-anchors UsageSchedule — a
+            // carry-forward meter's actual carried-in allowance for this outgoing window would
+            // otherwise be lost once the new schedule is installed. Null (falling back to live
+            // resolution at rating time) when the resolver/repository were not supplied.
+            MeterAllowances = await MeterAllowanceSnapshot.CaptureAsync(
+                subscription,
+                new BillingPeriod(
+                    0,
+                    subscription.CurrentUsagePeriodStartUtc,
+                    subscription.CurrentUsagePeriodEndUtc,
+                    periodKey),
+                _usage,
+                _allowances,
+                cancellationToken)
+        };
+    }
 
     private static SubscriptionOperationResult<SubscriptionResponse> Failure(
         PaymentFailureKind kind,

--- a/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
@@ -271,14 +271,33 @@ public sealed class SubscriptionUsageOveragePreviewService : ISubscriptionUsageO
                 correlationId);
         }
 
-        var currentCharge = UsageChargeCalculator.Charge(currentAggregateGross, subscription.Price);
-        var projectedCharge = UsageChargeCalculator.Charge(projectedAggregateGross, subscription.Price);
+        UsageCharge currentCharge;
+        UsageCharge projectedCharge;
+        UsageCharge additionalCharge;
 
-        // The difference of two fully rated aggregate totals, never rated on its own — a tier
-        // boundary the additional units cross, or a rounding step at the discount or tax
-        // boundary, can price the same units differently depending on what came before them in
-        // the period, or in another meter sharing the same invoice.
-        var additionalCharge = UsageChargeCalculator.Difference(projectedCharge, currentCharge);
+        try
+        {
+            // A gross total that comfortably fits a long on its own can still overflow once tax
+            // is added on top inside SubscriptionAmountCalculator.TaxBreakdownFor — checked there,
+            // so it throws instead of silently wrapping. Caught here the same way the tier-walk
+            // overflow above is, rather than left to bubble up as an unhandled 500.
+            currentCharge = UsageChargeCalculator.Charge(currentAggregateGross, subscription.Price);
+            projectedCharge = UsageChargeCalculator.Charge(projectedAggregateGross, subscription.Price);
+
+            // The difference of two fully rated aggregate totals, never rated on its own — a tier
+            // boundary the additional units cross, or a rounding step at the discount or tax
+            // boundary, can price the same units differently depending on what came before them in
+            // the period, or in another meter sharing the same invoice.
+            additionalCharge = UsageChargeCalculator.Difference(projectedCharge, currentCharge);
+        }
+        catch (OverflowException)
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_usage_preview_invalid",
+                "The projected charge is outside the range this preview can compute.",
+                correlationId);
+        }
 
         var response = new SubscriptionUsageOveragePreviewResponse
         {

--- a/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
@@ -188,57 +188,88 @@ public sealed class SubscriptionUsageOveragePreviewService : ISubscriptionUsageO
         var currentOverageUnits = Math.Max(0, currentUsage - allowance);
         var projectedOverageUnits = Math.Max(0, projectedUsage - allowance);
 
-        var currentAllocations = SubscriptionUsageRater.OverageAllocations(
-            meter, currentOverageUnits, subscription.CurrencyCode);
-        var projectedAllocations = SubscriptionUsageRater.OverageAllocations(
-            meter, projectedOverageUnits, subscription.CurrencyCode);
-        var additionalAllocations = SubscriptionUsageRater.OverageAllocations(
-            meter,
-            projectedOverageUnits,
-            subscription.CurrencyCode,
-            fromOverageUnitsExclusive: currentOverageUnits);
+        UsageTierAllocationResult currentAllocations;
+        UsageTierAllocationResult projectedAllocations;
+        UsageTierAllocationResult additionalAllocations;
+        long currentAggregateGross;
+        long projectedAggregateGross;
 
-        // The worker totals overage across every billable meter before it ever discounts or
-        // taxes anything — see SubscriptionUsageRatingProcessor.EnsureInvoiceAsync. A preview
-        // that discounted and taxed only the requested meter in isolation could disagree with the
-        // eventual invoice at a rounding boundary whenever another meter also carries overage.
-        // Read every other billable meter's *current* contribution so the aggregate this preview
-        // discounts and taxes is the same aggregate the invoice will be.
-        var otherMetersAggregateGross = 0L;
-
-        foreach (var otherMeter in subscription.Plan.Meters)
+        try
         {
-            if (otherMeter.ResetPolicy == MeterResetPolicy.Never ||
-                string.Equals(otherMeter.MeterKey, meter.MeterKey, StringComparison.Ordinal))
+            currentAllocations = SubscriptionUsageRater.OverageAllocations(
+                meter, currentOverageUnits, subscription.CurrencyCode);
+            projectedAllocations = SubscriptionUsageRater.OverageAllocations(
+                meter, projectedOverageUnits, subscription.CurrencyCode);
+            additionalAllocations = SubscriptionUsageRater.OverageAllocations(
+                meter,
+                projectedOverageUnits,
+                subscription.CurrencyCode,
+                fromOverageUnitsExclusive: currentOverageUnits);
+
+            // The worker totals overage across every billable meter before it ever discounts or
+            // taxes anything — see SubscriptionUsageRatingProcessor.EnsureInvoiceAsync. A preview
+            // that discounted and taxed only the requested meter in isolation could disagree with
+            // the eventual invoice at a rounding boundary whenever another meter also carries
+            // overage. Read every other billable meter's *current* contribution so the aggregate
+            // this preview discounts and taxes is the same aggregate the invoice will be.
+            //
+            // Summed with checked arithmetic throughout: a technically valid but very large
+            // quantity or unit rate can make an individual meter's tier total, and then this
+            // running aggregate, wrap a plain long — silently mispricing the preview instead of
+            // refusing it.
+            var otherMetersAggregateGross = 0L;
+
+            foreach (var otherMeter in subscription.Plan.Meters)
             {
-                continue;
+                if (otherMeter.ResetPolicy == MeterResetPolicy.Never ||
+                    string.Equals(otherMeter.MeterKey, meter.MeterKey, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                // Every non-Never meter shares the subscription's own usage schedule, so the
+                // period already resolved for the requested meter applies here too — no second
+                // resolution.
+                var otherCounter = await _usage.GetCounterAsync(
+                    context.TenantId,
+                    SubscriptionUsageCounter.CreateId(subscription.ItemId, otherMeter.MeterKey, period.Key),
+                    cancellationToken);
+                var otherLedger = await _usage.SummariseLedgerAsync(
+                    context.TenantId,
+                    subscription.ItemId,
+                    otherMeter.MeterKey,
+                    period.Key,
+                    cancellationToken);
+                var otherUsage = otherLedger.RecordCount > 0
+                    ? otherLedger.Balance
+                    : otherCounter?.Balance ?? 0;
+                var otherAllowance = await _allowances.EffectiveAsync(
+                    subscription, otherMeter, period, otherCounter, cancellationToken);
+                var otherOverageUnits = Math.Max(0, otherUsage - otherAllowance);
+
+                var otherGross = SubscriptionUsageRater.OverageAllocations(
+                    otherMeter, otherOverageUnits, subscription.CurrencyCode).TotalAmountMinor;
+
+                checked
+                {
+                    otherMetersAggregateGross += otherGross;
+                }
             }
 
-            // Every non-Never meter shares the subscription's own usage schedule, so the period
-            // already resolved for the requested meter applies here too — no second resolution.
-            var otherCounter = await _usage.GetCounterAsync(
-                context.TenantId,
-                SubscriptionUsageCounter.CreateId(subscription.ItemId, otherMeter.MeterKey, period.Key),
-                cancellationToken);
-            var otherLedger = await _usage.SummariseLedgerAsync(
-                context.TenantId,
-                subscription.ItemId,
-                otherMeter.MeterKey,
-                period.Key,
-                cancellationToken);
-            var otherUsage = otherLedger.RecordCount > 0
-                ? otherLedger.Balance
-                : otherCounter?.Balance ?? 0;
-            var otherAllowance = await _allowances.EffectiveAsync(
-                subscription, otherMeter, period, otherCounter, cancellationToken);
-            var otherOverageUnits = Math.Max(0, otherUsage - otherAllowance);
-
-            otherMetersAggregateGross += SubscriptionUsageRater.OverageAllocations(
-                otherMeter, otherOverageUnits, subscription.CurrencyCode).TotalAmountMinor;
+            checked
+            {
+                currentAggregateGross = otherMetersAggregateGross + currentAllocations.TotalAmountMinor;
+                projectedAggregateGross = otherMetersAggregateGross + projectedAllocations.TotalAmountMinor;
+            }
         }
-
-        var currentAggregateGross = otherMetersAggregateGross + currentAllocations.TotalAmountMinor;
-        var projectedAggregateGross = otherMetersAggregateGross + projectedAllocations.TotalAmountMinor;
+        catch (OverflowException)
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_usage_preview_invalid",
+                "The projected charge is outside the range this preview can compute.",
+                correlationId);
+        }
 
         var currentCharge = UsageChargeCalculator.Charge(currentAggregateGross, subscription.Price);
         var projectedCharge = UsageChargeCalculator.Charge(projectedAggregateGross, subscription.Price);

--- a/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
@@ -163,7 +163,28 @@ public sealed class SubscriptionUsageOveragePreviewService : ISubscriptionUsageO
         var allowance = await _allowances.EffectiveAsync(
             subscription, meter, period, counter, cancellationToken);
 
-        var projectedUsage = currentUsage + request.AdditionalQuantity;
+        long projectedUsage;
+
+        try
+        {
+            // A valid positive request.AdditionalQuantity added to a very large existing balance
+            // could otherwise wrap into a negative projected usage and price a negative "additional"
+            // charge — checked here rather than trusted, since both operands individually pass
+            // validation.
+            checked
+            {
+                projectedUsage = currentUsage + request.AdditionalQuantity;
+            }
+        }
+        catch (OverflowException)
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_usage_preview_invalid",
+                "The projected usage is outside the range this preview can compute.",
+                correlationId);
+        }
+
         var currentOverageUnits = Math.Max(0, currentUsage - allowance);
         var projectedOverageUnits = Math.Max(0, projectedUsage - allowance);
 
@@ -177,14 +198,55 @@ public sealed class SubscriptionUsageOveragePreviewService : ISubscriptionUsageO
             subscription.CurrencyCode,
             fromOverageUnitsExclusive: currentOverageUnits);
 
-        var currentCharge = UsageChargeCalculator.Charge(
-            currentAllocations.TotalAmountMinor, subscription.Price);
-        var projectedCharge = UsageChargeCalculator.Charge(
-            projectedAllocations.TotalAmountMinor, subscription.Price);
+        // The worker totals overage across every billable meter before it ever discounts or
+        // taxes anything — see SubscriptionUsageRatingProcessor.EnsureInvoiceAsync. A preview
+        // that discounted and taxed only the requested meter in isolation could disagree with the
+        // eventual invoice at a rounding boundary whenever another meter also carries overage.
+        // Read every other billable meter's *current* contribution so the aggregate this preview
+        // discounts and taxes is the same aggregate the invoice will be.
+        var otherMetersAggregateGross = 0L;
 
-        // The difference of two fully rated totals, never rated on its own — a tier boundary the
-        // additional units cross, or a rounding step at the discount or tax boundary, can price
-        // the same units differently depending on what came before them in the period.
+        foreach (var otherMeter in subscription.Plan.Meters)
+        {
+            if (otherMeter.ResetPolicy == MeterResetPolicy.Never ||
+                string.Equals(otherMeter.MeterKey, meter.MeterKey, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Every non-Never meter shares the subscription's own usage schedule, so the period
+            // already resolved for the requested meter applies here too — no second resolution.
+            var otherCounter = await _usage.GetCounterAsync(
+                context.TenantId,
+                SubscriptionUsageCounter.CreateId(subscription.ItemId, otherMeter.MeterKey, period.Key),
+                cancellationToken);
+            var otherLedger = await _usage.SummariseLedgerAsync(
+                context.TenantId,
+                subscription.ItemId,
+                otherMeter.MeterKey,
+                period.Key,
+                cancellationToken);
+            var otherUsage = otherLedger.RecordCount > 0
+                ? otherLedger.Balance
+                : otherCounter?.Balance ?? 0;
+            var otherAllowance = await _allowances.EffectiveAsync(
+                subscription, otherMeter, period, otherCounter, cancellationToken);
+            var otherOverageUnits = Math.Max(0, otherUsage - otherAllowance);
+
+            otherMetersAggregateGross += SubscriptionUsageRater.OverageAllocations(
+                otherMeter, otherOverageUnits, subscription.CurrencyCode).TotalAmountMinor;
+        }
+
+        var currentAggregateGross = otherMetersAggregateGross + currentAllocations.TotalAmountMinor;
+        var projectedAggregateGross = otherMetersAggregateGross + projectedAllocations.TotalAmountMinor;
+
+        var currentCharge = UsageChargeCalculator.Charge(currentAggregateGross, subscription.Price);
+        var projectedCharge = UsageChargeCalculator.Charge(projectedAggregateGross, subscription.Price);
+
+        // The difference of two fully rated aggregate totals, never rated on its own — a tier
+        // boundary the additional units cross, or a rounding step at the discount or tax
+        // boundary, can price the same units differently depending on what came before them in
+        // the period, or in another meter sharing the same invoice.
         var additionalCharge = UsageChargeCalculator.Difference(projectedCharge, currentCharge);
 
         var response = new SubscriptionUsageOveragePreviewResponse

--- a/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
@@ -1,0 +1,257 @@
+using FluentValidation;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Estimates the cost of additional metered usage using the active subscription's own
+/// snapshotted terms, and the same rating, discount and tax logic
+/// <see cref="Outbox.SubscriptionUsageRatingProcessor"/> uses to charge the final usage invoice.
+/// </summary>
+/// <remarks>
+/// Deliberately read-only. No usage record, counter update, invoice, payment, outbox event or
+/// audit event is ever written from here — this only takes dependencies capable of reading, so
+/// there is nothing here that could write even by mistake.
+/// <para>
+/// Reads exclusively from the subscription's own snapshot — <see cref="SubscriptionDetail.Plan"/>
+/// and <see cref="SubscriptionDetail.Price"/> — never from the mutable plan catalogue. An edit to
+/// the catalogue after this subscription was sold must not change what this preview reports, for
+/// the same reason it must not change what period-end rating eventually charges.
+/// </para>
+/// </remarks>
+public sealed class SubscriptionUsageOveragePreviewService : ISubscriptionUsageOveragePreviewService
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly IMeterAllowanceResolver _allowances;
+    private readonly ISubscriptionContextResolver _contextResolver;
+    private readonly IValidator<PreviewUsageOverageRequest> _validator;
+    private readonly TimeProvider _time;
+
+    public SubscriptionUsageOveragePreviewService(
+        ISubscriptionRepository subscriptions,
+        ISubscriptionUsageRepository usage,
+        IMeterAllowanceResolver allowances,
+        ISubscriptionContextResolver contextResolver,
+        IValidator<PreviewUsageOverageRequest> validator,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _usage = usage;
+        _allowances = allowances;
+        _contextResolver = contextResolver;
+        _validator = validator;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>> PreviewAsync(
+        PreviewUsageOverageRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var invalid = await SubscriptionValidation.CheckAsync<
+            PreviewUsageOverageRequest, SubscriptionUsageOveragePreviewResponse>(
+            _validator,
+            request,
+            "subscription_usage_preview_invalid",
+            "The overage preview request is invalid.",
+            correlationId,
+            cancellationToken);
+
+        if (invalid is not null)
+        {
+            return invalid;
+        }
+
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            request.OrganizationId,
+            cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionUsageOveragePreviewResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        var subscription = await _subscriptions.GetLiveAsync(
+            context.TenantId,
+            context.OrganizationId,
+            now,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "This organization has no active subscription.",
+                correlationId);
+        }
+
+        var meter = subscription.Plan.Meters.Find(candidate =>
+            string.Equals(candidate.MeterKey, request.MeterKey, StringComparison.Ordinal));
+
+        if (meter is null)
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_meter_not_found",
+                "The plan does not define this meter.",
+                correlationId);
+        }
+
+        if (!MeterPeriodResolver.TryGetPeriod(subscription, meter, now, out var period))
+        {
+            return Failure(
+                PaymentFailureKind.Unavailable,
+                "subscription_schedule_unavailable",
+                "The usage period could not be determined.",
+                correlationId);
+        }
+
+        if (!meter.OverageAllowed)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_meter_overage_not_allowed",
+                "This meter does not allow usage beyond its included quantity.",
+                correlationId);
+        }
+
+        var hasRateTable = meter.RateTables.Exists(table => string.Equals(
+            table.CurrencyCode, subscription.CurrencyCode, StringComparison.OrdinalIgnoreCase));
+
+        if (!hasRateTable)
+        {
+            // A silent zero would misreport a plan-authoring gap as "no charge" — the one place
+            // this preview refuses outright rather than reusing period-end rating's own tolerant
+            // fallback, since a hypothetical quote has no other charge to fall back to.
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_meter_rate_unavailable",
+                "No overage rate is configured for this subscription's currency.",
+                correlationId);
+        }
+
+        var counter = await _usage.GetCounterAsync(
+            context.TenantId,
+            SubscriptionUsageCounter.CreateId(subscription.ItemId, meter.MeterKey, period.Key),
+            cancellationToken);
+
+        // The append-only ledger is authoritative; the counter is only a fallback for a legacy
+        // period whose ledger read returns nothing — the same precedence period-end rating uses
+        // (see SubscriptionUsageRatingProcessor.EnsureInvoiceAsync).
+        var ledger = await _usage.SummariseLedgerAsync(
+            context.TenantId,
+            subscription.ItemId,
+            meter.MeterKey,
+            period.Key,
+            cancellationToken);
+        var currentUsage = ledger.RecordCount > 0 ? ledger.Balance : counter?.Balance ?? 0;
+
+        var allowance = await _allowances.EffectiveAsync(
+            subscription, meter, period, counter, cancellationToken);
+
+        var projectedUsage = currentUsage + request.AdditionalQuantity;
+        var currentOverageUnits = Math.Max(0, currentUsage - allowance);
+        var projectedOverageUnits = Math.Max(0, projectedUsage - allowance);
+
+        var currentAllocations = SubscriptionUsageRater.OverageAllocations(
+            meter, currentOverageUnits, subscription.CurrencyCode);
+        var projectedAllocations = SubscriptionUsageRater.OverageAllocations(
+            meter, projectedOverageUnits, subscription.CurrencyCode);
+        var additionalAllocations = SubscriptionUsageRater.OverageAllocations(
+            meter,
+            projectedOverageUnits,
+            subscription.CurrencyCode,
+            fromOverageUnitsExclusive: currentOverageUnits);
+
+        var currentCharge = UsageChargeCalculator.Charge(
+            currentAllocations.TotalAmountMinor, subscription.Price);
+        var projectedCharge = UsageChargeCalculator.Charge(
+            projectedAllocations.TotalAmountMinor, subscription.Price);
+
+        // The difference of two fully rated totals, never rated on its own — a tier boundary the
+        // additional units cross, or a rounding step at the discount or tax boundary, can price
+        // the same units differently depending on what came before them in the period.
+        var additionalCharge = UsageChargeCalculator.Difference(projectedCharge, currentCharge);
+
+        var response = new SubscriptionUsageOveragePreviewResponse
+        {
+            MeterKey = meter.MeterKey,
+            UnitLabel = meter.UnitLabel,
+            CurrencyCode = subscription.CurrencyCode,
+            PeriodKey = period.Key,
+            PeriodStartUtc = period.StartUtc,
+            PeriodEndUtc = period.EndUtc,
+            CalculatedAtUtc = now,
+            IncludedQuantity = allowance,
+            CurrentUsage = currentUsage,
+            CurrentOverage = currentOverageUnits,
+            AdditionalQuantity = request.AdditionalQuantity,
+            ProjectedUsage = projectedUsage,
+            ProjectedOverage = projectedOverageUnits,
+            CurrentCharge = Describe(currentCharge),
+            AdditionalCharge = Describe(additionalCharge),
+            ProjectedPeriodCharge = Describe(projectedCharge),
+            AdditionalTierBreakdown = additionalAllocations.Allocations
+                .Select(Describe)
+                .ToList(),
+            Discount = new UsageOveragePreviewDiscountResponse
+            {
+                AutomaticBasisPoints = SubscriptionDiscountPresentation.RateOf(subscription.Price) ?? 0,
+                // Stated explicitly: a promotional discount code never reaches metered overage,
+                // today or in this preview — see UsageChargeCalculator's own remarks.
+                PromotionalCodeApplied = false
+            },
+            Tax = new UsageOveragePreviewTaxResponse
+            {
+                RateBasisPoints = subscription.Price.TaxRateBasisPoints,
+                Mode = (subscription.Price.TaxMode ?? TaxMode.Exclusive).ToString()
+            },
+            WritesUsage = false,
+            ChargesPayment = false,
+            FinalChargeDependsOnActualPeriodEndUsage = true
+        };
+
+        return SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>.Success(
+            response, correlationId);
+    }
+
+    private static UsageChargeAmountsResponse Describe(UsageCharge charge) => new()
+    {
+        GrossMinor = charge.GrossMinor,
+        AutomaticDiscountMinor = charge.AutomaticDiscountMinor,
+        NetMinor = charge.NetMinor,
+        TaxMinor = charge.TaxMinor,
+        TotalMinor = charge.TotalMinor
+    };
+
+    private static UsageOverageTierAllocationResponse Describe(TierAllocation allocation) => new()
+    {
+        FromOverageQuantity = allocation.FromOverageQuantity,
+        ToOverageQuantity = allocation.ToOverageQuantity,
+        Units = allocation.Units,
+        UnitAmountMinor = allocation.UnitAmountMinor,
+        AmountMinor = allocation.AmountMinor
+    };
+
+    private static SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse> Failure(
+        PaymentFailureKind kind,
+        string errorCode,
+        string errorMessage,
+        string correlationId) =>
+        SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>.Failure(
+            kind, errorCode, errorMessage, correlationId);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
@@ -22,54 +22,115 @@ public static class SubscriptionUsageRater
     {
         ArgumentNullException.ThrowIfNull(meter);
 
-        if (!meter.OverageAllowed)
-        {
-            return 0;
-        }
+        return OverageAllocations(
+            meter,
+            Math.Max(0, balance - meter.IncludedQuantity),
+            currencyCode).TotalAmountMinor;
+    }
 
-        var overageUnits = Math.Max(0, balance - meter.IncludedQuantity);
+    /// <summary>
+    /// Prices a range of overage units and reports which tier band each unit fell into.
+    /// </summary>
+    /// <param name="overageUnits">
+    /// The overage, already computed by the caller — from the plan's own included quantity for
+    /// period-end rating, or from an effective allowance (trial grant, carry-forward) for a
+    /// preview. Kept separate from a raw balance so both callers can agree on what "overage" means
+    /// without this method ever reading <see cref="PlanMeter.IncludedQuantity"/> itself.
+    /// </param>
+    /// <param name="fromOverageUnitsExclusive">
+    /// Only the tier bands covering units after this point are priced and reported — the "already
+    /// billed" prefix of a preview's projected range, so its allocations describe only the
+    /// hypothetical addition rather than the whole period.
+    /// </param>
+    public static UsageTierAllocationResult OverageAllocations(
+        PlanMeter meter,
+        long overageUnits,
+        string currencyCode,
+        long fromOverageUnitsExclusive = 0)
+    {
+        ArgumentNullException.ThrowIfNull(meter);
 
-        if (overageUnits == 0)
+        if (!meter.OverageAllowed || overageUnits <= fromOverageUnitsExclusive)
         {
-            return 0;
+            return new UsageTierAllocationResult(0, []);
         }
 
         var table = meter.RateTables.Find(table =>
             string.Equals(table.CurrencyCode, currencyCode, StringComparison.OrdinalIgnoreCase));
 
         // A meter with no rate table for this subscription's currency cannot be priced. Skipping
-        // it is a plan-authoring gap to fix, not a reason to fail every other meter's charge.
+        // it is a plan-authoring gap to fix, not a reason to fail every other meter's charge. A
+        // preview refuses outright instead — see subscription_meter_rate_unavailable — since a
+        // hypothetical quote of zero would be misleading rather than merely incomplete.
         if (table is null)
         {
-            return 0;
+            return new UsageTierAllocationResult(0, []);
         }
 
-        return WalkTiers(table.Tiers, overageUnits);
+        return WalkTierRange(table.Tiers, fromOverageUnitsExclusive, overageUnits);
     }
 
-    private static long WalkTiers(List<MeterTier> tiers, long overageUnits)
+    private static UsageTierAllocationResult WalkTierRange(
+        List<MeterTier> tiers,
+        long fromOverageUnitsExclusive,
+        long toOverageUnitsInclusive)
     {
         var previousBound = 0L;
-        var remaining = overageUnits;
         Int128 total = 0;
+        List<TierAllocation>? allocations = null;
 
         foreach (var tier in tiers)
         {
-            if (remaining <= 0)
+            if (previousBound >= toOverageUnitsInclusive)
             {
                 break;
             }
 
-            var bandWidth = tier.UpToQuantity is { } upTo
-                ? Math.Max(0, upTo - previousBound)
-                : remaining;
-            var bandUnits = Math.Min(remaining, bandWidth);
+            var tierEnd = tier.UpToQuantity is { } upTo
+                ? Math.Min(upTo, toOverageUnitsInclusive)
+                : toOverageUnitsInclusive;
 
-            total += (Int128)bandUnits * tier.UnitAmountMinor;
-            remaining -= bandUnits;
-            previousBound = tier.UpToQuantity ?? previousBound;
+            if (tierEnd > previousBound)
+            {
+                var rangeStart = Math.Max(previousBound, fromOverageUnitsExclusive);
+
+                if (tierEnd > rangeStart)
+                {
+                    var units = tierEnd - rangeStart;
+                    var amount = (Int128)units * tier.UnitAmountMinor;
+                    total += amount;
+                    (allocations ??= []).Add(new TierAllocation(
+                        rangeStart + 1,
+                        tierEnd,
+                        units,
+                        tier.UnitAmountMinor,
+                        (long)amount));
+                }
+            }
+
+            previousBound = tier.UpToQuantity ?? tierEnd;
         }
 
-        return (long)total;
+        return new UsageTierAllocationResult((long)total, allocations ?? []);
     }
 }
+
+/// <summary>
+/// One tier band's slice of a priced overage range: which overage units it covered, at what rate.
+/// </summary>
+/// <param name="FromOverageQuantity">
+/// The first overage unit this band covers, counted from the first overage unit overall (1),
+/// not from wherever the priced range started.
+/// </param>
+/// <param name="ToOverageQuantity">The last overage unit this band covers, inclusive.</param>
+public readonly record struct TierAllocation(
+    long FromOverageQuantity,
+    long ToOverageQuantity,
+    long Units,
+    long UnitAmountMinor,
+    long AmountMinor);
+
+/// <summary>A priced range's total, and the bands that made it up.</summary>
+public readonly record struct UsageTierAllocationResult(
+    long TotalAmountMinor,
+    IReadOnlyList<TierAllocation> Allocations);

--- a/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
@@ -70,6 +70,16 @@ public static class SubscriptionUsageRater
         return WalkTierRange(table.Tiers, fromOverageUnitsExclusive, overageUnits);
     }
 
+    /// <summary>
+    /// Walks the tier table with checked arithmetic throughout, including the <c>Int128</c> tier
+    /// multiplication and every narrowing cast back down to <c>long</c>. A rate table's unit
+    /// amount and a technically valid (merely very large) quantity can each pass validation on
+    /// their own and still multiply, sum or narrow into something that no longer fits a
+    /// <c>long</c> minor-unit amount — silently wrapping there would misprice the charge instead
+    /// of refusing it. <see cref="OverflowException"/> propagates to the caller, which is
+    /// responsible for turning it into a refusal (the preview) or a deferral (period-end rating)
+    /// rather than ever persisting a wrapped amount.
+    /// </summary>
     private static UsageTierAllocationResult WalkTierRange(
         List<MeterTier> tiers,
         long fromOverageUnitsExclusive,
@@ -79,39 +89,42 @@ public static class SubscriptionUsageRater
         Int128 total = 0;
         List<TierAllocation>? allocations = null;
 
-        foreach (var tier in tiers)
+        checked
         {
-            if (previousBound >= toOverageUnitsInclusive)
+            foreach (var tier in tiers)
             {
-                break;
-            }
-
-            var tierEnd = tier.UpToQuantity is { } upTo
-                ? Math.Min(upTo, toOverageUnitsInclusive)
-                : toOverageUnitsInclusive;
-
-            if (tierEnd > previousBound)
-            {
-                var rangeStart = Math.Max(previousBound, fromOverageUnitsExclusive);
-
-                if (tierEnd > rangeStart)
+                if (previousBound >= toOverageUnitsInclusive)
                 {
-                    var units = tierEnd - rangeStart;
-                    var amount = (Int128)units * tier.UnitAmountMinor;
-                    total += amount;
-                    (allocations ??= []).Add(new TierAllocation(
-                        rangeStart + 1,
-                        tierEnd,
-                        units,
-                        tier.UnitAmountMinor,
-                        (long)amount));
+                    break;
                 }
+
+                var tierEnd = tier.UpToQuantity is { } upTo
+                    ? Math.Min(upTo, toOverageUnitsInclusive)
+                    : toOverageUnitsInclusive;
+
+                if (tierEnd > previousBound)
+                {
+                    var rangeStart = Math.Max(previousBound, fromOverageUnitsExclusive);
+
+                    if (tierEnd > rangeStart)
+                    {
+                        var units = tierEnd - rangeStart;
+                        var amount = (Int128)units * tier.UnitAmountMinor;
+                        total += amount;
+                        (allocations ??= []).Add(new TierAllocation(
+                            rangeStart + 1,
+                            tierEnd,
+                            units,
+                            tier.UnitAmountMinor,
+                            (long)amount));
+                    }
+                }
+
+                previousBound = tier.UpToQuantity ?? tierEnd;
             }
 
-            previousBound = tier.UpToQuantity ?? tierEnd;
+            return new UsageTierAllocationResult((long)total, allocations ?? []);
         }
-
-        return new UsageTierAllocationResult((long)total, allocations ?? []);
     }
 }
 

--- a/server/Subscription.DomainService/Services/UsageChargeCalculator.cs
+++ b/server/Subscription.DomainService/Services/UsageChargeCalculator.cs
@@ -1,0 +1,74 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Discounts and taxes a metered overage amount, exactly the way period-end usage rating charges
+/// it (<see cref="Outbox.SubscriptionUsageRatingProcessor"/>).
+/// </summary>
+/// <remarks>
+/// Extracted so the overage preview and the final invoice cannot drift apart: both call this one
+/// method with the same price snapshot, so a subscriber previewing an upgrade sees the figure the
+/// period-end invoice would actually charge, not a second calculation that happens to usually
+/// agree with it.
+/// </remarks>
+public static class UsageChargeCalculator
+{
+    public static UsageCharge Charge(long grossAmountMinor, PriceSnapshot price)
+    {
+        ArgumentNullException.ThrowIfNull(price);
+
+        // The price's automatic discount applies to what the price charges, and overage is one of
+        // the things it charges. Through the shared calculator with no volume band — a band prices
+        // seats and has no meaning for metered units, so the synthetic pass-through outcome below
+        // is empty and both combination policies agree.
+        var builtIn = BuiltInDiscountCalculator.Resolve(
+            grossAmountMinor,
+            new QuantityDiscountOutcome(null, 0, grossAmountMinor, 0, grossAmountMinor),
+            price.AutomaticDiscountBasisPoints,
+            price.QuantityDiscountCombination);
+
+        // Tax is on the aggregate, after the discount, at the subscription's own snapshotted rate
+        // and mode — the same "one charge, taxed the way it was sold" scope period-end rating uses.
+        var breakdown = SubscriptionAmountCalculator.TaxBreakdownFor(
+            builtIn.SubtotalMinor,
+            price.TaxRateBasisPoints,
+            price.TaxMode);
+
+        return new UsageCharge(
+            grossAmountMinor,
+            builtIn.DiscountAmountMinor,
+            breakdown.NetAmountMinor,
+            breakdown.TaxAmountMinor,
+            breakdown.TotalAmountMinor);
+    }
+
+    /// <summary>
+    /// What an additional slice of usage would add, found as the difference between two fully
+    /// rated totals rather than rated on its own.
+    /// </summary>
+    /// <remarks>
+    /// A tier boundary crossed by the additional units, or a rounding step at the discount or tax
+    /// boundary, can price the same units differently depending on what came before them in the
+    /// period. Rating the difference of two whole-period charges is the only way to guarantee the
+    /// additional figure matches what the period-end invoice would actually add.
+    /// </remarks>
+    public static UsageCharge Difference(UsageCharge projected, UsageCharge baseline) => new(
+        projected.GrossMinor - baseline.GrossMinor,
+        projected.AutomaticDiscountMinor - baseline.AutomaticDiscountMinor,
+        projected.NetMinor - baseline.NetMinor,
+        projected.TaxMinor - baseline.TaxMinor,
+        projected.TotalMinor - baseline.TotalMinor);
+}
+
+/// <summary>
+/// One charge, broken into what it grossed, what was discounted off it, and how the remainder
+/// split into net and tax. <see cref="TotalMinor"/> is always <see cref="NetMinor"/> plus
+/// <see cref="TaxMinor"/>, by construction.
+/// </summary>
+public readonly record struct UsageCharge(
+    long GrossMinor,
+    long AutomaticDiscountMinor,
+    long NetMinor,
+    long TaxMinor,
+    long TotalMinor);

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -198,6 +198,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<
             IValidator<RecordUsageRequest>,
             RecordUsageRequestValidator>();
+        services.AddTransient<
+            IValidator<PreviewUsageOverageRequest>,
+            PreviewUsageOverageRequestValidator>();
 
         // Scoped: these read the caller's context, which belongs to one request.
         services.AddScoped<
@@ -264,6 +267,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IMeterAllowanceResolver, MeterAllowanceResolver>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
+        services.AddScoped<
+            ISubscriptionUsageOveragePreviewService,
+            SubscriptionUsageOveragePreviewService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();
         services.AddScoped<IUsageThresholdEmailService, UsageThresholdEmailService>();
         services.AddScoped<

--- a/server/Subscription.DomainService/Validators/PreviewUsageOverageRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PreviewUsageOverageRequestValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using Subscription.DomainService.Requests;
+
+namespace Subscription.DomainService.Validators;
+
+public sealed class PreviewUsageOverageRequestValidator : AbstractValidator<PreviewUsageOverageRequest>
+{
+    public PreviewUsageOverageRequestValidator()
+    {
+        RuleFor(request => request.MeterKey).NotEmpty().MaximumLength(64);
+
+        RuleFor(request => request.AdditionalQuantity)
+            .GreaterThan(0)
+            .WithMessage("The additional quantity must be a positive whole number.");
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -746,6 +746,47 @@ public sealed class SubscriptionCancellationServiceTests
             "never even reaches for the subscription once the operation id itself is unrecognised");
     }
 
+    /// <summary>
+    /// Guards the P1 finding fixed alongside the overflow hardening: cancelling mid-trial must
+    /// freeze the trial's own grant onto the outgoing window, before Status moves to Canceled and
+    /// Trial is cleared — not the plain plan allowance a live resolve would find afterward.
+    /// </summary>
+    [Fact]
+    public async Task An_immediate_cancellation_mid_trial_freezes_the_trial_grant_not_the_post_cancellation_allowance()
+    {
+        _subscription!.Status = SubscriptionStatus.Trialing;
+        _subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = _time.GetUtcNow().UtcDateTime.AddDays(-4),
+            EndsAtUtc = _time.GetUtcNow().UtcDateTime.AddDays(10),
+            Grants = [new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 300 }]
+        };
+        _subscription.Plan.Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                IncludedQuantity = 500,
+                ResetPolicy = MeterResetPolicy.Periodic,
+                OverageAllowed = true
+            }
+        ];
+        var usage = new Mock<ISubscriptionUsageRepository>();
+        usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await ServiceWithUsage(usage.Object).CancelAsync(
+            "sub-1", immediately: true, null, null, "corr-1", CancellationToken.None);
+
+        _transition!.OutgoingUsagePeriod!.MeterAllowances.Should().NotBeNull(
+            "an allowance/usage repository was supplied, so the snapshot must be captured");
+        _transition.OutgoingUsagePeriod.MeterAllowances!["screening"].Should().Be(300,
+            "the trial's own grant at the instant of cancellation, not the plan's plain 500 a " +
+            "live resolve against the post-cancellation (no-trial) subscription would find");
+    }
+
     [Fact]
     public async Task Reconciling_with_no_closure_repository_configured_does_nothing()
     {
@@ -860,6 +901,25 @@ public sealed class SubscriptionCancellationServiceTests
         _time,
         _scheduler.Object,
         _closures.Object);
+
+    /// <summary>
+    /// Only the allowance-snapshot tests need a real usage repository/resolver wired in — every
+    /// other test above must keep exercising the legacy (no snapshot) path unchanged.
+    /// </summary>
+    private SubscriptionCancellationService ServiceWithUsage(ISubscriptionUsageRepository usage) => new(
+        _subscriptions.Object,
+        _links.Object,
+        _contextResolver.Object,
+        new SubscriptionOutboxEventFactory(),
+        new SubscriptionResponseMapper(),
+        _cache.Object,
+        NullLogger<SubscriptionCancellationService>.Instance,
+        _time,
+        _scheduler.Object,
+        _closures.Object,
+        options: null,
+        usage: usage,
+        allowances: new MeterAllowanceResolver(usage));
 
     private static SubscriptionDetail NewSubscription() => new()
     {

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -198,6 +198,91 @@ public sealed class SubscriptionPlanChangeServiceTests
         carried.Subject.UnitAmountMinor.Should().Be(2_000);
     }
 
+    /// <summary>
+    /// Guards the P1 finding fixed alongside the overflow hardening: a plan change must freeze a
+    /// carry-forward meter's actual carried-in allowance onto the outgoing window before the
+    /// schedule swap re-anchors UsageSchedule — a live resolve against the new schedule afterward
+    /// cannot see the old anchor's carried allowance at all (see MeterAllowance.CarriedIn's own
+    /// remarks on why a window before the current anchor never carries).
+    /// </summary>
+    /// <remarks>
+    /// Uses a non-zero <c>CarryForwardCap</c> and a genuinely partial previous window (80 of 100
+    /// used) so the carried allowance itself is non-zero (20) — a cap of zero would be rejected by
+    /// <c>PlanDefinitionRequestValidator</c> and would not exercise the carry math at all.
+    /// </remarks>
+    [Fact]
+    public async Task A_downgrade_freezes_the_carried_forward_allowance_before_the_schedule_re_anchors()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Active, 2_000);
+        _subscription.UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        };
+        _subscription.CurrentUsagePeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+        _subscription.CurrentUsagePeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+        _subscription.Plan.Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                IncludedQuantity = 100,
+                ResetPolicy = MeterResetPolicy.CarryForward,
+                CarryForwardCap = 50,
+                OverageAllowed = true
+            }
+        ];
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice(1_000));
+
+        var usage = new Mock<ISubscriptionUsageRepository>();
+        usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageCounter
+            {
+                MeterKey = "screening",
+                Balance = 80,
+                LimitSnapshot = 100
+            });
+
+        PendingUsagePeriod? captured = null;
+        _subscriptions
+            .Setup(repository => repository.TryChangePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<string?>(),
+                It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(),
+                It.IsAny<PendingUsagePeriod>(), It.IsAny<long>(), It.IsAny<string?>(),
+                It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>(),
+                It.IsAny<SubscriptionDocumentSource?>()))
+            .Callback((string _, string _, int _, string? _, PlanSnapshot _, PriceSnapshot _,
+                    List<SubscriptionQuantityItem> _, SubscriptionPlanSchedule _,
+                    PendingUsagePeriod pending, long _, string? _, SubscriptionOutboxEvent _,
+                    CancellationToken _, SubscriptionDocumentSource? _) => captured = pending)
+            .ReturnsAsync(true);
+
+        var result = await ServiceWithUsage(usage.Object).ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        captured.Should().NotBeNull();
+        captured!.MeterAllowances.Should().NotBeNull(
+            "an allowance/usage repository was supplied, so the snapshot must be captured");
+        captured.MeterAllowances!["screening"].Should().Be(120,
+            "the plan's own 100 plus the 20 actually carried forward — 80 used of a 100 limit, " +
+            "under the 50 cap — captured against the old anchor before the plan change installs " +
+            "a new UsageSchedule that could no longer see it");
+    }
+
     [Fact]
     public async Task A_downgrade_never_calls_the_gateway()
     {
@@ -1056,6 +1141,26 @@ public sealed class SubscriptionPlanChangeServiceTests
         NullLogger<SubscriptionPlanChangeService>.Instance,
         _time,
         billingProfile: _billingProfile.Object);
+
+    /// <summary>
+    /// Only the allowance-snapshot test needs a real usage repository/resolver wired in — every
+    /// other test above must keep exercising the legacy (no snapshot) path unchanged.
+    /// </summary>
+    private SubscriptionPlanChangeService ServiceWithUsage(ISubscriptionUsageRepository usage) => new(
+        _contextResolver.Object,
+        _subscriptions.Object,
+        _catalogue.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new SubscriptionResponseMapper(),
+        new ChangeSubscriptionPlanRequestValidator(),
+        NullLogger<SubscriptionPlanChangeService>.Instance,
+        _time,
+        billingProfile: _billingProfile.Object,
+        usage: usage,
+        allowances: new MeterAllowanceResolver(usage));
 
     private static ChangeSubscriptionPlanRequest Request() => new()
     {

--- a/server/XUnitTest/Subscription/SubscriptionUsageControllerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageControllerTests.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+using Api.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>The metered overage preview endpoint's HTTP-facing behaviour.</summary>
+public sealed class SubscriptionUsageControllerTests
+{
+    [Fact]
+    public void The_controller_requires_authentication()
+    {
+        typeof(SubscriptionUsageController)
+            .GetCustomAttribute<AuthorizeAttribute>()
+            .Should().NotBeNull("every subscription-usage endpoint, including the preview, must " +
+                "be reached only by an authenticated caller");
+    }
+
+    [Fact]
+    public async Task A_successful_preview_returns_the_envelope_with_the_correlation_id()
+    {
+        var overage = new Mock<ISubscriptionUsageOveragePreviewService>();
+        overage
+            .Setup(service => service.PreviewAsync(
+                It.IsAny<PreviewUsageOverageRequest>(), "trace-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>.Success(
+                new SubscriptionUsageOveragePreviewResponse { MeterKey = "screening" }, "trace-1"));
+        var controller = Controller(overage.Object);
+
+        var result = await controller.PreviewOverage(
+            new PreviewUsageOverageRequest { MeterKey = "screening", AdditionalQuantity = 100 },
+            CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var envelope = ok.Value.Should()
+            .BeOfType<ApiResponse<SubscriptionUsageOveragePreviewResponse>>().Subject;
+        envelope.Success.Should().BeTrue();
+        envelope.Data!.MeterKey.Should().Be("screening");
+        envelope.Meta.CorrelationId.Should().Be("trace-1");
+    }
+
+    [Fact]
+    public async Task A_validation_failure_returns_400_with_the_named_error_code()
+    {
+        var overage = new Mock<ISubscriptionUsageOveragePreviewService>();
+        overage
+            .Setup(service => service.PreviewAsync(
+                It.IsAny<PreviewUsageOverageRequest>(), "trace-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_usage_preview_invalid",
+                "The overage preview request is invalid.",
+                "trace-1"));
+        var controller = Controller(overage.Object);
+
+        var result = await controller.PreviewOverage(
+            new PreviewUsageOverageRequest(), CancellationToken.None);
+
+        var objectResult = result.Should().BeOfType<ObjectResult>().Subject;
+        objectResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        var envelope = objectResult.Value.Should()
+            .BeOfType<ApiResponse<SubscriptionUsageOveragePreviewResponse>>().Subject;
+        envelope.Success.Should().BeFalse();
+        envelope.Error!.Code.Should().Be("subscription_usage_preview_invalid");
+    }
+
+    [Theory]
+    [InlineData(PaymentFailureKind.NotFound, StatusCodes.Status404NotFound)]
+    [InlineData(PaymentFailureKind.Conflict, StatusCodes.Status409Conflict)]
+    [InlineData(PaymentFailureKind.Unavailable, StatusCodes.Status503ServiceUnavailable)]
+    public async Task Named_failures_map_to_their_documented_status_code(
+        PaymentFailureKind kind, int expectedStatus)
+    {
+        var overage = new Mock<ISubscriptionUsageOveragePreviewService>();
+        overage
+            .Setup(service => service.PreviewAsync(
+                It.IsAny<PreviewUsageOverageRequest>(), "trace-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>.Failure(
+                kind, "some_error_code", "failed", "trace-1"));
+        var controller = Controller(overage.Object);
+
+        var result = await controller.PreviewOverage(
+            new PreviewUsageOverageRequest { MeterKey = "screening", AdditionalQuantity = 1 },
+            CancellationToken.None);
+
+        result.Should().BeOfType<ObjectResult>().Subject.StatusCode.Should().Be(expectedStatus);
+    }
+
+    [Fact]
+    public async Task The_organization_id_on_the_request_body_is_forwarded_to_the_service()
+    {
+        var overage = new Mock<ISubscriptionUsageOveragePreviewService>();
+        overage
+            .Setup(service => service.PreviewAsync(
+                It.IsAny<PreviewUsageOverageRequest>(), "trace-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<SubscriptionUsageOveragePreviewResponse>.Success(
+                new SubscriptionUsageOveragePreviewResponse(), "trace-1"));
+        var controller = Controller(overage.Object);
+
+        await controller.PreviewOverage(
+            new PreviewUsageOverageRequest
+            {
+                MeterKey = "screening",
+                AdditionalQuantity = 1,
+                OrganizationId = "org-9"
+            },
+            CancellationToken.None);
+
+        overage.Verify(
+            service => service.PreviewAsync(
+                It.Is<PreviewUsageOverageRequest>(r => r.OrganizationId == "org-9"),
+                "trace-1",
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "only the console gets to act on this, and that is decided downstream in " +
+            "SubscriptionContextResolver — this only proves the value reaches the service");
+    }
+
+    private static SubscriptionUsageController Controller(
+        ISubscriptionUsageOveragePreviewService overagePreview)
+    {
+        var controller = new SubscriptionUsageController(
+            Mock.Of<IUsageRecordingService>(), overagePreview)
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+        controller.HttpContext.TraceIdentifier = "trace-1";
+        return controller;
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
@@ -311,6 +311,34 @@ public sealed class SubscriptionUsageOveragePreviewServiceTests
         result.ErrorCode.Should().Be("subscription_usage_preview_invalid");
     }
 
+    /// <summary>
+    /// A distinct failure point from the tier-walk overflow above: a gross overage total that
+    /// comfortably fits a <c>long</c> on its own — the tier walk never overflows — can still
+    /// overflow once this subscription's own 7.7% exclusive tax (see <c>NewSubscription</c>) is
+    /// added on top inside <c>SubscriptionAmountCalculator.TaxBreakdownFor</c>. Must be refused
+    /// the same way, not bubble up as an unhandled 500.
+    /// </summary>
+    [Fact]
+    public async Task A_gross_total_that_only_overflows_after_tax_is_a_named_failure()
+    {
+        _subscription = NewSubscription(tiers:
+        [
+            new MeterTier { UpToQuantity = null, UnitAmountMinor = 9_000_000_000_000_000_000 }
+        ]);
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = 151, LimitSnapshot = 150 });
+
+        var result = await Service().PreviewAsync(NewRequest(1), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "1 overage unit at 9 quintillion is a gross that fits a long, but 7.7% tax on top of " +
+            "it does not, and must be refused rather than silently wrapped");
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_usage_preview_invalid");
+    }
+
     [Fact]
     public async Task A_non_positive_additional_quantity_is_refused()
     {

--- a/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
@@ -284,6 +284,33 @@ public sealed class SubscriptionUsageOveragePreviewServiceTests
         result.ErrorCode.Should().Be("subscription_usage_preview_invalid");
     }
 
+    /// <summary>
+    /// Hardening beyond the currentUsage+additionalQuantity check above: a technically valid unit
+    /// rate and a technically valid (if unusual) overage quantity can still multiply past
+    /// <c>long.MaxValue</c> once the tier total's <c>Int128</c> is narrowed back down to
+    /// <c>long</c>. See SubscriptionUsageRater.WalkTierRange's own remarks.
+    /// </summary>
+    [Fact]
+    public async Task A_tier_total_that_would_overflow_a_long_is_a_named_failure_not_a_wrapped_charge()
+    {
+        _subscription = NewSubscription(tiers:
+        [
+            new MeterTier { UpToQuantity = null, UnitAmountMinor = 5_000_000_000_000_000_000 }
+        ]);
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = 153, LimitSnapshot = 150 });
+
+        var result = await Service().PreviewAsync(NewRequest(1), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "3 overage units at 5 quintillion each is ~15 quintillion — past long.MaxValue " +
+            "(~9.2 quintillion) — and must be refused rather than silently wrapped negative");
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_usage_preview_invalid");
+    }
+
     [Fact]
     public async Task A_non_positive_additional_quantity_is_refused()
     {

--- a/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
@@ -267,6 +267,24 @@ public sealed class SubscriptionUsageOveragePreviewServiceTests
     }
 
     [Fact]
+    public async Task An_additional_quantity_that_would_overflow_the_projection_is_a_named_failure()
+    {
+        // A valid positive AdditionalQuantity added to a balance already near long.MaxValue would
+        // otherwise wrap into a negative projected usage — checked arithmetic must catch this
+        // rather than let it silently produce a nonsensical negative charge.
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = long.MaxValue - 10, LimitSnapshot = 150 });
+
+        var result = await Service().PreviewAsync(NewRequest(20), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_usage_preview_invalid");
+    }
+
+    [Fact]
     public async Task A_non_positive_additional_quantity_is_refused()
     {
         var result = await Service().PreviewAsync(NewRequest(0), "corr-1", CancellationToken.None);

--- a/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
@@ -1,0 +1,376 @@
+using FluentAssertions;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Previewing the cost of additional metered usage — advisory, and never writing anything.
+/// </summary>
+public sealed class SubscriptionUsageOveragePreviewServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 25, 10, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail _subscription = NewSubscription();
+
+    public SubscriptionUsageOveragePreviewServiceTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+
+        _usage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((0L, 0L));
+
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = 170, LimitSnapshot = 150 });
+
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+    }
+
+    [Fact]
+    public async Task Current_usage_plus_additional_produces_the_projected_totals()
+    {
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.CurrentUsage.Should().Be(170);
+        result.Value.IncludedQuantity.Should().Be(150);
+        result.Value.CurrentOverage.Should().Be(20);
+        result.Value.ProjectedUsage.Should().Be(270);
+        result.Value.ProjectedOverage.Should().Be(120);
+    }
+
+    [Fact]
+    public async Task The_documented_example_figures_match_exactly()
+    {
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        var response = result.Value!;
+        response.CurrentCharge.GrossMinor.Should().Be(2_000);
+        response.CurrentCharge.TaxMinor.Should().Be(154);
+        response.CurrentCharge.TotalMinor.Should().Be(2_154);
+        response.AdditionalCharge.GrossMinor.Should().Be(10_000);
+        response.AdditionalCharge.TaxMinor.Should().Be(770);
+        response.AdditionalCharge.TotalMinor.Should().Be(10_770);
+        response.ProjectedPeriodCharge.GrossMinor.Should().Be(12_000);
+        response.ProjectedPeriodCharge.TaxMinor.Should().Be(924);
+        response.ProjectedPeriodCharge.TotalMinor.Should().Be(12_924);
+    }
+
+    [Fact]
+    public async Task The_additional_total_is_the_projected_total_minus_the_current_total()
+    {
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        var response = result.Value!;
+        response.AdditionalCharge.TotalMinor.Should().Be(
+            response.ProjectedPeriodCharge.TotalMinor - response.CurrentCharge.TotalMinor);
+        response.AdditionalCharge.TaxMinor.Should().Be(
+            response.ProjectedPeriodCharge.TaxMinor - response.CurrentCharge.TaxMinor);
+        response.AdditionalCharge.NetMinor.Should().Be(
+            response.ProjectedPeriodCharge.NetMinor - response.CurrentCharge.NetMinor);
+    }
+
+    [Fact]
+    public async Task Additional_usage_crossing_a_tier_boundary_reports_the_exact_bands()
+    {
+        _subscription = NewSubscription(tiers:
+        [
+            new MeterTier { UpToQuantity = 50, UnitAmountMinor = 10 },
+            new MeterTier { UpToQuantity = null, UnitAmountMinor = 5 }
+        ]);
+        // 30 current overage, 40 additional — spans the remaining 20 units of the first tier and
+        // 20 units of the second.
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = 180, LimitSnapshot = 150 });
+
+        var result = await Service().PreviewAsync(NewRequest(40), "corr-1", CancellationToken.None);
+
+        var breakdown = result.Value!.AdditionalTierBreakdown;
+        breakdown.Should().HaveCount(2);
+        breakdown[0].FromOverageQuantity.Should().Be(31);
+        breakdown[0].ToOverageQuantity.Should().Be(50);
+        breakdown[0].Units.Should().Be(20);
+        breakdown[0].UnitAmountMinor.Should().Be(10);
+        breakdown[0].AmountMinor.Should().Be(200);
+        breakdown[1].FromOverageQuantity.Should().Be(51);
+        breakdown[1].ToOverageQuantity.Should().Be(70);
+        breakdown[1].Units.Should().Be(20);
+        breakdown[1].UnitAmountMinor.Should().Be(5);
+        breakdown[1].AmountMinor.Should().Be(100);
+    }
+
+    [Theory]
+    [InlineData(AutomaticDiscountCombination.BestDiscount)]
+    [InlineData(AutomaticDiscountCombination.Additive)]
+    public async Task Automatic_discounts_apply_under_either_combination_policy(
+        AutomaticDiscountCombination combination)
+    {
+        _subscription.Price.AutomaticDiscountBasisPoints = 800;
+        _subscription.Price.QuantityDiscountCombination = combination;
+
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.Value!.CurrentCharge.AutomaticDiscountMinor.Should().Be(160);
+        result.Value.Discount.AutomaticBasisPoints.Should().Be(800);
+    }
+
+    [Fact]
+    public async Task A_promotional_discount_never_reaches_the_preview_and_is_reported_as_such()
+    {
+        _subscription.Discount = new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = 5_000
+        };
+
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.Value!.Discount.PromotionalCodeApplied.Should().BeFalse();
+        // 20% off would have shown here had the promotion reached usage; it must not.
+        result.Value.CurrentCharge.GrossMinor.Should().Be(2_000);
+    }
+
+    [Fact]
+    public async Task Inclusive_tax_matches_the_period_end_calculation_exactly()
+    {
+        _subscription.Price.TaxRateBasisPoints = 1_000;
+        _subscription.Price.TaxMode = TaxMode.Inclusive;
+
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.Value!.CurrentCharge.TotalMinor.Should().Be(2_000);
+        result.Value.CurrentCharge.TaxMinor.Should().Be(182);
+        result.Value.CurrentCharge.NetMinor.Should().Be(1_818);
+        result.Value.Tax.Mode.Should().Be(nameof(TaxMode.Inclusive));
+    }
+
+    [Fact]
+    public async Task A_trial_grant_replaces_the_included_quantity()
+    {
+        _subscription.Status = SubscriptionStatus.Trialing;
+        _subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = _time.GetUtcNow().UtcDateTime.AddDays(-1),
+            EndsAtUtc = _time.GetUtcNow().UtcDateTime.AddDays(13),
+            Grants = [new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 25 }]
+        };
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageCounter?)null);
+
+        var result = await Service().PreviewAsync(NewRequest(10), "corr-1", CancellationToken.None);
+
+        result.Value!.IncludedQuantity.Should().Be(25,
+            "a trial grant replaces the plan's own included quantity");
+    }
+
+    [Fact]
+    public async Task A_missing_currency_rate_table_returns_a_named_error_rather_than_zero()
+    {
+        _subscription.Plan.Meters[0].RateTables[0].CurrencyCode = "EUR";
+
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_meter_rate_unavailable");
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+    }
+
+    [Fact]
+    public async Task Overage_not_allowed_is_a_named_conflict_not_a_zero_charge()
+    {
+        _subscription.Plan.Meters[0].OverageAllowed = false;
+
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_meter_overage_not_allowed");
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+    }
+
+    [Fact]
+    public async Task Ledger_usage_wins_when_a_crash_left_the_counter_projection_behind()
+    {
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = 100, LimitSnapshot = 150 });
+        _usage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                TenantId, "sub-1", "screening", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((170L, 3L));
+
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.Value!.CurrentUsage.Should().Be(170,
+            "the ledger is authoritative whenever it has records at all");
+    }
+
+    [Fact]
+    public async Task No_meter_is_not_found()
+    {
+        var request = NewRequest(100);
+        request.MeterKey = "not-a-meter";
+
+        var result = await Service().PreviewAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_meter_not_found");
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+    }
+
+    [Fact]
+    public async Task No_subscription_is_not_found()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_not_found");
+    }
+
+    [Fact]
+    public async Task A_non_positive_additional_quantity_is_refused()
+    {
+        var result = await Service().PreviewAsync(NewRequest(0), "corr-1", CancellationToken.None);
+
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_usage_preview_invalid");
+    }
+
+    [Fact]
+    public async Task The_response_states_it_neither_writes_nor_charges_anything()
+    {
+        var result = await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        result.Value!.WritesUsage.Should().BeFalse();
+        result.Value.ChargesPayment.Should().BeFalse();
+        result.Value.FinalChargeDependsOnActualPeriodEndUsage.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Nothing_is_ever_written_to_the_usage_ledger_or_counter()
+    {
+        await Service().PreviewAsync(NewRequest(100), "corr-1", CancellationToken.None);
+
+        _usage.Verify(
+            repository => repository.TryAppendRecordAsync(
+                It.IsAny<SubscriptionUsageRecord>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _usage.Verify(
+            repository => repository.ApplyDeltaAsync(
+                It.IsAny<SubscriptionUsageCounter>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _usage.Verify(
+            repository => repository.TryRepairCounterAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<long>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _usage.Verify(
+            repository => repository.TryMarkThresholdNotifiedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private SubscriptionUsageOveragePreviewService Service() => new(
+        _subscriptions.Object,
+        _usage.Object,
+        new MeterAllowanceResolver(_usage.Object),
+        _contextResolver.Object,
+        new PreviewUsageOverageRequestValidator(),
+        _time);
+
+    private static PreviewUsageOverageRequest NewRequest(long additionalQuantity) => new()
+    {
+        MeterKey = "screening",
+        AdditionalQuantity = additionalQuantity
+    };
+
+    private static SubscriptionDetail NewSubscription(List<MeterTier>? tiers = null) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            TaxRateBasisPoints = 770,
+            TaxMode = TaxMode.Exclusive
+        },
+        CurrentUsagePeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentUsagePeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        },
+        Plan = new PlanSnapshot
+        {
+            Meters =
+            [
+                new PlanMeter
+                {
+                    MeterKey = "screening",
+                    UnitLabel = "screenings",
+                    IncludedQuantity = 150,
+                    OverageAllowed = true,
+                    RateTables =
+                    [
+                        new MeterRateTable
+                        {
+                            CurrencyCode = "CHF",
+                            Tiers = tiers ?? [new MeterTier { UpToQuantity = null, UnitAmountMinor = 100 }]
+                        }
+                    ]
+                }
+            ]
+        }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
@@ -82,6 +82,89 @@ public sealed class SubscriptionUsageRaterTests
         SubscriptionUsageRater.OverageAmountMinor(meter, 100, "CHF").Should().Be(1_000);
     }
 
+    [Fact]
+    public void Allocations_for_the_full_range_report_every_tier_band_that_contributed()
+    {
+        var meter = NewMeter(includedQuantity: 500, tiers: [Tier(400, 10), Tier(null, 5)]);
+
+        var result = SubscriptionUsageRater.OverageAllocations(meter, 700, "CHF");
+
+        result.TotalAmountMinor.Should().Be(5_500);
+        result.Allocations.Should().HaveCount(2);
+        result.Allocations[0].FromOverageQuantity.Should().Be(1);
+        result.Allocations[0].ToOverageQuantity.Should().Be(400);
+        result.Allocations[0].Units.Should().Be(400);
+        result.Allocations[0].UnitAmountMinor.Should().Be(10);
+        result.Allocations[0].AmountMinor.Should().Be(4_000);
+        result.Allocations[1].FromOverageQuantity.Should().Be(401);
+        result.Allocations[1].ToOverageQuantity.Should().Be(700);
+        result.Allocations[1].Units.Should().Be(300);
+        result.Allocations[1].UnitAmountMinor.Should().Be(5);
+        result.Allocations[1].AmountMinor.Should().Be(1_500);
+    }
+
+    [Fact]
+    public void Allocations_starting_partway_through_a_tier_report_only_the_units_after_that_point()
+    {
+        var meter = NewMeter(includedQuantity: 150, tiers: [Tier(null, 100)]);
+
+        // 20 overage already billed; 100 more requested — units 21 through 120.
+        var result = SubscriptionUsageRater.OverageAllocations(
+            meter, overageUnits: 120, currencyCode: "CHF", fromOverageUnitsExclusive: 20);
+
+        result.TotalAmountMinor.Should().Be(10_000);
+        result.Allocations.Should().ContainSingle();
+        result.Allocations[0].FromOverageQuantity.Should().Be(21);
+        result.Allocations[0].ToOverageQuantity.Should().Be(120);
+        result.Allocations[0].Units.Should().Be(100);
+        result.Allocations[0].AmountMinor.Should().Be(10_000);
+    }
+
+    [Fact]
+    public void Allocations_crossing_a_tier_boundary_split_the_additional_units_correctly()
+    {
+        var meter = NewMeter(includedQuantity: 0, tiers: [Tier(400, 10), Tier(null, 5)]);
+
+        // Already 350 overage units billed (all inside the first tier); 100 more requested spans
+        // the remaining 50 units of the first tier plus 50 of the second.
+        var result = SubscriptionUsageRater.OverageAllocations(
+            meter, overageUnits: 450, currencyCode: "CHF", fromOverageUnitsExclusive: 350);
+
+        result.TotalAmountMinor.Should().Be(750); // 50 * 10 + 50 * 5
+        result.Allocations.Should().HaveCount(2);
+        result.Allocations[0].FromOverageQuantity.Should().Be(351);
+        result.Allocations[0].ToOverageQuantity.Should().Be(400);
+        result.Allocations[0].Units.Should().Be(50);
+        result.Allocations[0].AmountMinor.Should().Be(500);
+        result.Allocations[1].FromOverageQuantity.Should().Be(401);
+        result.Allocations[1].ToOverageQuantity.Should().Be(450);
+        result.Allocations[1].Units.Should().Be(50);
+        result.Allocations[1].AmountMinor.Should().Be(250);
+    }
+
+    [Fact]
+    public void Allocations_with_nothing_additional_beyond_the_starting_point_are_empty()
+    {
+        var meter = NewMeter(includedQuantity: 0, tiers: [Tier(null, 10)]);
+
+        var result = SubscriptionUsageRater.OverageAllocations(
+            meter, overageUnits: 100, currencyCode: "CHF", fromOverageUnitsExclusive: 100);
+
+        result.TotalAmountMinor.Should().Be(0);
+        result.Allocations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void The_total_returning_method_matches_the_allocation_totals_sum()
+    {
+        var meter = NewMeter(includedQuantity: 500, tiers: [Tier(400, 10), Tier(null, 5)]);
+
+        var total = SubscriptionUsageRater.OverageAmountMinor(meter, 1_200, "CHF");
+        var allocations = SubscriptionUsageRater.OverageAllocations(meter, 700, "CHF");
+
+        total.Should().Be(allocations.TotalAmountMinor);
+    }
+
     private static MeterTier Tier(long? upTo, long unitAmountMinor) =>
         new() { UpToQuantity = upTo, UnitAmountMinor = unitAmountMinor };
 

--- a/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
@@ -165,6 +165,44 @@ public sealed class SubscriptionUsageRaterTests
         total.Should().Be(allocations.TotalAmountMinor);
     }
 
+    /// <summary>
+    /// A technically valid unit rate and a technically valid (if unusual) overage quantity can
+    /// still multiply past <c>long.MaxValue</c> once the <c>Int128</c> tier total is narrowed back
+    /// down to <c>long</c> — checked arithmetic throughout WalkTierRange must throw rather than
+    /// silently wrap into a mispriced (and possibly negative) charge.
+    /// </summary>
+    [Fact]
+    public void A_tier_total_that_would_overflow_a_long_throws_rather_than_wraps()
+    {
+        var meter = NewMeter(
+            includedQuantity: 0,
+            tiers: [Tier(null, 5_000_000_000_000_000_000)]);
+
+        // 3 units at 5 quintillion each is ~15 quintillion, past long.MaxValue (~9.2 quintillion).
+        var act = () => SubscriptionUsageRater.OverageAllocations(meter, overageUnits: 3, currencyCode: "CHF");
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    /// <summary>
+    /// A rate and quantity that individually fit comfortably in a <c>long</c>, and whose product
+    /// also fits, must not be refused just because the intermediate arithmetic happens to use a
+    /// wider type. Checked arithmetic must never reject a charge that was never actually going to
+    /// overflow.
+    /// </summary>
+    [Fact]
+    public void A_large_but_valid_tier_total_still_prices_correctly()
+    {
+        var meter = NewMeter(
+            includedQuantity: 0,
+            tiers: [Tier(null, 1_000_000_000_000)]);
+
+        var result = SubscriptionUsageRater.OverageAllocations(
+            meter, overageUnits: 1_000_000, currencyCode: "CHF");
+
+        result.TotalAmountMinor.Should().Be(1_000_000_000_000L * 1_000_000);
+    }
+
     private static MeterTier Tier(long? upTo, long unitAmountMinor) =>
         new() { UpToQuantity = upTo, UnitAmountMinor = unitAmountMinor };
 

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -489,6 +489,130 @@ public sealed class SubscriptionUsageRatingProcessorTests
         _createdInvoice.Should().BeNull();
     }
 
+    /// <summary>
+    /// The actual crash scenario the allowance-snapshot finding is about: the ledger append landed
+    /// but the counter (and its LimitSnapshot) never did, for a window a cancellation or plan
+    /// change has already cut short and queued as a PendingUsagePeriod. With no counter to freeze
+    /// an allowance for on its own, final rating must trust the snapshot captured on the pending
+    /// period itself rather than resolve live against a synthetic subscription's current
+    /// (post-transition) status/trial/schedule.
+    /// </summary>
+    [Fact]
+    public async Task A_pending_periods_frozen_allowance_snapshot_is_used_even_when_the_counter_never_existed()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.Status = SubscriptionStatus.Canceled; // post-cancellation: no trial anymore.
+        subscription.PendingUsagePeriods =
+        [
+            new PendingUsagePeriod
+            {
+                PeriodKey = "M20260801T000000Z",
+                PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
+                PeriodEndUtc = subscription.CurrentUsagePeriodEndUtc,
+                Plan = subscription.Plan,
+                Price = subscription.Price,
+                CurrencyCode = "CHF",
+                CorrelationId = "cancel-1",
+                // The frozen trial-grant-like allowance captured before cancellation — deliberately
+                // different from the plan's plain 500, which is what a live resolve against this
+                // now-Canceled, no-trial subscription would fall back to.
+                MeterAllowances = new Dictionary<string, long>(StringComparer.Ordinal)
+                {
+                    ["screening"] = 300
+                }
+            }
+        ];
+        _due = [subscription];
+        // No counter at all: the ledger append landed, the counter projection never did.
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _usage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                TenantId, "sub-1", "screening", "M20260801T000000Z", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((700, 1));
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        // 700 - 300 (frozen) = 400 overage, at 10/unit = 4,000. Using the live plan allowance of
+        // 500 instead would have priced only 200 units (2,000) — silently under-billing the
+        // customer for usage their trial grant never actually covered.
+        _createdInvoice!.TotalAmountMinor.Should().Be(4_000,
+            "the frozen trial-grant snapshot, not the plan's plain allowance a live resolve " +
+            "against the post-cancellation subscription would find");
+    }
+
+    /// <summary>
+    /// A PendingUsagePeriod queued before the allowance snapshot existed carries no
+    /// <see cref="PendingUsagePeriod.MeterAllowances"/> at all — production documents already in
+    /// flight when this shipped. Final rating must still price them, falling back to the live
+    /// resolver exactly as it did before the snapshot existed.
+    /// </summary>
+    [Fact]
+    public async Task A_legacy_pending_period_with_no_allowance_snapshot_falls_back_to_the_live_resolver()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.Status = SubscriptionStatus.Canceled;
+        subscription.PendingUsagePeriods =
+        [
+            new PendingUsagePeriod
+            {
+                PeriodKey = "M20260801T000000Z",
+                PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
+                PeriodEndUtc = subscription.CurrentUsagePeriodEndUtc,
+                Plan = subscription.Plan,
+                Price = subscription.Price,
+                CurrencyCode = "CHF",
+                CorrelationId = "cancel-1"
+                // MeterAllowances intentionally left null — a legacy document.
+            }
+        ];
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 700)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        // No LimitSnapshot on the counter, so the live resolver falls back to the plan's own 500.
+        // 700 - 500 = 200 overage, at 10/unit = 2,000 — the same figure this exact scenario priced
+        // to before the snapshot existed (see A_canceled_subscriptions_final_window_is_rated_from_its_own_snapshot).
+        _createdInvoice!.TotalAmountMinor.Should().Be(2_000,
+            "a legacy document with no snapshot must still be rated, live, exactly as before");
+    }
+
+    /// <summary>
+    /// A rate table authored with a very large unit amount, combined with a large but real
+    /// balance, can multiply past <c>long.MaxValue</c> once the tier total is narrowed back down.
+    /// There is no HTTP response here to refuse with, so the period is deferred instead of ever
+    /// persisting a wrapped (and possibly negative) invoice total.
+    /// </summary>
+    [Fact]
+    public async Task A_period_whose_overage_would_overflow_a_long_is_deferred_rather_than_mispriced()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.Plan.Meters[0].RateTables[0].Tiers =
+        [
+            new MeterTier { UpToQuantity = null, UnitAmountMinor = 5_000_000_000_000_000_000 }
+        ];
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 503)]); // 3 overage units.
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        _createdInvoice.Should().BeNull(
+            "an invoice that could only be built from a wrapped total must never be persisted");
+        _usageInvoices.Verify(
+            repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     [Fact]
     public async Task Tax_is_applied_once_to_the_aggregate_not_per_meter_line()
     {

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -603,13 +603,114 @@ public sealed class SubscriptionUsageRatingProcessorTests
                 TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([NewCounter("screening", 503)]); // 3 overage units.
 
-        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+        var closedCount = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
         _createdInvoice.Should().BeNull(
             "an invoice that could only be built from a wrapped total must never be persisted");
         _usageInvoices.Verify(
             repository => repository.TryCreateAsync(
                 It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Deferred must mean genuinely untouched, not merely "no invoice": the usage clock must
+        // not advance past the unbilled period, or the next sweep would never look at it again.
+        closedCount.Should().Be(0,
+            "a deferred period is not closed — the next sweep must find it still due");
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "advancing the usage clock here would roll the subscription forward past usage that " +
+            "was never actually billed");
+    }
+
+    /// <summary>
+    /// The same overflow, but for a cut-short (PendingUsagePeriod) window on a canceled
+    /// subscription. Deferring here must leave every piece of pending-period bookkeeping in
+    /// place — the snapshot itself and its closure record — so the next sweep retries the period
+    /// exactly as it would any other not-yet-ready one, rather than silently discarding it.
+    /// </summary>
+    [Fact]
+    public async Task A_pending_periods_overflow_leaves_its_snapshot_and_closure_untouched()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.Status = SubscriptionStatus.Canceled;
+        subscription.Plan.Meters[0].RateTables[0].Tiers =
+        [
+            new MeterTier { UpToQuantity = null, UnitAmountMinor = 5_000_000_000_000_000_000 }
+        ];
+        subscription.PendingUsagePeriods =
+        [
+            new PendingUsagePeriod
+            {
+                PeriodKey = "M20260801T000000Z",
+                PeriodStartUtc = subscription.CurrentUsagePeriodStartUtc,
+                PeriodEndUtc = subscription.CurrentUsagePeriodEndUtc,
+                Plan = subscription.Plan,
+                Price = subscription.Price,
+                CurrencyCode = "CHF",
+                CorrelationId = "cancel-1",
+                MeterAllowances = new Dictionary<string, long> { ["screening"] = 0 }
+            }
+        ];
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 503)]);
+        _closures
+            .Setup(repository => repository.GetAsync(
+                TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UsagePeriodClosure?)null);
+
+        var closedCount = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        closedCount.Should().Be(0,
+            "a deferred pending period is not closed — the next sweep must find it still pending");
+        _createdInvoice.Should().BeNull();
+        _subscriptions.Verify(
+            repository => repository.TryRemovePendingUsagePeriodAsync(
+                TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()),
+            Times.Never,
+            "removing the snapshot here would make the period vanish with no invoice ever created");
+        _closures.Verify(
+            repository => repository.TryMarkClosedAsync(
+                TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()),
+            Times.Never,
+            "marking the closure Closed here would stop the next sweep from ever revisiting it");
+    }
+
+    /// <summary>
+    /// A gross overage total that comfortably fits a <c>long</c> on its own can still overflow
+    /// once exclusive tax is added on top — a distinct failure point from the tier-walk overflow
+    /// above, which never reaches tax at all. Must be deferred the same way.
+    /// </summary>
+    [Fact]
+    public async Task A_gross_total_that_only_overflows_after_tax_is_deferred_rather_than_mispriced()
+    {
+        var subscription = NewSubscription("sub-1");
+        subscription.Plan.Meters[0].RateTables[0].Tiers =
+        [
+            new MeterTier { UpToQuantity = null, UnitAmountMinor = 9_000_000_000_000_000_000 }
+        ];
+        subscription.Price.TaxRateBasisPoints = 10_000; // 100% — doubles the gross once taxed.
+        subscription.Price.TaxMode = TaxMode.Exclusive;
+        _due = [subscription];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 501)]); // 1 overage unit: gross = 9e18, fits a long.
+
+        var closedCount = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        _createdInvoice.Should().BeNull(
+            "gross plus tax overflows a long even though gross alone did not, and must never be " +
+            "persisted as a wrapped total");
+        closedCount.Should().Be(0,
+            "a deferred period is not closed — the next sweep must find it still due");
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/server/XUnitTest/Subscription/UsageChargeCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/UsageChargeCalculatorTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Discounting and taxing a metered overage amount — shared by period-end rating and the overage
+/// preview, so both must agree exactly.
+/// </summary>
+public sealed class UsageChargeCalculatorTests
+{
+    [Fact]
+    public void No_discount_and_no_tax_charges_the_gross_untouched()
+    {
+        var charge = UsageChargeCalculator.Charge(2_000, NewPrice());
+
+        charge.GrossMinor.Should().Be(2_000);
+        charge.AutomaticDiscountMinor.Should().Be(0);
+        charge.NetMinor.Should().Be(2_000);
+        charge.TaxMinor.Should().Be(0);
+        charge.TotalMinor.Should().Be(2_000);
+    }
+
+    [Fact]
+    public void An_automatic_discount_reduces_the_amount_before_tax()
+    {
+        var price = NewPrice(automaticDiscountBasisPoints: 800, taxRateBasisPoints: 1_000);
+
+        var charge = UsageChargeCalculator.Charge(2_000, price);
+
+        charge.AutomaticDiscountMinor.Should().Be(160);
+        charge.NetMinor.Should().Be(1_840);
+        charge.TaxMinor.Should().Be(184);
+        charge.TotalMinor.Should().Be(2_024);
+    }
+
+    [Fact]
+    public void Exclusive_tax_is_added_on_top_of_the_net_amount()
+    {
+        var price = NewPrice(taxRateBasisPoints: 770, taxMode: TaxMode.Exclusive);
+
+        var charge = UsageChargeCalculator.Charge(2_000, price);
+
+        charge.NetMinor.Should().Be(2_000);
+        charge.TaxMinor.Should().Be(154);
+        charge.TotalMinor.Should().Be(2_154);
+    }
+
+    [Fact]
+    public void Inclusive_tax_is_extracted_from_the_configured_amount()
+    {
+        var price = NewPrice(taxRateBasisPoints: 1_000, taxMode: TaxMode.Inclusive);
+
+        var charge = UsageChargeCalculator.Charge(2_000, price);
+
+        charge.TotalMinor.Should().Be(2_000);
+        charge.TaxMinor.Should().Be(182);
+        charge.NetMinor.Should().Be(1_818);
+    }
+
+    [Theory]
+    [InlineData(AutomaticDiscountCombination.BestDiscount)]
+    [InlineData(AutomaticDiscountCombination.Additive)]
+    public void Either_combination_policy_is_honoured_when_only_an_automatic_discount_applies(
+        AutomaticDiscountCombination combination)
+    {
+        // No volume band ever reaches metered usage, so with only an automatic discount present
+        // both combination policies must agree — there is nothing to combine with.
+        var price = NewPrice(automaticDiscountBasisPoints: 500, quantityDiscountCombination: combination);
+
+        var charge = UsageChargeCalculator.Charge(1_000, price);
+
+        charge.AutomaticDiscountMinor.Should().Be(50);
+        charge.TotalMinor.Should().Be(950);
+    }
+
+    [Fact]
+    public void The_difference_of_two_charges_matches_a_field_by_field_subtraction()
+    {
+        var price = NewPrice(automaticDiscountBasisPoints: 800, taxRateBasisPoints: 770);
+
+        var current = UsageChargeCalculator.Charge(2_000, price);
+        var projected = UsageChargeCalculator.Charge(12_000, price);
+
+        var additional = UsageChargeCalculator.Difference(projected, current);
+
+        additional.GrossMinor.Should().Be(projected.GrossMinor - current.GrossMinor);
+        additional.AutomaticDiscountMinor.Should().Be(
+            projected.AutomaticDiscountMinor - current.AutomaticDiscountMinor);
+        additional.NetMinor.Should().Be(projected.NetMinor - current.NetMinor);
+        additional.TaxMinor.Should().Be(projected.TaxMinor - current.TaxMinor);
+        additional.TotalMinor.Should().Be(projected.TotalMinor - current.TotalMinor);
+    }
+
+    [Fact]
+    public void The_matched_period_end_example_produces_the_documented_figures()
+    {
+        // The exact figures from the overage preview's documented example: 20 current overage
+        // units and 120 projected overage units, both at 100 minor units each, no discount, 7.7%
+        // exclusive tax.
+        var price = NewPrice(taxRateBasisPoints: 770, taxMode: TaxMode.Exclusive);
+
+        var current = UsageChargeCalculator.Charge(2_000, price);
+        var projected = UsageChargeCalculator.Charge(12_000, price);
+        var additional = UsageChargeCalculator.Difference(projected, current);
+
+        current.TaxMinor.Should().Be(154);
+        current.TotalMinor.Should().Be(2_154);
+        projected.TaxMinor.Should().Be(924);
+        projected.TotalMinor.Should().Be(12_924);
+        additional.GrossMinor.Should().Be(10_000);
+        additional.TaxMinor.Should().Be(770);
+        additional.TotalMinor.Should().Be(10_770);
+    }
+
+    private static PriceSnapshot NewPrice(
+        int? automaticDiscountBasisPoints = null,
+        int? taxRateBasisPoints = null,
+        TaxMode? taxMode = null,
+        AutomaticDiscountCombination? quantityDiscountCombination = null) => new()
+    {
+        CurrencyCode = "CHF",
+        AutomaticDiscountBasisPoints = automaticDiscountBasisPoints,
+        TaxRateBasisPoints = taxRateBasisPoints,
+        TaxMode = taxMode,
+        QuantityDiscountCombination = quantityDiscountCombination
+    };
+}

--- a/server/XUnitTest/Subscription/UsageChargePreviewParityTests.cs
+++ b/server/XUnitTest/Subscription/UsageChargePreviewParityTests.cs
@@ -174,6 +174,284 @@ public sealed class UsageChargePreviewParityTests
         }
     };
 
+    [Fact]
+    public async Task CarryForward_meters_are_rated_by_final_rating_not_silently_skipped()
+    {
+        // CarryForward still resets, rates and reports per window — only Never sits outside the
+        // per-period sweep. CarryForwardCap = 0 keeps the effective allowance equal to the plan's
+        // own IncludedQuantity, so this test isolates the reset-policy filter itself rather than
+        // also depending on the carried-in amount.
+        var subscription = NewSubscription();
+        subscription.Plan.Meters[0].ResetPolicy = MeterResetPolicy.CarryForward;
+        subscription.Plan.Meters[0].CarryForwardCap = 0;
+
+        var ratingUsage = new Mock<ISubscriptionUsageRepository>();
+        var subscriptions = new Mock<ISubscriptionRepository>();
+        var usageInvoices = new Mock<ISubscriptionUsageInvoiceRepository>();
+        var billingAccounts = new Mock<IBillingAccountRepository>();
+        var gateway = new Mock<ISubscriptionBillingGateway>();
+        SubscriptionUsageInvoice? createdInvoice = null;
+
+        subscriptions
+            .Setup(repository => repository.ListDueForUsageRatingAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([subscription]);
+        subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, subscription.ItemId, It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        usageInvoices
+            .Setup(repository => repository.GetAsync(
+                TenantId, subscription.ItemId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageInvoice?)null);
+        usageInvoices
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionUsageInvoice, CancellationToken>((invoice, _) => createdInvoice = invoice)
+            .ReturnsAsync(true);
+        ratingUsage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, subscription.ItemId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new SubscriptionUsageCounter { MeterKey = "screening", Balance = 700 }]);
+        ratingUsage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageCounter?)null);
+
+        var ratingProcessor = new SubscriptionUsageRatingProcessor(
+            subscriptions.Object,
+            ratingUsage.Object,
+            usageInvoices.Object,
+            billingAccounts.Object,
+            gateway.Object,
+            new SubscriptionOutboxEventFactory(),
+            new OptionsStub(),
+            NullLogger<SubscriptionUsageRatingProcessor>.Instance,
+            new ControlledTimeProvider(new DateTimeOffset(
+                subscription.CurrentUsagePeriodEndUtc, TimeSpan.Zero)));
+
+        await ratingProcessor.CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        // Before this fix, `.Where(meter => meter.ResetPolicy == MeterResetPolicy.Periodic)`
+        // would have skipped this meter outright and produced no line at all.
+        createdInvoice.Should().NotBeNull();
+        createdInvoice!.Lines.Should().ContainSingle(line => line.MeterKey == "screening");
+        createdInvoice.Lines[0].OverageQuantity.Should().Be(200, "700 balance − 500 allowance");
+        createdInvoice.Lines[0].AmountMinor.Should().Be(2_000);
+    }
+
+    [Fact]
+    public async Task Trial_grant_allowance_agrees_between_preview_and_final_rating()
+    {
+        // Plan allowance 150, trial grant 500, usage 300 — the example from the reviewed defect.
+        // Final rating must resolve the same effective (trial) allowance the preview does, not
+        // `PlanMeter.IncludedQuantity` directly, or it would bill 150 units nobody was ever quoted.
+        var subscription = NewSubscription();
+        subscription.Plan.Meters[0].IncludedQuantity = 150;
+        subscription.Status = SubscriptionStatus.Trialing;
+        subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = subscription.CurrentUsagePeriodStartUtc,
+            EndsAtUtc = subscription.CurrentUsagePeriodEndUtc,
+            Grants = [new TrialMeterGrant { MeterKey = "screening", IncludedQuantity = 500 }]
+        };
+
+        var ratingUsage = new Mock<ISubscriptionUsageRepository>();
+        var subscriptions = new Mock<ISubscriptionRepository>();
+        var usageInvoices = new Mock<ISubscriptionUsageInvoiceRepository>();
+        var billingAccounts = new Mock<IBillingAccountRepository>();
+        var gateway = new Mock<ISubscriptionBillingGateway>();
+        SubscriptionUsageInvoice? createdInvoice = null;
+
+        subscriptions
+            .Setup(repository => repository.ListDueForUsageRatingAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([subscription]);
+        subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, subscription.ItemId, It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        usageInvoices
+            .Setup(repository => repository.GetAsync(
+                TenantId, subscription.ItemId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageInvoice?)null);
+        usageInvoices
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionUsageInvoice, CancellationToken>((invoice, _) => createdInvoice = invoice)
+            .ReturnsAsync(true);
+        ratingUsage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, subscription.ItemId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new SubscriptionUsageCounter { MeterKey = "screening", Balance = 300 }]);
+        ratingUsage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageCounter?)null);
+
+        var ratingProcessor = new SubscriptionUsageRatingProcessor(
+            subscriptions.Object,
+            ratingUsage.Object,
+            usageInvoices.Object,
+            billingAccounts.Object,
+            gateway.Object,
+            new SubscriptionOutboxEventFactory(),
+            new OptionsStub(),
+            NullLogger<SubscriptionUsageRatingProcessor>.Instance,
+            new ControlledTimeProvider(new DateTimeOffset(
+                subscription.CurrentUsagePeriodEndUtc, TimeSpan.Zero)));
+
+        await ratingProcessor.CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        createdInvoice.Should().NotBeNull();
+        // The buggy computation — `IncludedQuantity` straight off the plan, ignoring the trial
+        // grant — would have billed 300 − 150 = 150 units. Documented here as the wrong answer
+        // this fix removes, not as behaviour under test.
+        SubscriptionUsageRater.OverageAmountMinor(subscription.Plan.Meters[0], 300, "CHF")
+            .Should().Be(1_500, "this is what the pre-fix computation would have billed");
+        createdInvoice!.Lines.Should().BeEmpty("300 usage is under the 500 trial allowance");
+        createdInvoice.TotalAmountMinor.Should().Be(0);
+
+        // The preview must agree: usage arrives as a hypothetical addition on top of nothing
+        // recorded yet, landing on the same total balance (300) the rating pass just closed.
+        var previewUsage = new Mock<ISubscriptionUsageRepository>();
+        previewUsage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                TenantId, subscription.ItemId, "screening", It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((0L, 0L));
+        previewUsage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageCounter?)null);
+
+        var previewSubscriptions = new Mock<ISubscriptionRepository>();
+        previewSubscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var contextResolver = new Mock<ISubscriptionContextResolver>();
+        contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        var previewService = new SubscriptionUsageOveragePreviewService(
+            previewSubscriptions.Object,
+            previewUsage.Object,
+            new MeterAllowanceResolver(previewUsage.Object),
+            contextResolver.Object,
+            new PreviewUsageOverageRequestValidator(),
+            new ControlledTimeProvider(new DateTimeOffset(
+                subscription.CurrentUsagePeriodStartUtc.AddDays(1), TimeSpan.Zero)));
+
+        var previewResult = await previewService.PreviewAsync(
+            new PreviewUsageOverageRequest { MeterKey = "screening", AdditionalQuantity = 300 },
+            "corr-1",
+            CancellationToken.None);
+
+        previewResult.IsSuccess.Should().BeTrue();
+        previewResult.Value!.IncludedQuantity.Should().Be(500, "the trial grant, not the plan's 150");
+        previewResult.Value.ProjectedOverage.Should().Be(0);
+        previewResult.Value.ProjectedPeriodCharge.TotalMinor.Should().Be(
+            createdInvoice.TotalAmountMinor);
+    }
+
+    [Fact]
+    public async Task Two_overage_meters_at_a_rounding_boundary_agree_with_the_aggregate_not_a_slice()
+    {
+        // A 5% automatic discount and a 7.7% tax, at these particular gross figures, round
+        // differently depending on whether they are applied to the whole invoice's overage or to
+        // one meter's slice of it — the exact scenario the third defect describes. Rating the
+        // requested meter's delta in isolation would have priced this preview at 338; rating the
+        // whole aggregate — as the invoice actually will — prices it at 337.
+        var subscription = NewSubscription();
+        subscription.Price.AutomaticDiscountBasisPoints = 500;
+        subscription.Price.TaxRateBasisPoints = 770;
+        subscription.Plan.Meters.Add(new PlanMeter
+        {
+            MeterKey = "storage",
+            UnitLabel = "GB",
+            IncludedQuantity = 200,
+            OverageAllowed = true,
+            RateTables =
+            [
+                new MeterRateTable
+                {
+                    CurrencyCode = "CHF",
+                    Tiers = [new MeterTier { UpToQuantity = null, UnitAmountMinor = 7 }]
+                }
+            ]
+        });
+
+        var usage = new Mock<ISubscriptionUsageRepository>();
+        usage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                TenantId, subscription.ItemId, "screening", It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((0L, 0L));
+        usage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                TenantId, subscription.ItemId, "storage", It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((0L, 0L));
+        usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.Is<string>(id => id.Contains("screening", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>()))
+            // 600 usage − 500 included = 100 overage units × 10 = 1,000 gross.
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = 600, LimitSnapshot = 500 });
+        usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.Is<string>(id => id.Contains("storage", StringComparison.Ordinal)),
+                It.IsAny<CancellationToken>()))
+            // 250 usage − 200 included = 50 overage units × 7 = 350 gross.
+            .ReturnsAsync(new SubscriptionUsageCounter { Balance = 250, LimitSnapshot = 200 });
+
+        var subscriptions = new Mock<ISubscriptionRepository>();
+        subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var contextResolver = new Mock<ISubscriptionContextResolver>();
+        contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        var previewService = new SubscriptionUsageOveragePreviewService(
+            subscriptions.Object,
+            usage.Object,
+            new MeterAllowanceResolver(usage.Object),
+            contextResolver.Object,
+            new PreviewUsageOverageRequestValidator(),
+            new ControlledTimeProvider(new DateTimeOffset(
+                subscription.CurrentUsagePeriodStartUtc.AddDays(1), TimeSpan.Zero)));
+
+        // 33 additional units on "screening" at 10/unit adds 330 gross (100 → 133 overage units).
+        var result = await previewService.PreviewAsync(
+            new PreviewUsageOverageRequest { MeterKey = "screening", AdditionalQuantity = 33 },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var response = result.Value!;
+
+        response.CurrentCharge.GrossMinor.Should().Be(1_350, "screening 1,000 + storage 350");
+        response.CurrentCharge.TotalMinor.Should().Be(1_382);
+        response.ProjectedPeriodCharge.GrossMinor.Should().Be(1_680, "screening 1,330 + storage 350");
+        response.ProjectedPeriodCharge.TotalMinor.Should().Be(1_719);
+        response.AdditionalCharge.TotalMinor.Should().Be(337,
+            "the aggregate difference — 338 is what discounting and taxing the requested meter " +
+            "alone would have produced, and would disagree with the invoice");
+    }
+
     private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
     {
         public SubscriptionOptions CurrentValue { get; } = new();

--- a/server/XUnitTest/Subscription/UsageChargePreviewParityTests.cs
+++ b/server/XUnitTest/Subscription/UsageChargePreviewParityTests.cs
@@ -1,0 +1,185 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The overage preview and period-end rating must never disagree: fed the same subscription and
+/// the same eventual usage, they have to land on identical gross, discount, tax and total figures.
+/// </summary>
+public sealed class UsageChargePreviewParityTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    [Fact]
+    public async Task Preview_and_final_rating_agree_on_gross_discount_tax_and_total()
+    {
+        var subscription = NewSubscription();
+
+        // Period-end rating: the period has just ended with a counter balance of 700.
+        var ratingUsage = new Mock<ISubscriptionUsageRepository>();
+        var subscriptions = new Mock<ISubscriptionRepository>();
+        var usageInvoices = new Mock<ISubscriptionUsageInvoiceRepository>();
+        var billingAccounts = new Mock<IBillingAccountRepository>();
+        var gateway = new Mock<ISubscriptionBillingGateway>();
+        SubscriptionUsageInvoice? createdInvoice = null;
+
+        subscriptions
+            .Setup(repository => repository.ListDueForUsageRatingAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([subscription]);
+        subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, subscription.ItemId, It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        usageInvoices
+            .Setup(repository => repository.GetAsync(
+                TenantId, subscription.ItemId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageInvoice?)null);
+        usageInvoices
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionUsageInvoice, CancellationToken>((invoice, _) => createdInvoice = invoice)
+            .ReturnsAsync(true);
+        ratingUsage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, subscription.ItemId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new SubscriptionUsageCounter { MeterKey = "screening", Balance = 700 }]);
+
+        var ratingProcessor = new SubscriptionUsageRatingProcessor(
+            subscriptions.Object,
+            ratingUsage.Object,
+            usageInvoices.Object,
+            billingAccounts.Object,
+            gateway.Object,
+            new SubscriptionOutboxEventFactory(),
+            new OptionsStub(),
+            NullLogger<SubscriptionUsageRatingProcessor>.Instance,
+            new ControlledTimeProvider(new DateTimeOffset(
+                subscription.CurrentUsagePeriodEndUtc, TimeSpan.Zero)));
+
+        await ratingProcessor.CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        createdInvoice.Should().NotBeNull();
+
+        // The overage preview: nothing recorded yet this period, and the same 700 units are asked
+        // for as a single hypothetical addition.
+        var previewUsage = new Mock<ISubscriptionUsageRepository>();
+        previewUsage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                TenantId, subscription.ItemId, "screening", It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((0L, 0L));
+        previewUsage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionUsageCounter?)null);
+
+        var previewSubscriptions = new Mock<ISubscriptionRepository>();
+        previewSubscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+        var contextResolver = new Mock<ISubscriptionContextResolver>();
+        contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        var previewService = new SubscriptionUsageOveragePreviewService(
+            previewSubscriptions.Object,
+            previewUsage.Object,
+            new MeterAllowanceResolver(previewUsage.Object),
+            contextResolver.Object,
+            new PreviewUsageOverageRequestValidator(),
+            // A moment inside the same period the rating pass just closed.
+            new ControlledTimeProvider(new DateTimeOffset(
+                subscription.CurrentUsagePeriodStartUtc.AddDays(14), TimeSpan.Zero)));
+
+        var previewResult = await previewService.PreviewAsync(
+            new PreviewUsageOverageRequest { MeterKey = "screening", AdditionalQuantity = 700 },
+            "corr-1",
+            CancellationToken.None);
+
+        previewResult.IsSuccess.Should().BeTrue();
+        var projected = previewResult.Value!.ProjectedPeriodCharge;
+
+        projected.GrossMinor.Should().Be(
+            createdInvoice!.Lines.Sum(line => line.AmountMinor));
+        projected.AutomaticDiscountMinor.Should().Be(createdInvoice.DiscountAmountMinor);
+        projected.NetMinor.Should().Be(createdInvoice.NetAmountMinor);
+        projected.TaxMinor.Should().Be(createdInvoice.TaxAmountMinor);
+        projected.TotalMinor.Should().Be(createdInvoice.TotalAmountMinor);
+    }
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            AutomaticDiscountBasisPoints = 800,
+            TaxRateBasisPoints = 770,
+            TaxMode = TaxMode.Exclusive
+        },
+        CurrentUsagePeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentUsagePeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        },
+        Plan = new PlanSnapshot
+        {
+            Meters =
+            [
+                new PlanMeter
+                {
+                    MeterKey = "screening",
+                    UnitLabel = "screenings",
+                    IncludedQuantity = 500,
+                    OverageAllowed = true,
+                    RateTables =
+                    [
+                        new MeterRateTable
+                        {
+                            CurrencyCode = "CHF",
+                            Tiers = [new MeterTier { UpToQuantity = null, UnitAmountMinor = 10 }]
+                        }
+                    ]
+                }
+            ]
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new();
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
## Summary

Adds `POST /api/subscription-usage/overage/preview` — a read-only endpoint that estimates the cost of additional metered usage using the active subscription's snapshotted terms and the *exact* rating, discount and tax logic used for the final usage invoice. The preview neither records usage nor charges the customer.

The core ask — a shared calculator so the preview and period-end invoicing can never drift apart — is implemented as two extractions:

- **`UsageChargeCalculator`** (`Subscription.DomainService/Services/UsageChargeCalculator.cs`): the discount+tax logic previously inlined in `SubscriptionUsageRatingProcessor.EnsureInvoiceAsync` is now `UsageChargeCalculator.Charge(grossAmountMinor, price)`, called by both the rating processor and the new preview service. Also provides `Difference(projected, baseline)` for the "additional = projected − current" rule below.
- **`SubscriptionUsageRater.OverageAllocations`**: the tier walker now reports per-band allocations over an arbitrary overage range (with an optional exclusive starting point, `fromOverageUnitsExclusive`), not just a total. `OverageAmountMinor` is kept as a compatibility wrapper so `SubscriptionUsageRatingProcessor` and any other existing caller are unaffected.

### New files (server)
- `Subscription.DomainService/Services/UsageChargeCalculator.cs`
- `Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs` (+ `ISubscriptionUsageOveragePreviewService.cs`)
- `Subscription.DomainService/Requests/PreviewUsageOverageRequest.cs` (+ `Validators/PreviewUsageOverageRequestValidator.cs`)
- `Subscription.DomainService/Responses/SubscriptionUsageOveragePreviewResponse.cs`
- `POST` action `PreviewOverage` on `Api/Controllers/SubscriptionUsageController.cs`

### New files (client)
- `use-preview-usage-overage.ts` hook (thin `useMutation` fetch wrapper — no client-side pricing)
- `PreviewUsageOverageRequest` / `UsageOveragePreviewResult` (+ nested) types and a `previewUsageOverage` service method in the existing `subscription-simulation` module

### Documentation
- New "Metered overage preview" section in `Subscription.DomainService/README.md`, matching the existing prose style (what it reuses, what it deliberately never does).

## Design notes

- **Ledger vs counter**: same precedence as period-end rating — the append-only ledger is authoritative whenever it has records; the counter is only a fallback for a legacy period with no ledger records.
- **Allowance**: resolved via `IMeterAllowanceResolver.EffectiveAsync`, so a trial grant or carried-forward allowance changes `includedQuantity` in the preview exactly as it changes enforcement.
- **`additionalCharge` is a difference, never rated standalone**: computed as `projectedPeriodCharge − currentCharge`, field by field, because a tier boundary or a rounding step at the discount/tax boundary can price the same units differently depending on what came before them.
- **Promotional discounts are explicitly excluded**, matching current behavior (only the price's own `AutomaticDiscountBasisPoints` reaches metered overage) — `discount.promotionalCodeApplied` is always `false` rather than silently omitted.
- **No writes possible by construction**: the preview service's constructor only takes read-capable dependencies (no invoice repository, no billing gateway, no outbox, no audit trail, no closure repository) — there is nothing here that could write even by mistake, not just nothing that does.

## Judgment calls / scope decisions

- **Route placement**: nested the action under the existing `SubscriptionUsageController` (`subscription-usage/overage/preview`) rather than a new controller, mirroring how `GetCurrent` already lives there.
- **Error code → HTTP mapping**: reused the existing `PaymentFailureKind` → status code switch (`SubscriptionApiResults.ToActionResult`) rather than inventing new plumbing — `Conflict` → 409 for both `subscription_meter_overage_not_allowed` and `subscription_meter_rate_unavailable`, `Unavailable` → 503 for `subscription_schedule_unavailable`.
- **Client module placement**: added the new hook/service method/types to the existing `client/app/cross-modules/utilities/subscription-simulation` module rather than a separate module, since that module already hosts the real (non-simulation) `/api/subscription-usage` client code (`recordUsage`, `RecordUsageRequest`) alongside the simulation harness — this endpoint follows that existing precedent rather than starting a new module for one endpoint.
- **`additionalTierBreakdown` is informational only**: it reports which tier bands the additional units crossed and what each contributed (for display), but is not itself re-summed into the charge — the authoritative `additionalCharge` is always the difference of two fully-rated totals, per the spec's explicit instruction not to independently tax/discount the new units alone.
- **No controller tests existed previously** for `SubscriptionUsageController` (only `GetCurrent`/`Record` were untested at the controller layer) — added a new `SubscriptionUsageControllerTests.cs` covering the new action only (auth attribute presence, envelope shape, validation-failure status/code, named-failure → status mapping, and organization-id forwarding), rather than backfilling coverage for the pre-existing actions, to stay scoped to this change.

## Test plan

- [x] Current usage 170, allowance 150, plus 100 → projected usage 270, projected overage 120
- [x] Additional usage crossing multiple tiers returns exact per-band units/amounts
- [x] Additional total == projected total − current total, including rounding at discount/tax boundaries
- [x] Automatic discounts work under both combination policies; promotional discount stays excluded
- [x] Inclusive and exclusive tax previews exactly match period-end invoice calculations
- [x] Trial grants and carry-forward allowance affect the previewed included quantity
- [x] Subscription snapshot terms are what's read (service never touches the plan catalogue — no catalogue dependency exists on the service at all)
- [x] Missing currency rate table and overage-not-allowed return named errors, not a misleading zero price
- [x] Ledger usage wins when a crash left the counter projection behind
- [x] Repositories verified to receive no mutation calls (`TryAppendRecordAsync`, `ApplyDeltaAsync`, `TryRepairCounterAsync`, `TryMarkThresholdNotifiedAsync`, `TryTransitionAsync` — all `Times.Never`)
- [x] Controller tests: authentication (`[Authorize]` presence), organization scope forwarding, response envelope, validation, correlation id
- [x] Parity test: same subscription + usage fed into preview and final rating (`SubscriptionUsageRatingProcessor`) asserts identical gross, discount, tax and total

## Build/test verification

- `dotnet build server/Api/Api.csproj` — 0 errors
- `dotnet test --filter "FullyQualifiedName!~Integration"` (from `server/`) — 3103 passed, 4 pre-existing failures in `SubscriptionSimulation*` tests confirmed unrelated (reproduced identically on unmodified `origin/dev` via `git stash`), 1 skipped
- `npm run type-check` (from `client/`) — 0 errors