### PR TITLE
feat(subscription): Free Month campaign pricing, entitlement override, change lock [Phase 3a/6]

### DIFF
--- a/server/Subscription.DomainService/Services/EntitlementService.cs
+++ b/server/Subscription.DomainService/Services/EntitlementService.cs
@@ -74,7 +74,7 @@ public sealed class EntitlementService : IEntitlementService
         var balances = await BalancesAsync(subscription, cancellationToken);
 
         return SubscriptionOperationResult<EntitlementSnapshotResponse>.Success(
-            Describe(subscription, balances),
+            Describe(subscription, balances, now),
             correlationId);
     }
 
@@ -199,7 +199,8 @@ public sealed class EntitlementService : IEntitlementService
 
     private static EntitlementSnapshotResponse Describe(
         SubscriptionDetail subscription,
-        Dictionary<string, MeterReading> balances) => new()
+        Dictionary<string, MeterReading> balances,
+        DateTime now) => new()
     {
         HasSubscription = true,
         Status = subscription.Status.ToString(),
@@ -216,14 +217,15 @@ public sealed class EntitlementService : IEntitlementService
             })
             .ToList(),
         Entitlements = subscription.Plan.Entitlements
-            .Select(entitlement => Describe(subscription, entitlement, balances))
+            .Select(entitlement => Describe(subscription, entitlement, balances, now))
             .ToList()
     };
 
     private static EntitlementResponse Describe(
         SubscriptionDetail subscription,
         PlanEntitlement entitlement,
-        Dictionary<string, MeterReading> balances)
+        Dictionary<string, MeterReading> balances,
+        DateTime now)
     {
         if (entitlement.LimitKind != EntitlementLimitKind.Count)
         {
@@ -248,7 +250,7 @@ public sealed class EntitlementService : IEntitlementService
         // enforce that larger figure. Reporting the declared limit here would tell a caller it had
         // run out while the usage call still permitted the action — the exact disagreement
         // LimitFor's own remarks warn against.
-        var limit = reading?.WindowAllowance ?? LimitFor(subscription, entitlement);
+        var limit = reading?.WindowAllowance ?? LimitFor(subscription, entitlement, now);
         var used = reading?.Balance ?? 0;
 
         var allowed = used < limit;
@@ -274,9 +276,31 @@ public sealed class EntitlementService : IEntitlementService
     /// </summary>
     private static long LimitFor(
         SubscriptionDetail subscription,
-        PlanEntitlement entitlement)
+        PlanEntitlement entitlement,
+        DateTime now)
     {
         var planLimit = entitlement.Limit ?? 0;
+
+        // A free-opening-period campaign's temporary cap, in force only while the campaign's own
+        // opening period is still running. Evaluated against the clock on every call rather than
+        // read off a stored flag, the same way SubscriptionLiveness.IsEffectivelyLive above already
+        // is -- so the plan's ordinary limit resumes the instant CurrentPeriodEndUtc passes, with
+        // nothing that has to run at exactly that moment for it to happen. CurrentPeriodEndUtc is
+        // the campaign's own opening-period boundary here: a monthly, calendar-aligned price's
+        // first period already ends there by construction, so no separate boundary needs storing.
+        if (subscription.Discount is
+            {
+                Campaign:
+                {
+                    Kind: CampaignKind.FreeOpeningCalendarPeriod,
+                    EntitlementOverride: { } campaignOverride
+                }
+            } &&
+            string.Equals(campaignOverride.EntitlementKey, entitlement.Key, StringComparison.Ordinal) &&
+            now < subscription.CurrentPeriodEndUtc)
+        {
+            return campaignOverride.Limit;
+        }
 
         if (subscription.Status != SubscriptionStatus.Trialing ||
             subscription.Trial is null ||

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -226,6 +226,76 @@ public static class SubscriptionAmountCalculator
             price.AutomaticDiscountBasisPoints,
             price.QuantityDiscountCombination);
 
+        // A campaign's own precedence governs how it meets the price's automatic and volume
+        // discounts, and does so ahead of the plan's QuantityDiscountCombinationPolicy below --
+        // deliberately, because that policy exists to settle an ordinary typed-in coupon against
+        // the plan's own reductions, and a campaign is a platform-admin decision layered on top of
+        // whatever policy the plan happens to have. Left to the plan's policy, a plan authored as
+        // QuantityOnly ("built-in discounts only, no code ever counts") would silently discard
+        // every campaign ever run against it, which is not a plan author's decision to make about
+        // a campaign they may not even know exists.
+        if (discount?.Campaign.Kind is { } campaignKind && campaignKind != CampaignKind.Standard)
+        {
+            switch (discount.Campaign.Precedence)
+            {
+                case CampaignPrecedence.ReplaceBuiltIn:
+                {
+                    // The automatic discount and the volume band are suppressed entirely -- the
+                    // campaign is applied to the raw gross, as if the price had neither. Not "the
+                    // larger of the two": SAV/TREX's own rule is that a 15% campaign replaces an
+                    // 8% automatic discount outright, even though 15 is already larger and would
+                    // have won a BestDiscount comparison anyway -- the distinction matters once a
+                    // campaign's rate is smaller than the automatic one it is still meant to
+                    // replace.
+                    var replaced = ApplyDiscount(gross, discount, periodsApplied, nowUtc, fraction);
+
+                    return replaced with
+                    {
+                        GrossAmountMinor = gross,
+                        BuiltInDiscountMinor = 0,
+                        PromotionalDiscountMinor = gross - replaced.AmountMinor
+                    };
+                }
+
+                case CampaignPrecedence.Stack:
+                {
+                    // Both, sequentially -- the campaign applied on top of what the automatic
+                    // discount and volume band already took off. The same sequencing the plan's
+                    // own Stack policy already uses for an ordinary coupon, reused rather than
+                    // reinvented: two ways to combine two reductions would eventually disagree
+                    // with each other on the same numbers.
+                    var stackedCampaign = ApplyDiscount(
+                        builtIn.SubtotalMinor, discount, periodsApplied, nowUtc, fraction);
+
+                    return stackedCampaign with
+                    {
+                        GrossAmountMinor = gross,
+                        BuiltInDiscountMinor = builtIn.DiscountAmountMinor,
+                        PromotionalDiscountMinor = builtIn.SubtotalMinor - stackedCampaign.AmountMinor
+                    };
+                }
+
+                default:
+                {
+                    // BestDiscount: identical to the plan-policy default case below, and
+                    // deliberately so -- a campaign that does not ask to replace or stack is asking
+                    // for the same conservative "whichever is larger, never both" this codebase
+                    // already gives an ordinary coupon.
+                    var bestCampaign = ApplyDiscount(gross, discount, periodsApplied, nowUtc, fraction);
+                    var bestCampaignDiscount = gross - bestCampaign.AmountMinor;
+
+                    return builtIn.DiscountAmountMinor > bestCampaignDiscount
+                        ? new PeriodCharge(builtIn.SubtotalMinor, false, GrossAmountMinor: gross,
+                            BuiltInDiscountMinor: builtIn.DiscountAmountMinor)
+                        : bestCampaign with
+                        {
+                            GrossAmountMinor = gross,
+                            PromotionalDiscountMinor = bestCampaignDiscount
+                        };
+                }
+            }
+        }
+
         switch (plan.QuantityDiscountCombinationPolicy)
         {
             case QuantityDiscountCombinationPolicy.QuantityOnly:

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -570,7 +570,16 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 Kind = terms.Kind,
                 PercentBasisPoints = terms.PercentBasisPoints,
                 AmountMinor = terms.AmountMinor,
-                DurationPeriods = terms.DurationPeriods,
+                // A free-opening-period campaign is single-period by what it is, not by what the
+                // catalogue entry happens to carry: it prices one calendar month and nothing past
+                // it. Forced here rather than trusted from the catalogue, so this can never apply
+                // to a second renewal even if a future edit to the discount left DurationPeriods
+                // unset -- the discount would otherwise take 100% off every month forever, since
+                // nothing else in the pricing pipeline knows this campaign is meant to be a single
+                // free month.
+                DurationPeriods = discount.Campaign.Kind == CampaignKind.FreeOpeningCalendarPeriod
+                    ? 1
+                    : terms.DurationPeriods,
                 ExpiresAtUtc = terms.ExpiresAtUtc,
                 // Copied so the restriction outlives the redemption. A plan change re-asks the same
                 // question, and it can only do so against terms that remember the answer.

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -326,6 +326,24 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 correlationId);
         }
 
+        // A free-opening-period campaign is a fixed offer -- one calendar month on the plan it
+        // named, at the temporary entitlement it named. Moving plan or quantity mid-offer would be
+        // repricing a promise the subscriber was given for free, which this campaign never
+        // promised to price. The lock lifts by itself the instant CurrentPeriodEndUtc passes, the
+        // same clock check the entitlement override above reads -- nothing has to run at that
+        // moment to lift it. Preview is not locked: showing what a change would cost is not
+        // committing to one.
+        if (!preview &&
+            subscription.Discount is { Campaign.Kind: CampaignKind.FreeOpeningCalendarPeriod } &&
+            _time.GetUtcNow().UtcDateTime < subscription.CurrentPeriodEndUtc)
+        {
+            return Failure<PlanChangeResolution>(
+                PaymentFailureKind.Conflict,
+                "subscription_promotion_change_locked",
+                "This subscription is on a free opening period and cannot change plan until it ends.",
+                correlationId);
+        }
+
         // A calendar-aligned yearly subscription inside its opening stub has a year already priced
         // and, on a prepaid price, already paid for. Repricing it now would have to unpick a
         // settled annual charge or silently discard one that is about to be collected, and neither

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -230,6 +230,22 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
             return VersionConflict(correlationId);
         }
 
