### PR TITLE
feat(subscription): first-annual-period campaign pricing [Phase 3b/6]

### DIFF
--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -368,18 +368,35 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
     /// Whether a price's cadence is one this campaign kind can actually price.
     /// </summary>
     /// <remarks>
-    /// FirstAnnualPeriod exists to discount an opening stub and a first annual period, neither of
-    /// which a non-yearly price has. FreeOpeningCalendarPeriod exists to give away a calendar
-    /// month, which only a monthly price billed on calendar boundaries has a month to give.
-    /// Authored against the wrong cadence, either campaign would validate cleanly and then never
-    /// be redeemable -- refused here instead, at the one point an author can still fix it.
+    /// FirstAnnualPeriod exists to discount a first annual period and nothing past it, and relies
+    /// on the exact mechanism an ordinary calendar-aligned yearly promotion already uses to do
+    /// that -- forcing <see cref="DiscountTerms.DurationPeriods"/> to 1 and letting the existing
+    /// stub/<see cref="PendingAnnualPeriod"/>/renewal accounting expire it after one year, with
+    /// the opening stub excluded exactly as any other promotional code already is on that cadence.
+    /// <para>
+    /// That accounting is proven correct only for calendar-aligned billing: an anniversary-billed
+    /// yearly price has no stub and no separate "period 1 doesn't count" moment for the discount
+    /// to attach to, so <c>DurationPeriods = 1</c> there discounts two years, not one -- a real
+    /// money bug, not a cosmetic one. Refused here, at the one point an author can still fix it,
+    /// rather than trusted to redemption where the wrong number of years would already be quoted.
+    /// </para>
+    /// <para>
+    /// FreeOpeningCalendarPeriod exists to give away a calendar month, which only a monthly price
+    /// billed on calendar boundaries has a month to give.
+    /// </para>
     /// </remarks>
     private static string? CheckCadence(CampaignKind kind, string priceId, Price price) => kind switch
     {
         CampaignKind.FirstAnnualPeriod when price.Interval != BillingInterval.Year
-            || price.IntervalCount != 1 =>
-            $"The price '{priceId}' does not bill yearly, so a first-annual-period campaign can " +
-            "never apply to it.",
+            || price.IntervalCount != 1
+            || !CalendarBillingAlignment.IsCalendarAligned(
+                price.BillingAlignment,
+                price.Interval,
+                price.IntervalCount,
+                price.CalendarStubBaseUnitAmountMinor) =>
+            $"The price '{priceId}' is not a calendar-aligned yearly price with a stub base " +
+            "price configured, so a first-annual-period campaign has no opening stub and annual " +
+            "period boundary to expire itself at -- it would discount two years instead of one.",
         CampaignKind.FreeOpeningCalendarPeriod when !CalendarBillingAlignment.IsCalendarAligned(
                 price.BillingAlignment, price.Interval, price.IntervalCount) ||
             price.Interval != BillingInterval.Month =>

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -577,7 +577,17 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 // unset -- the discount would otherwise take 100% off every month forever, since
                 // nothing else in the pricing pipeline knows this campaign is meant to be a single
                 // free month.
-                DurationPeriods = discount.Campaign.Kind == CampaignKind.FreeOpeningCalendarPeriod
+                //
+                // A first-annual-period campaign is single-period for the same reason, on the same
+                // cadence an ordinary calendar-aligned yearly promotion already relies on: forcing
+                // this to 1 is exactly what an ordinary "10% off, one period" discount does on this
+                // price, and the existing stub/PendingAnnualPeriod/renewal accounting already
+                // expires it after one year without anything here needing to know that. Safe to
+                // force unconditionally because CheckCadence already refused this campaign kind
+                // against anything but a calendar-aligned yearly price, where that accounting is
+                // proven correct.
+                DurationPeriods = discount.Campaign.Kind
+                    is CampaignKind.FreeOpeningCalendarPeriod or CampaignKind.FirstAnnualPeriod
                     ? 1
                     : terms.DurationPeriods,
                 ExpiresAtUtc = terms.ExpiresAtUtc,

--- a/server/XUnitTest/Subscription/CalendarAnnualDiscountConsumptionTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualDiscountConsumptionTests.cs
@@ -133,6 +133,25 @@ public sealed class CalendarAnnualDiscountConsumptionTests
             "one payment reduced by the promotion means one period of it spent");
     }
 
