### PR TITLE
feat(subscription): campaign discount data model, validation and authoring API [Phase 1/5]

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -590,6 +590,23 @@
             them one at a time invites a new street beside an old city on the next document issued.
             </remarks>
         </member>
+        <member name="T:Api.Controllers.SubscriptionDiscountsController">
+            <remarks>
+            Every action here manages the discount/campaign catalogue -- authoring, editing, retiring and
+            listing it -- never redeeming one. A buyer applying a code at checkout goes through the
+            subscription endpoints instead, which is why this whole controller sits behind
+            <c>SubscriptionCampaignManager</c> rather than plain authentication: creating a discount that
+            is 100% off, or one that replaces a price's own automatic discount, is a commercial decision,
+            the same reasoning that scopes subscription background-work recovery to its own policy.
+            <para>
+            That policy has no effect until the identity provider maps a role to the
+            <c>subscription.campaign.manage</c> permission claim it requires -- until that mapping exists,
+            every caller is refused, including whoever manages discounts today under plain authentication.
+            This is a deployment precondition, not a code change: the mapping has to land before this
+            controller does, or discount authoring goes dark the moment it deploys.
+            </para>
+            </remarks>
+        </member>
         <member name="T:Api.Controllers.SubscriptionMerchantProfileController">
             <summary>
             The legal identity this tenant issues its invoices and credit notes under.

--- a/server/Api/Controllers/SubscriptionDiscountsController.cs
+++ b/server/Api/Controllers/SubscriptionDiscountsController.cs
@@ -6,7 +6,22 @@ using Subscription.DomainService.Services;
 
 namespace Api.Controllers;
 
-[ApiController, Authorize, Route("subscription-discounts")]
+/// <remarks>
+/// Every action here manages the discount/campaign catalogue -- authoring, editing, retiring and
+/// listing it -- never redeeming one. A buyer applying a code at checkout goes through the
+/// subscription endpoints instead, which is why this whole controller sits behind
+/// <c>SubscriptionCampaignManager</c> rather than plain authentication: creating a discount that
+/// is 100% off, or one that replaces a price's own automatic discount, is a commercial decision,
+/// the same reasoning that scopes subscription background-work recovery to its own policy.
+/// <para>
+/// That policy has no effect until the identity provider maps a role to the
+/// <c>subscription.campaign.manage</c> permission claim it requires -- until that mapping exists,
+/// every caller is refused, including whoever manages discounts today under plain authentication.
+/// This is a deployment precondition, not a code change: the mapping has to land before this
+/// controller does, or discount authoring goes dark the moment it deploys.
+/// </para>
+/// </remarks>
+[ApiController, Authorize(Policy = "SubscriptionCampaignManager"), Route("subscription-discounts")]
 public sealed class SubscriptionDiscountsController : ControllerBase
 {
     private readonly IDiscountCatalogueService _catalogue;
@@ -19,11 +34,30 @@ public sealed class SubscriptionDiscountsController : ControllerBase
         return (await _catalogue.ListAsync(organizationId, correlationId, cancellationToken)).ToActionResult(correlationId);
     }
 
+    [HttpGet("{discountId}")]
+    public async Task<IActionResult> Get(string discountId, [FromQuery] string? organizationId, CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        return (await _catalogue.GetAsync(discountId, organizationId, correlationId, cancellationToken)).ToActionResult(correlationId);
+    }
+
     [HttpPost]
     public async Task<IActionResult> Create([FromBody] CreateDiscountRequest request, CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
         return (await _catalogue.CreateAsync(request, correlationId, cancellationToken)).ToActionResult(correlationId);
+    }
+
+    [HttpPut("{discountId}")]
+    public async Task<IActionResult> Update(
+        string discountId,
+        [FromBody] UpdateDiscountRequest request,
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        return (await _catalogue.UpdateAsync(discountId, request, organizationId, correlationId, cancellationToken))
+            .ToActionResult(correlationId);
     }
 
     [HttpPut("{discountId}/archive")]

--- a/server/Api/Program.cs
+++ b/server/Api/Program.cs
@@ -94,6 +94,20 @@ services.AddAuthorization(options =>
         policy => policy
             .RequireAuthenticatedUser()
             .RequireClaim("permission", "subscription.background-work.manage"));