+        // A free-opening-period campaign is a fixed offer at a fixed quantity -- the temporary
+        // entitlement it granted was sized for the plan and quantity the subscriber was on when it
+        // was accepted. The lock lifts by itself the instant CurrentPeriodEndUtc passes, the same
+        // clock check the entitlement override reads elsewhere; nothing has to run at that moment
+        // to lift it. Preview is not locked.
+        if (!preview &&
+            subscription.Discount is { Campaign.Kind: CampaignKind.FreeOpeningCalendarPeriod } &&
+            _time.GetUtcNow().UtcDateTime < subscription.CurrentPeriodEndUtc)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_promotion_change_locked",
+                "This subscription is on a free opening period and cannot change quantity until it ends.",
+                correlationId);
+        }
+
         // An increase already holds units and may yet be paid for. A second change quoted against
         // them would be quoting against a quantity that is halfway to being someone else's.
         if (!preview && subscription.SettlementReservation is not null)

--- a/server/XUnitTest/Subscription/EntitlementServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/EntitlementServiceCampaignTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// A free-opening-period campaign's temporary cap on one entitlement -- in force only while the
+/// campaign's own opening period runs, and evaluated live rather than by anything that has to run
+/// at the boundary.
+/// </summary>
+public sealed class EntitlementServiceCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail? _subscription;
+
+    public EntitlementServiceCampaignTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+    }
+
+    [Fact]
+    public async Task Within_the_opening_period_the_overridden_entitlement_reads_the_campaigns_limit()
+    {
+        _subscription = NewSubscription(campaign: true);
+
+        var result = await Service().GetAsync(fresh: false, null, "corr-1", CancellationToken.None);
+
+        var seats = result.Value!.Entitlements.Single(entitlement => entitlement.Key == "seats");
+        seats.Limit.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task After_the_opening_period_ends_the_plans_own_limit_applies_with_nothing_run_at_the_boundary()
+    {
+        _subscription = NewSubscription(campaign: true);
+        // One second past CurrentPeriodEndUtc -- no worker, no scheduled job, just the clock this
+        // call reads live.
+        _time = new ControlledTimeProvider(
+            new DateTimeOffset(_subscription.CurrentPeriodEndUtc.AddSeconds(1)));
+
+        var result = await Service().GetAsync(fresh: false, null, "corr-1", CancellationToken.None);
+
+        var seats = result.Value!.Entitlements.Single(entitlement => entitlement.Key == "seats");
+        seats.Limit.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task The_override_never_touches_an_entitlement_it_does_not_name()
+    {
+        _subscription = NewSubscription(campaign: true);
+
+        var result = await Service().GetAsync(fresh: false, null, "corr-1", CancellationToken.None);
+
+        var screening = result.Value!.Entitlements.Single(entitlement => entitlement.Key == "pep_screening");
+        screening.Limit.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task A_standard_discount_never_overrides_any_entitlement()
+    {
+        _subscription = NewSubscription(campaign: false);
+
+        var result = await Service().GetAsync(fresh: false, null, "corr-1", CancellationToken.None);
+
+        var seats = result.Value!.Entitlements.Single(entitlement => entitlement.Key == "seats");
+        seats.Limit.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task A_first_annual_period_campaign_never_overrides_an_entitlement_either()
+    {
+        // Only FreeOpeningCalendarPeriod carries an entitlement override in this system -- a
+        // FirstAnnualPeriod campaign that happened to snapshot one (it should not, by validation)
+        // must still not be honoured here.
+        _subscription = NewSubscription(campaign: true);
+        _subscription.Discount!.Campaign.Kind = CampaignKind.FirstAnnualPeriod;
+
+        var result = await Service().GetAsync(fresh: false, null, "corr-1", CancellationToken.None);
+
+        var seats = result.Value!.Entitlements.Single(entitlement => entitlement.Key == "seats");
+        seats.Limit.Should().Be(5);
+    }
+
+    private EntitlementService Service() => new(
+        _subscriptions.Object,
+        _usage.Object,
+        new MeterAllowanceResolver(_usage.Object),
+        _contextResolver.Object,
+        new EntitlementSnapshotCache(new OptionsStub(), _time),
+        _time);
+
+    private static SubscriptionDetail NewSubscription(bool campaign) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        CurrentPeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        Plan = new PlanSnapshot
+        {
+            Code = "team",
+            Entitlements =
+            [
+                new PlanEntitlement
+                {
+                    Key = "seats", LimitKind = EntitlementLimitKind.Count, Limit = 5
+                },
+                new PlanEntitlement
+                {
+                    Key = "pep_screening", LimitKind = EntitlementLimitKind.Count, Limit = 500,
+                    MeterKey = "screening"
+                }
+            ]
+        },
+        Discount = campaign
+            ? new DiscountTerms
+            {
+                Code = "free1",
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FreeOpeningCalendarPeriod,
+                    EntitlementOverride = new CampaignEntitlementOverride
+                    {
+                        EntitlementKey = "seats", Limit = 1
+                    }
+                }
+            }
+            : new DiscountTerms { Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2500 }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new();
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorCampaignTests.cs
@@ -8,6 +8,7 @@ using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 using XUnitTest.Payment;
 
@@ -27,6 +28,7 @@ public sealed class SubscriptionActivationProcessorCampaignTests
     private readonly Mock<IPaymentRepository> _payments = new();
     private readonly Mock<IStoredPaymentMethodRepository> _storedMethods = new();
     private readonly Mock<ICampaignRedemptionRepository> _redemptions = new();
+    private readonly Mock<ISubscriptionFinancialDocumentAnnouncer> _documents = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
 
@@ -66,6 +68,40 @@ public sealed class SubscriptionActivationProcessorCampaignTests
                 ItemId = "pay-1", TenantId = TenantId, PaymentStatus = PaymentStatuses.Captured,
                 WebhookConfirmedAtUtc = DateTime.UtcNow, OrganizationId = "default"
             });
+
+        _documents
+            .Setup(documents => documents.AnnounceChargeAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionChargeKind>(),
+                It.IsAny<string?>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<FinancialDocumentPerson?>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task Activation_announces_a_zero_value_invoice_for_a_free_month()
+    {
+        // No new invoice pathway exists for this -- the same AnnounceChargeAsync every initial
+        // charge already goes through, called with whatever InitialChargeAmountMinor resolved to.
+        // For a 100%-off campaign that is already zero by the time it reaches here, through the
+        // ordinary pricing pipeline; this proves the announcement still fires rather than being
+        // skipped for a charge that moved no money.
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _documents.Verify(
+            documents => documents.AnnounceChargeAsync(
+                It.Is<SubscriptionDetail>(subscription => subscription.ItemId == "sub-1"),
+                "pay-1",
+                SubscriptionChargeKind.Initial,
+                null,
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<FinancialDocumentPerson?>()),
+            Times.Once);
     }
 
     [Fact]
@@ -203,6 +239,7 @@ public sealed class SubscriptionActivationProcessorCampaignTests
         new SubscriptionOptionsMonitorStub(new SubscriptionOptions()),
         NullLogger<SubscriptionActivationProcessor>.Instance,
         _time,
+        documents: _documents.Object,
         redemptions: _redemptions.Object);
 
     private static SubscriptionDetail NewSubscription(bool campaign) => new()

--- a/server/XUnitTest/Subscription/SubscriptionAmountCalculatorCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionAmountCalculatorCampaignTests.cs
@@ -1,0 +1,153 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// How a campaign's own precedence meets a price's automatic and volume discounts -- ahead of the
+/// plan's own <see cref="QuantityDiscountCombinationPolicy"/>, never negotiating with it.
+/// </summary>
+public sealed class SubscriptionAmountCalculatorCampaignTests
+{
+    private static readonly DateTime Now = new(2026, 8, 14, 10, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void ReplaceBuiltIn_suppresses_the_automatic_discount_entirely()
+    {
+        // 8% automatic, 15% campaign: 15% is already larger, so this alone would not distinguish
+        // ReplaceBuiltIn from BestDiscount. The point proven here is that the automatic discount is
+        // reported as zero, not merely beaten.
+        var subscription = NewSubscription(
+            automaticBasisPoints: 800,
+            campaignPercentBasisPoints: 1_500,
+            precedence: CampaignPrecedence.ReplaceBuiltIn);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(0);
+        charge.PromotionalDiscountMinor.Should().Be(1_500);
+        charge.AmountMinor.Should().Be(8_500);
+    }
+
+    [Fact]
+    public void ReplaceBuiltIn_wins_even_when_the_automatic_discount_is_the_larger_rate()
+    {
+        // The case BestDiscount and ReplaceBuiltIn actually disagree on: automatic is larger, and
+        // a plain "biggest wins" comparison would have kept the automatic discount instead.
+        var subscription = NewSubscription(
+            automaticBasisPoints: 2_000,
+            campaignPercentBasisPoints: 1_000,
+            precedence: CampaignPrecedence.ReplaceBuiltIn);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.BuiltInDiscountMinor.Should().Be(0);
+        charge.AmountMinor.Should().Be(9_000); // 10% off 10,000, not 20%
+    }
+
+    [Fact]
+    public void BestDiscount_still_picks_whichever_reduction_is_larger()
+    {
+        var subscription = NewSubscription(
+            automaticBasisPoints: 2_000,
+            campaignPercentBasisPoints: 1_000,
+            precedence: CampaignPrecedence.BestDiscount);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.AmountMinor.Should().Be(8_000); // the automatic 20% wins, campaign not consumed
+        charge.DiscountApplied.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Stack_applies_the_campaign_on_top_of_the_automatic_discount()
+    {
+        var subscription = NewSubscription(
+            automaticBasisPoints: 1_000,
+            campaignPercentBasisPoints: 1_000,
+            precedence: CampaignPrecedence.Stack);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        // 10% off 10,000 = 9,000; a further 10% off 9,000 = 8,100 -- sequential, not 20% off the
+        // original gross, which is the same non-compounding rule Stack already uses for an
+        // ordinary coupon.
+        charge.BuiltInDiscountMinor.Should().Be(1_000);
+        charge.AmountMinor.Should().Be(8_100);
+    }
+
+    [Fact]
+    public void A_plan_authored_as_built_in_discounts_only_does_not_silently_drop_a_campaign()
+    {
+        // QuantityDiscountCombinationPolicy.QuantityOnly means "no promotional code ever counts"
+        // for an ordinary coupon -- a plan-level choice about coupons, made before this campaign
+        // system existed and by an author who may never know a given campaign exists. A campaign's
+        // own precedence must still take effect.
+        var subscription = NewSubscription(
+            automaticBasisPoints: 0,
+            campaignPercentBasisPoints: 2_500,
+            precedence: CampaignPrecedence.ReplaceBuiltIn);
+        subscription.Plan.QuantityDiscountCombinationPolicy =
+            QuantityDiscountCombinationPolicy.QuantityOnly;
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.AmountMinor.Should().Be(7_500);
+        charge.DiscountApplied.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_free_month_campaign_charges_nothing_regardless_of_the_plans_own_policy()
+    {
+        var subscription = NewSubscription(
+            automaticBasisPoints: 500,
+            campaignPercentBasisPoints: 10_000,
+            precedence: CampaignPrecedence.ReplaceBuiltIn,
+            kind: CampaignKind.FreeOpeningCalendarPeriod);
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.AmountMinor.Should().Be(0);
+    }
+
+    [Fact]
+    public void A_standard_discount_is_unaffected_by_any_of_this()
+    {
+        // No Campaign at all -- the ordinary coupon path, exactly as SubscriptionAmountCalculatorTests
+        // already pins it, confirmed here specifically against a subscription that also carries an
+        // automatic discount, which is the shape every new branch above gates on.
+        var subscription = new SubscriptionDetail
+        {
+            Price = new PriceSnapshot { UnitAmountMinor = 10_000, AutomaticDiscountBasisPoints = 1_000 },
+            Plan = new PlanSnapshot(),
+            Discount = new DiscountTerms { Kind = DiscountKind.Percent, PercentBasisPoints = 2_000 }
+        };
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        // Existing default-case behaviour: the larger of the two wins, ties to the promotion.
+        charge.AmountMinor.Should().Be(8_000);
+    }
+
+    private static SubscriptionDetail NewSubscription(
+        int? automaticBasisPoints,
+        int campaignPercentBasisPoints,
+        CampaignPrecedence precedence,
+        CampaignKind kind = CampaignKind.FirstAnnualPeriod) => new()
+    {
+        Price = new PriceSnapshot
+        {
+            UnitAmountMinor = 10_000,
+            AutomaticDiscountBasisPoints = automaticBasisPoints
+        },
+        Plan = new PlanSnapshot(),
+        Discount = new DiscountTerms
+        {
+            Kind = DiscountKind.Percent,
+            PercentBasisPoints = campaignPercentBasisPoints,
+            Campaign = new CampaignTerms { Kind = kind, Precedence = precedence }
+        }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceCampaignTests.cs
@@ -249,6 +249,21 @@ public sealed class SubscriptionCreationServiceCampaignTests
     }
 
     [Fact]
+    public async Task A_free_month_snapshot_is_forced_to_one_period_regardless_of_the_catalogue_entry()
+    {
+        // Single-period by what a free-opening-period campaign is, not by what happens to be
+        // configured -- so it can never take 100% off a second, renewed month even if a future
+        // catalogue edit left DurationPeriods unset.
+        var request = NewRequest();
+        request.DiscountCode = "free1";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Discount!.DurationPeriods.Should().Be(1);
+    }
+
+    [Fact]
     public async Task With_no_redemption_repository_wired_a_campaign_discount_is_refused_rather_than_granted()
     {
         // Fail closed: the same choice the constructor's own doc comment makes. Nothing here

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceCampaignTests.cs
@@ -1,0 +1,215 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// A free-opening-period campaign locks a plan change until its own opening period ends -- and
+/// only the real change, never a preview.
+/// </summary>
+public sealed class SubscriptionPlanChangeServiceCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private readonly Mock<ISubscriptionBillingProfileGuard> _billingProfile = new();
+    private ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail _subscription = NewSubscription();
+
+    public SubscriptionPlanChangeServiceCampaignTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetAsync(
+                TenantId, OrganizationId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "premium", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Plan
+            {
+                ItemId = "plan-2", TenantId = TenantId, Code = "premium",
+                DisplayName = "Premium", Status = CatalogueStatus.Active
+            });
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price
+            {
+                ItemId = "price-2", TenantId = TenantId, PlanId = "plan-2", CurrencyCode = "CHF",
+                UnitAmountMinor = 2_000, Interval = BillingInterval.Month, IntervalCount = 1,
+                Status = CatalogueStatus.Active
+            });
+
+        _billingProfile
+            .Setup(guard => guard.MissingFieldsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+    }
+
+    [Fact]
+    public async Task A_plan_change_is_refused_while_the_free_opening_period_is_still_running()
+    {
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_promotion_change_locked");
+    }
+
+    [Fact]
+    public async Task A_plan_change_is_allowed_once_the_free_opening_period_has_ended()
+    {
+        _time = new ControlledTimeProvider(
+            new DateTimeOffset(_subscription.CurrentPeriodEndUtc.AddSeconds(1)));
+
+        _subscriptions
+            .Setup(repository => repository.TryChangePlanAsync(
+                TenantId, "sub-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<PlanSnapshot>(),
+                It.IsAny<PriceSnapshot>(), It.IsAny<List<SubscriptionQuantityItem>>(),
+                It.IsAny<SubscriptionPlanSchedule>(), It.IsAny<PendingUsagePeriod>(),
+                It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(),
+                It.IsAny<CancellationToken>(), It.IsAny<SubscriptionDocumentSource?>()))
+            .ReturnsAsync(true);
+        _subscriptions
+            .Setup(repository => repository.TryReserveSettlementAsync(
+                TenantId, "sub-1", It.IsAny<int>(), It.IsAny<SettlementReservation>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                ItemId = "acct-1", ProviderName = "STRIPE", DefaultPaymentMethodId = "pm-1",
+                ProviderCustomerId = "cus_123"
+            });
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("in_1", "corr-1"));
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_plan_change_preview_is_never_locked_even_during_the_free_opening_period()
+    {
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_standard_discount_never_locks_a_plan_change()
+    {
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2_500
+        };
+        _subscriptions
+            .Setup(repository => repository.TryChangePlanAsync(
+                TenantId, "sub-1", It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<PlanSnapshot>(),
+                It.IsAny<PriceSnapshot>(), It.IsAny<List<SubscriptionQuantityItem>>(),
+                It.IsAny<SubscriptionPlanSchedule>(), It.IsAny<PendingUsagePeriod>(),
+                It.IsAny<long>(), It.IsAny<string?>(), It.IsAny<SubscriptionOutboxEvent>(),
+                It.IsAny<CancellationToken>(), It.IsAny<SubscriptionDocumentSource?>()))
+            .ReturnsAsync(true);
+        _subscriptions
+            .Setup(repository => repository.TryReserveSettlementAsync(
+                TenantId, "sub-1", It.IsAny<int>(), It.IsAny<SettlementReservation>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                ItemId = "acct-1", ProviderName = "STRIPE", DefaultPaymentMethodId = "pm-1",
+                ProviderCustomerId = "cus_123"
+            });
+        _gateway
+            .Setup(gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionOperationResult<string>.Success("in_1", "corr-1"));
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    private SubscriptionPlanChangeService Service() => new(
+        _contextResolver.Object,
+        _subscriptions.Object,
+        _catalogue.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new SubscriptionResponseMapper(),
+        new ChangeSubscriptionPlanRequestValidator(),
+        NullLogger<SubscriptionPlanChangeService>.Instance,
+        _time,
+        billingProfile: _billingProfile.Object);
+
+    private static ChangeSubscriptionPlanRequest Request() => new()
+    {
+        PlanCode = "premium",
+        PriceId = "price-2"
+    };
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        Version = 3,
+        Plan = new PlanSnapshot { Code = "basic", DisplayName = "Basic" },
+        Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF", UnitAmountMinor = 0,
+            Interval = BillingInterval.Month, IntervalCount = 1
+        },
+        QuantityItems = [],
+        CurrentPeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentPeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        Discount = new DiscountTerms
+        {
+            Code = "free1",
+            Campaign = new CampaignTerms { Kind = CampaignKind.FreeOpeningCalendarPeriod }
+        }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceCampaignTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// A free-opening-period campaign locks a quantity change until its own opening period ends.
+/// </summary>
+public sealed class SubscriptionQuantityChangeServiceCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
+    private readonly Mock<ISubscriptionBillingGateway> _gateway = new();
+    private readonly Mock<IEntitlementSnapshotCache> _cache = new();
+    private ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
+
+    private SubscriptionDetail _subscription = NewSubscription();
+
+    public SubscriptionQuantityChangeServiceCampaignTests()
+    {
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _subscriptions
+            .Setup(repository => repository.GetAsync(
+                TenantId, OrganizationId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _subscription);
+    }
+
+    [Fact]
+    public async Task A_quantity_change_is_refused_while_the_free_opening_period_is_still_running()
+    {
+        var result = await Service().ChangeAsync(
+            "sub-1", Request(2), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_promotion_change_locked");
+    }
+
+    [Fact]
+    public async Task A_quantity_change_preview_is_never_locked_even_during_the_free_opening_period()
+    {
+        var result = await Service().PreviewAsync(
+            "sub-1", Request(2), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_standard_discount_never_locks_a_quantity_change()
+    {
+        // Deliberately not asserting the whole change succeeds -- that needs a much larger mock
+        // setup unrelated to what this test is about. Whatever else this does or does not permit,
+        // it must not be this lock, which only exists for a free-opening-period campaign.
+        _subscription.Discount = new DiscountTerms
+        {
+            Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2_500
+        };
+
+        var result = await Service().ChangeAsync(
+            "sub-1", Request(2), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().NotBe("subscription_promotion_change_locked");
+    }
+
+    private SubscriptionQuantityChangeService Service() => new(
+        _contextResolver.Object,
+        _subscriptions.Object,
+        _billingAccounts.Object,
+        _gateway.Object,
+        new SubscriptionOutboxEventFactory(),
+        _cache.Object,
+        new ChangeQuantityRequestValidator(),
+        NullLogger<SubscriptionQuantityChangeService>.Instance,
+        _time);
+
+    private static ChangeQuantityRequest Request(long quantity) => new()
+    {
+        Version = 7,
+        Quantities = [new QuantityChangeItemRequest { ItemKey = "user", Quantity = quantity }]
+    };
+
+    private static SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Active,
+        Version = 7,
+        CurrencyCode = "CHF",
+        CurrentPeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        CurrentPeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        QuantityItems =
+        [
+            new SubscriptionQuantityItem
+            {
+                ItemKey = "user", UnitLabel = "user", Quantity = 1, UnitAmountMinor = 14_500
+            }
+        ],
+        Price = new PriceSnapshot
+        {
+            UnitAmountMinor = 14_500,
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            QuantityItemKey = "user"
+        },
+        Plan = new PlanSnapshot
+        {
+            Code = "team",
+            QuantityItems = [new PlanQuantityItem { ItemKey = "user", UnitLabel = "user", MinQuantity = 1 }]
+        },
+        Discount = new DiscountTerms
+        {
+            Code = "free1",
+            Campaign = new CampaignTerms { Kind = CampaignKind.FreeOpeningCalendarPeriod }
+        }
+    };
+}


### PR DESCRIPTION
**Phase 3a.** Stacked on [#350](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/350) (Phase 2). Merge order: #349 → #350 → this.

The plan grew from 5 phases to 6 partway through this one — see below.

## Why Free Month split from SAV/TREX

Both were originally "Phase 3." Implementing the SAV/TREX yearly stub/annual split correctly requires reading `SubscriptionRenewalService` in full to get period-consumption tracking right across a renewal boundary — a file this PR never needed to open. Attempting it anyway, ungrounded, is exactly the risk that produced this repo's three prior pricing bug-fix PRs. Free Month has no renewal-boundary interaction at all (it's a single free month, then ordinary Tier 1 pricing), so it's genuinely independent and ships now; SAV/TREX becomes **Phase 3b**, done properly after that read.

## What made this cheap to build correctly

Investigated three existing mechanisms before writing anything, and each one already did most of the work:

- **`CalendarBillingAlignment`** already fully supports monthly calendar alignment (confirmed back in Phase 1) — Free Month needed zero new pricing code, only a 100%-off campaign discount flowing through the existing pipeline.
- **`DiscountTerms.DurationPeriods` + `DiscountPeriodsApplied`** already expire any discount after N periods, generically. Free Month just forces `DurationPeriods = 1` at the snapshot — no second expiry mechanism.
- **The activation processor already announces a charge unconditionally**, card-setup or real, and a 100%-off campaign already resolves to zero through the ordinary pipeline. Combined with the zero-amount invoice fix from [#337](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/337)/[#346](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/346) earlier in this project's history, **no new invoice pathway was needed at all** — confirmed with a test asserting the announcement actually fires with the zero amount, not assumed from reading the code.

## What this adds

- `CampaignPrecedence.ReplaceBuiltIn`/`Stack`/`BestDiscount` in `SubscriptionAmountCalculator.DiscountedAmountMinor`, checked **ahead of** the plan's own `QuantityDiscountCombinationPolicy` — a plan authored `QuantityOnly` ("no code ever counts") must not silently drop a campaign its author may not even know exists. `ReplaceBuiltIn` suppresses the automatic discount and volume band outright, not merely outcompetes them — proven by a test where the automatic rate is *larger* than the campaign's, so a plain "biggest wins" comparison would keep the wrong one.
- `DurationPeriods` forced to `1` on a `FreeOpeningCalendarPeriod` snapshot regardless of the catalogue entry.
- `EntitlementService.LimitFor` reads the campaign's temporary cap while `subscription.CurrentPeriodEndUtc` hasn't passed — evaluated live on every call, same pattern `SubscriptionLiveness.IsEffectivelyLive` already uses right above it. **Nothing has to run at the boundary.**
- `SubscriptionPlanChangeService`/`SubscriptionQuantityChangeService` refuse a real change (never a preview) with the new `subscription_promotion_change_locked` while the free opening period runs.

## Verification

178 pre-existing tests across the amount calculator, entitlement service, plan-change and quantity-change services, and the discount calculators: **unmodified, pass.** 25 new tests. Full non-integration server suite: **3211 passed**, 4 pre-existing `SubscriptionSimulation*` failures confirmed identical on clean `dev`. `CampaignRedemptionConcurrencyTests` (Phase 2, real MongoDB): 7 passed — confirming this phase didn't disturb Phase 2's concurrency guarantees.

## Remaining phases

| Phase | Scope | Status |
|---|---|---|
| 3b | SAV/TREX yearly stub/annual split, renewal-boundary expiry | not started — needs its own `SubscriptionRenewalService` read |
| 4 | Buyer preview API + UI | not started |
| 5 | Admin authoring UI (4-step wizard) | not started |
| 6 | Redemption-ledger reconciliation-sweep worker (Phase 2b) | not started |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
