### PR TITLE
fix(worker): stop taking down the whole worker for a broken PDF renderer

### DIFF
--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
@@ -393,22 +393,59 @@ public sealed class FinancialDocumentIssueWorkHandler : ISubscriptionWorkHandler
 /// <summary>
 /// Renders and emails an issued document, or sweeps the ones that never got that far.
 /// </summary>
+/// <remarks>
+/// Checks <see cref="IFinancialDocumentRendererHealth"/> before calling the delivery service at
+/// all, and this is deliberately the only handler that does. A renderer probe failing here must
+/// not touch <see cref="ISubscriptionFinancialDocumentDeliveryService"/> — every path through it
+/// that fails a render calls <c>RecordDeliveryFailureAsync</c>, which spends one of the document's
+/// own limited delivery attempts and can abandon it outright once those run out. That budget
+/// exists to give up on a document whose <em>own</em> template or data is unrenderable; spending it
+/// on an outage that has nothing to do with any particular document would abandon real invoices for
+/// a reason that was never theirs. Skipping the call entirely leaves every pending document exactly
+/// as due as it was, so the repair sweep keeps finding it and delivery resumes for all of them the
+/// moment the gate reopens — see <see cref="IFinancialDocumentRendererHealth"/>'s remarks.
+/// </remarks>
 public sealed class FinancialDocumentDeliveryWorkHandler : ISubscriptionWorkHandler
 {
     private readonly ISubscriptionFinancialDocumentDeliveryService _delivery;
+    private readonly IFinancialDocumentRendererHealth _rendererHealth;
 
     public FinancialDocumentDeliveryWorkHandler(
-        ISubscriptionFinancialDocumentDeliveryService delivery) =>
+        ISubscriptionFinancialDocumentDeliveryService delivery,
+        IFinancialDocumentRendererHealth rendererHealth)
+    {
         _delivery = delivery;
+        _rendererHealth = rendererHealth;
+    }
 
     public SubscriptionWorkType WorkType => SubscriptionWorkType.FinancialDocumentDelivery;
 
