### PR TITLE
Fix subscription dispatcher audit service lifetime

### DIFF
--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
@@ -31,7 +31,6 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<SubscriptionWorkDispatcher> _logger;
     private readonly SubscriptionWorkMetrics? _metrics;
-    private readonly ISubscriptionAuditTrail? _audit;
     private readonly TimeProvider _time;
     private readonly TimeSpan? _leaseRenewalInterval;
     private readonly TimeSpan? _leaseOverride;
@@ -59,11 +58,9 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
         TimeProvider? time = null,
         TimeSpan? leaseRenewalInterval = null,
         TimeSpan? leaseOverride = null,
-        SubscriptionWorkMetrics? metrics = null,
-        ISubscriptionAuditTrail? audit = null)
+        SubscriptionWorkMetrics? metrics = null)
     {
         _metrics = metrics;
-        _audit = audit;
         _queue = queue;
         _scopeFactory = scopeFactory;
         _options = options;
@@ -345,14 +342,20 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
         TimeSpan duration,
         CancellationToken cancellationToken)
     {
-        if (_audit is null)
-        {
-            return;
-        }
-
         try
         {
-            await _audit.RecordAsync(
+            // The dispatcher is a singleton because the hosted scheduler is one. Audit storage is
+            // scoped, so it must be resolved inside an operation scope rather than captured by the
+            // singleton. Establish the work item's tenant before resolving/using anything whose
+            // repository is selected from ambient tenant context.
+            using var scope = _scopeFactory.CreateScope();
+            var services = scope.ServiceProvider;
+            using var tenant = services
+                .GetRequiredService<IPaymentTenantContextScopeFactory>()
+                .Establish(work.TenantId);
+            var audit = services.GetRequiredService<ISubscriptionAuditTrail>();
+
+            await audit.RecordAsync(
                 new SubscriptionAuditEvent
                 {
                     TenantId = work.TenantId,

--- a/server/XUnitTest/Subscription/SubscriptionWorkDispatcherTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionWorkDispatcherTests.cs
@@ -479,6 +479,10 @@ public sealed class SubscriptionWorkDispatcherTests
         var services = new ServiceCollection();
         services.AddSingleton(_tenantContext.Object);
         services.AddSingleton<ISubscriptionWorkHandler>(_handler);
+        if (audit is not null)
+        {
+            services.AddScoped(_ => audit);
+        }
 
         var options = new SubscriptionOptions
         {
@@ -495,8 +499,7 @@ public sealed class SubscriptionWorkDispatcherTests
             time ?? _time,
             renewalInterval,
             lease,
-            metrics: null,
-            audit: audit);
+            metrics: null);
     }
 
     private static SubscriptionBackgroundWork Work(


### PR DESCRIPTION
Fixes worker startup scope validation: the singleton SubscriptionWorkDispatcher no longer captures the scoped ISubscriptionAuditTrail. Dead-letter auditing now opens an operation scope, establishes the queued tenant, and resolves the audit trail inside that scope. Tests register the audit dependency as scoped. Verification: Worker builds with 0 errors; focused SubscriptionWorkDispatcherTests exit successfully; git diff --check passes.