### PR TITLE
Fix organization-scoped plan duplication

### DIFF
--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -53,7 +53,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
 
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
-            null,
+            request.OrganizationId,
             cancellationToken);
 
         if (!resolution.IsSuccess)
@@ -78,9 +78,14 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         var plan = BuildPlan(request, context.TenantId);
 
         plan.Code = request.Code;
+        // Null is the tenant-wide catalogue scope and must remain null. For an organization-scoped
+        // plan, persist the resolver's answer rather than the caller's request: only the console may
+        // name another organization, while every other caller is kept in the organization carried
+        // by its authenticated context. Using the raw request here would let an untrusted caller
+        // write a plan into somebody else's catalogue.
         plan.OrganizationId = string.IsNullOrWhiteSpace(request.OrganizationId)
             ? null
-            : request.OrganizationId;
+            : context.OrganizationId;
 
         string? predecessorDisplayName = null;
 

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -235,6 +235,29 @@ public sealed class PlanCatalogueServiceTests
     }
 
     [Fact]
+    public async Task Creating_an_organization_plan_resolves_the_requested_scope_and_persists_the_answer()
+    {
+        var request = NewPlan();
+        request.OrganizationId = "org-requested";
+
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                "corr-1", "org-requested", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, "org-resolved", "actor-1", "user-1")));
+
+        var result = await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.OrganizationId.Should().Be("org-resolved",
+            "the organization resolver, not an untrusted request body, owns catalogue scope");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                "corr-1", "org-requested", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task A_duplicate_plan_code_is_a_conflict()
     {
         _catalogue
@@ -978,6 +1001,33 @@ public sealed class PlanCatalogueServiceTests
         _created!.PredecessorPlanId.Should().Be("plan-0");
         result.Value!.PredecessorDisplayName.Should().Be("Legacy professional",
             "the caller should not need a second lookup to render a link");
+    }
+
+    [Fact]
+    public async Task An_organization_scoped_plan_can_be_duplicated_as_its_successor()
+    {
+        var predecessor = StoredPlan();
+        predecessor.ItemId = "plan-0";
+        predecessor.OrganizationId = "org-9";
+        predecessor.DisplayName = "Legacy professional";
+        StorePlan(predecessor);
+
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                "corr-1", "org-9", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, "org-9", "actor-1", "user-1")));
+
+        var request = NewPlan();
+        request.OrganizationId = "org-9";
+        request.PredecessorPlanId = "plan-0";
+
+        var result = await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.OrganizationId.Should().Be("org-9");
+        _created.PredecessorPlanId.Should().Be("plan-0");
+        result.Value!.PredecessorDisplayName.Should().Be("Legacy professional");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes organization-scoped plan duplication failing with subscription_plan_predecessor_not_found. The creation path now resolves the requested organization through the shared policy and persists the resolver-approved scope instead of the raw request. Includes regression tests for scoped predecessor duplication and scope persistence. Verification: focused PlanCatalogueServiceTests passed; git diff --check passed.