### PR TITLE
feat(subscription): campaign redemption ledger, atomic reservation, activation/cancellation wiring [Phase 2/5]

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -42,6 +42,12 @@ jobs:
       # only be demonstrated against a real collection, and a filter that leaves the class out means
       # they are demonstrated nowhere — the suite passes, and nothing has been tried.
       #
+      # CampaignRedemptionConcurrencyTests is named for the same reason and was added with the
+      # class: one-use campaign reservation is a unique index and a compare-and-set, so "two
+      # subscriptions race and exactly one wins" is a claim about MongoDB rather than about our
+      # code. Left out, the suite reported 48 passing tests on the pull request that introduced it
+      # and had tried none of them.
+      #
       # Several integration classes are still outside this filter and so run nowhere. Widening it
       # belongs in its own change, since whatever it turns up would arrive as unrelated failures on
       # whichever pull request happened to widen it.
@@ -49,5 +55,5 @@ jobs:
         run: >-
           dotnet test server/XUnitTest/XUnitTest.csproj
           --no-restore
-          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests"
+          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests"
           --verbosity minimal

--- a/server/Subscription.DomainService/Entities/CampaignRedemption.cs
+++ b/server/Subscription.DomainService/Entities/CampaignRedemption.cs
@@ -1,0 +1,67 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One subscription's durable claim on a campaign discount.
+/// </summary>
+/// <remarks>
+/// This is the mechanism that makes "one use per organization" actually true rather than merely
+/// likely. A campaign's rule lives on <see cref="Discount.Campaign"/>; this is the ledger that
+/// enforces it, because a rule checked only in application code before an insert is a race, and a
+/// unique index checked by the database is not.
+/// <para>
+/// One row per (tenant, organization, discount) that a one-use campaign has ever been reserved
+/// for — never deleted, so a released slot's history is not lost the moment it frees up. A
+/// non-one-use campaign can accumulate many rows for the same discount across different
+/// subscriptions; a one-use one is guaranteed exactly one row that is not
+/// <see cref="CampaignRedemptionState.Released"/> at any moment, by
+/// <see cref="Repositories.CampaignRedemptionIndexDefinitions"/>'s partial unique index rather than
+/// by anything checked here.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class CampaignRedemption
+{
+    [BsonId] public string ItemId { get; set; } = Guid.NewGuid().ToString();
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Never null, unlike <see cref="Discount.OrganizationId"/>. A tenant-wide campaign is still
+    /// redeemed by one specific organization, and that organization is exactly the scope one-use
+    /// enforcement has to key on -- a null here would make every organization in the tenant share
+    /// one slot on a tenant-wide one-use campaign, which is not what "one use per organization"
+    /// means.
+    /// </summary>
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string DiscountId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The <see cref="Discount.Version"/> this reservation was accepted at. A later edit to the
+    /// catalogue entry must never be able to reprice an already-reserved redemption -- this is
+    /// what a reconciliation sweep or an audit reads back to confirm which terms actually applied,
+    /// independent of what the catalogue entry says today.
+    /// </summary>
+    public long CampaignVersion { get; set; }
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public CampaignRedemptionState State { get; set; } = CampaignRedemptionState.Reserved;
+
+    /// <summary>
+    /// Copied from <see cref="Entities.CampaignTerms.OneUsePerOrganization"/> at reservation time,
+    /// not read live from the catalogue. This is the field
+    /// <see cref="Repositories.CampaignRedemptionIndexDefinitions"/>'s partial unique index
+    /// actually filters on -- a campaign that is not one-use may accumulate more than one row for
+    /// the same organization and discount, and the index has to know which kind of row this is
+    /// without a second lookup.
+    /// </summary>
+    public bool OneUsePerOrganization { get; set; }
+
+    public DateTime ReservedAtUtc { get; set; }
+    public DateTime? RedeemedAtUtc { get; set; }
+    public DateTime? ReleasedAtUtc { get; set; }
+    public DateTime LastUpdatedAtUtc { get; set; }
+}

--- a/server/Subscription.DomainService/Entities/DiscountTerms.cs
+++ b/server/Subscription.DomainService/Entities/DiscountTerms.cs
@@ -55,10 +55,17 @@ public sealed class DiscountTerms
     public long DiscountVersion { get; set; }
 
     /// <summary>
-    /// When this snapshot was accepted -- the instant a checkout or activation redeemed it, not
-    /// when the discount catalogue entry was created. Absent on a subscription created before this
-    /// field existed.
+    /// When this discount was accepted into this subscription's terms -- signup, for every
+    /// discount alike, not when the discount catalogue entry was created. Absent on a subscription
+    /// created before this field existed.
     /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Entities.CampaignRedemption"/>'s own <c>ReservedAtUtc</c> and
+    /// <c>RedeemedAtUtc</c> for a campaign discount, which can genuinely differ from this one: a
+    /// campaign is reserved at this same signup instant but not <em>redeemed</em>, in the ledger's
+    /// sense, until the subscription activates. This field never moves after signup; the ledger's
+    /// does.
+    /// </remarks>
     public DateTime? RedeemedAtUtc { get; set; }
 
     /// <summary>

--- a/server/Subscription.DomainService/Enums/CampaignRedemptionState.cs
+++ b/server/Subscription.DomainService/Enums/CampaignRedemptionState.cs
@@ -1,0 +1,39 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Where one subscription's claim on a campaign stands.
+/// </summary>
+/// <remarks>
+/// Explicit values because this is persisted, the same reason <see cref="SubscriptionStatus"/>'s
+/// are: inserting a member without one would renumber every value after it and silently
+/// reinterpret a stored document.
+/// <para>
+/// <see cref="Released"/> must stay the highest ordinal.
+/// <see cref="Repositories.CampaignRedemptionIndexDefinitions"/>'s partial unique index expresses
+/// "not Released" as <c>State &lt; Released</c>, because MongoDB's partial-filter expressions do
+/// not support <c>$ne</c> or <c>$in</c> — only equality and ordered comparisons. Adding a state
+/// after <see cref="Released"/> rather than before it would silently break that index's meaning
+/// without changing a line in this file.
+/// </para>
+/// </remarks>
+public enum CampaignRedemptionState
+{
+    /// <summary>Claimed at subscription creation. Grants the discount, consumes nothing durable yet.</summary>
+    Reserved = 0,
+
+    /// <summary>The subscription activated. The claim is now permanent.</summary>
+    Redeemed = 1,
+
+    /// <summary>
+    /// The subscription ended before ever activating, and this claim is queued to be given back.
+    /// Distinct from <see cref="Released"/> so a crash between the two is visible rather than
+    /// silently either state.
+    /// </summary>
+    ReleasePending = 2,
+
+    /// <summary>
+    /// Given back. A one-use campaign's slot is free for a different organization again. Must
+    /// remain the highest ordinal -- see the remarks above.
+    /// </summary>
+    Released = 3
+}

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -48,6 +48,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     private readonly ILogger<SubscriptionActivationProcessor> _logger;
     private readonly TimeProvider _time;
     private readonly ISubscriptionAuditTrail? _audit;
+    private readonly ICampaignRedemptionRepository? _redemptions;
 
     public SubscriptionActivationProcessor(
         ISubscriptionPaymentLinkRepository links,
@@ -60,7 +61,8 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         ILogger<SubscriptionActivationProcessor> logger,
         TimeProvider? time = null,
         ISubscriptionAuditTrail? audit = null,
-        ISubscriptionFinancialDocumentAnnouncer? documents = null)
+        ISubscriptionFinancialDocumentAnnouncer? documents = null,
+        ICampaignRedemptionRepository? redemptions = null)
     {
         _links = links;
         _subscriptions = subscriptions;
@@ -73,6 +75,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         _time = time ?? TimeProvider.System;
         _audit = audit;
         _documents = documents;
+        _redemptions = redemptions;
     }
 
     /// <summary>
@@ -362,6 +365,22 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             return false;
         }
 
