### PR TITLE
feat(subscription): restyle the invoice to the reference design

### DIFF
--- a/server/Subscription.DomainService/Services/FinancialDocumentHtmlTemplate.cs
+++ b/server/Subscription.DomainService/Services/FinancialDocumentHtmlTemplate.cs
@@ -51,9 +51,13 @@ public static class FinancialDocumentHtmlTemplate
         html.Append("<style>").Append(Styles(palette)).Append("</style></head><body>");
 
         AppendHeader(html, document, logo?.DataUri);
+
+        // Order follows the reference design: identity, then who the document is between, then the
+        // amount, then what it is made of. The previous order put the amount before the facts that
+        // qualify it, which read as a headline with its own footnotes underneath.
+        AppendSubject(html, document);
         AppendParties(html, document);
         AppendHeadline(html, document, money);
-        AppendSubject(html, document);
 
         if (document.Trial is { } trial)
         {
@@ -68,6 +72,7 @@ public static class FinancialDocumentHtmlTemplate
         }
 
         AppendTotals(html, document, money);
+        AppendPaymentInstructions(html, document);
         AppendFooter(html, document, money);
 
         html.Append("</body></html>");
@@ -215,7 +220,7 @@ public static class FinancialDocumentHtmlTemplate
 
     private static void AppendSubject(StringBuilder html, SubscriptionFinancialDocument document)
     {
-        html.Append("<table class=\"meta wide\">");
+        html.Append("<table class=\"meta\">");
         AppendMetaRow(html, "Invoice number", document.DocumentNumber);
         AppendMetaRow(html, "Date of issue", Date(document.IssuedAtUtc));
         AppendMetaRow(html, "Currency", document.CurrencyCode);
@@ -264,7 +269,7 @@ public static class FinancialDocumentHtmlTemplate
         FinancialDocumentTrial trial,
         SubscriptionFinancialDocument document)
     {
-        html.Append("<div class=\"note\"><div class=\"label\">Trial</div><table class=\"meta wide\">");
+        html.Append("<div class=\"note\"><div class=\"label\">Trial</div><table class=\"meta\">");
         AppendMetaRow(html, "Trial period", $"{Date(trial.StartsAtUtc)} to {Date(trial.EndsAtUtc)}");
         AppendMetaRow(html, "Timezone", document.Period.TimeZoneId);
         AppendMetaRow(
@@ -292,12 +297,26 @@ public static class FinancialDocumentHtmlTemplate
         }
 
         html.Append("<table class=\"lines\"><thead><tr>");
-        html.Append("<th>Description</th><th class=\"num\">Quantity</th>");
-        html.Append("<th class=\"num\">Unit</th><th class=\"num\">Amount</th></tr></thead><tbody>");
+        html.Append("<th>Description</th><th class=\"num\">Qty</th>");
+        html.Append("<th class=\"num\">Unit price</th><th class=\"num\">Tax</th>");
+        html.Append("<th class=\"num\">Amount</th></tr></thead><tbody>");
+
+        // The document carries one rate for all of its lines rather than a rate per line, so the
+        // column states that rate rather than implying a per-line figure the record does not hold.
+        var lineTax = LineTaxLabel(document.Amounts);
 
         foreach (var line in document.Lines)
         {
-            html.Append("<tr><td>").Append(Escape(line.Description)).Append("</td>");
+            html.Append("<tr><td>").Append(Escape(line.Description));
+
+            // The item key under the description, the way the design carries "25–40 Users" under
+            // its plan name: it is what tells two lines with the same wording apart.
+            if (line.ItemKey is { Length: > 0 } itemKey)
+            {
+                html.Append("<span class=\"sub\">").Append(Escape(itemKey)).Append("</span>");
+            }
+
+            html.Append("</td>");
             html.Append("<td class=\"num\">")
                 .Append(line.Quantity is { } quantity
                     ? Escape(quantity.ToString(CultureInfo.InvariantCulture))
@@ -306,6 +325,7 @@ public static class FinancialDocumentHtmlTemplate
             html.Append("<td class=\"num\">")
                 .Append(line.UnitAmountMinor is { } unit ? Escape(money.Format(unit)) : "&mdash;")
                 .Append("</td>");
+            html.Append("<td class=\"num\">").Append(lineTax).Append("</td>");
             html.Append("<td class=\"num\">").Append(Escape(money.Format(line.AmountMinor)))
                 .Append("</td></tr>");
         }
@@ -434,6 +454,50 @@ public static class FinancialDocumentHtmlTemplate
         html.Append("</table>");
     }
 
+    /// <summary>
+    /// The rate shown against each line, or an em dash when the document carries none.
+    /// </summary>
+    /// <remarks>
+    /// "10% incl." in the reference design. Abbreviated rather than spelled out because it sits in
+    /// a narrow numeric column, and the unabbreviated form is already stated once in the totals,
+    /// where there is room for it.
+    /// </remarks>
+    private static string LineTaxLabel(FinancialDocumentAmounts amounts)
+    {
+        if (amounts.TaxRateBasisPoints is not > 0)
+        {
+            return "&mdash;";
+        }
+
+        var mode = string.Equals(amounts.TaxMode, "Inclusive", StringComparison.OrdinalIgnoreCase)
+            ? "incl."
+            : "excl.";
+
+        return Escape($"{Percent(amounts.TaxRateBasisPoints.Value)} {mode}");
+    }
+
+    /// <summary>
+    /// How to pay, in the place the reference design puts it: after the totals, before the footer.
+    /// </summary>
+    /// <remarks>
+    /// The design prints bank fields with em dashes where a value has yet to be issued. This prints
+    /// only what the merchant actually snapshotted onto the document, because a labelled row with a
+    /// dash beside it reads as a value that exists and was withheld, rather than as a field this
+    /// tenant does not use. Absent instructions render nothing at all.
+    /// </remarks>
+    private static void AppendPaymentInstructions(
+        StringBuilder html,
+        SubscriptionFinancialDocument document)
+    {
+        if (document.Merchant.PaymentInstructions is not { Length: > 0 } instructions)
+        {
+            return;
+        }
+
+        html.Append("<div class=\"pay\"><div class=\"pay-title\">How to pay</div>");
+        html.Append("<div class=\"pay-body\">").Append(Escape(instructions)).Append("</div></div>");
+    }
+
     private static void AppendFooter(
         StringBuilder html,
         SubscriptionFinancialDocument document,
@@ -443,11 +507,6 @@ public static class FinancialDocumentHtmlTemplate
         html.Append("<div class=\"summary-line\">").Append(Escape(document.DocumentNumber))
             .Append(" · ").Append(Escape(money.Format(document.Amounts.TotalMinor)))
             .Append(" · ").Append(Escape(StatusText(document))).Append("</div>");
-
-        if (document.Merchant.PaymentInstructions is { Length: > 0 } instructions)
-        {
-            html.Append("<div>").Append(Escape(instructions)).Append("</div>");
-        }
 
         if (document.Merchant.SupportEmail is { Length: > 0 } supportEmail)
         {
@@ -550,10 +609,19 @@ public static class FinancialDocumentHtmlTemplate
             : $"Every {subject.IntervalCount.ToString(CultureInfo.InvariantCulture)} " +
                 $"{subject.Interval.ToString().ToLowerInvariant()}s";
 
+    /// <summary>
+    /// A date as the reference design writes it: "August 26, 2026".
+    /// </summary>
+    /// <remarks>
+    /// Long form rather than ISO, and invariant rather than localised. The design spells the month
+    /// out, which also removes the one ambiguity a numeric date carries across readers — 08-09 is
+    /// two different days depending on where it is read, and a month name is the same day
+    /// everywhere. The instants beside it stay ISO: those exist to be compared, not read.
+    /// </remarks>
     private static string Date(DateTime instantUtc) =>
         instantUtc == default
             ? "—"
-            : instantUtc.ToUniversalTime().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            : instantUtc.ToUniversalTime().ToString("MMMM d, yyyy", CultureInfo.InvariantCulture);
 
     private static string Instant(DateTime instantUtc) =>
         instantUtc == default
@@ -601,44 +669,56 @@ public static class FinancialDocumentHtmlTemplate
     /// </remarks>
     private static string Styles(Palette palette) =>
         $"*{{box-sizing:border-box}}" +
-        "@page{size:A4;margin:18mm 16mm}" +
-        "body{font:12px/1.5 'Helvetica Neue',Helvetica,Arial,sans-serif;color:#1a1a1a;" +
+        "@page{size:A4;margin:16mm 14mm}" +
+        // No @font-face and no network font, by the same rule that forbids a remote logo. The stack
+        // is the one a headless Chromium can actually satisfy; the design's own face is not
+        // installed in the render container, so asking for it here would silently fall back anyway.
+        "body{font:11px/1.55 -apple-system,'Segoe UI',Helvetica,Arial,sans-serif;color:#1a1a1a;" +
         "margin:0;padding:0;-webkit-print-color-adjust:exact;print-color-adjust:exact}" +
         ".head{display:flex;justify-content:space-between;align-items:flex-start;" +
-        "padding-bottom:16px;margin-bottom:20px}" +
-        ".logo{max-height:40px;max-width:220px}" +
-        $".merchant{{font-size:18px;font-weight:700;color:{palette.Primary}}}" +
-        $".kind{{font-size:22px;font-weight:700;color:#1a1a1a}}" +
-        ".cols{display:flex;gap:32px;margin-bottom:20px}" +
+        "margin-bottom:28px}" +
+        ".logo{max-height:34px;max-width:200px}" +
+        $".merchant{{font-size:19px;font-weight:700;letter-spacing:.02em;color:{palette.Primary}}}" +
+        ".kind{font-size:19px;font-weight:700;color:#1a1a1a}" +
+        ".cols{display:flex;gap:40px;margin-bottom:28px}" +
         ".col{flex:1}" +
-        ".label{font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:#666;" +
-        "margin-bottom:4px}" +
-        ".spaced{margin-top:12px}" +
+        // Sentence case, not the small-caps the previous template used. The reference design labels
+        // every field as ordinary prose — "Bill to", "Date of issue" — and uppercase letterspacing
+        // is the single change that made the old output read as a different document.
+        ".label{font-size:11px;color:#697386;margin-bottom:4px}" +
+        ".spaced{margin-top:14px}" +
         ".strong{font-weight:600}" +
-        ".muted{color:#666}" +
-        $".headline{{font-size:22px;font-weight:700;color:{palette.Primary};margin-bottom:16px}}" +
+        ".muted{color:#697386}" +
+        // Black, and not the brand colour. The design gives the amount its weight through size
+        // alone; colouring it as well made the figure compete with the wordmark above it.
+        ".headline{font-size:19px;font-weight:700;color:#1a1a1a;margin-bottom:26px}" +
         "table{border-collapse:collapse;width:100%}" +
-        ".meta th{text-align:left;font-weight:400;color:#666;padding:2px 12px 2px 0;" +
+        ".meta{margin-bottom:26px;width:auto}" +
+        ".meta th{text-align:left;font-weight:400;color:#697386;padding:2px 28px 2px 0;" +
         "white-space:nowrap;vertical-align:top}" +
-        ".meta td{padding:2px 0;vertical-align:top}" +
-        ".meta.wide{margin-bottom:20px}" +
-        $".note{{background:{palette.Accent};padding:12px 14px;margin-bottom:20px;" +
+        ".meta td{padding:2px 0;vertical-align:top;font-weight:600}" +
+        $".note{{background:{palette.Accent};padding:12px 14px;margin-bottom:22px;" +
         "break-inside:avoid}" +
-        ".lines{margin-bottom:16px}" +
+        ".lines{margin-bottom:0}" +
         ".lines thead{display:table-header-group}" +
-        ".lines th{text-align:left;font-size:10px;letter-spacing:.1em;text-transform:uppercase;" +
-        "color:#666;border-bottom:1px solid #ddd;padding:6px 8px}" +
-        ".lines td{border-bottom:1px solid #f0f0f0;padding:6px 8px}" +
+        ".lines th{text-align:left;font-weight:400;color:#697386;" +
+        "border-bottom:1px solid #e6e8eb;padding:8px 10px 8px 0}" +
+        ".lines td{border-bottom:1px solid #e6e8eb;padding:10px 10px 10px 0;vertical-align:top}" +
         ".lines tr{break-inside:avoid}" +
+        ".sub{display:block;color:#697386;margin-top:2px}" +
         ".num{text-align:right;white-space:nowrap}" +
-        ".totals{width:auto;margin-left:auto;min-width:280px;break-inside:avoid}" +
-        ".totals th{text-align:left;font-weight:400;color:#444;padding:3px 24px 3px 0;" +
-        "white-space:nowrap}" +
-        ".totals td{padding:3px 0}" +
+        // Indented to sit under the right-hand half of the line table, which is what makes the
+        // totals read as a continuation of it rather than as a second table.
+        ".totals{width:55%;margin-left:auto;margin-top:0;break-inside:avoid}" +
+        ".totals th{text-align:left;font-weight:400;color:#1a1a1a;padding:8px 24px 8px 0;" +
+        "white-space:nowrap;border-bottom:1px solid #e6e8eb}" +
+        ".totals td{padding:8px 0;border-bottom:1px solid #e6e8eb}" +
         ".totals tr{break-inside:avoid}" +
-        ".totals tr.grand th,.totals tr.grand td{font-weight:600;font-size:14px;" +
-        "border-top:1px solid #1a1a1a;padding-top:8px}" +
-        ".foot{margin-top:32px;padding-top:12px;border-top:1px solid #ddd;font-size:10px;" +
-        "color:#666;break-inside:avoid}" +
-        ".summary-line{color:#1a1a1a;margin-bottom:4px}";
+        ".totals tr.grand th,.totals tr.grand td{font-weight:700;border-bottom:none}" +
+        ".pay{margin-top:34px;break-inside:avoid}" +
+        ".pay-title{font-weight:600;margin-bottom:4px}" +
+        ".pay-body{color:#697386;margin-bottom:10px;white-space:pre-line}" +
+        ".foot{margin-top:40px;padding-top:12px;border-top:1px solid #e6e8eb;" +
+        "color:#697386;break-inside:avoid}" +
+        ".summary-line{margin-bottom:4px}";
 }

--- a/server/Subscription.DomainService/Services/FinancialDocumentMoneyFormatter.cs
+++ b/server/Subscription.DomainService/Services/FinancialDocumentMoneyFormatter.cs
@@ -23,6 +23,7 @@ public sealed class FinancialDocumentMoneyFormatter
     private readonly ICurrencyMinorUnitResolver _currency;
     private readonly string _currencyCode;
     private readonly int _decimals;
+    private readonly bool _known;
 
     public FinancialDocumentMoneyFormatter(
         ICurrencyMinorUnitResolver currency,
@@ -35,11 +36,24 @@ public sealed class FinancialDocumentMoneyFormatter
             ? string.Empty
             : currencyCode.ToUpperInvariant();
         _decimals = DecimalsFor(currency, _currencyCode);
+
+        // Asked once, here, because Format cannot tell the two failures apart on its own: the
+        // resolver refuses an unconfigured currency and a zero amount with the same false.
+        _known = currency.TryConvert(1m, _currencyCode, out var units) && units >= 1;
     }
 
     public string Format(long amountMinor)
     {
         var negative = amountMinor < 0;
+
+        // Zero is a number, and the resolver will not convert it: TryConvertBack rejects anything
+        // at or below zero, so without this a nil subtotal, an untaxed document or a zero total
+        // printed as a bare "CHF". On a Total line that reads as missing data rather than as
+        // nothing owed, which is the one reading a financial record must never invite.
+        if (amountMinor == 0 && _known)
+        {
+            return $"{_currencyCode} {FormatAmount(0m)}";
+        }
 
         // Converted as a magnitude and re-signed, because the resolver describes an amount rather
         // than a direction — and a credit note's figures are the same amounts pointing the other way.
@@ -52,12 +66,15 @@ public sealed class FinancialDocumentMoneyFormatter
             return _currencyCode;
         }
 
-        var text = amount.ToString(
-            $"N{_decimals.ToString(CultureInfo.InvariantCulture)}",
-            CultureInfo.InvariantCulture);
+        var text = FormatAmount(amount);
 
         return negative ? $"-{_currencyCode} {text}" : $"{_currencyCode} {text}";
     }
+
+    private string FormatAmount(decimal amount) =>
+        amount.ToString(
+            $"N{_decimals.ToString(CultureInfo.InvariantCulture)}",
+            CultureInfo.InvariantCulture);
 
     /// <summary>
     /// How many decimal places this currency has, asked rather than assumed.

--- a/server/XUnitTest/Subscription/FinancialDocumentHtmlTemplateTests.cs
+++ b/server/XUnitTest/Subscription/FinancialDocumentHtmlTemplateTests.cs
@@ -1,7 +1,9 @@
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Payment.DomainService.Entities;
 using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Services;
@@ -338,6 +340,147 @@ public sealed class FinancialDocumentHtmlTemplateTests
     public void The_footer_names_the_document_its_total_and_its_status()
     {
         Render().Should().Contain("INV-2026-000001 · CHF 1,000.00 · Paid");
+    }
+
+    [Fact]
+    public void A_zero_amount_prints_as_zero_rather_than_as_a_bare_currency_code()
+    {
+        // Against the real resolver, not the permissive fake below: TryConvertBack refuses anything
+        // at or below zero, so every nil figure on a document used to render as "CHF" with no
+        // number at all. On a Total line that reads as missing data rather than as nothing owed,
+        // which is the one reading a financial record must never invite.
+        var money = new FinancialDocumentMoneyFormatter(RealResolver(), "CHF");
+
+        money.Format(0).Should().Be("CHF 0.00");
+        money.Format(1_000_00).Should().Be("CHF 1,000.00");
+        money.Format(-2_50).Should().Be("-CHF 2.50");
+    }
+
+    [Fact]
+    public void An_unconfigured_currency_still_prints_the_code_alone()
+    {
+        // The fallback the zero fix must not swallow. Printing minor units for a currency whose
+        // exponent is unknown would be wrong by a factor of a hundred, so the code alone stands.
+        var money = new FinancialDocumentMoneyFormatter(RealResolver(), "XXX");
+
+        money.Format(0).Should().Be("XXX");
+        money.Format(1_000_00).Should().Be("XXX");
+    }
+
+    [Fact]
+    public void The_line_table_carries_the_columns_the_design_asks_for()
+    {
+        var html = Render(document => document.Amounts.TaxRateBasisPoints = 1_000);
+
+        html.Should().Contain("<th>Description</th>");
+        html.Should().Contain(">Qty</th>");
+        html.Should().Contain(">Unit price</th>");
+        html.Should().Contain(">Tax</th>");
+        html.Should().Contain(">Amount</th>");
+    }
+
+    [Fact]
+    public void Each_line_states_the_rate_the_document_was_taxed_at()
+    {
+        // The document carries one rate rather than a rate per line, so the column states that rate.
+        // Abbreviated, because the column is narrow and the full form is already in the totals.
+        Render(document =>
+        {
+            document.Amounts.TaxRateBasisPoints = 1_000;
+            document.Amounts.TaxMode = "Inclusive";
+        }).Should().Contain("10% incl.");
+
+        Render(document =>
+        {
+            document.Amounts.TaxRateBasisPoints = 770;
+            document.Amounts.TaxMode = "Exclusive";
+        }).Should().Contain("7.7% excl.");
+    }
+
+    [Fact]
+    public void An_untaxed_document_leaves_the_line_tax_column_empty_rather_than_claiming_zero()
+    {
+        var html = Render(document => document.Amounts.TaxRateBasisPoints = null);
+
+        html.Should().NotContain("0% incl.");
+        html.Should().NotContain("0% excl.");
+    }
+
+    [Fact]
+    public void The_document_facts_are_stated_before_the_parties_and_the_amount()
+    {
+        // The reference design's order: identity, then who it is between, then the money. Asserted
+        // because the previous template led with the amount and read as a headline with its own
+        // footnotes underneath.
+        var html = Render();
+
+        html.IndexOf("Invoice number", StringComparison.Ordinal)
+            .Should().BeLessThan(html.IndexOf("Bill to", StringComparison.Ordinal));
+        html.IndexOf("Bill to", StringComparison.Ordinal)
+            .Should().BeLessThan(html.IndexOf("class=\"headline\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Labels_are_sentence_case_rather_than_letterspaced_capitals()
+    {
+        // The single change that made the old output read as a different document from the design.
+        var html = Render();
+
+        html.Should().NotContain("text-transform:uppercase");
+        html.Should().NotContain("letter-spacing:.12em");
+    }
+
+    [Fact]
+    public void Payment_instructions_get_their_own_section_above_the_footer()
+    {
+        var html = Render(document =>
+            document.Merchant.PaymentInstructions = "Pay by bank transfer to IBAN CH00.");
+
+        html.Should().Contain("How to pay");
+        html.Should().Contain("Pay by bank transfer to IBAN CH00.");
+        html.IndexOf("How to pay", StringComparison.Ordinal)
+            .Should().BeLessThan(html.IndexOf("class=\"foot\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_merchant_with_no_payment_instructions_renders_no_empty_section()
+    {
+        // Rather than a heading with a dash under it, which reads as a value withheld instead of a
+        // field this tenant does not use.
+        Render(document => document.Merchant.PaymentInstructions = null)
+            .Should().NotContain("How to pay");
+    }
+
+    [Fact]
+    public void The_stylesheet_asks_for_no_font_it_cannot_be_given()
+    {
+        // Self-contained by the same rule that forbids a remote logo: no @font-face, no network
+        // fetch. The design's own face is not installed in the render container.
+        var html = Render();
+
+        html.Should().NotContain("@font-face");
+        html.Should().NotContain("fonts.googleapis");
+    }
+
+    /// <summary>
+    /// The real resolver, configured the way an environment configures it.
+    /// </summary>
+    /// <remarks>
+    /// The fake below answers every conversion with true, including the zero the real one refuses.
+    /// That is why a nil total rendered as a bare currency code for as long as it did: every test
+    /// asserted against a resolver more permissive than the one in production.
+    /// </remarks>
+    private static ICurrencyMinorUnitResolver RealResolver()
+    {
+        var options = new Mock<IOptionsMonitor<PaymentOptions>>();
+        options
+            .SetupGet(monitor => monitor.CurrentValue)
+            .Returns(new PaymentOptions
+            {
+                CurrencyMinorUnits = new Dictionary<string, int> { ["CHF"] = 2, ["JPY"] = 0 }
+            });
+
+        return new CurrencyMinorUnitResolver(options.Object);
     }
 
     private static string Render(


### PR DESCRIPTION
Restyles the financial-document template to the AMLORA reference design.

## The gap was mostly one decision, repeated

Every label was set in letterspaced capitals where the design writes ordinary prose. That single choice is what made the output read as a different document:

| Before | Design, and now |
|---|---|
| `BILL TO` | Bill to |
| `DESCRIPTION QUANTITY UNIT AMOUNT` | Description · Qty · Unit price · Tax · Amount |
| `CONTACT`, `INITIATED BY`, `HOW THIS CHANGE WAS SETTLED` | sentence case throughout |

## What changed

- **Labels** in sentence case; `text-transform` and `letter-spacing` gone.
- **Section order** follows the design — identity, parties, amount, then what the amount is made of. The amount used to lead, which read as a headline with its own footnotes underneath.
- **Headline is black**, not the brand colour. Size already gave it weight; colour as well made it compete with the wordmark above it.
- **Line table** gains `Qty`, `Unit price`, `Tax`, `Amount`, and carries the item key under the description the way the design carries "25–40 Users" under a plan name.
- **Totals** sit under the right half of the table with a hairline under each row, so they read as a continuation of it rather than as a second table.
- **Payment instructions** get their own section above the footer, where the design puts them, instead of a line inside it.
- **Dates** read "August 26, 2026". The UTC instants stay ISO — those exist to be compared, not read.
- Hairlines `#e6e8eb`, muted text `#697386`, body 11px/1.55.

## Two parts of the design deliberately not reproduced

**No "Pay online" link.** No document carries a hosted payment URL to point at, and a dead link is worse than no link.

**No due date.** Nothing issued here awaits payment — a document exists because a charge, trial or refund already happened. The headline states the total and what became of it, which is the honest analogue of the same visual weight.

Both were judgement calls. Say the word and either can change.

## A defect this had to fix to be possible

**Zero amounts printed as a bare currency code.** `TryConvertBack` refuses anything at or below zero, so `Format(0)` fell into the branch meant for a currency whose exponent is unknown and returned `"CHF"`. On the locally generated invoice that produced:

```
Subtotal      CHF
Net subtotal  CHF
Tax           CHF
Total         CHF
```

`Total CHF` reads as missing data, not as nothing owed — the one reading a financial record must never invite. The design cannot be met while that is true, so it is fixed here, contained to the document formatter. `CurrencyMinorUnitResolver` is untouched, so no payment-path behaviour moves.

**Why it survived this long:** every existing test asserted against a mock whose `TryConvertBack` answers `true` for everything, including the zero the real resolver refuses. The fake was more permissive than production. The new tests use the real `CurrencyMinorUnitResolver`, and **were confirmed to fail against the old code before the fix went in** — disabling the fix failed exactly one test, the right one.

## Verification

- **168 financial-document unit tests pass**, 21 pre-existing ones unchanged — the restyle preserved every semantic they pin.
- 10 new tests: zero formatting, the unconfigured-currency fallback the fix must not swallow, the new columns, per-line tax label and its absence, section order, sentence-case labels, the payment section and its absence, and no `@font-face`.
- Full non-integration server suite: **3154 passed**, 4 failures in `SubscriptionSimulation*` permission guards — **confirmed identical on clean `dev`** by stashing.
- `FinancialDocumentLedgerIntegrationTests` (15) need a local mongod and were not run. They run in no CI workflow either, which is worth fixing separately.

## Not addressed

The PDF embeds **Arial only**. The template asks for `-apple-system, 'Segoe UI', Helvetica, Arial` and the render container has none of the first three, so it falls to Arial. Matching the design's typeface needs a font installed in the container or embedded as a `data:` URI — a CSS change alone cannot do it. Out of scope here; happy to take it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