+    /// <summary>
+    /// A first-annual-period campaign is, at this layer, nothing but an ordinary calendar-aligned
+    /// yearly promotion with <see cref="DiscountTerms.DurationPeriods"/> forced to 1 -- the same
+    /// mechanism the two tests above already prove correct. This closes the loop for the campaign
+    /// specifically, rather than trusting that a <see cref="CampaignTerms"/> attached to the
+    /// discount does not somehow change this accounting.
+    /// </summary>
+    [Fact]
+    public async Task A_first_annual_period_campaign_spends_its_one_period_at_the_boundary_like_any_other_promotion()
+    {
+        var subscription = InStub(prepaid: false);
+        subscription.Discount!.Campaign = new CampaignTerms { Kind = CampaignKind.FirstAnnualPeriod };
+
+        await Renewal().RenewAsync(subscription, CancellationToken.None);
+
+        _transition!.DiscountPeriodsApplied.Should().Be(1,
+            "the campaign's own discount reduced the year exactly as an ordinary promotion would");
+    }
+
     private SubscriptionRenewalService Renewal() => new(
         _subscriptions.Object,
         _billingAccounts.Object,

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
@@ -28,6 +28,7 @@ public sealed class DiscountCatalogueServiceCampaignTests
     private const string OrganizationId = "org-1";
     private const string PlanId = "plan-pro";
     private const string YearlyPriceId = "price-pro-yearly";
+    private const string CalendarYearlyPriceId = "price-pro-yearly-calendar";
     private const string MonthlyPriceId = "price-pro-monthly";
     private const string CalendarMonthlyPriceId = "price-pro-calendar-monthly";
     private const string ArchivedPriceId = "price-pro-retired";
@@ -54,6 +55,11 @@ public sealed class DiscountCatalogueServiceCampaignTests
             .Setup(repository => repository.GetPriceAsync(
                 TenantId, YearlyPriceId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Price(YearlyPriceId, BillingInterval.Year, BillingAlignment.Anniversary));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, CalendarYearlyPriceId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CalendarYearlyPrice());
 
         _catalogue
             .Setup(repository => repository.GetPriceAsync(
@@ -249,10 +255,27 @@ public sealed class DiscountCatalogueServiceCampaignTests
         result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
     }
 
+    /// <summary>
+    /// The gap this closes: an anniversary-billed yearly price has no stub and no "period 1 does
+    /// not count" moment for <see cref="DiscountTerms.DurationPeriods"/> = 1 to attach to, so
+    /// authoring one here would silently discount two years instead of the one the campaign's own
+    /// name promises. Refused at the one point an author can still pick a different price.
+    /// </summary>
     [Fact]
-    public async Task A_first_annual_period_campaign_accepts_an_ordinary_yearly_price()
+    public async Task A_first_annual_period_campaign_refuses_an_anniversary_billed_yearly_price()
     {
         var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_applicability_invalid");
+    }
+
+    [Fact]
+    public async Task A_first_annual_period_campaign_accepts_a_calendar_aligned_yearly_price()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [CalendarYearlyPriceId]);
 
         var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
 
@@ -361,7 +384,7 @@ public sealed class DiscountCatalogueServiceCampaignTests
     [Fact]
     public async Task The_redeemable_window_is_computed_and_frozen_at_authoring_time()
     {
-        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [CalendarYearlyPriceId]);
         request.ValidFromDate = new DateOnly(2026, 3, 1);
         request.ValidThroughDate = new DateOnly(2026, 3, 31);
         request.TimeZoneId = "Europe/Zurich";
@@ -384,7 +407,7 @@ public sealed class DiscountCatalogueServiceCampaignTests
         // transition night, not just the window crossing it. BillingLocalTime.ToUtc already
         // carries this policy everywhere else in the billing domain; this proves it is actually
         // being reused here rather than a second, untested implementation of the same idea.
-        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [CalendarYearlyPriceId]);
         request.ValidFromDate = new DateOnly(2026, 3, 29);
         request.ValidThroughDate = new DateOnly(2026, 3, 30);
         request.TimeZoneId = "Europe/Zurich";