+        if (_redemptions is not null &&
+            subscription.Discount is { Campaign.Kind: not CampaignKind.Standard } discount)
+        {
+            // After the transition commits, never before: a campaign is redeemed because this
+            // subscription actually activated, and marking it redeemed on a transition that then
+            // failed to apply would grant the permanent half of a redemption for an activation
+            // that never happened. Idempotent against a duplicate delivery of this same event --
+            // the repository itself guarantees that, not a check made here.
+            await _redemptions.TryMarkRedeemedAsync(
+                subscription.TenantId,
+                discount.DiscountId!,
+                subscription.ItemId,
+                _time.GetUtcNow().UtcDateTime,
+                cancellationToken);
+        }
+
         if (!IsCardSetup(link))
         {
             await AdoptProviderCustomerAsync(subscription, payment, cancellationToken);
@@ -563,8 +582,9 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
 
     private async Task ExpireAsync(
         SubscriptionDetail subscription,
-        CancellationToken cancellationToken) =>
-        await _subscriptions.TryTransitionAsync(
+        CancellationToken cancellationToken)
+    {
+        var applied = await _subscriptions.TryTransitionAsync(
             subscription.TenantId,
             subscription.ItemId,
             new SubscriptionTransition(
@@ -579,6 +599,24 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                     subscription.CorrelationId)
             },
             cancellationToken);
+
+        // The transition's own guard is what makes this safe to call unconditionally: it only
+        // ever moves a subscription out of Incomplete, and Incomplete is exactly "never
+        // activated" -- there is no path from here to a subscription that already redeemed its
+        // campaign. TryReleaseAsync's own guard against an already-Redeemed row is defence in
+        // depth on top of that, not the only thing preventing it.
+        if (applied &&
+            _redemptions is not null &&
+            subscription.Discount is { Campaign.Kind: not CampaignKind.Standard } discount)
+        {
+            await _redemptions.TryReleaseAsync(
+                subscription.TenantId,
+                discount.DiscountId!,
+                subscription.ItemId,
+                _time.GetUtcNow().UtcDateTime,
+                cancellationToken);
+        }
+    }
 
     private async Task RescheduleAsync(
         SubscriptionPaymentLink link,

--- a/server/Subscription.DomainService/Repositories/CampaignRedemptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/CampaignRedemptionIndexDefinitions.cs
@@ -1,0 +1,67 @@
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// The index that makes "one use per organization" true, rather than merely checked.
+/// </summary>
+public static class CampaignRedemptionIndexDefinitions
+{
+    public const string OneUseIndexName = "campaign_redemption_one_use_per_org";
+    public const string SubscriptionLookupIndexName = "campaign_redemption_by_subscription";
+
+    public static IReadOnlyCollection<CreateIndexModel<CampaignRedemption>> CreateIndexes() =>
+    [
+        // Unique across the rows a one-use campaign actually needs to be unique for: one active
+        // claim per organization and discount, where "active" is anything that is not Released.
+        // A non-one-use campaign is entirely outside this index's filter and can accumulate as
+        // many rows as it has subscriptions -- there is nothing to enforce there.
+        //
+        // Released is deliberately excluded from the filter, not merely from what a caller reads
+        // back. Every row this feature writes stays in the collection forever -- an abandoned
+        // subscription's own row, and whichever different subscription later reclaims the freed
+        // slot, are two separate documents with two separate histories. Had a Released row still
+        // counted toward this index, reclaiming a freed slot would have had nowhere to insert a
+        // second document, and the only way to satisfy the index would have been to overwrite the
+        // abandoned subscription's own row -- silently erasing which subscription actually held
+        // the campaign before it was given back. A concurrency test caught exactly this before it
+        // shipped.
+        //
+        // "$lt Released" rather than "$ne Released": MongoDB's partialFilterExpression supports
+        // only equality and the ordered comparisons ($gt/$gte/$lt/$lte/$exists/$type), never $ne
+        // or $in -- confirmed by running this against a real server, not assumed from the docs.
+        // This works only because CampaignRedemptionState.Released is deliberately the highest
+        // ordinal of a closed four-value enum, so "less than Released" and "not Released" are the
+        // same set for every value that enum can hold. A state added after Released, rather than
+        // before it, would silently break this index's meaning without changing a single line
+        // here -- which is why CampaignRedemptionState's own doc comment calls this out at the
+        // enum, not only at this one call site.
+        new(
+            Builders<CampaignRedemption>.IndexKeys
+                .Ascending(redemption => redemption.TenantId)
+                .Ascending(redemption => redemption.OrganizationId)
+                .Ascending(redemption => redemption.DiscountId),
+            new CreateIndexOptions<CampaignRedemption>
+            {
+                Unique = true,
+                Name = OneUseIndexName,
+                PartialFilterExpression = new BsonDocument
+                {
+                    { nameof(CampaignRedemption.OneUsePerOrganization), true },
+                    {
+                        nameof(CampaignRedemption.State),
+                        new BsonDocument("$lt", (int)CampaignRedemptionState.Released)
+                    }
+                }
+            }),
+        new(
+            Builders<CampaignRedemption>.IndexKeys
+                .Ascending(redemption => redemption.TenantId)
+                .Ascending(redemption => redemption.DiscountId)
+                .Ascending(redemption => redemption.SubscriptionId),
+            new CreateIndexOptions<CampaignRedemption> { Name = SubscriptionLookupIndexName })
+    ];
+}

--- a/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
@@ -1,0 +1,173 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// The Mongo-backed ledger behind <see cref="ICampaignRedemptionRepository"/>.
+/// </summary>
+/// <remarks>
+/// The reservation this exists for is not "insert, and handle the duplicate-key exception if
+/// somebody beat us to it" — that pattern (used by
+/// <see cref="Payment.DomainService.Entities.BillingAccount"/>'s reconciliation, for instance)
+/// answers "did my write happen", and every writer there was writing the <em>same</em> intended
+/// values, so losing a race to an equivalent write is harmless. Here two different subscriptions
+/// racing for one slot must produce two different outcomes for two different callers, so the
+/// filter, the update, and the exception handler below all exist to answer the sharper question
+/// "whose subscription actually holds this now."
+/// </remarks>
+public sealed class CampaignRedemptionRepository : ICampaignRedemptionRepository
+{
+    private readonly IDbContextProvider _db;
+    private readonly ConcurrentDictionary<string, byte> _indexed = new();
+
+    public CampaignRedemptionRepository(IDbContextProvider db) => _db = db;
+
+    public async Task<CampaignReservationOutcome> TryReserveAsync(
+        CampaignRedemption reservation, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(reservation);
+        await EnsureIndexesAsync(reservation.TenantId, cancellationToken);
+
+        // A retry of the same subscription's own attempt, whether one-use or not: its row already
+        // exists regardless of state, and that is success either way -- including when the state
+        // is already Redeemed, which a genuine retry of subscription creation cannot actually
+        // reach in practice (creation runs before activation), but which this must not treat as a
+        // conflict if it somehow did.
+        var existing = await FindAsync(
+            reservation.TenantId, reservation.DiscountId, reservation.SubscriptionId,
+            cancellationToken);
+
+        if (existing is not null)
+        {
+            return CampaignReservationOutcome.AlreadyReservedBySameSubscription;
+        }
+
+        reservation.State = CampaignRedemptionState.Reserved;
+
+        try
+        {
+            await Collection(reservation.TenantId)
+                .InsertOneAsync(reservation, cancellationToken: cancellationToken);
+
+            return CampaignReservationOutcome.Reserved;
+        }
+        catch (Exception exception) when (reservation.OneUsePerOrganization && IsDuplicateKey(exception))
+        {
+            // CampaignRedemptionIndexDefinitions.OneUseIndexName refused this insert: an active
+            // (non-Released) claim already exists for this organization and discount. Whose it is
+            // still has to be re-read rather than assumed -- the FindAsync check above and this
+            // insert are two separate operations, and two concurrent attempts for the very same
+            // subscription can both pass that check before either one inserts. The loser lands
+            // here even though the winner was its own retry, not a stranger's, so this is
+            // resolved the only way it safely can be: read what is actually there now.
+            var current = await FindAsync(
+                reservation.TenantId, reservation.DiscountId, reservation.SubscriptionId,
+                cancellationToken);
+
+            return current is not null
+                ? CampaignReservationOutcome.AlreadyReservedBySameSubscription
+                : CampaignReservationOutcome.HeldByAnotherSubscription;
+        }
+    }
+
+    public async Task TryMarkRedeemedAsync(
+        string tenantId,
+        string discountId,
+        string subscriptionId,
+        DateTime redeemedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        await Collection(tenantId).UpdateOneAsync(
+            Builders<CampaignRedemption>.Filter.And(
+                Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
+                Builders<CampaignRedemption>.Filter.Eq(item => item.DiscountId, discountId),
+                Builders<CampaignRedemption>.Filter.Eq(item => item.SubscriptionId, subscriptionId),
+                // Only from Reserved. Idempotent against a repeat call -- already Redeemed matches
+                // nothing here and ModifiedCount is silently zero, which is the correct outcome for
+                // a duplicate activation event rather than an error.
+                Builders<CampaignRedemption>.Filter.Eq(
+                    item => item.State, CampaignRedemptionState.Reserved)),
+            Builders<CampaignRedemption>.Update
+                .Set(item => item.State, CampaignRedemptionState.Redeemed)
+                .Set(item => item.RedeemedAtUtc, redeemedAtUtc)
+                .Set(item => item.LastUpdatedAtUtc, redeemedAtUtc),
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task TryReleaseAsync(
+        string tenantId,
+        string discountId,
+        string subscriptionId,
+        DateTime releasedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var collection = Collection(tenantId);
+        var byKey = Builders<CampaignRedemption>.Filter.And(
+            Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
+            Builders<CampaignRedemption>.Filter.Eq(item => item.DiscountId, discountId),
+            Builders<CampaignRedemption>.Filter.Eq(item => item.SubscriptionId, subscriptionId));
+
+        // Reserved -> ReleasePending first and committed on its own, so a crash before the second
+        // step below leaves a state a reconciliation sweep can find and finish -- rather than a
+        // Reserved row indistinguishable from one nothing has happened to. Never touches an
+        // already-Redeemed row: once a campaign activated, a later cancellation does not give it
+        // back.
+        await collection.UpdateOneAsync(
+            Builders<CampaignRedemption>.Filter.And(
+                byKey,
+                Builders<CampaignRedemption>.Filter.Eq(
+                    item => item.State, CampaignRedemptionState.Reserved)),
+            Builders<CampaignRedemption>.Update
+                .Set(item => item.State, CampaignRedemptionState.ReleasePending)
+                .Set(item => item.LastUpdatedAtUtc, releasedAtUtc),
+            cancellationToken: cancellationToken);
+
+        // Idempotent against a repeat call: already Released matches nothing here and
+        // ModifiedCount is silently zero.
+        await collection.UpdateOneAsync(
+            Builders<CampaignRedemption>.Filter.And(
+                byKey,
+                Builders<CampaignRedemption>.Filter.Eq(
+                    item => item.State, CampaignRedemptionState.ReleasePending)),
+            Builders<CampaignRedemption>.Update
+                .Set(item => item.State, CampaignRedemptionState.Released)
+                .Set(item => item.ReleasedAtUtc, releasedAtUtc)
+                .Set(item => item.LastUpdatedAtUtc, releasedAtUtc),
+            cancellationToken: cancellationToken);
+    }
+
+    public Task<CampaignRedemption?> FindAsync(
+        string tenantId, string discountId, string subscriptionId, CancellationToken cancellationToken) =>
+        Collection(tenantId).Find(Builders<CampaignRedemption>.Filter.And(
+                Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
+                Builders<CampaignRedemption>.Filter.Eq(item => item.DiscountId, discountId),
+                Builders<CampaignRedemption>.Filter.Eq(item => item.SubscriptionId, subscriptionId)))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexed.ContainsKey(tenantId)) return;
+        await Collection(tenantId).Indexes.CreateManyAsync(
+            CampaignRedemptionIndexDefinitions.CreateIndexes(), cancellationToken);
+        _indexed.TryAdd(tenantId, 0);
+    }
+
+    private const int DuplicateKeyErrorCode = 11000;
+
+    private static bool IsDuplicateKey(Exception exception) =>
+        exception switch
+        {
+            MongoWriteException write =>
+                write.WriteError?.Category == ServerErrorCategory.DuplicateKey,
+            MongoCommandException command => command.Code == DuplicateKeyErrorCode,
+            _ => false
+        };
+
+    private IMongoCollection<CampaignRedemption> Collection(string tenantId) =>
+        SubscriptionCollections.Of<CampaignRedemption>(
+            _db, tenantId, SubscriptionCollections.CampaignRedemptions);
+}

--- a/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
@@ -1,0 +1,76 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>What a reservation attempt found.</summary>
+public enum CampaignReservationOutcome
+{
+    /// <summary>A new reservation was created for this subscription.</summary>
+    Reserved,
+
+    /// <summary>
+    /// This subscription already held the reservation -- a retry landed here, either because the
+    /// caller genuinely retried or because two concurrent attempts for the same subscription
+    /// raced and both need to see success.
+    /// </summary>
+    AlreadyReservedBySameSubscription,
+
+    /// <summary>
+    /// A different subscription holds this campaign for this organization, and the campaign is
+    /// one-use. Nothing was written.
+    /// </summary>
+    HeldByAnotherSubscription
+}
+
+public interface ICampaignRedemptionRepository
+{
+    /// <summary>
+    /// Atomically claims a campaign for a subscription, or reports who already holds it.
+    /// </summary>
+    /// <remarks>
+    /// Safe under concurrency by construction, not by a check-then-insert this method happens to
+    /// order carefully: two callers racing for the same one-use campaign either both land on
+    /// <see cref="CampaignReservationOutcome.Reserved"/> for the same subscription id (the same
+    /// logical attempt, retried) or exactly one gets <see cref="CampaignReservationOutcome.Reserved"/>
+    /// and the other gets <see cref="CampaignReservationOutcome.HeldByAnotherSubscription"/> --
+    /// there is no interleaving that lets both through. A non-one-use campaign never returns
+    /// <see cref="CampaignReservationOutcome.HeldByAnotherSubscription"/>: every subscription gets
+    /// its own row.
+    /// </remarks>
+    Task<CampaignReservationOutcome> TryReserveAsync(
+        CampaignRedemption reservation, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reserved -> Redeemed. Idempotent: called again for a subscription already Redeemed
+    /// succeeds without writing anything, the same way a repeated payment-provider webhook must
+    /// never be told its second delivery failed.
+    /// </summary>
+    Task TryMarkRedeemedAsync(
+        string tenantId,
+        string discountId,
+        string subscriptionId,
+        DateTime redeemedAtUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Reserved -> ReleasePending -> Released, in one call. Idempotent, and a no-op on a
+    /// subscription that already reached <see cref="Enums.CampaignRedemptionState.Redeemed"/> --
+    /// once activated, a campaign is never released by a later cancellation.
+    /// </summary>
+    /// <remarks>
+    /// The intermediate <see cref="Enums.CampaignRedemptionState.ReleasePending"/> is written and
+    /// committed before the second step is attempted, so a crash between the two leaves a durable,
+    /// specific state for a reconciliation sweep to find and complete -- rather than leaving the
+    /// row at <see cref="Enums.CampaignRedemptionState.Reserved"/>, indistinguishable from a
+    /// reservation nothing has happened to yet.
+    /// </remarks>
+    Task TryReleaseAsync(
+        string tenantId,
+        string discountId,
+        string subscriptionId,
+        DateTime releasedAtUtc,
+        CancellationToken cancellationToken);
+
+    Task<CampaignRedemption?> FindAsync(
+        string tenantId, string discountId, string subscriptionId, CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -39,6 +39,7 @@ internal static class SubscriptionCollections
 
     public const string UsagePeriodClosures = "SubscriptionUsagePeriodClosures";
     public const string UsagePeriodClaims = "SubscriptionUsagePeriodClaims";
+    public const string CampaignRedemptions = "SubscriptionCampaignRedemptions";
 
     public static IMongoCollection<TDocument> Of<TDocument>(
         IDbContextProvider dbContextProvider,

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -40,6 +40,7 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
     private readonly IOptionsMonitor<SubscriptionOptions>? _options;
     private readonly ISubscriptionUsageRepository? _usage;
     private readonly IMeterAllowanceResolver? _allowances;
+    private readonly ICampaignRedemptionRepository? _redemptions;
 
     public SubscriptionCancellationService(
         ISubscriptionRepository subscriptions,
@@ -54,7 +55,8 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         IUsagePeriodClosureRepository? closures = null,
         IOptionsMonitor<SubscriptionOptions>? options = null,
         ISubscriptionUsageRepository? usage = null,
-        IMeterAllowanceResolver? allowances = null)
+        IMeterAllowanceResolver? allowances = null,
+        ICampaignRedemptionRepository? redemptions = null)
     {
         _subscriptions = subscriptions;
         _links = links;
@@ -69,6 +71,7 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
         _options = options;
         _usage = usage;
         _allowances = allowances;
+        _redemptions = redemptions;
     }
 
     public async Task<SubscriptionOperationResult<SubscriptionResponse>> CancelAsync(
@@ -469,6 +472,24 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                     subscription.TenantId, subscription.ItemId, reservation.PeriodKey,
                     reservation.CloseOperationId, cancellationToken);
             }
+        }
+
+        // subscription.Status here is the status this call was asked to move it away from,
+        // captured before the transition above -- Incomplete means it never activated. A
+        // subscription cancelled after activating keeps its campaign redeemed; TryReleaseAsync's
+        // own guard against an already-Redeemed row is defence in depth on top of that check, not
+        // the only thing preventing it.
+        if (applied &&
+            _redemptions is not null &&
+            subscription.Status == SubscriptionStatus.Incomplete &&
+            subscription.Discount is { Campaign.Kind: not CampaignKind.Standard } discount)
+        {
+            await _redemptions.TryReleaseAsync(
+                subscription.TenantId,
+                discount.DiscountId!,
+                subscription.ItemId,
+                now,
+                cancellationToken);
         }
 
         return applied;

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -37,7 +37,8 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         ILogger<SubscriptionCreationService> logger,
         TimeProvider? time = null,
         ISubscriptionWorkScheduler? scheduler = null,
-        ISubscriptionBillingProfileGuard? billingProfile = null)
+        ISubscriptionBillingProfileGuard? billingProfile = null,
+        ICampaignRedemptionRepository? redemptions = null)
     {
         _catalogue = catalogue;
         _subscriptions = subscriptions;
@@ -47,8 +48,20 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         _logger = logger;
         _scheduler = scheduler;
         _billingProfile = billingProfile;
+        _redemptions = redemptions;
         _time = time ?? TimeProvider.System;
     }
+
+    /// <summary>
+    /// Optional the way <see cref="_scheduler"/> and <see cref="_billingProfile"/> are: a great
+    /// many existing tests construct this service without one, and a subscription request that
+    /// names no campaign discount never touches it. Absent, a campaign discount code is refused
+    /// with <c>subscription_discount_reservation_conflict</c> rather than granted without ever
+    /// having reserved it — the same fail-closed choice <see cref="_billingProfile"/>'s own doc
+    /// comment makes for the opposite direction (absent there means the requirement is simply not
+    /// enforced, which is safe only because nothing there can be redeemed twice).
+    /// </summary>
+    private readonly ICampaignRedemptionRepository? _redemptions;
 
     /// <summary>
     /// Whether there is anybody to address this organization's invoices to.
@@ -127,11 +140,38 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         if (!await _subscriptions.TryCreateAsync(subscription, cancellationToken))
         {
+            // A campaign discount turns this ordinary conflict into a possible crash-window
+            // retry: a prior attempt for this organization may already have persisted its own
+            // subscription and died before finishing that subscription's own reservation. Rather
+            // than reporting a hard conflict on every retry of a genuinely half-finished attempt,
+            // recognise it and complete the missing reservation on the subscription that already
+            // exists.
+            if (subscription.Discount is { Campaign.Kind: not CampaignKind.Standard })
+            {
+                var recovered = await TryRecoverIncompleteReservationAsync(
+                    context, subscription.Discount, correlationId, cancellationToken);
+                if (recovered is not null)
+                {
+                    return recovered;
+                }
+            }
+
             return Failure(
                 PaymentFailureKind.Conflict,
                 "subscription_already_active",
                 "This organization already has a live subscription.",
                 correlationId);
+        }
+
+        if (subscription.Discount is { Campaign.Kind: not CampaignKind.Standard } campaignDiscount)
+        {
+            var reserved = await ReserveCampaignAsync(
+                context, subscription, campaignDiscount, correlationId, cancellationToken);
+
+            if (!reserved.IsSuccess)
+            {
+                return reserved;
+            }
         }
 
         _logger.LogInformation(
@@ -481,6 +521,30 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 "The discount code has expired.",
                 correlationId);
 
+        // The legacy expiry above and this window are deliberately separate checks rather than
+        // one merged rule: ExpiresAtUtc governs a discount with no campaign at all, and reading a
+        // Standard discount's absent RedeemableFromUtc/UntilUtc as "always redeemable" is exactly
+        // right for it. A campaign's own window only exists once Kind is not Standard, so this
+        // check has nothing to do for every discount created before campaigns did.
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (discount.Campaign.Kind != CampaignKind.Standard)
+        {
+            if (discount.Campaign.RedeemableFromUtc is { } from && now < from)
+                return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_discount_not_started",
+                    "This campaign has not started yet.",
+                    correlationId);
+
+            if (discount.Campaign.RedeemableUntilUtc is { } until && now >= until)
+                return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                    PaymentFailureKind.Validation,
+                    "subscription_discount_expired",
+                    "This campaign has ended.",
+                    correlationId);
+        }
+
         // One rule, shared with the plan-change path, so a restriction cannot be enforced at signup
         // and forgotten the first time the subscriber moves.
         if (!SubscriptionDiscountApplicability.Permits(discount, plan.Code, price.ItemId))