+
+    // Authoring a campaign is not an ordinary tenant operation either -- creating a discount that
+    // is 100% off, or that replaces a price's own automatic discount, is a commercial decision the
+    // identity provider must grant deliberately to platform-admin roles, the same way background-
+    // work recovery above is scoped to billing/operations roles rather than to authentication
+    // alone. The permission claim itself has to be mapped to a role by the identity provider
+    // before this is ever enforced against real traffic; until that mapping exists, every caller
+    // -- including one that should have access -- is refused, which is the safe failure mode for a
+    // permission nobody has been granted yet.
+    options.AddPolicy(
+        "SubscriptionCampaignManager",
+        policy => policy
+            .RequireAuthenticatedUser()
+            .RequireClaim("permission", "subscription.campaign.manage"));
 });
 
 builder.Services.Configure<MvcOptions>(options =>

--- a/server/Subscription.DomainService/Entities/CampaignEntitlementOverride.cs
+++ b/server/Subscription.DomainService/Entities/CampaignEntitlementOverride.cs
@@ -1,0 +1,30 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// A count entitlement's limit, temporarily replaced for as long as a campaign applies.
+/// </summary>
+/// <remarks>
+/// Names one <see cref="PlanEntitlement.Key"/> and one replacement <see cref="Limit"/> — never a
+/// list, because every campaign this exists for today overrides exactly one entitlement, and a
+/// list would have to answer what happens when two overrides name the same key with no product
+/// requirement to answer it from.
+/// <para>
+/// Every other entitlement the plan grants is untouched: this is a substitution for one key, not
+/// a second entitlement set layered over the plan's own.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class CampaignEntitlementOverride
+{
+    /// <summary>The <see cref="PlanEntitlement.Key"/> this replaces. Never interpreted here.</summary>
+    public string EntitlementKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The replacement cap. Positive, and validated at authoring time to never exceed the plan's
+    /// own limit for the same key — a campaign can shrink what a subscriber may use, never grow it
+    /// past what the plan they are actually on already grants.
+    /// </summary>
+    public long Limit { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/Discount.cs
+++ b/server/Subscription.DomainService/Entities/Discount.cs
@@ -29,4 +29,105 @@ public sealed class Discount
     public List<string> ApplicablePriceIds { get; set; } = [];
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime LastUpdatedDateUtc { get; set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// Incremented on every successful edit. An update request must name the value it read, and a
+    /// mismatch is refused with <c>subscription_discount_version_conflict</c> rather than applied
+    /// over an edit the caller never saw -- the same reason a stale write to any shared record is
+    /// worth refusing rather than silently winning.
+    /// </summary>
+    public long Version { get; set; }
+
+    /// <summary>
+    /// Campaign behaviour layered on top of the ordinary percentage or fixed reduction above.
+    /// Always present, never null -- gated the same way <see cref="Price.BillingAlignment"/> gates
+    /// on its own zero value rather than on a nullable wrapper. A discount created before campaigns
+    /// existed, or one a caller creates without naming a kind, deserializes with
+    /// <see cref="CampaignTerms.Kind"/> at its zero value, <see cref="CampaignKind.Standard"/>,
+    /// which every campaign-specific code path treats identically to "no campaign at all".
+    /// </summary>
+    public CampaignTerms Campaign { get; set; } = new();
+}
+
+/// <summary>
+/// The campaign-specific rules a discount carries beyond <see cref="DiscountTerms.Kind"/>'s plain
+/// percentage or fixed reduction: which billing periods it may touch, how it interacts with a
+/// price's own automatic and volume discounts, when it may be redeemed, and what else changes
+/// alongside the reduction.
+/// </summary>
+/// <remarks>
+/// One embedded document rather than a dozen fields flattened onto <see cref="Discount"/>, so
+/// every campaign-specific code path has a single thing to gate on --
+/// <c>discount.Campaign.Kind != CampaignKind.Standard</c> -- instead of remembering to check each
+/// field individually. An accidental campaign behaviour on an ordinary discount would otherwise be
+/// one missed <c>if</c> away.
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class CampaignTerms
+{
+    public CampaignKind Kind { get; set; } = CampaignKind.Standard;
+    public CampaignPrecedence Precedence { get; set; } = CampaignPrecedence.BestDiscount;
+
+    /// <summary>
+    /// The campaign's own validity window, as the admin who authored it typed it -- calendar
+    /// dates, with no time of day, interpreted in <see cref="TimeZoneId"/>. Null for a
+    /// <see cref="CampaignKind.Standard"/> discount, which has no window of its own and is instead
+    /// governed by the legacy <see cref="DiscountTerms.ExpiresAtUtc"/>.
+    /// </summary>
+    public DateOnly? ValidFromDate { get; set; }
+
+    /// <summary>
+    /// Inclusive: the last calendar date the campaign may still be redeemed on, in
+    /// <see cref="TimeZoneId"/>. Converted at authoring time into the exclusive
+    /// <see cref="RedeemableUntilUtc"/> that redemption actually checks against -- never
+    /// re-derived at redemption time, so a time-zone rule change between authoring and redemption
+    /// cannot move a boundary a subscriber was already shown.
+    /// </summary>
+    public DateOnly? ValidThroughDate { get; set; }
+
+    /// <summary>The IANA zone <see cref="ValidFromDate"/> and <see cref="ValidThroughDate"/> are read in.</summary>
+    public string? TimeZoneId { get; set; }
+
+    /// <summary>
+    /// <see cref="ValidFromDate"/> converted to an instant, computed and persisted at authoring
+    /// time rather than derived on every redemption check.
+    /// </summary>
+    public DateTime? RedeemableFromUtc { get; set; }
+
+    /// <summary>
+    /// The instant after which the campaign may no longer be redeemed -- exclusive, and the local
+    /// midnight that begins the day <em>after</em> <see cref="ValidThroughDate"/>, so the whole of
+    /// the inclusive end date is still redeemable.
+    /// </summary>
+    public DateTime? RedeemableUntilUtc { get; set; }
+
+    /// <summary>
+    /// Whether an organization may redeem this campaign more than once. Enforced by a unique index
+    /// on the redemption ledger, not by this flag alone -- this only decides whether the reservation
+    /// attempt is made under a scope that can collide.
+    /// </summary>
+    public bool OneUsePerOrganization { get; set; }
+
+    /// <summary>
+    /// For <see cref="CampaignKind.FirstAnnualPeriod"/>: whether the campaign's reduction also
+    /// applies to a calendar-aligned yearly price's opening stub, in addition to the first full
+    /// annual period. The stub never consumes the campaign on its own -- only the annual period
+    /// does -- regardless of this flag.
+    /// </summary>
+    public bool ApplyToOpeningStub { get; set; }
+
+    /// <summary>
+    /// Whether activating a subscription under this campaign requires a stored payment method,
+    /// even on a plan that does not otherwise require one upfront. A campaign that sets this
+    /// overrides the plan's own <c>RequirePaymentMethodUpfront</c> for the duration it applies --
+    /// never the reverse, since a plan requiring a card cannot be waived by a campaign that says
+    /// nothing about it.
+    /// </summary>
+    public bool RequiresPaymentMethodUpfront { get; set; }
+
+    /// <summary>
+    /// For <see cref="CampaignKind.FreeOpeningCalendarPeriod"/>: the one count entitlement this
+    /// campaign temporarily caps, and to what. Null for every other kind.
+    /// </summary>
+    public CampaignEntitlementOverride? EntitlementOverride { get; set; }
 }

--- a/server/Subscription.DomainService/Entities/DiscountTerms.cs
+++ b/server/Subscription.DomainService/Entities/DiscountTerms.cs
@@ -43,4 +43,36 @@ public sealed class DiscountTerms
 
     /// <summary>The prices this code was authored for. Empty is unrestricted.</summary>
     public List<string> ApplicablePriceIds { get; set; } = [];
+
+    /// <summary>
+    /// The catalogue entry this was copied from, and the <see cref="Discount.Version"/> it was
+    /// copied at. Carried so a later reconciliation or audit can point back at the campaign that
+    /// produced this snapshot -- never re-read from the catalogue, for the same reason nothing
+    /// else on this snapshot is: the catalogue entry can move on, and this subscription must not.
+    /// </summary>
+    public string? DiscountId { get; set; }
+
+    public long DiscountVersion { get; set; }
+
+    /// <summary>
+    /// When this snapshot was accepted -- the instant a checkout or activation redeemed it, not
+    /// when the discount catalogue entry was created. Absent on a subscription created before this
+    /// field existed.
+    /// </summary>
+    public DateTime? RedeemedAtUtc { get; set; }
+
+    /// <summary>
+    /// The campaign rules accepted at redemption, copied whole from <see cref="Discount.Campaign"/>
+    /// at the instant this snapshot was taken. Its own <see cref="CampaignTerms.Kind"/> is the gate
+    /// every campaign-specific code path checks -- a snapshot taken from a
+    /// <see cref="CampaignKind.Standard"/> discount, or one taken before campaigns existed, carries
+    /// a default-constructed <see cref="CampaignTerms"/> whose <c>Kind</c> is
+    /// <see cref="CampaignKind.Standard"/>, and every campaign path treats that identically to
+    /// there being no campaign at all.
+    /// <para>
+    /// A later edit or archival of the catalogue entry never reaches this: the subscriber is judged
+    /// by the terms they redeemed, and that is exactly what a snapshot exists to freeze.
+    /// </para>
+    /// </summary>
+    public CampaignTerms Campaign { get; set; } = new();
 }

--- a/server/Subscription.DomainService/Enums/CampaignKind.cs
+++ b/server/Subscription.DomainService/Enums/CampaignKind.cs
@@ -1,0 +1,43 @@
+using System.Text.Json.Serialization;
+
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// What kind of promotion a discount is layered onto a plan and price as, beyond the ordinary
+/// percentage or fixed reduction <see cref="DiscountKind"/> already describes.
+/// </summary>
+/// <remarks>
+/// Zero, <see cref="Standard"/>, is what every discount authored before this existed deserializes
+/// to — same convention as <see cref="AutomaticDiscountCombination.BestDiscount"/> being zero: the
+/// unset value has to be the one that changes nothing, because a document nobody meant to touch
+/// still deserializes through this field.
+/// <para>
+/// A discount's <see cref="DiscountKind"/> says how much it takes off; this says which billing
+/// periods it is allowed to touch and what else happens alongside the reduction. The two are
+/// independent axes, the same way <see cref="BillingAlignment"/> is independent of
+/// <see cref="BillingInterval"/>.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum CampaignKind
+{
+    /// <summary>
+    /// An ordinary discount: no campaign date window of its own, no redemption ledger entry, no
+    /// entitlement override. Everything before campaigns existed, and everything created without
+    /// naming one of the kinds below.
+    /// </summary>
+    Standard = 0,
+
+    /// <summary>
+    /// Discounts a calendar-aligned yearly price's opening stub and its first full annual period,
+    /// and only those. A renewal past the first annual period reverts to the price's own
+    /// automatic discount.
+    /// </summary>
+    FirstAnnualPeriod = 1,
+
+    /// <summary>
+    /// A 100% reduction on a calendar-aligned monthly price's opening period only — from signup to
+    /// the next local calendar-month boundary — paired with a temporary entitlement override.
+    /// </summary>
+    FreeOpeningCalendarPeriod = 2
+}

--- a/server/Subscription.DomainService/Enums/CampaignPrecedence.cs
+++ b/server/Subscription.DomainService/Enums/CampaignPrecedence.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// How a campaign's reduction interacts with a price's own automatic and volume discounts.
+/// </summary>
+/// <remarks>
+/// Zero is <see cref="BestDiscount"/>, the same conservative default
+/// <see cref="AutomaticDiscountCombination"/> already uses for the same reason: a campaign
+/// document that predates this field, or one authored by a caller that never named it, must read
+/// back as the answer that can never overcharge <em>or</em> silently discount more than either
+/// side individually promised. Authoring a campaign with <see cref="ReplaceBuiltIn"/> is a
+/// deliberate choice made when that campaign is created — it is not what an absent value means.
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum CampaignPrecedence
+{
+    /// <summary>
+    /// Whichever single reduction is larger — the campaign's, or the price's own automatic and
+    /// volume discounts combined under its own <see cref="AutomaticDiscountCombination"/> — never
+    /// both. The conservative default.
+    /// </summary>
+    BestDiscount = 0,
+
+    /// <summary>
+    /// The campaign reduction only. The price's automatic and volume discounts are suppressed for
+    /// as long as the campaign applies, and restored the moment it no longer does — a renewal past
+    /// <see cref="CampaignKind.FirstAnnualPeriod"/>'s window, for example.
+    /// </summary>
+    ReplaceBuiltIn = 1,
+
+    /// <summary>
+    /// Both reductions, combined the same way two automatic discounts already are: added, not
+    /// compounded, and capped at 100% of the gross.
+    /// </summary>
+    Stack = 2
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionDiscountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionDiscountRepository.cs
@@ -8,4 +8,23 @@ public interface ISubscriptionDiscountRepository
     Task<Discount?> FindActiveByCodeAsync(string tenantId, string? organizationId, string code, CancellationToken cancellationToken);
     Task<IReadOnlyList<Discount>> ListAsync(string tenantId, string? organizationId, CancellationToken cancellationToken);
     Task<bool> TryArchiveAsync(string tenantId, string discountId, CancellationToken cancellationToken);
+
+    /// <summary>Scoped the same way every other lookup here is: a discount outside this tenant is unknown, never forbidden.</summary>
+    Task<Discount?> FindByIdAsync(string tenantId, string discountId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Replaces a discount's editable fields, atomically checking <paramref name="expectedVersion"/>
+    /// against the stored value and incrementing it on success.
+    /// </summary>
+    /// <remarks>
+    /// One update, filtered on the version rather than read-modify-write: two admins editing the
+    /// same campaign a moment apart must not silently overwrite each other, and a filter checked
+    /// in the database is the only way that is actually true rather than merely likely.
+    /// </remarks>
+    /// <returns>
+    /// True if the version matched and the write applied. False either because the discount does
+    /// not exist in this scope, or because the version had already moved -- the caller
+    /// distinguishes the two with a fresh <see cref="FindByIdAsync"/>.
+    /// </returns>
+    Task<bool> TryUpdateAsync(Discount discount, long expectedVersion, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Repositories/SubscriptionDiscountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionDiscountRepository.cs
@@ -75,6 +75,30 @@ public sealed class SubscriptionDiscountRepository : ISubscriptionDiscountReposi
         return result.ModifiedCount == 1;
     }
 
+    public Task<Discount?> FindByIdAsync(
+        string tenantId, string discountId, CancellationToken cancellationToken) =>
+        Collection(tenantId).Find(Builders<Discount>.Filter.And(
+                Builders<Discount>.Filter.Eq(item => item.TenantId, tenantId),
+                Builders<Discount>.Filter.Eq(item => item.ItemId, discountId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<bool> TryUpdateAsync(
+        Discount discount, long expectedVersion, CancellationToken cancellationToken)
+    {
+        discount.LastUpdatedDateUtc = DateTime.UtcNow;
+        discount.Version = expectedVersion + 1;
+
+        var result = await Collection(discount.TenantId).ReplaceOneAsync(
+            Builders<Discount>.Filter.And(
+                Builders<Discount>.Filter.Eq(item => item.TenantId, discount.TenantId),
+                Builders<Discount>.Filter.Eq(item => item.ItemId, discount.ItemId),
+                Builders<Discount>.Filter.Eq(item => item.Version, expectedVersion)),
+            discount,
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
     {
         if (_indexed.ContainsKey(tenantId)) return;

--- a/server/Subscription.DomainService/Requests/ICampaignDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/ICampaignDiscountRequest.cs
@@ -1,0 +1,31 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Requests;
+
+/// <summary>
+/// The fields <see cref="CreateDiscountRequest"/> and <see cref="UpdateDiscountRequest"/> share,
+/// so campaign validation is written once and applied to both.
+/// </summary>
+/// <remarks>
+/// Deliberately excludes <c>Code</c> and <c>OrganizationId</c>: both are immutable after creation,
+/// so an update request never carries them and a shared rule set must not expect to find them.
+/// </remarks>
+public interface ICampaignDiscountRequest
+{
+    DiscountKind Kind { get; }
+    int? PercentBasisPoints { get; }
+    long? AmountMinor { get; }
+    string? CurrencyCode { get; }
+    List<string> ApplicablePlanCodes { get; }
+    List<string> ApplicablePriceIds { get; }
+
+    CampaignKind CampaignKind { get; }
+    CampaignPrecedence CampaignPrecedence { get; }
+    DateOnly? ValidFromDate { get; }
+    DateOnly? ValidThroughDate { get; }
+    string? TimeZoneId { get; }
+    bool OneUsePerOrganization { get; }
+    bool RequiresPaymentMethodUpfront { get; }
+    string? EntitlementOverrideKey { get; }
+    long? EntitlementOverrideLimit { get; }
+}

--- a/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
@@ -2,10 +2,26 @@ using Subscription.DomainService.Enums;
 
 namespace Subscription.DomainService.Requests;
 
-public sealed class CreateDiscountRequest : ICampaignDiscountRequest
+/// <summary>
+/// An edit to an existing discount. Everything <see cref="CreateDiscountRequest"/> accepts, plus
+/// the version the caller last read.
+/// </summary>
+/// <remarks>
+/// Code and scope are deliberately absent: both are immutable after creation, per the same rule
+/// that makes a subscription's snapshot trustworthy -- a code that could be renamed out from under
+/// an already-issued link, or a discount that could be re-scoped to a different organization after
+/// subscribers have already redeemed it, would make every previous redemption's restriction mean
+/// something different than it did when it was accepted.
+/// </remarks>
+public sealed class UpdateDiscountRequest : ICampaignDiscountRequest
 {
-    public string? OrganizationId { get; set; }
-    public string Code { get; set; } = string.Empty;
+    /// <summary>
+    /// The <see cref="Entities.Discount.Version"/> this edit was read at. A mismatch against the
+    /// stored value is refused with <c>subscription_discount_version_conflict</c> rather than
+    /// applied over an edit the caller never saw.
+    /// </summary>
+    public long ExpectedVersion { get; set; }
+
     public string DisplayName { get; set; } = string.Empty;
     public DiscountKind Kind { get; set; }
     public int? PercentBasisPoints { get; set; }
@@ -14,21 +30,13 @@ public sealed class CreateDiscountRequest : ICampaignDiscountRequest
     public int? DurationPeriods { get; set; }
     public DateTime? ExpiresAtUtc { get; set; }
     public List<string> ApplicablePlanCodes { get; set; } = [];
-    /// <summary>Empty is unrestricted by price. Narrows with the plan list, not instead of it.</summary>
     public List<string> ApplicablePriceIds { get; set; } = [];
 
     public CampaignKind CampaignKind { get; set; } = CampaignKind.Standard;
     public CampaignPrecedence CampaignPrecedence { get; set; } = CampaignPrecedence.BestDiscount;
     public DateOnly? ValidFromDate { get; set; }
     public DateOnly? ValidThroughDate { get; set; }
-
-    /// <summary>
-    /// The zone <see cref="ValidFromDate"/> and <see cref="ValidThroughDate"/> are read in.
-    /// Required whenever either date is given; ignored for a <see cref="Enums.CampaignKind.Standard"/>
-    /// request that names neither.
-    /// </summary>
     public string? TimeZoneId { get; set; }
-
     public bool OneUsePerOrganization { get; set; }
     public bool ApplyToOpeningStub { get; set; }
     public bool RequiresPaymentMethodUpfront { get; set; }

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -15,4 +15,34 @@ public sealed class DiscountResponse
     public List<string> ApplicablePlanCodes { get; init; } = [];
     public List<string> ApplicablePriceIds { get; init; } = [];
     public string Status { get; init; } = string.Empty;
+
+    /// <summary>Read back on every response so a subsequent edit can be sent as an expected value.</summary>
+    public long Version { get; init; }
+
+    public string CampaignKind { get; init; } = string.Empty;
+    public string CampaignPrecedence { get; init; } = string.Empty;
+    public DateOnly? ValidFromDate { get; init; }
+    public DateOnly? ValidThroughDate { get; init; }
+    public string? TimeZoneId { get; init; }
+    public DateTime? RedeemableFromUtc { get; init; }
+    public DateTime? RedeemableUntilUtc { get; init; }
+    public bool OneUsePerOrganization { get; init; }
+    public bool ApplyToOpeningStub { get; init; }
+    public bool RequiresPaymentMethodUpfront { get; init; }
+    public string? EntitlementOverrideKey { get; init; }
+    public long? EntitlementOverrideLimit { get; init; }
+
+    /// <summary>How this campaign's effective state reads today, for the catalogue list.</summary>
+    /// <remarks>
+    /// One of: Upcoming, Active, Expired, Archived. Standard, when the discount carries no
+    /// campaign window — Active/Archived only, exactly as before this field existed.
+    /// <para>
+    /// Reserved and redeemed counts are deliberately not on this response yet: they read off the
+    /// redemption ledger, which does not exist until the concurrency/reservation phase of this
+    /// feature lands. Adding them here now, always zero, would tell a UI built against this API
+    /// that a campaign has never been redeemed when the honest answer is "not tracked yet" --
+    /// worse than the fields being absent.
+    /// </para>
+    /// </remarks>
+    public string EffectiveState { get; init; } = string.Empty;
 }

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -5,6 +5,7 @@ using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
 
@@ -13,18 +14,24 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
     private readonly ISubscriptionDiscountRepository _discounts;
     private readonly ISubscriptionCatalogueRepository _catalogue;
     private readonly ISubscriptionContextResolver _context;
-    private readonly IValidator<CreateDiscountRequest> _validator;
+    private readonly IValidator<CreateDiscountRequest> _createValidator;
+    private readonly IValidator<UpdateDiscountRequest> _updateValidator;
+    private readonly TimeProvider _time;
 
     public DiscountCatalogueService(
         ISubscriptionDiscountRepository discounts,
         ISubscriptionCatalogueRepository catalogue,
         ISubscriptionContextResolver context,
-        IValidator<CreateDiscountRequest> validator)
+        IValidator<CreateDiscountRequest> createValidator,
+        IValidator<UpdateDiscountRequest> updateValidator,
+        TimeProvider? time = null)
     {
         _discounts = discounts;
         _catalogue = catalogue;
         _context = context;
-        _validator = validator;
+        _createValidator = createValidator;
+        _updateValidator = updateValidator;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<SubscriptionOperationResult<DiscountResponse>> CreateAsync(
@@ -38,15 +45,21 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
             correlationId, request.OrganizationId, cancellationToken);
         if (!resolution.IsSuccess) return resolution.ToFailure<DiscountResponse>(correlationId);
         var invalid = await SubscriptionValidation.CheckAsync<CreateDiscountRequest, DiscountResponse>(
-            _validator, request, "subscription_discount_invalid", "The discount is invalid.",
+            _createValidator, request, "subscription_discount_invalid", "The discount is invalid.",
             correlationId, cancellationToken);
         if (invalid is not null) return invalid;
 
         var context = resolution.Context!;
 
         var applicability = await CheckApplicabilityAsync(
-            request, context, correlationId, cancellationToken);
+            request, context.TenantId, context.OrganizationId, correlationId, cancellationToken);
         if (applicability is not null) return applicability;
+
+        var campaign = BuildCampaignTerms(request, out var campaignInvalid);
+        if (campaignInvalid is not null)
+        {
+            return Invalid(campaignInvalid, correlationId);
+        }
 
         var discount = new Discount
         {
@@ -71,7 +84,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
                 AmountMinor = request.AmountMinor,
                 DurationPeriods = request.DurationPeriods,
                 ExpiresAtUtc = request.ExpiresAtUtc
-            }
+            },
+            Campaign = campaign!
         };
 
         if (!await _discounts.TryCreateAsync(discount, cancellationToken))
@@ -81,9 +95,180 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         return SubscriptionOperationResult<DiscountResponse>.Success(Map(discount), correlationId);
     }
 
+    public async Task<SubscriptionOperationResult<DiscountResponse>> GetAsync(
+        string discountId, string? organizationId, string correlationId, CancellationToken cancellationToken)
+    {
+        var resolution = await _context.ResolveAsync(correlationId, organizationId, cancellationToken);
+        if (!resolution.IsSuccess) return resolution.ToFailure<DiscountResponse>(correlationId);
+        var context = resolution.Context!;
+
+        var item = await _discounts.FindByIdAsync(context.TenantId, discountId, cancellationToken);
+
+        // Visible to this caller means owned by the caller's own scope or unscoped/tenant-wide --
+        // the same rule ListAsync already applies, restated here because a lookup by id has no
+        // list to filter.
+        if (item is null || !VisibleTo(item, context.OrganizationId))
+            return SubscriptionOperationResult<DiscountResponse>.Failure(
+                PaymentFailureKind.NotFound, "subscription_discount_not_found",
+                "The discount does not exist.", correlationId);
+
+        return SubscriptionOperationResult<DiscountResponse>.Success(Map(item), correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<DiscountResponse>> UpdateAsync(
+        string discountId,
+        UpdateDiscountRequest request,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = await _context.ResolveAsync(correlationId, organizationId, cancellationToken);
+        if (!resolution.IsSuccess) return resolution.ToFailure<DiscountResponse>(correlationId);
+        var context = resolution.Context!;
+
+        var invalid = await SubscriptionValidation.CheckAsync<UpdateDiscountRequest, DiscountResponse>(
+            _updateValidator, request, "subscription_discount_invalid", "The discount is invalid.",
+            correlationId, cancellationToken);
+        if (invalid is not null) return invalid;
+
+        var existing = await _discounts.FindByIdAsync(context.TenantId, discountId, cancellationToken);
+        if (existing is null || !VisibleTo(existing, context.OrganizationId))
+            return SubscriptionOperationResult<DiscountResponse>.Failure(
+                PaymentFailureKind.NotFound, "subscription_discount_not_found",
+                "The discount does not exist.", correlationId);
+
+        // Code and scope are immutable, so the applicability check below is run with the request's
+        // plan/price restrictions against the discount's own (unchangeable) organization -- never
+        // against whatever the request happened to resolve to, which for a tenant-wide discount
+        // would be the wrong catalogue to check against. SubscriptionContext.OrganizationId is
+        // non-nullable and cannot represent "tenant-wide", which is why the scope is passed
+        // straight through rather than rebuilding a context around it.
+        var applicability = await CheckApplicabilityAsync(
+            request, context.TenantId, existing.OrganizationId, correlationId, cancellationToken);
+        if (applicability is not null) return applicability;
+
+        var campaign = BuildCampaignTerms(request, out var campaignInvalid);
+        if (campaignInvalid is not null)
+        {
+            return Invalid(campaignInvalid, correlationId);
+        }
+
+        existing.DisplayName = request.DisplayName.Trim();
+        existing.CurrencyCode = request.CurrencyCode?.Trim().ToUpperInvariant();
+        existing.ApplicablePlanCodes =
+            request.ApplicablePlanCodes.Distinct(StringComparer.Ordinal).ToList();
+        existing.ApplicablePriceIds =
+            request.ApplicablePriceIds.Distinct(StringComparer.Ordinal).ToList();
+        existing.Terms = new DiscountTerms
+        {
+            Code = existing.Code,
+            Kind = request.Kind,
+            PercentBasisPoints = request.PercentBasisPoints,
+            AmountMinor = request.AmountMinor,
+            DurationPeriods = request.DurationPeriods,
+            ExpiresAtUtc = request.ExpiresAtUtc
+        };
+        existing.Campaign = campaign!;
+
+        if (!await _discounts.TryUpdateAsync(existing, request.ExpectedVersion, cancellationToken))
+        {
+            // Distinguishing "gone since you read it" from "somebody else edited it" needs another
+            // read: TryUpdateAsync's filter cannot tell the two apart, because a document that no
+            // longer matches the version filter looks identical whether the row vanished or just
+            // moved on.
+            var stillThere = await _discounts.FindByIdAsync(context.TenantId, discountId, cancellationToken);
+            return stillThere is null
+                ? SubscriptionOperationResult<DiscountResponse>.Failure(
+                    PaymentFailureKind.NotFound, "subscription_discount_not_found",
+                    "The discount does not exist.", correlationId)
+                : SubscriptionOperationResult<DiscountResponse>.Failure(
+                    PaymentFailureKind.Conflict, "subscription_discount_version_conflict",
+                    "Another update has already been applied. Reload the discount and try again.",
+                    correlationId);
+        }
+
+        return SubscriptionOperationResult<DiscountResponse>.Success(Map(existing), correlationId);
+    }
+
+    /// <summary>
+    /// Whether an unscoped (tenant-wide) or organization-scoped discount is visible to a caller
+    /// resolved for this organization. Mirrors <see cref="ISubscriptionDiscountRepository.ListAsync"/>'s
+    /// own rule, restated here for a single-item lookup that has no list to filter.
+    /// </summary>
+    private static bool VisibleTo(Discount item, string? organizationId) =>
+        item.OrganizationId is null ||
+        string.Equals(item.OrganizationId, organizationId, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Builds the campaign sub-document from a request, computing and freezing
+    /// <see cref="CampaignTerms.RedeemableFromUtc"/> and <see cref="CampaignTerms.RedeemableUntilUtc"/>
+    /// at authoring time.
+    /// </summary>
+    /// <remarks>
+    /// Computed once here rather than re-derived at every redemption check, so a time-zone
+    /// database update between authoring and redemption cannot silently move a boundary a
+    /// subscriber was already shown when the code was offered to them.
+    /// <para>
+    /// The end date is inclusive as authored and exclusive as stored: <c>RedeemableUntilUtc</c> is
+    /// local midnight of the day <em>after</em> <c>ValidThroughDate</c>, so the entire authored end
+    /// date is still redeemable. Both ends go through <see cref="BillingLocalTime.ToUtc"/>, which
+    /// already carries the DST gap/ambiguity policy this billing domain uses everywhere else --
+    /// reusing it here rather than writing a second one is the point.
+    /// </para>
+    /// </remarks>
+    private static CampaignTerms? BuildCampaignTerms(
+        ICampaignDiscountRequest request, out string? error)
+    {
+        error = null;
+
+        if (request.CampaignKind == CampaignKind.Standard)
+        {
+            return new CampaignTerms();
+        }
+
+        if (!BillingLocalTime.TryFindTimeZone(request.TimeZoneId, out var timeZone))
+        {
+            error = $"'{request.TimeZoneId}' is not a recognised time zone.";
+            return null;
+        }
+
+        // Validated non-null by CampaignDiscountRequestValidator whenever CampaignKind is not
+        // Standard -- asserted rather than re-checked, since this is only ever called after that
+        // validator has already run.
+        var from = request.ValidFromDate!.Value;
+        var through = request.ValidThroughDate!.Value;
+
+        var redeemableFromUtc = BillingLocalTime.ToUtc(from.ToDateTime(TimeOnly.MinValue), timeZone);
+        var redeemableUntilUtc = BillingLocalTime.ToUtc(
+            through.AddDays(1).ToDateTime(TimeOnly.MinValue), timeZone);
+
+        return new CampaignTerms
+        {
+            Kind = request.CampaignKind,
+            Precedence = request.CampaignPrecedence,
+            ValidFromDate = from,
+            ValidThroughDate = through,
+            TimeZoneId = request.TimeZoneId,
+            RedeemableFromUtc = redeemableFromUtc,
+            RedeemableUntilUtc = redeemableUntilUtc,
+            OneUsePerOrganization = request.OneUsePerOrganization,
+            ApplyToOpeningStub = request is CreateDiscountRequest { ApplyToOpeningStub: true } or
+                UpdateDiscountRequest { ApplyToOpeningStub: true },
+            RequiresPaymentMethodUpfront = request.RequiresPaymentMethodUpfront,
+            EntitlementOverride = request.EntitlementOverrideKey is { Length: > 0 } key
+                ? new CampaignEntitlementOverride
+                {
+                    EntitlementKey = key,
+                    Limit = request.EntitlementOverrideLimit!.Value
+                }
+                : null
+        };
+    }
+
     /// <summary>
     /// Checks that the plans and prices a discount is restricted to actually exist, in this caller's
-    /// scope, and agree with each other. Null when they do.
+    /// scope, agree with each other, and -- for a campaign -- carry a cadence that campaign kind can
+    /// actually price.
     /// </summary>
     /// <remarks>
     /// A restriction naming something that does not exist is a discount that can never be redeemed:
@@ -93,26 +278,30 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
     /// environment can, so it is refused where the author can still fix it.
     /// <para>
     /// A price is also checked against the plan list when both are given, because with both narrowing
-    /// each other a price belonging to an unlisted plan matches nothing — the same unredeemable
+    /// each other a price belonging to an unlisted plan matches nothing -- the same unredeemable
     /// discount, arrived at by a different mistake.
     /// </para>
     /// </remarks>
     private async Task<SubscriptionOperationResult<DiscountResponse>?> CheckApplicabilityAsync(
-        CreateDiscountRequest request,
-        SubscriptionContext context,
+        ICampaignDiscountRequest request,
+        string tenantId,
+        string? organizationId,
         string correlationId,
         CancellationToken cancellationToken)
     {
         if (request.ApplicablePlanCodes.Count == 0 && request.ApplicablePriceIds.Count == 0)
         {
-            // Unrestricted, which is the ordinary case and has nothing to resolve.
+            // Unrestricted, which is the ordinary case and has nothing to resolve. A campaign kind
+            // that needs at least one price is already refused by the request validator before
+            // this is reached, so an unrestricted request here is never a campaign one.
             return null;
         }
 
         // The plans this caller can actually sell, which is the same list a subscribe request is
-        // resolved against — the discount cannot be more applicable than the catalogue it points at.
-        var plans = await _catalogue.ListPlansAsync(
-            context.TenantId, context.OrganizationId, cancellationToken);
+        // resolved against -- the discount cannot be more applicable than the catalogue it points at.
+        // Already filtered to CatalogueStatus.Active, so a plan named here that has been archived
+        // reads as unknown -- the same refusal an actually-nonexistent code would produce.
+        var plans = await _catalogue.ListPlansAsync(tenantId, organizationId, cancellationToken);
 
         var unknownPlan = request.ApplicablePlanCodes.Find(code =>
             !plans.Any(plan => string.Equals(plan.Code, code, StringComparison.Ordinal)));
@@ -124,7 +313,18 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
 
         foreach (var priceId in request.ApplicablePriceIds)
         {
-            var price = await _catalogue.GetPriceAsync(context.TenantId, priceId, cancellationToken);
+            var price = await _catalogue.GetPriceAsync(tenantId, priceId, cancellationToken);
+
+            // Unlike ListPlansAsync, GetPriceAsync does not filter by status -- it exists to look
+            // up one specific id regardless of whether it can still be sold, which every other
+            // caller of it wants. A new campaign must not be authored against a price nobody can
+            // buy any more, so that is checked here rather than assumed from the plan check above.
+            if (price is not null && price.Status != CatalogueStatus.Active)
+            {
+                return Invalid(
+                    $"The price '{priceId}' has been retired and cannot be used for a new discount.",
+                    correlationId);
+            }
 
             // Visible to this caller means: on a plan this caller can see. A price id from another
             // organization reads as unknown rather than as forbidden, so the refusal cannot be used
@@ -147,6 +347,82 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
                         + "could never be redeemed.",
                     correlationId);
             }
+
+            var cadence = CheckCadence(request.CampaignKind, priceId, price!);
+            if (cadence is not null)
+            {
+                return Invalid(cadence, correlationId);
+            }
+
+            var entitlement = CheckEntitlementOverride(request, plan);
+            if (entitlement is not null)
+            {
+                return Invalid(entitlement, correlationId);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Whether a price's cadence is one this campaign kind can actually price.
+    /// </summary>
+    /// <remarks>
+    /// FirstAnnualPeriod exists to discount an opening stub and a first annual period, neither of
+    /// which a non-yearly price has. FreeOpeningCalendarPeriod exists to give away a calendar
+    /// month, which only a monthly price billed on calendar boundaries has a month to give.
+    /// Authored against the wrong cadence, either campaign would validate cleanly and then never
+    /// be redeemable -- refused here instead, at the one point an author can still fix it.
+    /// </remarks>
+    private static string? CheckCadence(CampaignKind kind, string priceId, Price price) => kind switch
+    {
+        CampaignKind.FirstAnnualPeriod when price.Interval != BillingInterval.Year
+            || price.IntervalCount != 1 =>
+            $"The price '{priceId}' does not bill yearly, so a first-annual-period campaign can " +
+            "never apply to it.",
+        CampaignKind.FreeOpeningCalendarPeriod when !CalendarBillingAlignment.IsCalendarAligned(
+                price.BillingAlignment, price.Interval, price.IntervalCount) ||
+            price.Interval != BillingInterval.Month =>
+            $"The price '{priceId}' is not a monthly, calendar-aligned price, so a " +
+            "free-opening-period campaign has no calendar month to give away on it.",
+        _ => null
+    };
+
+    /// <summary>
+    /// Whether a temporary entitlement override actually names something this plan grants, and
+    /// caps it no higher than the plan already does.
+    /// </summary>
+    /// <remarks>
+    /// A key that does not exist on the plan is not an override of anything. A limit higher than
+    /// the plan's own is not temporary at all -- it would let the campaign grant more than the
+    /// plan the subscriber is actually on.
+    /// </remarks>
+    private static string? CheckEntitlementOverride(ICampaignDiscountRequest request, Plan plan)
+    {
+        if (request.EntitlementOverrideKey is not { Length: > 0 } key)
+        {
+            return null;
+        }
+
+        var entitlement = plan.Entitlements.FirstOrDefault(
+            item => string.Equals(item.Key, key, StringComparison.Ordinal));
+
+        if (entitlement is null)
+        {
+            return $"The plan '{plan.Code}' has no entitlement '{key}' to temporarily cap.";
+        }
+
+        if (entitlement.LimitKind != EntitlementLimitKind.Count)
+        {
+            return $"The entitlement '{key}' on plan '{plan.Code}' is not a count, so it has no " +
+                "limit for a campaign to temporarily override.";
+        }
+
+        if (request.EntitlementOverrideLimit is { } limit &&
+            entitlement.Limit is { } planLimit && limit > planLimit)
+        {
+            return $"The temporary limit for '{key}' cannot exceed the plan's own limit of " +
+                $"{planLimit}.";
         }
 
         return null;
@@ -187,7 +463,7 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         return SubscriptionOperationResult<DiscountResponse>.Success(Map(item), correlationId);
     }
 
-    private static DiscountResponse Map(Discount item) => new()
+    private DiscountResponse Map(Discount item) => new()
     {
         DiscountId = item.ItemId, OrganizationId = item.OrganizationId, Code = item.Code,
         DisplayName = item.DisplayName, Kind = item.Terms.Kind.ToString(),
@@ -195,6 +471,57 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         CurrencyCode = item.CurrencyCode, DurationPeriods = item.Terms.DurationPeriods,
         ExpiresAtUtc = item.Terms.ExpiresAtUtc, ApplicablePlanCodes = [.. item.ApplicablePlanCodes],
         ApplicablePriceIds = [.. item.ApplicablePriceIds],
-        Status = item.Status.ToString()
+        Status = item.Status.ToString(),
+        Version = item.Version,
+        CampaignKind = item.Campaign.Kind.ToString(),
+        CampaignPrecedence = item.Campaign.Precedence.ToString(),
+        ValidFromDate = item.Campaign.ValidFromDate,
+        ValidThroughDate = item.Campaign.ValidThroughDate,
+        TimeZoneId = item.Campaign.TimeZoneId,
+        RedeemableFromUtc = item.Campaign.RedeemableFromUtc,
+        RedeemableUntilUtc = item.Campaign.RedeemableUntilUtc,
+        OneUsePerOrganization = item.Campaign.OneUsePerOrganization,
+        ApplyToOpeningStub = item.Campaign.ApplyToOpeningStub,
+        RequiresPaymentMethodUpfront = item.Campaign.RequiresPaymentMethodUpfront,
+        EntitlementOverrideKey = item.Campaign.EntitlementOverride?.EntitlementKey,
+        EntitlementOverrideLimit = item.Campaign.EntitlementOverride?.Limit,
+        EffectiveState = EffectiveState(item)
     };
+
+    /// <summary>
+    /// Upcoming, Active, Expired or Archived, for the catalogue list -- computed rather than
+    /// stored, so it is never stale between a boundary passing and the next time this document is
+    /// written.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="CampaignKind.Standard"/> discount has no window, so it is Active whenever its
+    /// <see cref="CatalogueStatus"/> is, exactly as before this field existed -- Archived is the
+    /// only state a legacy discount can be told apart by.
+    /// </remarks>
+    private string EffectiveState(Discount item)
+    {
+        if (item.Status == CatalogueStatus.Archived)
+        {
+            return "Archived";
+        }
+
+        if (item.Campaign.Kind == CampaignKind.Standard)
+        {
+            return "Active";
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (item.Campaign.RedeemableFromUtc is { } from && now < from)
+        {
+            return "Upcoming";
+        }
+
+        if (item.Campaign.RedeemableUntilUtc is { } until && now >= until)
+        {
+            return "Expired";
+        }
+
+        return "Active";
+    }
 }

--- a/server/Subscription.DomainService/Services/IDiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IDiscountCatalogueService.cs
@@ -6,6 +6,8 @@ namespace Subscription.DomainService.Services;
 public interface IDiscountCatalogueService
 {
     Task<SubscriptionOperationResult<DiscountResponse>> CreateAsync(CreateDiscountRequest request, string correlationId, CancellationToken cancellationToken);
+    Task<SubscriptionOperationResult<DiscountResponse>> GetAsync(string discountId, string? organizationId, string correlationId, CancellationToken cancellationToken);
+    Task<SubscriptionOperationResult<DiscountResponse>> UpdateAsync(string discountId, UpdateDiscountRequest request, string? organizationId, string correlationId, CancellationToken cancellationToken);
     Task<SubscriptionOperationResult<IReadOnlyList<DiscountResponse>>> ListAsync(string? organizationId, string correlationId, CancellationToken cancellationToken);
     Task<SubscriptionOperationResult<DiscountResponse>> ArchiveAsync(string discountId, string? organizationId, string correlationId, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -183,6 +183,7 @@ public static class ApplicationServiceCollectionExtensions
             IValidator<CreateSubscriptionRequest>,
             CreateSubscriptionRequestValidator>();
         services.AddTransient<IValidator<CreateDiscountRequest>, CreateDiscountRequestValidator>();
+        services.AddTransient<IValidator<UpdateDiscountRequest>, UpdateDiscountRequestValidator>();
         services.AddTransient<
             IValidator<UpdateBillingProfileRequest>,
             UpdateBillingProfileRequestValidator>();

--- a/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
@@ -1,0 +1,121 @@
+using FluentValidation;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Validators;
+
+/// <summary>
+/// The campaign rules shared by <see cref="CreateDiscountRequestValidator"/> and
+/// <see cref="UpdateDiscountRequestValidator"/>.
+/// </summary>
+/// <remarks>
+/// Structural only — format, range and cross-field agreement a request carries on its own.
+/// Anything that needs the catalogue (a named plan or price actually existing, a
+/// <see cref="CampaignKind.FirstAnnualPeriod"/> price actually being yearly, an entitlement key
+/// actually existing on the plan) is checked in <c>DiscountCatalogueService</c> instead, the same
+/// way the existing plan/price applicability check already is — a validator here has no
+/// repository to ask, and inventing one would duplicate the exact lookup the service already does
+/// for the non-campaign case.
+/// </remarks>
+public abstract class CampaignDiscountRequestValidator<T> : AbstractValidator<T>
+    where T : ICampaignDiscountRequest
+{
+    protected CampaignDiscountRequestValidator()
+    {
+        RuleFor(request => request.PercentBasisPoints).NotNull().InclusiveBetween(1, 10_000)
+            .When(request => request.Kind == DiscountKind.Percent);
+        RuleFor(request => request.AmountMinor).NotNull().GreaterThan(0)
+            .When(request => request.Kind == DiscountKind.FixedAmount);
+        RuleFor(request => request.CurrencyCode).NotEmpty().Length(3)
+            .When(request => request.Kind == DiscountKind.FixedAmount);
+        RuleForEach(request => request.ApplicablePlanCodes).NotEmpty().MaximumLength(64);
+        RuleForEach(request => request.ApplicablePriceIds).NotEmpty().MaximumLength(64);
+        RuleFor(request => request).Must(request =>
+            request.Kind != DiscountKind.Percent || request.AmountMinor is null)
+            .WithMessage("A percentage discount cannot also define a fixed amount.");
+        RuleFor(request => request).Must(request =>
+            request.Kind != DiscountKind.FixedAmount || request.PercentBasisPoints is null)
+            .WithMessage("A fixed discount cannot also define a percentage.");
+
+        var isCampaign = (Func<T, bool>)(request => request.CampaignKind != CampaignKind.Standard);
+
+        // A campaign has a window; a Standard discount does not, and is governed by the legacy
+        // ExpiresAtUtc instead. Requiring one to be present the moment the other is absent is what
+        // keeps the two mechanisms from silently blending into each other.
+        RuleFor(request => request.ValidFromDate).NotNull()
+            .WithMessage("A campaign needs a start date.")
+            .When(isCampaign);
+        RuleFor(request => request.ValidThroughDate).NotNull()
+            .WithMessage("A campaign needs an end date.")
+            .When(isCampaign);
+        RuleFor(request => request.TimeZoneId).NotEmpty()
+            .WithMessage("A campaign needs a time zone its dates are read in.")
+            .When(isCampaign);
+        RuleFor(request => request).Must(request =>
+                BillingLocalTime.TryFindTimeZone(request.TimeZoneId, out _))
+            .WithMessage(request => $"'{request.TimeZoneId}' is not a recognised time zone.")
+            .When(request => isCampaign(request) && !string.IsNullOrWhiteSpace(request.TimeZoneId));
+        RuleFor(request => request).Must(request =>
+                request.ValidFromDate is null || request.ValidThroughDate is null ||
+                request.ValidThroughDate >= request.ValidFromDate)
+            .WithMessage("The campaign cannot end before it starts.")
+            .When(isCampaign);
+
+        RuleFor(request => request.ApplicablePriceIds).Must(prices => prices.Count > 0)
+            .WithMessage(
+                "This campaign kind needs at least one price named — it prices the opening " +
+                "stub and first annual period, or the free opening period, of a specific price, " +
+                "not of a plan in general.")
+            .When(request =>
+                request.CampaignKind is CampaignKind.FirstAnnualPeriod
+                    or CampaignKind.FreeOpeningCalendarPeriod);
+
+        // Exactly 100%, and never a fixed amount: a partial reduction or a currency-denominated
+        // one both leave a positive figure due on an "activate free of charge" period, which is
+        // the one outcome this campaign kind exists to rule out.
+        RuleFor(request => request).Must(request =>
+                request.Kind == DiscountKind.Percent && request.PercentBasisPoints == 10_000)
+            .WithMessage("A free-opening-period campaign must be a 100% reduction, not a partial one.")
+            .When(request => request.CampaignKind == CampaignKind.FreeOpeningCalendarPeriod);
+
+        RuleFor(request => request.OneUsePerOrganization).Equal(true)
+            .WithMessage("A free-opening-period campaign must be limited to one redemption per organization.")
+            .When(request => request.CampaignKind == CampaignKind.FreeOpeningCalendarPeriod);
+
+        RuleFor(request => request.RequiresPaymentMethodUpfront).Equal(true)
+            .WithMessage("A free-opening-period campaign must require a payment method before activation.")
+            .When(request => request.CampaignKind == CampaignKind.FreeOpeningCalendarPeriod);
+
+        RuleFor(request => request.EntitlementOverrideKey).NotEmpty()
+            .WithMessage("A free-opening-period campaign must name the entitlement it temporarily caps.")
+            .When(request => request.CampaignKind == CampaignKind.FreeOpeningCalendarPeriod);
+        RuleFor(request => request.EntitlementOverrideLimit).NotNull().GreaterThan(0)
+            .WithMessage("The temporary entitlement limit must be a positive number.")
+            .When(request => request.CampaignKind == CampaignKind.FreeOpeningCalendarPeriod);
+
+        // Both present or both absent, for every other campaign kind — half of a pair is not a
+        // request that can mean anything, and silently ignoring the one that is there would hide
+        // a caller's mistake rather than refuse it.
+        RuleFor(request => request).Must(request =>
+                (request.EntitlementOverrideKey is null) == (request.EntitlementOverrideLimit is null))
+            .WithMessage(
+                "An entitlement override needs both a key and a limit, or neither.")
+            .When(request => request.CampaignKind != CampaignKind.FreeOpeningCalendarPeriod);
+        RuleFor(request => request.EntitlementOverrideLimit).GreaterThan(0)
+            .WithMessage("The temporary entitlement limit must be a positive number.")
+            .When(request =>
+                request.CampaignKind != CampaignKind.FreeOpeningCalendarPeriod &&
+                request.EntitlementOverrideLimit is not null);
+
+        // A non-campaign discount carries none of this. Refused rather than silently dropped, so a
+        // caller who set a campaign field on a Standard discount finds out, instead of the field
+        // disappearing without explanation the moment it is saved.
+        RuleFor(request => request).Must(request =>
+                request.ValidFromDate is null && request.ValidThroughDate is null &&
+                string.IsNullOrEmpty(request.TimeZoneId) && !request.OneUsePerOrganization &&
+                !request.RequiresPaymentMethodUpfront && request.EntitlementOverrideKey is null)
+            .WithMessage("A standard discount cannot carry campaign fields. Set a campaign kind, or clear them.")
+            .When(request => !isCampaign(request));
+    }
+}

--- a/server/Subscription.DomainService/Validators/UpdateDiscountRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/UpdateDiscountRequestValidator.cs
@@ -3,11 +3,11 @@ using Subscription.DomainService.Requests;
 
 namespace Subscription.DomainService.Validators;
 
-public sealed class CreateDiscountRequestValidator : CampaignDiscountRequestValidator<CreateDiscountRequest>
+public sealed class UpdateDiscountRequestValidator : CampaignDiscountRequestValidator<UpdateDiscountRequest>
 {
-    public CreateDiscountRequestValidator()
+    public UpdateDiscountRequestValidator()
     {
-        RuleFor(request => request.Code).NotEmpty().MaximumLength(64).Matches("^[a-z0-9_-]+$");
+        RuleFor(request => request.ExpectedVersion).GreaterThanOrEqualTo(0);
         RuleFor(request => request.DisplayName).NotEmpty().MaximumLength(200);
         RuleFor(request => request.DurationPeriods).GreaterThan(0)
             .When(request => request.DurationPeriods.HasValue);

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
@@ -1,0 +1,592 @@
+using FluentAssertions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Validators;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Campaign authoring: the fields a promotional discount carries beyond an ordinary percentage or
+/// fixed reduction, and the ways an author's request for one of them can be wrong.
+/// </summary>
+/// <remarks>
+/// Two things this suite exists to prove above everything else. First, that a document with no
+/// campaign configuration is untouched by any of this — every legacy discount test in
+/// <see cref="DiscountCatalogueServiceTests"/> still passes unmodified, and this suite's own
+/// <see cref="A_legacy_discount_reads_back_as_standard_with_no_campaign_fields"/> pins the
+/// deserialization default that makes that true. Second, that the two gaps a campaign genuinely
+/// needs — a price that has been retired since a campaign was authored, and a date boundary that
+/// lands inside a daylight-saving transition — are refused rather than silently mispriced.
+/// </remarks>
+public sealed class DiscountCatalogueServiceCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string PlanId = "plan-pro";
+    private const string YearlyPriceId = "price-pro-yearly";
+    private const string MonthlyPriceId = "price-pro-monthly";
+    private const string CalendarMonthlyPriceId = "price-pro-calendar-monthly";
+    private const string ArchivedPriceId = "price-pro-retired";
+
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private Discount? _created;
+
+    public DiscountCatalogueServiceCampaignTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([PlanWithSeatEntitlement()]);
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, YearlyPriceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Price(YearlyPriceId, BillingInterval.Year, BillingAlignment.Anniversary));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, MonthlyPriceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Price(MonthlyPriceId, BillingInterval.Month, BillingAlignment.Anniversary));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, CalendarMonthlyPriceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Price(
+                CalendarMonthlyPriceId, BillingInterval.Month, BillingAlignment.CalendarMonth));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, ArchivedPriceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Price(
+                ArchivedPriceId,
+                BillingInterval.Month,
+                BillingAlignment.CalendarMonth,
+                status: CatalogueStatus.Archived));
+
+        _discounts
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<Discount>(), It.IsAny<CancellationToken>()))
+            .Callback<Discount, CancellationToken>((discount, _) => _created = discount)
+            .ReturnsAsync(true);
+    }
+
+    // ---- Backward compatibility -------------------------------------------------------------
+
+    [Fact]
+    public void A_legacy_discount_reads_back_as_standard_with_no_campaign_fields()
+    {
+        // Never deserialized through the catalogue service in this test — the point is that the
+        // entity itself defaults this way, so a document written before Campaign existed at all
+        // reads back with the gate every campaign code path checks already at its "off" value.
+        var legacy = new Discount();
+
+        legacy.Campaign.Kind.Should().Be(CampaignKind.Standard);
+        legacy.Campaign.Precedence.Should().Be(CampaignPrecedence.BestDiscount);
+        legacy.Campaign.ValidFromDate.Should().BeNull();
+        legacy.Campaign.RedeemableFromUtc.Should().BeNull();
+        legacy.Campaign.EntitlementOverride.Should().BeNull();
+        legacy.Version.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task A_standard_discount_still_creates_without_naming_any_campaign_field()
+    {
+        var result = await Service().CreateAsync(Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Campaign.Kind.Should().Be(CampaignKind.Standard);
+    }
+
+    [Fact]
+    public async Task A_standard_discount_refuses_a_campaign_field_set_without_a_campaign_kind()
+    {
+        // Refused rather than silently dropped -- an author who set a window on what they thought
+        // was a campaign discount has to be told the kind was never set, not have the window
+        // vanish without explanation the moment it is saved.
+        var request = Request();
+        request.ValidFromDate = new DateOnly(2026, 1, 1);
+        request.ValidThroughDate = new DateOnly(2026, 12, 31);
+        request.TimeZoneId = "Europe/Zurich";
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_invalid");
+    }
+
+    // ---- Structural validation ---------------------------------------------------------------
+
+    [Fact]
+    public async Task A_campaign_needs_its_window_and_time_zone()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        request.ValidFromDate = null;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_invalid");
+    }
+
+    [Fact]
+    public async Task An_unrecognised_time_zone_is_refused()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        request.TimeZoneId = "Mars/Olympus_Mons";
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_campaign_cannot_end_before_it_starts()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        request.ValidFromDate = new DateOnly(2026, 12, 31);
+        request.ValidThroughDate = new DateOnly(2026, 1, 1);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_campaign_that_prices_specific_periods_must_name_at_least_one_price()
+    {
+        // Unrestricted is a legitimate choice for a Standard discount, but FirstAnnualPeriod and
+        // FreeOpeningCalendarPeriod price a specific price's stub or opening period, not a plan's
+        // in general -- there is nothing to price without one named.
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, []);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(9_999)] // 99.99%, not 100%
+    public async Task A_free_month_reduction_must_be_exactly_100_percent(int basisPoints)
+    {
+        var request = FreeMonthRequest();
+        request.PercentBasisPoints = basisPoints;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_free_month_reduction_cannot_be_a_fixed_amount()
+    {
+        var request = FreeMonthRequest();
+        request.Kind = DiscountKind.FixedAmount;
+        request.PercentBasisPoints = null;
+        request.AmountMinor = 1_000;
+        request.CurrencyCode = "CHF";
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_free_month_must_be_one_use_per_organization()
+    {
+        var request = FreeMonthRequest();
+        request.OneUsePerOrganization = false;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_free_month_must_require_a_payment_method_upfront()
+    {
+        var request = FreeMonthRequest();
+        request.RequiresPaymentMethodUpfront = false;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_free_month_must_name_its_temporary_entitlement()
+    {
+        var request = FreeMonthRequest();
+        request.EntitlementOverrideKey = null;
+        request.EntitlementOverrideLimit = null;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    // ---- Catalogue-dependent applicability -----------------------------------------------------
+
+    [Fact]
+    public async Task A_first_annual_period_campaign_refuses_a_price_that_does_not_bill_yearly()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [MonthlyPriceId]);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+    }
+
+    [Fact]
+    public async Task A_first_annual_period_campaign_accepts_an_ordinary_yearly_price()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_free_opening_period_campaign_refuses_a_price_that_is_not_calendar_aligned()
+    {
+        // Monthly, but anniversary-aligned rather than calendar-aligned -- it has no calendar
+        // month boundary to give away for free, only an anniversary one.
+        var request = FreeMonthRequest();
+        request.ApplicablePriceIds = [MonthlyPriceId];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+    }
+
+    [Fact]
+    public async Task A_free_opening_period_campaign_refuses_a_yearly_price_even_if_calendar_aligned()
+    {
+        var request = FreeMonthRequest();
+        request.ApplicablePriceIds = [YearlyPriceId];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task A_free_opening_period_campaign_accepts_a_calendar_aligned_monthly_price()
+    {
+        var request = FreeMonthRequest();
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_archived_price_cannot_be_selected_for_a_new_campaign()
+    {
+        // A gap that predates campaigns: GetPriceAsync does not filter by status, since most
+        // callers look one up by id regardless of whether it can still be sold. Authoring a new
+        // discount against a retired price is not one of those callers.
+        var request = FreeMonthRequest();
+        request.ApplicablePriceIds = [ArchivedPriceId];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+    }
+
+    [Fact]
+    public async Task An_archived_price_is_still_refused_even_for_an_ordinary_non_campaign_discount()
+    {
+        // Same gap, proven on the path every discount already went through -- this is not a
+        // campaign-only fix.
+        var request = Request();
+        request.ApplicablePriceIds = [ArchivedPriceId];
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task An_entitlement_override_must_name_a_key_the_plan_actually_grants()
+    {
+        var request = FreeMonthRequest();
+        request.EntitlementOverrideKey = "nonexistent-entitlement";
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task An_entitlement_override_cannot_exceed_the_plans_own_limit()
+    {
+        var request = FreeMonthRequest();
+        request.EntitlementOverrideLimit = 999; // the plan's own seat limit is 5, set below.
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task An_entitlement_override_at_or_under_the_plans_limit_is_accepted()
+    {
+        var request = FreeMonthRequest();
+        request.EntitlementOverrideLimit = 1;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Campaign.EntitlementOverride!.Limit.Should().Be(1);
+    }
+
+    // ---- Redeemable window: DST-safe conversion ------------------------------------------------
+
+    [Fact]
+    public async Task The_redeemable_window_is_computed_and_frozen_at_authoring_time()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        request.ValidFromDate = new DateOnly(2026, 3, 1);
+        request.ValidThroughDate = new DateOnly(2026, 3, 31);
+        request.TimeZoneId = "Europe/Zurich";
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // 1 March local midnight in Zurich, before the spring DST change.
+        _created!.Campaign.RedeemableFromUtc.Should().Be(new DateTime(2026, 2, 28, 23, 0, 0, DateTimeKind.Utc));
+        // Exclusive: local midnight of 1 April, the day AFTER the inclusive 31 March end date --
+        // and 29 March 2026 is the night Europe/Zurich springs forward, so this instant is also
+        // proof the conversion survived crossing that transition.
+        _created!.Campaign.RedeemableUntilUtc.Should().Be(new DateTime(2026, 3, 31, 22, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task A_campaign_window_that_starts_inside_a_spring_forward_gap_still_resolves()
+    {
+        // Belt and braces on top of the previous test: the start date itself sitting on the
+        // transition night, not just the window crossing it. BillingLocalTime.ToUtc already
+        // carries this policy everywhere else in the billing domain; this proves it is actually
+        // being reused here rather than a second, untested implementation of the same idea.
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        request.ValidFromDate = new DateOnly(2026, 3, 29);
+        request.ValidThroughDate = new DateOnly(2026, 3, 30);
+        request.TimeZoneId = "Europe/Zurich";
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Campaign.RedeemableFromUtc.Should().NotBeNull();
+    }
+
+    // ---- Get / Update / version conflict -------------------------------------------------------
+
+    [Fact]
+    public async Task An_update_with_the_current_version_succeeds_and_increments_it()
+    {
+        var stored = StoredDiscount(version: 3);
+        _discounts
+            .Setup(repository => repository.FindByIdAsync(
+                TenantId, stored.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+        _discounts
+            .Setup(repository => repository.TryUpdateAsync(
+                It.IsAny<Discount>(), 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Service().UpdateAsync(
+            stored.ItemId, UpdateRequest(expectedVersion: 3), null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_update_against_a_stale_version_is_refused_as_a_conflict_not_silently_applied()
+    {
+        var stored = StoredDiscount(version: 3);
+        _discounts
+            .Setup(repository => repository.FindByIdAsync(
+                TenantId, stored.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+        _discounts
+            .Setup(repository => repository.TryUpdateAsync(
+                It.IsAny<Discount>(), 1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().UpdateAsync(
+            stored.ItemId, UpdateRequest(expectedVersion: 1), null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_version_conflict");
+    }
+
+    [Fact]
+    public async Task Getting_a_discount_from_another_organizations_scope_reads_as_not_found()
+    {
+        var stored = StoredDiscount(version: 0);
+        stored.OrganizationId = "org-somebody-else";
+        _discounts
+            .Setup(repository => repository.FindByIdAsync(
+                TenantId, stored.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+
+        var result = await Service().GetAsync(stored.ItemId, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_not_found");
+    }
+
+    [Fact]
+    public async Task A_tenant_wide_discount_is_visible_to_every_organization_in_the_tenant()
+    {
+        var stored = StoredDiscount(version: 0);
+        stored.OrganizationId = null;
+        _discounts
+            .Setup(repository => repository.FindByIdAsync(
+                TenantId, stored.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+
+        var result = await Service().GetAsync(stored.ItemId, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    // ---- Effective state --------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_campaign_before_its_window_reads_as_upcoming()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        request.ValidFromDate = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(1));
+        request.ValidThroughDate = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(1).AddMonths(1));
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.EffectiveState.Should().Be("Upcoming");
+    }
+
+    [Fact]
+    public async Task A_campaign_past_its_window_reads_as_expired()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        request.ValidFromDate = new DateOnly(2020, 1, 1);
+        request.ValidThroughDate = new DateOnly(2020, 1, 31);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.EffectiveState.Should().Be("Expired");
+    }
+
+    // ---- Helpers ------------------------------------------------------------------------------
+
+    private DiscountCatalogueService Service() => new(
+        _discounts.Object,
+        _catalogue.Object,
+        _contextResolver.Object,
+        new CreateDiscountRequestValidator(),
+        new UpdateDiscountRequestValidator());
+
+    private static CreateDiscountRequest Request() => new()
+    {
+        Code = "launch25",
+        DisplayName = "Launch offer",
+        Kind = DiscountKind.Percent,
+        PercentBasisPoints = 2_500
+    };
+
+    private static CreateDiscountRequest CampaignRequest(CampaignKind kind, List<string> priceIds) => new()
+    {
+        Code = "campaign-code",
+        DisplayName = "A campaign",
+        Kind = DiscountKind.Percent,
+        PercentBasisPoints = 1_000,
+        ApplicablePriceIds = priceIds,
+        CampaignKind = kind,
+        ValidFromDate = new DateOnly(2026, 1, 1),
+        ValidThroughDate = new DateOnly(2026, 12, 31),
+        TimeZoneId = "Europe/Zurich"
+    };
+
+    private static CreateDiscountRequest FreeMonthRequest()
+    {
+        var request = CampaignRequest(CampaignKind.FreeOpeningCalendarPeriod, [CalendarMonthlyPriceId]);
+        request.Kind = DiscountKind.Percent;
+        request.PercentBasisPoints = 10_000;
+        request.OneUsePerOrganization = true;
+        request.RequiresPaymentMethodUpfront = true;
+        request.EntitlementOverrideKey = "seats";
+        request.EntitlementOverrideLimit = 1;
+
+        return request;
+    }
+
+    private static UpdateDiscountRequest UpdateRequest(long expectedVersion) => new()
+    {
+        ExpectedVersion = expectedVersion,
+        DisplayName = "Updated name",
+        Kind = DiscountKind.Percent,
+        PercentBasisPoints = 3_000
+    };
+
+    private static Discount StoredDiscount(long version) => new()
+    {
+        ItemId = "discount-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Code = "existing-code",
+        DisplayName = "Existing",
+        Version = version,
+        Terms = new DiscountTerms
+        {
+            Code = "existing-code", Kind = DiscountKind.Percent, PercentBasisPoints = 1_000
+        }
+    };
+
+    private static Plan PlanWithSeatEntitlement() => new()
+    {
+        ItemId = PlanId,
+        TenantId = TenantId,
+        Code = "pro",
+        DisplayName = "pro",
+        Status = CatalogueStatus.Active,
+        Entitlements =
+        [
+            new PlanEntitlement { Key = "seats", LimitKind = EntitlementLimitKind.Count, Limit = 5 }
+        ]
+    };
+
+    private static Price Price(
+        string priceId,
+        BillingInterval interval,
+        BillingAlignment alignment,
+        CatalogueStatus status = CatalogueStatus.Active) => new()
+    {
+        ItemId = priceId,
+        TenantId = TenantId,
+        PlanId = PlanId,
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 10_000,
+        Interval = interval,
+        IntervalCount = 1,
+        BillingAlignment = alignment,
+        Status = status
+    };
+}

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
@@ -255,7 +255,8 @@ public sealed class DiscountCatalogueServiceTests
         _discounts.Object,
         _catalogue.Object,
         _contextResolver.Object,
-        new CreateDiscountRequestValidator());
+        new CreateDiscountRequestValidator(),
+        new UpdateDiscountRequestValidator());
 
     private static CreateDiscountRequest Request() => new()
     {


### PR DESCRIPTION
**Phase 1 of 5** for the "AMLora Campaign Discount Management and Buyer Validation" feature. Sequencing was agreed as phased PRs rather than one large one — the highest-risk pricing code this feature touches (yearly stub/annual splitting) already has three separate bug-fix PRs in this repo's recent history, and a diff nobody can hold in their head catches fewer bugs.

| Phase | Scope | This PR |
|---|---|---|
| 1 | Data model, backward compatibility, authoring API + validation | ✅ |
| 2 | Redemption ledger, atomic reservation, worker reconciliation sweep | not started |
| 3 | Pricing: SAV/TREX yearly split, Free Month activation, zero-value invoice | not started |
| 4 | Buyer preview API + UI | not started |
| 5 | Admin authoring UI (4-step wizard) | not started |

## What this adds

- `Discount` gains a `Campaign` sub-document (`CampaignTerms`: kind, precedence, window, one-use flag, opening-stub flag, payment-method-upfront flag, entitlement override) and `Version` for optimistic concurrency.
- `DiscountTerms` (the per-subscription snapshot) gains `DiscountId`, `DiscountVersion`, `RedeemedAtUtc` and its own copy of `Campaign` — a later catalogue edit can never reach into an already-redeemed subscription.
- New `GET /subscription-discounts/{id}` and `PUT /subscription-discounts/{id}`. The `PUT` requires `expectedVersion` and returns `409 subscription_discount_version_conflict` on a stale write, checked atomically in the Mongo filter — not read-modify-write.
- Validation split the way this codebase already splits it: structural rules in a shared FluentValidation base (`CampaignDiscountRequestValidator<T>`) used by both Create and Update; catalogue-dependent rules (a price actually being yearly, an entitlement key actually existing on the plan) extend the existing `CheckApplicabilityAsync`.
- A `SubscriptionCampaignManager` authorization policy, following `SubscriptionBackgroundWorkOperator`'s exact existing pattern.

## Backward compatibility — how it's actually verified, not just claimed

`Campaign` is never null. It's gated on `Kind`'s zero value, `CampaignKind.Standard`, the same convention `BillingAlignment` and `AutomaticDiscountCombination` already use in this codebase. A `Discount` document written before this PR deserializes with `Campaign.Kind == Standard`, and every campaign-specific code path treats that identically to there being no campaign at all.

**134 pre-existing discount tests pass completely unmodified.** Not adjusted, not skipped — the exact same assertions from before this PR, against the code after it.

## A pre-existing gap this PR found and fixed

`GetPriceAsync` doesn't filter by status. An archived price's id was passing the discount-applicability check as long as its parent plan was still active — nothing to do with campaigns, already true for an ordinary discount today on `dev`. Fixed for every discount, not only a campaign one. Confirmed real: I reverted the fix, ran the two tests that name it, watched them fail, then restored it.

## Two spec items deliberately not hardcoded

*"AMLora Free Month uses limit 1"* and *"ReplaceBuiltIn is used for the AMLora SAV, TREX and Free Month campaigns"* describe facts about three specific campaigns to be authored, not constraints on every campaign this system can ever create. Coding them as validation rules would make it impossible to later create a different campaign of the same kind with a different limit or precedence — contradicting the rest of the spec's design as a reusable, admin-configurable system. They're choices made when those three campaigns are actually created through this API, not code. Flag if this reading is wrong.

## Reuse, not reinvention

`CalendarBillingAlignment.Supports()` already covers `Month or Year` — checked before writing anything, so Free Month (Phase 3) is not blocked on a missing capability. The DST-safe date conversion for a campaign's redeemable window reuses `BillingLocalTime.ToUtc`, the exact gap/ambiguity policy already used everywhere else in this billing domain, rather than a second implementation of the same idea.

## Verification

- 134 pre-existing discount tests: unmodified, pass.
- 30 new tests, two of which were confirmed to fail against the code before their fix: the archived-price gap above, and the redeemable-window computation crossing Europe/Zurich's real 2026 spring-forward transition (29 March).
- Full non-integration server suite: **3187 passed**, 4 failures in `SubscriptionSimulation*` permission guards — confirmed identical on clean `dev` by stashing and re-running.
- `dotnet build` clean on `Subscription.DomainService`, `Api`, and `XUnitTest`, no new errors or warnings.

## Deployment precondition — please read before merging

`SubscriptionCampaignManager` refuses every caller, **including today's discount-catalogue users**, until `subscription.campaign.manage` is mapped to a role by the identity provider. This is called out on the controller's own XML doc and here. Please confirm that mapping is in place, or discount authoring goes dark the moment this deploys — the same shape of precondition as PR #327's Direct-mode fleet check earlier in this project's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