@@ -472,7 +495,7 @@ public sealed class DiscountCatalogueServiceCampaignTests
     [Fact]
     public async Task A_campaign_before_its_window_reads_as_upcoming()
     {
-        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [CalendarYearlyPriceId]);
         request.ValidFromDate = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(1));
         request.ValidThroughDate = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(1).AddMonths(1));
 
@@ -485,7 +508,7 @@ public sealed class DiscountCatalogueServiceCampaignTests
     [Fact]
     public async Task A_campaign_past_its_window_reads_as_expired()
     {
-        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [YearlyPriceId]);
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [CalendarYearlyPriceId]);
         request.ValidFromDate = new DateOnly(2020, 1, 1);
         request.ValidThroughDate = new DateOnly(2020, 1, 31);
 
@@ -588,5 +611,25 @@ public sealed class DiscountCatalogueServiceCampaignTests
         IntervalCount = 1,
         BillingAlignment = alignment,
         Status = status
+    };
+
+    /// <summary>
+    /// A yearly price that actually bills on calendar boundaries -- the only cadence a
+    /// FirstAnnualPeriod campaign can be authored against, since it needs a stub base price to
+    /// price the opening fraction from as well as the alignment itself.
+    /// </summary>
+    private static Price CalendarYearlyPrice() => new()
+    {
+        ItemId = CalendarYearlyPriceId,
+        TenantId = TenantId,
+        PlanId = PlanId,
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 120_000,
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        CalendarStubBasePriceId = "price-pro-monthly-stub-base",
+        CalendarStubBaseUnitAmountMinor = 10_000,
+        Status = CatalogueStatus.Active
     };
 }

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceCampaignTests.cs
@@ -263,6 +263,49 @@ public sealed class SubscriptionCreationServiceCampaignTests
         _created!.Discount!.DurationPeriods.Should().Be(1);
     }
 
+    /// <summary>
+    /// The exact mechanism a first-annual-period campaign relies on for correctness: forcing this
+    /// to 1 regardless of the catalogue entry is what lets the existing calendar-aligned yearly
+    /// stub/PendingAnnualPeriod/renewal accounting expire it after one year on its own, with
+    /// nothing in that accounting needing to know a campaign is involved at all.
+    /// </summary>
+    [Fact]
+    public async Task A_first_annual_period_snapshot_is_forced_to_one_period_regardless_of_the_catalogue_entry()
+    {
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-yearly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewCalendarYearlyPrice());
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "annual1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ItemId = "discount-annual1",
+                Version = 1,
+                Terms = new DiscountTerms
+                {
+                    Code = "annual1", Kind = DiscountKind.Percent, PercentBasisPoints = 1_500
+                },
+                ApplicablePriceIds = ["price-yearly"],
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FirstAnnualPeriod,
+                    RedeemableFromUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    RedeemableUntilUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                }
+            });
+
+        var request = NewRequest();
+        request.PriceId = "price-yearly";
+        request.DiscountCode = "annual1";
+
+        var result = await Service().CreateAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Discount!.DurationPeriods.Should().Be(1);
+    }
+
     [Fact]
     public async Task With_no_redemption_repository_wired_a_campaign_discount_is_refused_rather_than_granted()
     {
@@ -421,6 +464,23 @@ public sealed class SubscriptionCreationServiceCampaignTests
         UnitAmountMinor = 8900,
         Interval = BillingInterval.Month,
         IntervalCount = 1,
+        QuantityItemKey = "seat",
+        Status = CatalogueStatus.Active
+    };
+
+    /// <summary>The only cadence a first-annual-period campaign can ever be redeemed against.</summary>
+    private static Price NewCalendarYearlyPrice() => new()
+    {
+        ItemId = "price-yearly",
+        TenantId = TenantId,
+        PlanId = "plan-1",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 96_000,
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        CalendarStubBasePriceId = "price-1",
+        CalendarStubBaseUnitAmountMinor = 8_900,
         QuantityItemKey = "seat",
         Status = CatalogueStatus.Active
     };