@@ -511,10 +575,156 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 // Copied so the restriction outlives the redemption. A plan change re-asks the same
                 // question, and it can only do so against terms that remember the answer.
                 ApplicablePlanCodes = [.. discount.ApplicablePlanCodes],
-                ApplicablePriceIds = [.. discount.ApplicablePriceIds]
+                ApplicablePriceIds = [.. discount.ApplicablePriceIds],
+                // The catalogue entry's identity and version, and the campaign rules accepted at
+                // this exact instant -- never re-read from the catalogue later. A later edit or
+                // archival of discount.ItemId must not reach into this subscription: the redemption
+                // ledger keys off DiscountId and CampaignVersion below to make sure it never does.
+                DiscountId = discount.ItemId,
+                DiscountVersion = discount.Version,
+                // When this discount was accepted into this subscription's terms -- signup, for
+                // every discount alike. Distinct from CampaignRedemption's own Reserved/Redeemed
+                // timestamps below, which track the ledger's authoritative state and can move
+                // later than this: a campaign is Reserved now and Redeemed only at activation.
+                RedeemedAtUtc = now,
+                Campaign = discount.Campaign
             },
             correlationId);
     }
+
+    /// <summary>
+    /// Claims a just-persisted subscription's campaign, or undoes the subscription if it cannot.
+    /// </summary>
+    /// <remarks>
+    /// Ordered deliberately after <see cref="ISubscriptionRepository.TryCreateAsync"/> rather than
+    /// before it. Reserving first, against an id nothing has verified will ever become a real
+    /// subscription, would leave an orphaned reservation blocking every future attempt for this
+    /// organization and discount if the process died between the two -- with no persisted
+    /// subscription left to trace it back to. Reserving after leaves the opposite, narrower
+    /// failure instead: a subscription that exists but holds no reservation, which
+    /// <see cref="TryRecoverIncompleteReservationAsync"/> is written to find and finish.
+    /// <para>
+    /// This subscription cannot be deleted -- nothing in this codebase deletes a subscription
+    /// record, by design, the same reason nothing deletes a financial document. A reservation
+    /// that is refused is compensated instead by expiring this one immediately, which is what
+    /// frees <see cref="SubscriptionIndexDefinitions.SubscriptionReservationIndexName"/>'s
+    /// per-organization slot for a genuine next attempt.
+    /// </para>
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<SubscriptionDetail>> ReserveCampaignAsync(
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        DiscountTerms discount,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (_redemptions is null)
+        {
+            // Fail closed: granting a campaign discount with nothing actually enforcing its
+            // one-use rule is worse than refusing it. Every existing caller that does not name a
+            // campaign discount never reaches here.
+            await ExpireUnreservableAsync(subscription, cancellationToken);
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_discount_reservation_conflict",
+                "This discount could not be reserved.",
+                correlationId);
+        }
+
+        var outcome = await _redemptions.TryReserveAsync(
+            new CampaignRedemption
+            {
+                TenantId = context.TenantId,
+                OrganizationId = context.OrganizationId,
+                DiscountId = discount.DiscountId!,
+                CampaignVersion = discount.DiscountVersion,
+                SubscriptionId = subscription.ItemId,
+                OneUsePerOrganization = discount.Campaign.OneUsePerOrganization,
+                ReservedAtUtc = _time.GetUtcNow().UtcDateTime
+            },
+            cancellationToken);
+
+        if (outcome != CampaignReservationOutcome.HeldByAnotherSubscription)
+        {
+            return SubscriptionOperationResult<SubscriptionDetail>.Success(subscription, correlationId);
+        }
+
+        await ExpireUnreservableAsync(subscription, cancellationToken);
+
+        return Failure(
+            PaymentFailureKind.Conflict,
+            "subscription_discount_already_redeemed",
+            "This organization has already redeemed this campaign.",
+            correlationId);
+    }
+
+    /// <summary>
+    /// Recovers from the one crash window <see cref="ReserveCampaignAsync"/>'s ordering leaves
+    /// open: a prior attempt for this organization persisted its subscription and then died
+    /// before reserving its campaign. The organization-level unique index reports that as an
+    /// ordinary <c>subscription_already_active</c> conflict, indistinguishable from a genuine
+    /// second signup attempt, unless this looks specifically for the half-finished shape and
+    /// finishes it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately narrow: this only recognises the existing incomplete subscription as the same
+    /// logical attempt when it names the very same discount code. A different code is a genuinely
+    /// different signup this organization is not permitted to start while the first is still
+    /// live, and reporting the ordinary conflict for that case is correct, not a gap.
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<SubscriptionDetail>?> TryRecoverIncompleteReservationAsync(
+        SubscriptionContext context,
+        DiscountTerms attemptedDiscount,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (_redemptions is null)
+        {
+            return null;
+        }
+
+        var existing = await _subscriptions.GetIncompleteAsync(
+            context.TenantId, context.OrganizationId, cancellationToken);
+
+        if (existing?.Discount is not { } existingDiscount ||
+            !string.Equals(existingDiscount.DiscountId, attemptedDiscount.DiscountId, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var outcome = await _redemptions.TryReserveAsync(
+            new CampaignRedemption
+            {
+                TenantId = context.TenantId,
+                OrganizationId = context.OrganizationId,
+                DiscountId = existingDiscount.DiscountId!,
+                CampaignVersion = existingDiscount.DiscountVersion,
+                SubscriptionId = existing.ItemId,
+                OneUsePerOrganization = existingDiscount.Campaign.OneUsePerOrganization,
+                ReservedAtUtc = _time.GetUtcNow().UtcDateTime
+            },
+            cancellationToken);
+
+        return outcome == CampaignReservationOutcome.HeldByAnotherSubscription
+            ? Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_discount_already_redeemed",
+                "This organization has already redeemed this campaign.",
+                correlationId)
+            : SubscriptionOperationResult<SubscriptionDetail>.Success(existing, correlationId);
+    }
+
+    private async Task ExpireUnreservableAsync(
+        SubscriptionDetail subscription, CancellationToken cancellationToken) =>
+        await _subscriptions.TryTransitionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            new SubscriptionTransition(SubscriptionStatus.Incomplete, SubscriptionStatus.IncompleteExpired)
+            {
+                EndedAtUtc = _time.GetUtcNow().UtcDateTime,
+                ClearNextFeeBillingAt = true
+            },
+            cancellationToken);
 
     /// <summary>
     /// What reduced this subscription's charge, and where each reduction came from.

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -82,6 +82,9 @@ public static class ApplicationServiceCollectionExtensions
             SubscriptionInvoiceHistoryRepository>();
         services.AddSingleton<ISubscriptionDiscountRepository, SubscriptionDiscountRepository>();
         services.AddSingleton<
