### PR TITLE
config: seed Subscription:FinancialDocumentRenderMaxConcurrency

### DIFF
--- a/server/Api/appsettings.Development.json
+++ b/server/Api/appsettings.Development.json
@@ -33,5 +33,8 @@
   "SubscriptionSimulation": {
     "Enabled": true,
     "DataConsoleEnabled": true
+  },
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
   }
 }

--- a/server/Api/appsettings.dev.json
+++ b/server/Api/appsettings.dev.json
@@ -34,5 +34,8 @@
   "SubscriptionSimulation": {
     "Enabled": true,
     "DataConsoleEnabled": true
+  },
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
   }
 }

--- a/server/Api/appsettings.json
+++ b/server/Api/appsettings.json
@@ -38,5 +38,8 @@
     },
     "PublicBaseUrl": "https://dev-utilities.blocksdevelopers.com:5000",
     "IamBaseUrl": ""
+  },
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
   }
 }

--- a/server/Api/appsettings.prod.json
+++ b/server/Api/appsettings.prod.json
@@ -38,5 +38,8 @@
       "USD": 2,
       "JPY": 0
     }
+  },
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
   }
 }

--- a/server/Api/appsettings.stg.json
+++ b/server/Api/appsettings.stg.json
@@ -36,5 +36,8 @@
       "USD": 2,
       "JPY": 0
     }
+  },
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
   }
 }

--- a/server/Worker/appsettings.Development.json
+++ b/server/Worker/appsettings.Development.json
@@ -23,6 +23,9 @@
       "USD": 2,
       "JPY": 0
     }
-  }
+  },
 
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
+  }
 }

--- a/server/Worker/appsettings.dev.json
+++ b/server/Worker/appsettings.dev.json
@@ -27,6 +27,7 @@
   },
 
   "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1,
     "TenantIds": [ "T21223ef2472d47e08862329b03e814b7" ],
     "ReconciliationPollSeconds": 30
   }

--- a/server/Worker/appsettings.json
+++ b/server/Worker/appsettings.json
@@ -25,6 +25,9 @@
       "USD": 2,
       "JPY": 0
     }
-  }
+  },
 
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
+  }
 }

--- a/server/Worker/appsettings.prod.json
+++ b/server/Worker/appsettings.prod.json
@@ -24,5 +24,8 @@
       "JPY": 0
     },
     "PublicBaseUrl": "https://utilities.seliseblocks.com"
+  },
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
   }
 }

--- a/server/Worker/appsettings.stg.json
+++ b/server/Worker/appsettings.stg.json
@@ -24,5 +24,8 @@
       "JPY": 0
     },
     "PublicBaseUrl": "https://stg-utilities.blocksdevelopers.com"
+  },
+  "Subscription": {
+    "FinancialDocumentRenderMaxConcurrency": 1
   }
 }


### PR DESCRIPTION
Adds `Subscription:FinancialDocumentRenderMaxConcurrency: 1` to all ten appsettings files — `Api` and `Worker`, across base, `Development`, `dev`, `stg` and `prod`.

```json
{
  "Subscription": {
    "FinancialDocumentRenderMaxConcurrency": 1
  }
}
```

## This changes no behaviour today

The key is read by nothing. It appears nowhere else in the repository — not in C#, not in the gitops charts, not in the client — so `SubscriptionOptions` has no property to bind it to, and .NET's configuration binder ignores an unmapped key silently. This is a seed for code that will read it, not a live setting.

**The knob that does govern how much runs at once is `Subscription:SchedulerMaxParallelism`**, which defaults to `4` and is what `SubscriptionWorkDispatcher` hands to `Parallel.ForEachAsync`:

```csharp
var parallelism = Math.Max(1, options.SchedulerMaxParallelism);
```

If the intent is to stop financial-document rendering happening four at a time on the current build, that is the setting that would do it. Worth noting alongside it that `PuppeteerSharpEngine` already serialises on a `SemaphoreSlim(1, 1)` browser lock, so four parallel render items already queue behind a single browser — the effective render concurrency is 1 before any of this.

Raised so the choice is explicit; landing this as a seed is a reasonable thing to want, and it is what was asked for.

## How the files were edited

| | |
|---|---|
| `Worker/appsettings.dev.json` | already had a `Subscription` section — the key was **merged into it**, leaving `TenantIds` and `ReconciliationPollSeconds` untouched |
| The other nine | gained a new top-level `Subscription` block |
| BOM | preserved per file — three of the ten have one |
| Line endings | CRLF preserved throughout |

Every file was re-parsed after writing and its structure compared against the original, asserting the new key is the **only** difference. Every added line across the whole diff was audited: 10 key lines, 9 new `"Subscription": {` openers, and brace/comma adjustments — nothing else.

Done in a fresh worktree from `dev`, so the two `Worker` appsettings files that carry local-only edits on some machines came from `dev` pristine and no local values were swept in.

## CI

Server-only, so `Client PR validation` will not run — its `paths` filter is `client/**`. That is the intended behaviour while the check is not required; if it is ever made required, it needs the no-op path first so a server-only PR does not wait for a check GitHub never creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