### PR DESCRIPTION
Phase 3b/6 of campaign discount management. SAV/TREX-style "discount the first annual period, then revert" campaigns on calendar-aligned yearly pricing.

## What this actually needed, once traced end to end

Tracing `SubscriptionRenewalService` and `SubscriptionAmountCalculator` in full (the reason 3b was split from 3a) showed the pricing/expiry mechanics a `FirstAnnualPeriod` campaign needs already exist and are already proven correct: forcing `DiscountTerms.DurationPeriods` to `1` is exactly what an ordinary calendar-aligned yearly promotion already does, and the existing stub/`PendingAnnualPeriod`/renewal accounting already expires it after one year without any of that code needing to know a campaign is involved (`CalendarAnnualDiscountConsumptionTests` already proves this for all three settlement timings: prepaid-at-checkout, unpaid-at-boundary, and the combination across both transitions).

So the only new production code is the same forcing Free Month already does, extended to this campaign kind (`SubscriptionCreationService.ResolveDiscountAsync`).

## A gap this closes, found while tracing the above

Discount duration counting has a documented, intentional quirk on ordinary anniversary billing: the opening charge never spends a discount period (only calendar-aligned billing does that, at activation), so `DurationPeriods = 1` there discounts the signup period **and** the first renewal — two periods, not one. Fine for a generic "N months off" code; the test suite explicitly defends it as accepted behaviour.

It is not fine for a campaign literally named `FirstAnnualPeriod`, which promises exactly one year. Phase 1's own `CheckCadence` let this campaign kind be authored against any yearly price regardless of alignment, so a `FirstAnnualPeriod` campaign against an anniversary-billed yearly price would have silently discounted two years instead of one — a real revenue-impacting misconfiguration, not a cosmetic one, and one that validated cleanly and only surfaced at redemption. Closed by tightening `CheckCadence` to require calendar-aligned billing (with a stub base price configured) for this campaign kind, matching the existing `FreeOpeningCalendarPeriod` restriction in spirit.

This intentionally flips one Phase 1 test (`A_first_annual_period_campaign_accepts_an_ordinary_yearly_price`) that asserted the previously-permissive behavior — **confirmed with the user before implementing** (SAV/TREX's own yearly plans are calendar-aligned; a dedicated "exact one period regardless of alignment" mechanism was considered and rejected as unnecessary complexity for a case the product doesn't need). The opening stub is deliberately **not** discounted by this campaign kind, matching how an ordinary promotional code already behaves on this cadence — also confirmed with the user rather than assumed, since my own working notes from before this campaign's cadence math was fully traced suggested otherwise.

## Tests

- `DiscountCatalogueServiceCampaignTests`: the anniversary-yearly rejection (new test replacing the flipped one) plus a calendar-aligned acceptance case; four unrelated tests (DST window computation, effective-state) switched from the anniversary yearly fixture to a new calendar-aligned one so they keep testing what they were written to test rather than incidentally depending on the old permissive cadence check.
- `SubscriptionCreationServiceCampaignTests`: `DurationPeriods` is forced to `1` on the snapshot regardless of what the catalogue entry carries.
- `CalendarAnnualDiscountConsumptionTests`: one confirmatory test that a `FirstAnnualPeriod` campaign spends its one period at the boundary exactly like the ordinary promotions this suite already covers — closing the loop end to end for the campaign specifically rather than trusting inference.

## Verification

`dotnet test --filter "FullyQualifiedName!~Integration"`: **3213 passed**, same 4 pre-existing `SubscriptionSimulation*` baseline failures, 1 skipped (unrelated Aspose PDF test). No integration/Mongo-backed code touched by this phase, so `CampaignRedemptionConcurrencyTests` was not re-run.

## Remaining phases

4 (buyer preview API + UI), 5 (admin authoring UI), 6/2b (reconciliation-sweep worker for the redemption ledger's crash window).

## Merge order

This branch is based on `feat/campaign-free-month-pricing` (#351), which is based on `feat/campaign-discounts-redemption-ledger` (#350), which is based on `feat/campaign-discounts-data-model` (#349). Merge #349 to `dev` first, then #350, then #351, then this one, retargeting each PR's base as the prior one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