+            ICampaignRedemptionRepository,
+            CampaignRedemptionRepository>();
+        services.AddSingleton<
             ISubscriptionBillingProfileRepository,
             SubscriptionBillingProfileRepository>();
         services.AddSingleton<

--- a/server/XUnitTest/Integration/CampaignRedemptionConcurrencyTests.cs
+++ b/server/XUnitTest/Integration/CampaignRedemptionConcurrencyTests.cs
@@ -1,0 +1,216 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// The guarantee this whole feature's "one use per organization" claim rests on, proven against a
+/// real MongoDB rather than argued about in a code comment.
+/// </summary>
+/// <remarks>
+/// <see cref="CampaignRedemptionRepository"/> is deliberately not tested with a mock anywhere in
+/// this suite. A mock answers whatever it is told to, and the entire risk in this class is
+/// exactly the part a mock cannot represent: what two callers racing for the same document
+/// actually see from the database's own atomicity, not from an assumption about how a method
+/// happens to be sequenced.
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class CampaignRedemptionConcurrencyTests
+{
+    private readonly MongoIntegrationFixture _fixture;
+
+    public CampaignRedemptionConcurrencyTests(MongoIntegrationFixture fixture) => _fixture = fixture;
+
+    private ICampaignRedemptionRepository Repository() => new CampaignRedemptionRepository(_fixture.DbContextProvider);
+
+    [Fact]
+    public async Task Two_different_subscriptions_racing_for_a_one_use_campaign_converge_on_exactly_one_winner()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+        var organizationId = "org-race";
+
+        // Twenty concurrent attempts, all for the same one-use slot, from twenty different
+        // subscriptions. Genuine concurrency, not a sequence of awaits that merely looks
+        // concurrent: every task starts before any of them is awaited.
+        var attempts = Enumerable.Range(0, 20)
+            .Select(_ => Guid.NewGuid().ToString())
+            .Select(subscriptionId => repository.TryReserveAsync(
+                Reservation(tenantId, organizationId, discountId, subscriptionId, oneUse: true),
+                CancellationToken.None))
+            .ToArray();
+
+        var outcomes = await Task.WhenAll(attempts);
+
+        outcomes.Count(outcome => outcome == CampaignReservationOutcome.Reserved).Should().Be(1);
+        outcomes.Count(outcome => outcome == CampaignReservationOutcome.HeldByAnotherSubscription)
+            .Should().Be(19);
+    }
+
+    [Fact]
+    public async Task Retrying_the_same_subscription_against_the_same_campaign_always_succeeds()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+        var organizationId = "org-retry";
+        var subscriptionId = Guid.NewGuid().ToString();
+
+        var first = await repository.TryReserveAsync(
+            Reservation(tenantId, organizationId, discountId, subscriptionId, oneUse: true),
+            CancellationToken.None);
+
+        // Fifty retries of the exact same subscription, concurrently -- the shape a network-level
+        // retry storm against one slow request actually takes, not fifty neat sequential calls.
+        // High count deliberately: this is the exact window a naive "check then insert" gets
+        // wrong -- two concurrent attempts for the very same subscription can both pass the
+        // existence check before either one's insert lands, and the loser must recognise the
+        // winner as itself rather than as a stranger. A count of ten did not reproduce that
+        // window on this machine; fifty reliably does.
+        var retries = await Task.WhenAll(Enumerable.Range(0, 50).Select(_ =>
+            repository.TryReserveAsync(
+                Reservation(tenantId, organizationId, discountId, subscriptionId, oneUse: true),
+                CancellationToken.None)));
+
+        first.Should().Be(CampaignReservationOutcome.Reserved);
+        retries.Should().OnlyContain(outcome =>
+            outcome == CampaignReservationOutcome.Reserved ||
+            outcome == CampaignReservationOutcome.AlreadyReservedBySameSubscription);
+
+        var stored = await repository.FindAsync(tenantId, discountId, subscriptionId, CancellationToken.None);
+        stored.Should().NotBeNull();
+        stored!.State.Should().Be(CampaignRedemptionState.Reserved);
+    }
+
+    [Fact]
+    public async Task A_non_one_use_campaign_lets_every_subscription_reserve_its_own_row()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+        var organizationId = "org-shared";
+
+        var outcomes = await Task.WhenAll(Enumerable.Range(0, 10)
+            .Select(_ => Guid.NewGuid().ToString())
+            .Select(subscriptionId => repository.TryReserveAsync(
+                Reservation(tenantId, organizationId, discountId, subscriptionId, oneUse: false),
+                CancellationToken.None)));
+
+        outcomes.Should().OnlyContain(outcome => outcome == CampaignReservationOutcome.Reserved);
+    }
+
+    [Fact]
+    public async Task A_released_slot_can_be_reclaimed_by_a_different_subscription()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+        var organizationId = "org-reclaim";
+        var abandoned = Guid.NewGuid().ToString();
+        var reclaimer = Guid.NewGuid().ToString();
+
+        await repository.TryReserveAsync(
+            Reservation(tenantId, organizationId, discountId, abandoned, oneUse: true),
+            CancellationToken.None);
+
+        // The abandoned subscription never activates -- IncompleteExpired -- and its slot is
+        // given back.
+        await repository.TryReleaseAsync(
+            tenantId, discountId, abandoned, DateTime.UtcNow, CancellationToken.None);
+
+        var reclaim = await repository.TryReserveAsync(
+            Reservation(tenantId, organizationId, discountId, reclaimer, oneUse: true),
+            CancellationToken.None);
+
+        reclaim.Should().Be(CampaignReservationOutcome.Reserved);
+
+        var abandonedRow = await repository.FindAsync(
+            tenantId, discountId, abandoned, CancellationToken.None);
+        abandonedRow!.State.Should().Be(CampaignRedemptionState.Released);
+    }
+
+    [Fact]
+    public async Task Redeeming_is_idempotent_against_a_repeated_activation_event()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+        var subscriptionId = Guid.NewGuid().ToString();
+
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-redeem", discountId, subscriptionId, oneUse: true),
+            CancellationToken.None);
+
+        var firstRedeemedAt = DateTime.UtcNow;
+        await repository.TryMarkRedeemedAsync(
+            tenantId, discountId, subscriptionId, firstRedeemedAt, CancellationToken.None);
+
+        // A duplicate delivery of the same activation event, the way a payment webhook can arrive
+        // twice. Must not move the timestamp or throw the second time.
+        await repository.TryMarkRedeemedAsync(
+            tenantId, discountId, subscriptionId, DateTime.UtcNow.AddMinutes(5), CancellationToken.None);
+
+        var stored = await repository.FindAsync(tenantId, discountId, subscriptionId, CancellationToken.None);
+        stored!.State.Should().Be(CampaignRedemptionState.Redeemed);
+        stored.RedeemedAtUtc.Should().BeCloseTo(firstRedeemedAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task A_redeemed_reservation_is_never_released_by_a_later_cancellation()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+        var subscriptionId = Guid.NewGuid().ToString();
+
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-post-activation", discountId, subscriptionId, oneUse: true),
+            CancellationToken.None);
+        await repository.TryMarkRedeemedAsync(
+            tenantId, discountId, subscriptionId, DateTime.UtcNow, CancellationToken.None);
+
+        // A subscription that activated and was later cancelled must keep its campaign redeemed --
+        // this is the call site a cancellation-after-activation would make, and it must be a no-op.
+        await repository.TryReleaseAsync(
+            tenantId, discountId, subscriptionId, DateTime.UtcNow, CancellationToken.None);
+
+        var stored = await repository.FindAsync(tenantId, discountId, subscriptionId, CancellationToken.None);
+        stored!.State.Should().Be(CampaignRedemptionState.Redeemed);
+    }
+
+    [Fact]
+    public async Task Releasing_is_idempotent_against_a_repeated_call()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+        var subscriptionId = Guid.NewGuid().ToString();
+
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-double-release", discountId, subscriptionId, oneUse: true),
+            CancellationToken.None);
+
+        await repository.TryReleaseAsync(
+            tenantId, discountId, subscriptionId, DateTime.UtcNow, CancellationToken.None);
+        await repository.TryReleaseAsync(
+            tenantId, discountId, subscriptionId, DateTime.UtcNow, CancellationToken.None);
+
+        var stored = await repository.FindAsync(tenantId, discountId, subscriptionId, CancellationToken.None);
+        stored!.State.Should().Be(CampaignRedemptionState.Released);
+    }
+
+    private static CampaignRedemption Reservation(
+        string tenantId, string organizationId, string discountId, string subscriptionId, bool oneUse) => new()
+    {
+        TenantId = tenantId,
+        OrganizationId = organizationId,
+        DiscountId = discountId,
+        SubscriptionId = subscriptionId,
+        OneUsePerOrganization = oneUse,
+        CampaignVersion = 1,
+        ReservedAtUtc = DateTime.UtcNow
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorCampaignTests.cs
@@ -1,0 +1,233 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Repositories;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Redeeming a campaign at activation, and releasing it if activation never happens.
+/// </summary>
+public sealed class SubscriptionActivationProcessorCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+    private readonly Mock<IPaymentRepository> _payments = new();
+    private readonly Mock<IStoredPaymentMethodRepository> _storedMethods = new();
+    private readonly Mock<ICampaignRedemptionRepository> _redemptions = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail _subscription = NewSubscription(campaign: true);
+
+    public SubscriptionActivationProcessorCampaignTests()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _links
+            .Setup(repository => repository.TrySettleAsync(
+                TenantId, "link-1", It.IsAny<SubscriptionPaymentLinkState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _links
+            .Setup(repository => repository.ListDueAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new SubscriptionPaymentLink
+                {
+                    ItemId = "link-1", TenantId = TenantId, OrganizationId = OrganizationId,
+                    SubscriptionId = "sub-1", PaymentDetailId = "pay-1",
+                    Purpose = SubscriptionPaymentPurpose.InitialCharge, CorrelationId = "corr-1"
+                }
+            ]);
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "pay-1", TenantId = TenantId, PaymentStatus = PaymentStatuses.Captured,
+                WebhookConfirmedAtUtc = DateTime.UtcNow, OrganizationId = "default"
+            });
+    }
+
+    [Fact]
+    public async Task Activation_marks_a_campaign_discount_redeemed()
+    {
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                TenantId, "discount-1", "sub-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_standard_discount_never_touches_the_redemption_repository_on_activation()
+    {
+        _subscription = NewSubscription(campaign: false);
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task No_subscription_at_all_never_touches_the_redemption_repository()
+    {
+        _subscription = NewSubscription(campaign: false);
+        _subscription.CurrencyCode = "CHF"; // untouched, just avoiding an unused-variable warning
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false); // "another worker got there first"
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Expiry_of_an_unactivated_campaign_subscription_releases_it()
+    {
+        _subscription = NewSubscription(campaign: true);
+
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "pay-1", TenantId = TenantId, PaymentStatus = PaymentStatuses.Refused,
+                WebhookConfirmedAtUtc = DateTime.UtcNow, OrganizationId = "default"
+            });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                TenantId, "discount-1", "sub-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_standard_discount_never_touches_the_redemption_repository_on_expiry()
+    {
+        _subscription = NewSubscription(campaign: false);
+
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "pay-1", TenantId = TenantId, PaymentStatus = PaymentStatuses.Refused,
+                WebhookConfirmedAtUtc = DateTime.UtcNow, OrganizationId = "default"
+            });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Expiry_never_releases_when_the_expire_transition_itself_did_not_apply()
+    {
+        // "Another worker got there first" for the expiry transition too -- releasing here would
+        // be racing whatever that other worker is doing with the same reservation.
+        _subscription = NewSubscription(campaign: true);
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _payments
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, "pay-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PaymentDetail
+            {
+                ItemId = "pay-1", TenantId = TenantId, PaymentStatus = PaymentStatuses.Refused,
+                WebhookConfirmedAtUtc = DateTime.UtcNow, OrganizationId = "default"
+            });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private SubscriptionActivationProcessor Processor() => new(
+        _links.Object,
+        _subscriptions.Object,
+        _accounts.Object,
+        new SubscriptionOutboxEventFactory(),
+        _payments.Object,
+        _storedMethods.Object,
+        new SubscriptionOptionsMonitorStub(new SubscriptionOptions()),
+        NullLogger<SubscriptionActivationProcessor>.Instance,
+        _time,
+        redemptions: _redemptions.Object);
+
+    private static SubscriptionDetail NewSubscription(bool campaign) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Incomplete,
+        CurrencyCode = "CHF",
+        OrderId = "sub:sub-1",
+        CorrelationId = "corr-1",
+        Plan = new PlanSnapshot { Code = "professional" },
+        Discount = campaign
+            ? new DiscountTerms
+            {
+                Code = "free1",
+                DiscountId = "discount-1",
+                DiscountVersion = 1,
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FreeOpeningCalendarPeriod,
+                    OneUsePerOrganization = true
+                }
+            }
+            : new DiscountTerms { Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2500 }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceCampaignTests.cs
@@ -1,0 +1,156 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Releasing a campaign when the subscription it was reserved for never activated, and never
+/// releasing one that did.
+/// </summary>
+public sealed class SubscriptionCancellationServiceCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionPaymentLinkRepository> _links = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private readonly Mock<ICampaignRedemptionRepository> _redemptions = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail? _subscription;
+
+    public SubscriptionCancellationServiceCampaignTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetAsync(
+                TenantId, OrganizationId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
+    [Fact]
+    public async Task Cancelling_an_incomplete_campaign_subscription_releases_it()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Incomplete, campaign: true);
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                TenantId, "discount-1", "sub-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Cancelling_an_active_campaign_subscription_never_releases_it()
+    {
+        // The subscription already activated -- its campaign is permanently redeemed, and a later
+        // cancellation, immediate or not, must not give the slot back to a different organization.
+        _subscription = NewSubscription(SubscriptionStatus.Active, campaign: true);
+        _subscription.PendingAnnualPeriod = null;
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: true, null, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Cancelling_an_incomplete_standard_discount_subscription_never_touches_the_ledger()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Incomplete, campaign: false);
+
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_cancellation_that_scheduled_for_period_end_rather_than_ending_now_never_releases()
+    {
+        // Scheduling a future cancellation on an Active subscription does not go through
+        // EndNowAsync at all -- confirmed here so nobody assumes a release runs on that path too.
+        _subscription = NewSubscription(SubscriptionStatus.Active, campaign: true);
+        _subscription.PendingAnnualPeriod = null;
+
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private SubscriptionCancellationService Service() => new(
+        _subscriptions.Object,
+        _links.Object,
+        _contextResolver.Object,
+        new SubscriptionOutboxEventFactory(),
+        new SubscriptionResponseMapper(),
+        _cache.Object,
+        NullLogger<SubscriptionCancellationService>.Instance,
+        _time,
+        redemptions: _redemptions.Object);
+
+    private static SubscriptionDetail NewSubscription(SubscriptionStatus status, bool campaign) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = status,
+        CurrencyCode = "CHF",
+        CurrentPeriodEndUtc = new DateTime(2026, 8, 31, 21, 59, 59, DateTimeKind.Utc),
+        NextFeeBillingAtUtc = new DateTime(2026, 8, 31, 21, 59, 59, DateTimeKind.Utc),
+        Plan = new PlanSnapshot { Code = "professional" },
+        Price = new PriceSnapshot { CurrencyCode = "CHF", UnitAmountMinor = 8900 },
+        Discount = campaign
+            ? new DiscountTerms
+            {
+                Code = "free1",
+                DiscountId = "discount-1",
+                DiscountVersion = 1,
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FreeOpeningCalendarPeriod,
+                    OneUsePerOrganization = true
+                }
+            }
+            : new DiscountTerms { Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2500 }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceCampaignTests.cs
@@ -1,0 +1,412 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Reserving a campaign at signup: the ordering that makes a crash recoverable, and the retry
+/// that has to land on the same reservation rather than a second one.
+/// </summary>
+/// <remarks>
+/// <see cref="CampaignRedemptionRepository"/>'s own concurrency guarantees are proven against a
+/// real MongoDB in <c>CampaignRedemptionConcurrencyTests</c>, not here. This suite is entirely
+/// about a different question a mock answers perfectly well: given a particular reservation
+/// outcome, does this service make the right call afterwards -- does it persist the subscription
+/// at all, does it undo the one it already persisted, does it recognise its own earlier attempt.
+/// </remarks>
+public sealed class SubscriptionCreationServiceCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<ICampaignRedemptionRepository> _redemptions = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+    private readonly Mock<ISubscriptionBillingProfileGuard> _billingProfile = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail? _created;
+    private CampaignRedemption? _reservationAttempted;
+
+    public SubscriptionCreationServiceCampaignTests()
+    {
+        _billingProfile
+            .Setup(guard => guard.MissingFieldsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _billingProfile
+            .Setup(guard => guard.ContactDefaultsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingContactDefaults("Ada Byron", "billing@northwind.example"));
+
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "professional", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPlan());
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice());
+
+        _accounts
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionDetail, CancellationToken>(
+                (subscription, _) => _created = subscription)
+            .ReturnsAsync(true);
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "free1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CampaignDiscount());
+
+        _redemptions
+            .Setup(repository => repository.TryReserveAsync(
+                It.IsAny<CampaignRedemption>(), It.IsAny<CancellationToken>()))
+            .Callback<CampaignRedemption, CancellationToken>(
+                (reservation, _) => _reservationAttempted = reservation)
+            .ReturnsAsync(CampaignReservationOutcome.Reserved);
+    }
+
+    [Fact]
+    public async Task A_campaign_discount_is_reserved_only_after_the_subscription_is_persisted()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "free1";
+
+        var callOrder = new List<string>();
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionDetail, CancellationToken>((subscription, _) =>
+            {
+                callOrder.Add("persist");
+                _created = subscription;
+            })
+            .ReturnsAsync(true);
+        _redemptions
+            .Setup(repository => repository.TryReserveAsync(
+                It.IsAny<CampaignRedemption>(), It.IsAny<CancellationToken>()))
+            .Callback<CampaignRedemption, CancellationToken>((reservation, _) =>
+            {
+                callOrder.Add("reserve");
+                _reservationAttempted = reservation;
+            })
+            .ReturnsAsync(CampaignReservationOutcome.Reserved);
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // Reserving before persisting would leave an orphaned reservation with no subscription to
+        // trace it back to if the process died in between -- exactly the crash window this
+        // ordering exists to avoid.
+        callOrder.Should().Equal("persist", "reserve");
+        _reservationAttempted!.SubscriptionId.Should().Be(_created!.ItemId);
+        _reservationAttempted.DiscountId.Should().Be(_created.Discount!.DiscountId);
+    }
+
+    [Fact]
+    public async Task A_reservation_refused_by_a_different_subscription_expires_the_one_just_created()
+    {
+        _redemptions
+            .Setup(repository => repository.TryReserveAsync(
+                It.IsAny<CampaignRedemption>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CampaignReservationOutcome.HeldByAnotherSubscription);
+
+        SubscriptionTransition? transition = null;
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, SubscriptionTransition, CancellationToken>(
+                (_, _, given, _) => transition = given)
+            .ReturnsAsync(true);
+
+        var request = NewRequest();
+        request.DiscountCode = "free1";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_already_redeemed");
+
+        // Nothing here deletes a subscription record; the only recovery available is to move the
+        // one just created straight to a terminal state, which is also what frees this
+        // organization's reservation slot for a genuine next attempt.
+        transition.Should().NotBeNull();
+        transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Incomplete);
+        transition.NewStatus.Should().Be(SubscriptionStatus.IncompleteExpired);
+    }
+
+    [Fact]
+    public async Task A_retry_after_a_crash_between_persisting_and_reserving_completes_the_existing_reservation()
+    {
+        // The exact shape of the crash window: a prior attempt's subscription is already
+        // Incomplete and already carries this same discount's terms, but nothing ever reserved it.
+        var stranded = NewSubscription();
+
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stranded);
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false); // the organization-level unique index refuses a second Incomplete
+
+        var request = NewRequest();
+        request.DiscountCode = "free1";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        // The reservation is completed against the STRANDED subscription's own id, not a new one
+        // -- there is no second subscription to reserve for.
+        _reservationAttempted!.SubscriptionId.Should().Be(stranded.ItemId);
+        result.Value!.ItemId.Should().Be(stranded.ItemId);
+    }
+
+    [Fact]
+    public async Task A_retry_for_a_genuinely_different_discount_is_not_treated_as_a_recoverable_crash()
+    {
+        var strandedForADifferentCode = NewSubscription();
+        strandedForADifferentCode.Discount = new DiscountTerms
+        {
+            Code = "other", DiscountId = "discount-other", Campaign = new CampaignTerms()
+        };
+
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(strandedForADifferentCode);
+        _subscriptions
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var request = NewRequest();
+        request.DiscountCode = "free1";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_already_active");
+        _redemptions.Verify(
+            repository => repository.TryReserveAsync(
+                It.IsAny<CampaignRedemption>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_standard_discount_never_touches_the_redemption_repository()
+    {
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "launch25", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms
+                {
+                    Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2500
+                }
+            });
+
+        var request = NewRequest();
+        request.DiscountCode = "launch25";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _redemptions.Verify(
+            repository => repository.TryReserveAsync(
+                It.IsAny<CampaignRedemption>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task With_no_redemption_repository_wired_a_campaign_discount_is_refused_rather_than_granted()
+    {
+        // Fail closed: the same choice the constructor's own doc comment makes. Nothing here
+        // silently grants a one-use campaign with no mechanism actually enforcing one-use.
+        var service = new SubscriptionCreationService(
+            _catalogue.Object,
+            _subscriptions.Object,
+            _discounts.Object,
+            _accounts.Object,
+            new CreateSubscriptionRequestValidator(),
+            NullLogger<SubscriptionCreationService>.Instance,
+            _time,
+            billingProfile: _billingProfile.Object);
+
+        var request = NewRequest();
+        request.DiscountCode = "free1";
+
+        var result = await service.CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_reservation_conflict");
+    }
+
+    [Fact]
+    public async Task A_campaign_not_yet_started_is_refused_before_ever_reaching_the_ledger()
+    {
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "notyet", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms { Code = "notyet", Kind = DiscountKind.Percent, PercentBasisPoints = 10_000 },
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FreeOpeningCalendarPeriod,
+                    RedeemableFromUtc = _time.GetUtcNow().UtcDateTime.AddDays(1),
+                    RedeemableUntilUtc = _time.GetUtcNow().UtcDateTime.AddDays(30)
+                }
+            });
+
+        var request = NewRequest();
+        request.DiscountCode = "notyet";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_not_started");
+        _redemptions.Verify(
+            repository => repository.TryReserveAsync(
+                It.IsAny<CampaignRedemption>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_campaign_past_its_window_is_refused_as_expired()
+    {
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "over", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms { Code = "over", Kind = DiscountKind.Percent, PercentBasisPoints = 10_000 },
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FreeOpeningCalendarPeriod,
+                    RedeemableFromUtc = _time.GetUtcNow().UtcDateTime.AddDays(-30),
+                    RedeemableUntilUtc = _time.GetUtcNow().UtcDateTime.AddDays(-1)
+                }
+            });
+
+        var request = NewRequest();
+        request.DiscountCode = "over";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_expired");
+    }
+
+    private SubscriptionCreationService Service() => new(
+        _catalogue.Object,
+        _subscriptions.Object,
+        _discounts.Object,
+        _accounts.Object,
+        new CreateSubscriptionRequestValidator(),
+        NullLogger<SubscriptionCreationService>.Instance,
+        _time,
+        billingProfile: _billingProfile.Object,
+        redemptions: _redemptions.Object);
+
+    private static SubscriptionContext Context() =>
+        new(TenantId, OrganizationId, "actor-1", "user-1");
+
+    private static CreateSubscriptionRequest NewRequest() => new()
+    {
+        PlanCode = "professional",
+        PriceId = "price-1",
+        TimeZoneId = "Europe/Zurich",
+        Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 12 }]
+    };
+
+    private static Discount CampaignDiscount() => new()
+    {
+        ItemId = "discount-free1",
+        Version = 1,
+        Terms = new DiscountTerms { Code = "free1", Kind = DiscountKind.Percent, PercentBasisPoints = 10_000 },
+        Campaign = new CampaignTerms
+        {
+            Kind = CampaignKind.FreeOpeningCalendarPeriod,
+            OneUsePerOrganization = true,
+            RedeemableFromUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            RedeemableUntilUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        }
+    };
+
+    private static CampaignTerms CampaignTerms() => new()
+    {
+        Kind = CampaignKind.FreeOpeningCalendarPeriod,
+        OneUsePerOrganization = true
+    };
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "subscription-stranded",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Incomplete,
+        Discount = new DiscountTerms
+        {
+            Code = "free1", DiscountId = "discount-free1", DiscountVersion = 1,
+            Campaign = CampaignTerms()
+        }
+    };
+
+    private static Plan NewPlan() => new()
+    {
+        ItemId = "plan-1",
+        TenantId = TenantId,
+        Code = "professional",
+        DisplayName = "Professional",
+        Status = CatalogueStatus.Active,
+        Version = 3,
+        QuantityItems =
+        [
+            new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat", DefaultQuantity = 1 }
+        ]
+    };
+
+    private static Price NewPrice() => new()
+    {
+        ItemId = "price-1",
+        TenantId = TenantId,
+        PlanId = "plan-1",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 8900,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        QuantityItemKey = "seat",
+        Status = CatalogueStatus.Active
+    };
+}