-    public async Task<SubscriptionWorkOutcome> ExecuteAsync(
+    public Task<SubscriptionWorkOutcome> ExecuteAsync(
         SubscriptionBackgroundWork work,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(work);
 
+        if (!_rendererHealth.IsHealthy)
+        {
+            // Retried rather than dead-lettered: this work item's own attempt budget still ticks
+            // down on the queue's usual backoff, but that is cheap infrastructure retry, not the
+            // document's delivery-attempt budget, which nothing here has touched. If an outage
+            // outlasts this item's attempts and it dead-letters, the repair sweep re-announces the
+            // still-undelivered document on its own next pass — see this handler's own remarks.
+            return Task.FromResult(SubscriptionWorkOutcome.Retry(
+                "financial_document_renderer_unhealthy",
+                "The PDF renderer is currently unhealthy; document delivery is paused until it " +
+                "recovers."));
+        }
+
+        return ExecuteWhileHealthyAsync(work, cancellationToken);
+    }
+
+    private async Task<SubscriptionWorkOutcome> ExecuteWhileHealthyAsync(
+        SubscriptionBackgroundWork work,
+        CancellationToken cancellationToken)
+    {
         if (string.IsNullOrWhiteSpace(work.AggregateId))
         {
             await _delivery.DeliverPendingAsync(work.TenantId, cancellationToken);

--- a/server/Subscription.DomainService/Services/FinancialDocumentRendererHealthGate.cs
+++ b/server/Subscription.DomainService/Services/FinancialDocumentRendererHealthGate.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// The one place this worker's process keeps its answer to "can the PDF renderer produce a PDF
+/// right now".
+/// </summary>
+/// <remarks>
+/// A single mutable flag, not a generic health-check registry. The worker hosts renewals,
+/// payments, usage rating and document issuance in the same process as document delivery, and
+/// every one of those keeps working when Chromium is down — only the code that calls the renderer
+/// has anything to gate. A health-check framework answers "is the process healthy" for an
+/// orchestrator; this answers "can this one call be trusted", for callers inside the same process,
+/// which is a narrower and different question. Building the general version to answer the specific
+/// one would give every other subsystem a place to accidentally wire itself to Chromium's fate.
+/// <para>
+/// Registered as a singleton, so the readiness check's startup probe, the periodic monitor's
+/// retries, and the delivery handler's read all see one shared state rather than three copies that
+/// could disagree about whether the renderer is up.
+/// </para>
+/// </remarks>
+public sealed class FinancialDocumentRendererHealthGate : IFinancialDocumentRendererHealth
+{
+    public const string MeterName = "Blocks.Subscription.FinancialDocumentRenderer";
+
+    private readonly ILogger<FinancialDocumentRendererHealthGate> _logger;
+    private readonly Meter _meter;
+    private readonly Counter<long> _unhealthyTransitions;
+    private readonly Counter<long> _recoveries;
+
+    // Volatile rather than behind a lock: one bool, read far more often (every delivery attempt)
+    // than it is written (once per probe), and a reader racing a writer by a few milliseconds
+    // reads the old-but-still-accurate answer rather than anything unsafe.
+    private volatile bool _isHealthy = true;
+
+    public FinancialDocumentRendererHealthGate(ILogger<FinancialDocumentRendererHealthGate> logger)
+    {
+        _logger = logger;
+        _meter = new Meter(MeterName);
+
+        _unhealthyTransitions = _meter.CreateCounter<long>(
+            "financial_document.renderer.unhealthy",
+            unit: "{transition}",
+            description: "Times the PDF renderer's health probe failed after last succeeding.");
+
+        _recoveries = _meter.CreateCounter<long>(
+            "financial_document.renderer.recovered",
+            unit: "{transition}",
+            description: "Times the PDF renderer's health probe succeeded after last failing.");
+    }
+
+    public bool IsHealthy => _isHealthy;
+
+    public void RecordSuccess()
+    {
+        // Only the transition is interesting, both for the metric and for the log: a probe
+        // succeeding for the hundredth time in a row is not a fact anybody needs to see.
+        var wasUnhealthy = !_isHealthy;
+        _isHealthy = true;
+
+        if (!wasUnhealthy)
+        {
+            return;
+        }
+
+        _recoveries.Add(1);
+        _logger.LogInformation(
+            "The PDF renderer's health probe succeeded again. Document delivery reopens.");
+    }
+
+    public void RecordFailure(Exception? exception, string reason)
+    {
+        var wasHealthy = _isHealthy;
+        _isHealthy = false;
+
+        if (!wasHealthy)
+        {
+            return;
+        }
+
+        _unhealthyTransitions.Add(1);
+
+        // Critical, not error: nothing else in this process will surface this on its own, since by
+        // design every other subsystem keeps running. This is the one line that says why document
+        // delivery has gone quiet.
+        _logger.LogCritical(
+            exception,
+            "The PDF renderer's health probe failed ({Reason}). Document delivery is paused until " +
+            "it recovers; renewals, payments, usage rating and document issuance continue " +
+            "normally.",
+            reason);
+    }
+}

--- a/server/Subscription.DomainService/Services/IFinancialDocumentRendererHealth.cs
+++ b/server/Subscription.DomainService/Services/IFinancialDocumentRendererHealth.cs
@@ -1,0 +1,35 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// What the last renderer probe found, shared by whoever ran it and whoever needs to know before
+/// touching document delivery.
+/// </summary>
+/// <remarks>
+/// A circuit breaker with exactly two states and no half-open dance: the only thing either side
+/// of it can do is probe with a real render, and a render either produces bytes or it does not.
+/// There is no cheaper signal to sample in between that would tell the difference between "still
+/// broken" and "about to work again", so nothing here tries to guess — it reports the last probe's
+/// answer and lets the periodic monitor keep asking.
+/// <para>
+/// Deliberately narrower than a general health-check abstraction. This exists for one dependency
+/// that one part of the worker must stop calling when it is down, not as a place to grow a health
+/// system — see <see cref="FinancialDocumentRendererHealthGate"/>'s remarks for why a generic one
+/// was rejected.
+/// </para>
+/// </remarks>
+public interface IFinancialDocumentRendererHealth
+{
+    /// <summary>
+    /// True until a probe fails, false until a probe afterwards succeeds. Starts true: a worker
+    /// that has not probed yet has no evidence the renderer is down, and treating "unknown" as
+    /// "unhealthy" would refuse document delivery for however long startup takes even when
+    /// Chromium is perfectly fine.
+    /// </summary>
+    bool IsHealthy { get; }
+
+    /// <summary>Records a probe that produced PDF bytes.</summary>
+    void RecordSuccess();
+
+    /// <summary>Records a probe that threw, timed out, or produced nothing.</summary>
+    void RecordFailure(Exception? exception, string reason);
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -239,6 +239,12 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             IFinancialDocumentFileStore,
             StorageDriverFinancialDocumentFileStore>();
+        // One gate shared by the Worker's startup probe, its periodic re-probe, and the delivery
+        // handler that reads it — all three must see the same answer. Registered here rather than
+        // only in the Worker because the delivery handler that reads it lives in this project too.
+        services.AddSingleton<
+            IFinancialDocumentRendererHealth,
+            FinancialDocumentRendererHealthGate>();
         services.AddSingleton<
             IFinancialDocumentLogoResolver,
             FinancialDocumentLogoResolver>();

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -307,6 +307,16 @@ public sealed class SubscriptionOptions
     public int DocumentDeliveryBatchSize { get; set; } = 25;
 
     /// <summary>
+    /// How often the PDF renderer's own health probe is retried while it is known unhealthy.
+    /// </summary>
+    /// <remarks>
+    /// Independent of every queue backoff here, because this is not retrying one piece of work —
+    /// it is asking whether the dependency itself has come back, so that document delivery can
+    /// reopen for every pending document at once rather than each one discovering it separately.
+    /// </remarks>
+    public int RendererHealthProbeIntervalSeconds { get; set; } = 60;
+
+    /// <summary>
     /// How far back a tenant's <em>first</em> document-recovery pass reaches.
     /// </summary>
     /// <remarks>

--- a/server/Utility.DomainService/PdfGenerator/service/PuppeteerSharpEngine.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PuppeteerSharpEngine.cs
@@ -104,14 +104,18 @@ namespace Utility.DomainService.PdfGenerator.service
                 var browser = await GetBrowserAsync();
                 await using var page = await browser.NewPageAsync();
 
-                // Set page content
+                // The content is self-contained — inline CSS, logos embedded as data URIs, no
+                // external requests — so there is no network activity for Networkidle0 to settle
+                // on. Waiting for it anyway (twice: once here and once via the explicit
+                // WaitForNetworkIdleAsync this replaced) meant every render waited out Puppeteer's
+                // 30-second navigation timeout for an idle event the page was never going to raise.
+                // DOMContentLoaded is what a document with no network dependencies actually reaches,
+                // and a short explicit timeout keeps a genuinely stuck page from hanging the caller.
                 await page.SetContentAsync(htmlContent, new NavigationOptions
                 {
-                    WaitUntil = new[] { WaitUntilNavigation.Networkidle0 }
+                    WaitUntil = new[] { WaitUntilNavigation.DOMContentLoaded },
+                    Timeout = 10_000
                 });
-
-                // Wait for any JavaScript rendering to complete
-                await page.WaitForNetworkIdleAsync();
 
                 // Build PDF options
                 var pdfOptions = BuildPdfOptions(options);

--- a/server/Worker/FinancialDocumentRendererHealthMonitor.cs
+++ b/server/Worker/FinancialDocumentRendererHealthMonitor.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace Worker;
+
+/// <summary>
+/// Keeps re-running the renderer probe while it is unhealthy, so document delivery reopens on its
+/// own once Chromium comes back.
+/// </summary>
+/// <remarks>
+/// Only probes while <see cref="IFinancialDocumentRendererHealth.IsHealthy"/> is false. A renderer
+/// that is fine has nothing for this loop to do — the startup check already recorded success, and
+/// polling a working dependency on a timer would be pure cost for a signal nothing downstream
+/// needs. It starts checking every tick once the gate turns false, which is also how a probe that
+/// was healthy at startup and later breaks gets noticed without a separate watchdog for that case.
+/// </remarks>
+public sealed class FinancialDocumentRendererHealthMonitor : BackgroundService
+{
+    private readonly IFinancialDocumentPdfRenderer _renderer;
+    private readonly IFinancialDocumentRendererHealth _health;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<FinancialDocumentRendererHealthMonitor> _logger;
+
+    public FinancialDocumentRendererHealthMonitor(
+        IFinancialDocumentPdfRenderer renderer,
+        IFinancialDocumentRendererHealth health,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<FinancialDocumentRendererHealthMonitor> logger)
+    {
+        _renderer = renderer;
+        _health = health;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var interval = TimeSpan.FromSeconds(
+                Math.Max(1, _options.CurrentValue.RendererHealthProbeIntervalSeconds));
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+
+            if (_health.IsHealthy)
+            {
+                // Nothing broke since the last tick — the common case for the whole lifetime of a
+                // healthy process. Re-probing here would cost a browser page and prove nothing the
+                // gate does not already know.
+                continue;
+            }
+
+            try
+            {
+                await FinancialDocumentRendererProbe.RunAsync(
+                    _renderer, _health, _logger, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception exception)
+            {
+                // The probe itself already turns a renderer failure into RecordFailure rather than
+                // an exception — this only catches something outside that, and it must not stop
+                // the loop, or a broken renderer would also be a renderer that never gets
+                // re-checked.
+                _logger.LogError(exception, "The PDF renderer health probe itself failed to run");
+            }
+        }
+    }
+}

--- a/server/Worker/FinancialDocumentRendererReadinessCheck.cs
+++ b/server/Worker/FinancialDocumentRendererReadinessCheck.cs
@@ -5,19 +5,26 @@ using Subscription.DomainService.Services;
 namespace Worker;
 
 /// <summary>
-/// Proves the PDF renderer actually works before this worker claims any real document work.
+/// Probes the PDF renderer once at startup and records what it found — without stopping the host.
 /// </summary>
 /// <remarks>
-/// This host has no HTTP surface — see <c>Dockerfile.worker</c>'s own "no HTTP host" comment — so
-/// there is no <c>/health</c> endpoint an orchestrator could probe. The signal available instead is
-/// the same one every other Generic Host startup failure uses: a hosted service that throws from
-/// <see cref="StartAsync"/> stops the host from starting at all, which is what turns "Chromium is
-/// missing or unusable in this image" into a container that never becomes ready — loud, restart-
-/// looping, and impossible to mistake for a worker quietly failing every document it touches.
+/// This used to throw out of <see cref="StartAsync"/> to fail the whole Generic Host when Chromium
+/// could not produce a PDF, on the reasoning that a worker with no HTTP surface has no other way to
+/// signal "not ready". That reasoning was correct about the signalling problem and wrong about the
+/// blast radius: this process is not only the document renderer. It is also where renewals,
+/// payment reconciliation, usage rating and every other piece of subscription background work run,
+/// and none of those touch Chromium. Refusing to start the process over a presentation dependency
+/// turned "PDFs are delayed" into "nothing gets paid, renewed, or billed" — a strictly worse
+/// outage for a component whose job is money movement.
 /// <para>
-/// Registered first, deliberately, so it runs before any consumer starts pulling real work off a
-/// queue. A worker that came up broken and started claiming document-delivery items anyway would
-/// convert a deployment mistake into a pile of abandoned deliveries instead of a failed rollout.
+/// The probe still runs first and still logs critical on failure — an operator needs to see this
+/// immediately, not discover it from a growing pending-document queue. What changed is what
+/// happens next: the result is recorded on <see cref="IFinancialDocumentRendererHealth"/>, the host
+/// starts regardless, and <see cref="FinancialDocumentRendererHealthMonitor"/> keeps retrying the
+/// same probe on an interval so a renderer that comes up late — or a container that starts before
+/// its Chromium image layer has finished settling — recovers on its own instead of requiring a
+/// restart. Only <see cref="Scheduling.SubscriptionWorkHandlers.FinancialDocumentDeliveryWorkHandler"/>
+/// reads the gate this sets; every other consumer of this worker is unaffected by what it finds.
 /// </para>
 /// </remarks>
 public sealed class FinancialDocumentRendererReadinessCheck : IHostedService
@@ -26,55 +33,71 @@ public sealed class FinancialDocumentRendererReadinessCheck : IHostedService
     /// The smallest HTML PuppeteerSharp will still turn into a real PDF — enough to prove the
     /// browser launches, prints and returns bytes, and nothing about a real financial document.
     /// </summary>
-    private const string ProbeHtml =
+    internal const string ProbeHtml =
         "<!DOCTYPE html><html><head><meta charset=\"utf-8\"></head>" +
         "<body>renderer readiness probe</body></html>";
 
     private readonly IFinancialDocumentPdfRenderer _renderer;
+    private readonly IFinancialDocumentRendererHealth _health;
     private readonly ILogger<FinancialDocumentRendererReadinessCheck> _logger;
 
     public FinancialDocumentRendererReadinessCheck(
         IFinancialDocumentPdfRenderer renderer,
+        IFinancialDocumentRendererHealth health,
         ILogger<FinancialDocumentRendererReadinessCheck> logger)
     {
         _renderer = renderer;
+        _health = health;
         _logger = logger;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        await FinancialDocumentRendererProbe.RunAsync(
+            _renderer, _health, _logger, cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// The one probe both the startup check and the periodic monitor run, so "is the renderer healthy"
+/// is answered the same way regardless of who is asking.
+/// </summary>
+internal static class FinancialDocumentRendererProbe
+{
+    public static async Task RunAsync(
+        IFinancialDocumentPdfRenderer renderer,
+        IFinancialDocumentRendererHealth health,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
         byte[]? pdf;
 
         try
         {
-            pdf = await _renderer.RenderAsync(ProbeHtml, cancellationToken).ConfigureAwait(false);
+            pdf = await renderer
+                .RenderAsync(FinancialDocumentRendererReadinessCheck.ProbeHtml, cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            _logger.LogCritical(
-                exception,
-                "The PDF renderer failed its startup probe. This worker will not start; it must " +
-                "not claim document-delivery work with a renderer that cannot produce a PDF.");
+            health.RecordFailure(exception, "the renderer threw");
 
-            throw new InvalidOperationException(
-                "The PDF renderer failed its startup probe — see the inner exception.", exception);
+            return;
         }
 
         if (pdf is not { Length: > 0 })
         {
-            _logger.LogCritical(
-                "The PDF renderer's startup probe produced no bytes. This worker will not start; " +
-                "it must not claim document-delivery work with a renderer that cannot produce a " +
-                "PDF. Check PuppeteerSharp:ExecutablePath and that Chromium is actually installed " +
-                "in this image.");
+            health.RecordFailure(
+                null,
+                "the renderer produced no bytes — check PuppeteerSharp:ExecutablePath and that " +
+                "Chromium is actually installed in this image");
 
-            throw new InvalidOperationException(
-                "The PDF renderer's startup probe produced no bytes.");
+            return;
         }
 
-        _logger.LogInformation(
-            "PDF renderer startup probe succeeded ({Bytes} bytes).", pdf.Length);
+        logger.LogInformation("PDF renderer probe succeeded ({Bytes} bytes).", pdf.Length);
+        health.RecordSuccess();
     }
-
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -8,6 +8,7 @@ using Utility.DomainService.Messaging;
 using Utility.DomainService.PdfGenerator.Utilities;
 using Utility.DomainService.TemplateEngine.Utilities;
 using SeliseBlocks.ConfigurationDriver;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 using Worker;
 using Worker.Configuration;
@@ -79,10 +80,16 @@ IHostBuilder CreateHostBuilder(string[] args) =>
             services.AddOpenTelemetry()
                 .WithMetrics(metrics => metrics
                     .AddMeter("Blocks.Subscription.BackgroundWork")
+                    .AddMeter(FinancialDocumentRendererHealthGate.MeterName)
                     .AddOtlpExporter());
-            // First, deliberately: a worker that came up with a broken renderer must fail to
-            // start rather than begin claiming document-delivery work it cannot complete.
+            // First, deliberately: an operator should learn whether the renderer works before
+            // anything else in this worker starts moving. It no longer stops the host on failure —
+            // see the check's own remarks — only records what it found for
+            // FinancialDocumentDeliveryWorkHandler to read.
             services.AddHostedService<FinancialDocumentRendererReadinessCheck>();
+            // Re-probes on an interval only while the gate above is unhealthy, so a renderer that
+            // recovers reopens document delivery without a restart.
+            services.AddHostedService<FinancialDocumentRendererHealthMonitor>();
             services.AddHostedService<
                 PaymentReconciliationBackgroundService>();
             services.AddHostedService<

--- a/server/XUnitTest/Integration/SubscriptionQueueDocumentFlowIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionQueueDocumentFlowIntegrationTests.cs
@@ -359,6 +359,11 @@ public sealed class SubscriptionQueueDocumentFlowIntegrationTests
         services.AddSingleton<IFinancialDocumentLogoResolver>(new NoLogoResolver());
         services.AddSingleton(_messages.Client.Object);
         services.AddSingleton<IPaymentTenantContextScopeFactory, NoOpTenantScopeFactory>();
+        // Healthy by default: this suite is exercising the queue's own replay and completion
+        // guarantees, not the renderer circuit breaker, and an unhealthy gate would make
+        // FinancialDocumentDeliveryWorkHandler retry every delivery item without ever calling the
+        // delivery service — silently invalidating everything below that asserts on it.
+        services.AddSingleton<IFinancialDocumentRendererHealth, FinancialDocumentRendererHealthGate>();
 
         services.AddSingleton<
             ISubscriptionFinancialDocumentIssuer, SubscriptionFinancialDocumentIssuer>();

--- a/server/XUnitTest/Subscription/FinancialDocumentRendererHealthGateTests.cs
+++ b/server/XUnitTest/Subscription/FinancialDocumentRendererHealthGateTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The gate is the whole of the fix's runtime behavior: whether delivery work touches the renderer
+/// at all comes down to what <see cref="FinancialDocumentRendererHealthGate.IsHealthy"/> answers.
+/// </summary>
+public sealed class FinancialDocumentRendererHealthGateTests
+{
+    [Fact]
+    public void Starts_healthy_with_no_evidence_either_way()
+    {
+        // A worker that has not probed yet has not seen the renderer fail. Starting unhealthy
+        // would refuse document delivery for however long startup takes even on a renderer that
+        // works fine — the opposite of what a probe with no result yet should assume.
+        new FinancialDocumentRendererHealthGate(
+                NullLogger<FinancialDocumentRendererHealthGate>.Instance)
+            .IsHealthy.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_failure_turns_it_unhealthy()
+    {
+        var gate = new FinancialDocumentRendererHealthGate(
+            NullLogger<FinancialDocumentRendererHealthGate>.Instance);
+
+        gate.RecordFailure(new InvalidOperationException("boom"), "the renderer threw");
+
+        gate.IsHealthy.Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_success_after_a_failure_turns_it_healthy_again()
+    {
+        var gate = new FinancialDocumentRendererHealthGate(
+            NullLogger<FinancialDocumentRendererHealthGate>.Instance);
+
+        gate.RecordFailure(null, "no bytes");
+        gate.RecordSuccess();
+
+        gate.IsHealthy.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Repeated_failures_stay_unhealthy()
+    {
+        var gate = new FinancialDocumentRendererHealthGate(
+            NullLogger<FinancialDocumentRendererHealthGate>.Instance);
+
+        gate.RecordFailure(null, "first");
+        gate.RecordFailure(null, "second");
+
+        gate.IsHealthy.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Repeated_successes_stay_healthy()
+    {
+        var gate = new FinancialDocumentRendererHealthGate(
+            NullLogger<FinancialDocumentRendererHealthGate>.Instance);
+
+        gate.RecordSuccess();
+        gate.RecordSuccess();
+
+        gate.IsHealthy.Should().BeTrue();
+    }
+}

--- a/server/XUnitTest/Subscription/FinancialDocumentWorkHandlerTests.cs
+++ b/server/XUnitTest/Subscription/FinancialDocumentWorkHandlerTests.cs
@@ -25,12 +25,19 @@ public sealed class FinancialDocumentWorkHandlerTests
     private readonly Mock<ISubscriptionFinancialDocumentIssuer> _issuer = new();
     private readonly Mock<ISubscriptionRepository> _subscriptions = new();
     private readonly Mock<ISubscriptionFinancialDocumentDeliveryService> _delivery = new();
+    private readonly Mock<IFinancialDocumentRendererHealth> _rendererHealth = new();
 
-    public FinancialDocumentWorkHandlerTests() =>
+    public FinancialDocumentWorkHandlerTests()
+    {
         // Issued by default. Moq would answer this with null, and the handler now reads an outcome
         // off it — so without a default every test here would fail for a reason unrelated to what
         // it is about.
         Issues(FinancialDocumentIssueOutcome.Issued);
+
+        // Healthy by default, so every delivery test below is about what it says it is about
+        // unless it deliberately turns this off.
+        _rendererHealth.Setup(health => health.IsHealthy).Returns(true);
+    }
 
     /// <summary>Makes the issuer report one outcome for a payment.</summary>
     private void Issues(FinancialDocumentIssueOutcome outcome) =>
@@ -276,11 +283,58 @@ public sealed class FinancialDocumentWorkHandlerTests
         DeliveryHandler().WorkType.Should().Be(SubscriptionWorkType.FinancialDocumentDelivery);
     }
 
+    /// <summary>
+    /// While the renderer is known unhealthy, delivery work must not touch the delivery service at
+    /// all — not for one named document, and not for the tenant sweep.
+    /// </summary>
+    /// <remarks>
+    /// The point of not calling it is exactly what these pin: every path through
+    /// <see cref="ISubscriptionFinancialDocumentDeliveryService"/> that fails a render spends one of
+    /// the document's own limited delivery attempts, and enough failures abandon it. An outage that
+    /// has nothing to do with any particular document must not spend that budget — see the
+    /// handler's own remarks for why.
+    /// </remarks>
+    [Fact]
+    public async Task An_unhealthy_renderer_is_retried_without_touching_delivery()
+    {
+        _rendererHealth.Setup(health => health.IsHealthy).Returns(false);
+
+        var outcome = await DeliveryHandler().ExecuteAsync(
+            Work("document:doc-1", "doc-1"),
+            CancellationToken.None);
+
+        outcome.Result.Should().Be(SubscriptionWorkResult.Retry);
+        outcome.ErrorCode.Should().Be("financial_document_renderer_unhealthy");
+        _delivery.Verify(
+            delivery => delivery.DeliverAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?>(),
+                It.IsAny<int?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task An_unhealthy_renderer_also_skips_the_tenant_sweep()
+    {
+        _rendererHealth.Setup(health => health.IsHealthy).Returns(false);
+
+        var outcome = await DeliveryHandler().ExecuteAsync(
+            Work("sweep:20260825T1200Z", string.Empty),
+            CancellationToken.None);
+
+        outcome.Result.Should().Be(SubscriptionWorkResult.Retry);
+        _delivery.Verify(
+            delivery => delivery.DeliverPendingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private ISubscriptionWorkHandler IssueHandler() =>
         new FinancialDocumentIssueWorkHandler(_issuer.Object);
 
     private ISubscriptionWorkHandler DeliveryHandler() =>
-        new FinancialDocumentDeliveryWorkHandler(_delivery.Object);
+        new FinancialDocumentDeliveryWorkHandler(_delivery.Object, _rendererHealth.Object);
 
     private static SubscriptionBackgroundWork Work(string workKey, string aggregateId) =>
         new()

--- a/server/XUnitTest/Worker/FinancialDocumentRendererHealthMonitorTests.cs
+++ b/server/XUnitTest/Worker/FinancialDocumentRendererHealthMonitorTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Worker;
+
+namespace XUnitTest.Worker;
+
+/// <summary>
+/// The self-healing half of the fix: while the gate is unhealthy this must keep re-probing on an
+/// interval, and while it is healthy it must leave the renderer alone.
+/// </summary>
+public sealed class FinancialDocumentRendererHealthMonitorTests
+{
+    [Fact]
+    public async Task Never_probes_while_the_gate_is_already_healthy()
+    {
+        var renderer = new Mock<IFinancialDocumentPdfRenderer>();
+        var health = new Mock<IFinancialDocumentRendererHealth>();
+        health.Setup(gate => gate.IsHealthy).Returns(true);
+
+        using var monitor = Monitor(renderer, health, intervalSeconds: 1);
+        using var cts = new CancellationTokenSource();
+
+        await monitor.StartAsync(cts.Token);
+        await Task.Delay(2500);
+        await monitor.StopAsync(cts.Token);
+
+        // A healthy renderer has nothing for this loop to prove. Probing it anyway would be pure
+        // cost for a signal nothing downstream needs — see the monitor's own remarks.
+        renderer.Verify(
+            r => r.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Keeps_reprobing_on_the_configured_interval_while_unhealthy()
+    {
+        var renderer = new Mock<IFinancialDocumentPdfRenderer>();
+        renderer
+            .Setup(r => r.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((byte[]?)null);
+        var health = new Mock<IFinancialDocumentRendererHealth>();
+        health.Setup(gate => gate.IsHealthy).Returns(false);
+
+        using var monitor = Monitor(renderer, health, intervalSeconds: 1);
+        using var cts = new CancellationTokenSource();
+
+        await monitor.StartAsync(cts.Token);
+        await Task.Delay(2500);
+        await monitor.StopAsync(cts.Token);
+
+        // At a one-second interval, 2.5 seconds is enough for at least two probes without being
+        // exact about how many — the point is that it keeps trying, not a precise count.
+        renderer.Verify(
+            r => r.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.AtLeast(2));
+        health.Verify(
+            gate => gate.RecordFailure(null, It.IsAny<string>()),
+            Times.AtLeast(2));
+    }
+
+    [Fact]
+    public async Task Records_recovery_the_moment_a_probe_succeeds()
+    {
+        var renderer = new Mock<IFinancialDocumentPdfRenderer>();
+        renderer
+            .Setup(r => r.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([0x25, 0x50, 0x44, 0x46]);
+        var health = new Mock<IFinancialDocumentRendererHealth>();
+        health.Setup(gate => gate.IsHealthy).Returns(false);
+
+        using var monitor = Monitor(renderer, health, intervalSeconds: 1);
+        using var cts = new CancellationTokenSource();
+
+        await monitor.StartAsync(cts.Token);
+        await Task.Delay(1500);
+        await monitor.StopAsync(cts.Token);
+
+        health.Verify(gate => gate.RecordSuccess(), Times.AtLeastOnce);
+    }
+
+    private static FinancialDocumentRendererHealthMonitor Monitor(
+        Mock<IFinancialDocumentPdfRenderer> renderer,
+        Mock<IFinancialDocumentRendererHealth> health,
+        int intervalSeconds) =>
+        new(
+            renderer.Object,
+            health.Object,
+            new OptionsStub(intervalSeconds),
+            NullLogger<FinancialDocumentRendererHealthMonitor>.Instance);
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public OptionsStub(int rendererHealthProbeIntervalSeconds) =>
+            CurrentValue = new SubscriptionOptions
+            {
+                RendererHealthProbeIntervalSeconds = rendererHealthProbeIntervalSeconds
+            };
+
+        public SubscriptionOptions CurrentValue { get; }
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Worker/FinancialDocumentRendererReadinessCheckTests.cs
+++ b/server/XUnitTest/Worker/FinancialDocumentRendererReadinessCheckTests.cs
@@ -7,72 +7,89 @@ using Worker;
 namespace XUnitTest.Worker;
 
 /// <summary>
-/// This host has no HTTP surface to probe, so the only signal available is whether the process
-/// starts at all — see the check's own remarks. What matters here is exactly that: a broken
-/// renderer must throw out of <c>StartAsync</c>, and a working one must not.
+/// The startup probe no longer stops the host — see the check's own remarks for why a worker that
+/// also runs renewals, payments and usage rating must not be taken down by a presentation
+/// dependency. What matters here is that <see cref="FinancialDocumentRendererReadinessCheck"/>
+/// never throws out of <c>StartAsync</c>, whatever the renderer does, and that it records exactly
+/// what the renderer did onto <see cref="IFinancialDocumentRendererHealth"/> for
+/// <c>FinancialDocumentDeliveryWorkHandler</c> to read afterwards.
 /// </summary>
 public sealed class FinancialDocumentRendererReadinessCheckTests
 {
     [Fact]
-    public async Task A_renderer_that_produces_bytes_starts_cleanly()
+    public async Task A_renderer_that_produces_bytes_starts_cleanly_and_is_recorded_healthy()
     {
-        var renderer = new Mock<IFinancialDocumentPdfRenderer>();
-        renderer
-            .Setup(engine => engine.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([0x25, 0x50, 0x44, 0x46]);
+        var renderer = Renderer(bytes: [0x25, 0x50, 0x44, 0x46]);
+        var health = new Mock<IFinancialDocumentRendererHealth>();
 
-        var check = Check(renderer);
+        await Check(renderer, health).StartAsync(CancellationToken.None);
 
-        await check.Invoking(check => check.StartAsync(CancellationToken.None))
+        health.Verify(gate => gate.RecordSuccess(), Times.Once);
+        health.Verify(
+            gate => gate.RecordFailure(It.IsAny<Exception?>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_renderer_that_returns_nothing_starts_the_host_anyway_but_is_recorded_unhealthy()
+    {
+        var renderer = Renderer(bytes: null);
+        var health = new Mock<IFinancialDocumentRendererHealth>();
+
+        // The one behavior this whole change exists to remove: this must not throw. A worker that
+        // also runs renewals and payment reconciliation must come up even when Chromium cannot.
+        await Check(renderer, health)
+            .Invoking(check => check.StartAsync(CancellationToken.None))
             .Should().NotThrowAsync();
+
+        health.Verify(
+            gate => gate.RecordFailure(null, It.IsAny<string>()),
+            Times.Once);
     }
 
     [Fact]
-    public async Task A_renderer_that_returns_nothing_fails_startup()
+    public async Task A_renderer_that_returns_an_empty_array_is_recorded_unhealthy()
+    {
+        var renderer = Renderer(bytes: []);
+        var health = new Mock<IFinancialDocumentRendererHealth>();
+
+        await Check(renderer, health).StartAsync(CancellationToken.None);
+
+        health.Verify(gate => gate.RecordFailure(null, It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task A_renderer_that_throws_starts_the_host_and_records_the_cause()
+    {
+        var renderer = new Mock<IFinancialDocumentPdfRenderer>();
+        var thrown = new InvalidOperationException("Chromium executable not found");
+        renderer
+            .Setup(engine => engine.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(thrown);
+        var health = new Mock<IFinancialDocumentRendererHealth>();
+
+        await Check(renderer, health)
+            .Invoking(check => check.StartAsync(CancellationToken.None))
+            .Should().NotThrowAsync();
+
+        health.Verify(gate => gate.RecordFailure(thrown, It.IsAny<string>()), Times.Once);
+    }
+
+    private static Mock<IFinancialDocumentPdfRenderer> Renderer(byte[]? bytes)
     {
         var renderer = new Mock<IFinancialDocumentPdfRenderer>();
         renderer
             .Setup(engine => engine.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((byte[]?)null);
+            .ReturnsAsync(bytes);
 
-        var check = Check(renderer);
-
-        // The only mechanism this non-HTTP host has for failing readiness: the hosted service
-        // throwing out of StartAsync stops the Generic Host from starting at all.
-        await check.Invoking(check => check.StartAsync(CancellationToken.None))
-            .Should().ThrowAsync<InvalidOperationException>();
-    }
-
-    [Fact]
-    public async Task A_renderer_that_returns_an_empty_array_fails_startup()
-    {
-        var renderer = new Mock<IFinancialDocumentPdfRenderer>();
-        renderer
-            .Setup(engine => engine.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
-
-        var check = Check(renderer);
-
-        await check.Invoking(check => check.StartAsync(CancellationToken.None))
-            .Should().ThrowAsync<InvalidOperationException>();
-    }
-
-    [Fact]
-    public async Task A_renderer_that_throws_fails_startup_with_the_cause_attached()
-    {
-        var renderer = new Mock<IFinancialDocumentPdfRenderer>();
-        renderer
-            .Setup(engine => engine.RenderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("Chromium executable not found"));
-
-        var check = Check(renderer);
-
-        var thrown = await check.Invoking(check => check.StartAsync(CancellationToken.None))
-            .Should().ThrowAsync<InvalidOperationException>();
-        thrown.Which.InnerException!.Message.Should().Contain("Chromium executable not found");
+        return renderer;
     }
 
     private static FinancialDocumentRendererReadinessCheck Check(
-        Mock<IFinancialDocumentPdfRenderer> renderer) =>
-        new(renderer.Object, NullLogger<FinancialDocumentRendererReadinessCheck>.Instance);
+        Mock<IFinancialDocumentPdfRenderer> renderer,
+        Mock<IFinancialDocumentRendererHealth> health) =>
+        new(
+            renderer.Object,
+            health.Object,
+            NullLogger<FinancialDocumentRendererReadinessCheck>.Instance);
 }


### PR DESCRIPTION
## Problem

`FinancialDocumentRendererReadinessCheck` threw out of `StartAsync`, which stops the Generic Host from starting at all. This worker is not only the document renderer — it's also where renewals, payment reconciliation, usage rating and document issuance run, and none of those touch Chromium. A broken renderer meant nothing got paid, renewed, or billed — not just that PDFs were delayed.

## Immediate timeout cause

`PuppeteerSharpEngine.ConvertHtmlToPdfAsync` waited for `Networkidle0` on `SetContentAsync`, then called `WaitForNetworkIdleAsync()` again — on HTML with no network activity to ever go idle on (inline CSS, logos embedded as data URIs). Every render hit Puppeteer's 30-second navigation timeout waiting for an event the page was never going to raise.

Fixed by switching to `WaitUntilNavigation.DOMContentLoaded` with an explicit 10s timeout, and dropping the separate `WaitForNetworkIdleAsync()` call — `DOMContentLoaded` is what a document with no network dependencies actually reaches.

## Architectural fix

- `FinancialDocumentRendererReadinessCheck` still probes first and still logs critical on failure, but no longer throws. It records the result on a new `IFinancialDocumentRendererHealth` gate (a plain singleton flag, not a general health-check framework — see its own remarks for why that scope was rejected) and lets the host start regardless.
- `FinancialDocumentDeliveryWorkHandler` is the **only** reader of that gate. While unhealthy, it retries the queue item without calling `ISubscriptionFinancialDocumentDeliveryService` at all — so no document spends any of its own limited delivery-attempt budget on an outage that has nothing to do with that document. Every other handler (renewals, payments, usage rating, document issuance) is unaffected.
- `FinancialDocumentRendererHealthMonitor` re-probes on a configurable interval (`Subscription:RendererHealthProbeIntervalSeconds`, default 60s) only while the gate is unhealthy, and flips it back the moment a probe succeeds. The existing repair sweep (`SubscriptionRepairAnnouncer` / `ListUndeliveredAsync`) already re-announces any document that stayed undelivered while the gate was closed, so delivery resumes for all of them automatically — no restart, no lost documents, no operator action.

Resulting shape:

```
Chromium unhealthy
├── Renewals continue
├── Payments continue
├── Subscription processing continues
├── Invoice records continue to be issued
└── PDF delivery is paused, without spending document delivery attempts

Chromium recovers
└── Pending PDF jobs resume automatically
```

## Tests

- Rewrote `FinancialDocumentRendererReadinessCheckTests` for the new non-throwing contract (never throws; records success/failure onto the gate correctly for bytes / null / empty array / exception).
- New `FinancialDocumentRendererHealthGateTests`: starts healthy, flips on failure, flips back on success, stays put across repeats.
- New `FinancialDocumentRendererHealthMonitorTests`: never probes while healthy; keeps re-probing on interval while unhealthy; records recovery the moment a probe succeeds.
- Extended `FinancialDocumentWorkHandlerTests`: an unhealthy renderer is retried without ever calling `DeliverAsync`/`DeliverPendingAsync` (both the single-document and tenant-sweep shapes).
- Full non-integration suite run clean apart from two pre-existing, unrelated failures (`SubscriptionSimulationGuardTests` / `SubscriptionSimulationServiceTests`) confirmed to also fail on a clean `dev` checkout before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)