### PR DESCRIPTION
**Phase 2 of 5.** Stacked on [#349](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/349) (Phase 1) — this PR's base branch is `feat/campaign-discounts-data-model`, not `dev`, because every type here (`Discount.Campaign`, `DiscountTerms.DiscountId`/`Campaign`) was added there and does not exist on `dev` yet.

**Merge order: #349 first. Once it lands, retarget this PR to `dev` (or merge it into #349's branch and let that carry both) — the diff shown here will shrink to only Phase 2's own changes once GitHub sees #349 is in.**

## What this adds

`CampaignRedemption`, a new collection: one durable row per subscription's claim on a campaign — `Reserved` / `Redeemed` / `ReleasePending` / `Released`. One-use enforcement is a **partial unique index** on `(TenantId, OrganizationId, DiscountId)`, scoped to rows that are `OneUsePerOrganization` and not yet `Released` — confirmed against a real MongoDB, not assumed, because this index is the entire correctness argument for "one use per organization."

`TryReserveAsync` is a plain insert with a pre-check for a subscription's own retry, and a duplicate-key catch that re-reads to tell "a stranger holds this" from "my own concurrent attempt raced itself" apart. `TryMarkRedeemedAsync`/`TryReleaseAsync` are idempotent no-ops against a state that already moved on.

Wired into the lifecycle at three points, each guarded by the transition it rides on:

- **`SubscriptionCreationService.CreateAsync`** reserves *after* persisting, not before — reserving first would leave an orphaned reservation with no subscription to trace back to on a crash. Reserving after leaves the narrower, recoverable failure of a subscription that exists but holds no reservation, and `TryRecoverIncompleteReservationAsync` finds and finishes exactly that shape on a retry.
- **`SubscriptionActivationProcessor`** marks a campaign `Redeemed` right after its activation transition commits, and releases one on `IncompleteExpired` (which by construction never activated).
- **`SubscriptionCancellationService`** releases a campaign only when the subscription being cancelled was still `Incomplete` before the call — a cancellation after activation leaves an already-`Redeemed` campaign alone.

New failure codes: `subscription_discount_not_started`, `subscription_discount_already_redeemed`, `subscription_discount_reservation_conflict` (also the fail-closed answer when no `ICampaignRedemptionRepository` is wired in — granting a one-use campaign with nothing enforcing one-use is worse than refusing it).

## A design bug a concurrency test caught before it shipped

The first index attempt filtered only on `OneUsePerOrganization`, not on `State`. A released slot still counted toward the unique constraint, so reclaiming it for a different subscription had nowhere to insert a second document — and instead overwrote the abandoned subscription's own row, silently erasing which subscription had actually held the campaign. Fixed by excluding `Released` from the partial filter.

That fix then required expressing "not `Released`" as `State < Released` rather than `!= Released`: **MongoDB's `partialFilterExpression` supports only equality and ordered comparisons, never `$ne` or `$in`** — surfaced only by running index creation against a real server, not from reading documentation. `CampaignRedemptionState.Released` is now pinned as the enum's highest ordinal for exactly this reason, documented on both the enum and the index.

## Verification

**Real MongoDB (a local container, not a mock)** via `CampaignRedemptionConcurrencyTests`:
- 20 concurrent subscriptions racing a one-use campaign converge on exactly one winner.
- 50 concurrent retries of the same subscription all succeed as itself rather than as a stranger — 10 did not reliably reproduce that race window, 50 does.
- A non-one-use campaign lets every subscription reserve independently.
- A released slot is reclaimed by a different subscription while the original row survives, `Released`, as its own document.
- Redeeming and releasing are each idempotent against a repeated call.
- A `Redeemed` reservation is never released by a later call.
- **Five consecutive full runs, no flakes.**

19 new unit tests across the three wired services confirm the *decisions* around each outcome — persist-then-reserve ordering, expire-on-refusal, recover-on-retry, redeem-after-commit, release-only-while-incomplete, untouched for a Standard discount throughout.

Full non-integration server suite: **3189 passed**. Five failures — four are the pre-existing `SubscriptionSimulation*` permission-guard failures already confirmed on clean `dev`; the fifth, a `FinancialDocumentRendererHealthMonitor` timing test, passed 3-for-3 in isolation and is unrelated to anything touched here — flaky under full-suite parallel load, not a regression.

## Deliberately deferred to Phase 2b

The standalone reconciliation-sweep worker that repairs the one remaining crash window this inline wiring can't close alone: a process dying between a transition committing and its paired redeem/release call completing. That window is real, rare, and exactly what `ReleasePending` exists to make durable for — but the worker is a new scheduled job with its own lease/claim pattern and its own crash-simulation suite, and bolting it onto an already-large PR is a worse trade than reviewing it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
