### PR TITLE
feat(subscription): make a card-required trial free until it ends

### DIFF
--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -370,17 +370,24 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         if (_documents is not null)
         {
             // Announced after the transition commits, so a document is only ever promised for a
-            // subscription that actually started. Both, on a trial that took a card: the charge is a
-            // real charge and needs an invoice, and the trial is a real grant and needs its own
-            // zero-total document stating the terms.
-            await _documents.AnnounceChargeAsync(
-                subscription,
-                payment.ItemId,
-                SubscriptionChargeKind.Initial,
-                null,
-                link.CorrelationId,
-                cancellationToken,
-                SubscriptionDocumentSourceFactory.ActorOf(payment.UserId));
+            // subscription that actually started.
+            //
+            // Never for a card setup. The payment row behind a setup exists so the provider
+            // machinery has something to hang a session off and holds no money at all; invoicing it
+            // would issue a document for a charge that was never taken. A trial that collects a
+            // card now takes nothing on the day it starts, so this is the only announcement it
+            // gets until it converts.
+            if (!IsCardSetup(link))
+            {
+                await _documents.AnnounceChargeAsync(
+                    subscription,
+                    payment.ItemId,
+                    SubscriptionChargeKind.Initial,
+                    null,
+                    link.CorrelationId,
+                    cancellationToken,
+                    SubscriptionDocumentSourceFactory.ActorOf(payment.UserId));
+            }
 
             if (target == SubscriptionStatus.Trialing)
             {

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -22,10 +22,15 @@ public static class SubscriptionAmountCalculator
     /// What checkout actually charges when a subscription is first created.
     /// </summary>
     /// <remarks>
-    /// A card-free trial is charged nothing regardless of what a period would otherwise cost —
-    /// the money path cannot hold a card without charging it, so taking payment here would defeat
-    /// the entire point of a trial that starts free. Every other subscription reads its own frozen
-    /// figure, falling back only for one written before that was frozen at signup.
+    /// A trial is charged nothing, whether or not it asked for a card. Requiring a card and
+    /// charging for the first period were the same act for as long as the only way to hold a card
+    /// was to take money with it; they are separate now, and a trial that bills on its first day
+    /// is not a trial. The card is still collected — see <see cref="RequiresCardSetup"/>, which
+    /// this falls through to — it is just collected without a charge.
+    /// <para>
+    /// Every other subscription reads its own frozen figure, falling back only for one written
+    /// before that was frozen at signup.
+    /// </para>
     /// <para>
     /// Shared between the checkout charge and the purchase preview so the two read one expression
     /// rather than risk computing a different figure from the same subscription.
@@ -35,7 +40,7 @@ public static class SubscriptionAmountCalculator
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
-        if (subscription.Trial is { RequiresPaymentMethod: false })
+        if (subscription.Trial is not null)
         {
             return 0;
         }

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -360,12 +360,15 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             price.IntervalCount,
             price.CalendarStubBaseUnitAmountMinor);
 
-        // A card-free trial defers the first paid period to the day it ends, and for a yearly
-        // price that day decides the whole annual cycle: a 25 August signup on a trial running to
-        // 20 September starts its year on 1 October, not 1 September. The trial's end is known
-        // here, so the schedule is anchored on it rather than corrected later — every boundary
-        // derives from the anchor, and one anchored a month early stays a month early forever.
-        var scheduleAnchorUtc = trial is not null && !plan.TrialRequiresPaymentMethod
+        // A trial defers the first paid period to the day it ends, and for a yearly price that day
+        // decides the whole annual cycle: a 25 August signup on a trial running to 20 September
+        // starts its year on 1 October, not 1 September. The trial's end is known here, so the
+        // schedule is anchored on it rather than corrected later — every boundary derives from the
+        // anchor, and one anchored a month early stays a month early forever.
+        //
+        // Both trial modes, now that neither charges at signup. Anchoring a card-required trial at
+        // "now" was right only while it paid for its first period on day one.
+        var scheduleAnchorUtc = trial is not null
             ? trial.EndsAtUtc
             : now;
 
@@ -698,11 +701,15 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // though it may not be collected until its boundary — what the subscriber was quoted is
         // what settles, whichever of the two timings the price is on.
         //
-        // A card-free trial is the exception, for the same reason its stub is: which month the
-        // trial ends in decides both. A signup on 25 August whose trial runs to 20 September owes
-        // a 20–30 September stub and a year starting 1 October, and a year frozen today would say
-        // 1 September. It is priced at conversion instead, atomically with the stub it follows.
-        var annual = fraction.IsPartial && subscription.Trial is not { RequiresPaymentMethod: false }
+        // A trial is the exception, for the same reason its stub is: which month the trial ends in
+        // decides both. A signup on 25 August whose trial runs to 20 September owes a 20–30
+        // September stub and a year starting 1 October, and a year frozen today would say 1
+        // September. It is priced at conversion instead, atomically with the stub it follows.
+        //
+        // Either trial mode. This excluded only card-free trials while a card-required one paid for
+        // its first period on the day it signed up; now that neither pays anything at signup, a
+        // year frozen here would be frozen against the wrong month for both.
+        var annual = fraction.IsPartial && subscription.Trial is null
             ? BuildPendingAnnualPeriod(subscription, feePeriod.EndUtc, now)
             : null;
 
@@ -717,7 +724,11 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // A checkout paid tomorrow, resumed next week, or recovered by a sweep settles these
         // figures and not freshly derived ones — a stub priced by the day would otherwise shrink
         // underneath a customer who left the page open overnight.
-        if (subscription.Trial is not { RequiresPaymentMethod: false })
+        // No trial freezes an opening charge, because no trial has one. This field also carries a
+        // second meaning the renewal path depends on: a trial with it still unset is one that has
+        // not converted. Freezing a figure here for a card-required trial would both invent a
+        // charge nobody takes and permanently hide the conversion from TryResolveTrialConversion.
+        if (subscription.Trial is null)
         {
             // A promotional code belongs to the year, not to the days before it — so a yearly stub
             // is priced without one. Its automatic discount and volume band still apply, because
@@ -745,13 +756,18 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         subscription.CurrentPeriodEndUtc = feePeriod.EndUtc;
 
         // Only a card-free trial defers the first fee to the day it ends, because only that
-        // one starts without taking payment. A trial that demands a card is charged for its
-        // first period up front — the money path has no way to hold a card without charging it
-        // — so that period is already paid, and billing again on the trial's last day would
-        // take the same money twice. This condition deliberately mirrors the one
-        // SubscriptionCheckoutService uses to decide whether to charge at all.
+        // one starts without taking payment — which is now every trial, whether or not it asked
+        // for a card. This used to bill a card-required trial at its first period's end instead,
+        // because that period had already been paid for at signup and billing again on the trial's
+        // last day would have taken the same money twice. Card setup removed the charge, and with
+        // it the reason: billing at the period end would now charge a subscriber in the middle of
+        // a trial that is supposed to be free — on a calendar-aligned monthly price, the opening
+        // stub ends on the 1st, which for a trial running past it is days early.
+        //
+        // This condition deliberately mirrors the one SubscriptionCheckoutService uses to decide
+        // whether to charge at all.
         subscription.NextFeeBillingAtUtc =
-            subscription.Trial is { RequiresPaymentMethod: false } trial
+            subscription.Trial is { } trial
                 ? trial.EndsAtUtc
                 : feePeriod.EndUtc;
         subscription.CurrentUsagePeriodStartUtc = usagePeriod.StartUtc;

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -407,7 +407,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
 
         if (subscription.InitialChargeAmountMinor is not null ||
             !CalendarBillingAlignment.IsCalendarAligned(subscription.Price) ||
-            subscription.Trial is not { RequiresPaymentMethod: false, EndsAtUtc: var endsAtUtc } ||
+            subscription.Trial is not { EndsAtUtc: var endsAtUtc } ||
             endsAtUtc > nowUtc)
         {
             return false;

--- a/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedSubscriptionTests.cs
@@ -333,19 +333,72 @@ public sealed class CalendarAlignedSubscriptionTests
     }
 
     /// <summary>
-    /// A trial that takes a card is charged up front, so its first period is priced now like any
-    /// other signup.
+    /// Neither trial mode is billed before the day the trial ends.
     /// </summary>
+    /// <remarks>
+    /// The trap this guards, and it caught a real one. A calendar-aligned monthly price opens with
+    /// a stub that ends on the 1st, and billing at that stub's end is correct for an ordinary
+    /// signup. For a trial running past the 1st it is days early: a 25 August signup on a trial to
+    /// 8 September would have been charged on the 1st, a week into a trial that is supposed to be
+    /// free.
+    /// <para>
+    /// Card-free trials always pointed at the trial's end and were never exposed. Card-required
+    /// ones pointed at the stub's end, which was right only while they paid for that stub at
+    /// signup — removing the signup charge without moving this date would have turned a
+    /// double-charge into an early one.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task No_trial_is_billed_before_it_ends(bool requiresCard)
+    {
+        _time.Advance(new DateTimeOffset(2026, 8, 25, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = requiresCard;
+
+        await Subscribe();
+
+        _created!.NextFeeBillingAtUtc.Should().Be(
+            _created.Trial!.EndsAtUtc,
+            "the first fee falls on the day the trial stops, not on the calendar boundary the " +
+            "opening stub happens to end at");
+
+        // Stated separately from the equality above, because this is the consequence that costs a
+        // subscriber money and the sweep applies no trial guard of its own: ListDueForRenewalAsync
+        // selects Trialing subscriptions on NextFeeBillingAtUtc alone.
+        _created.NextFeeBillingAtUtc.Should().NotBeBefore(
+            _created.Trial.EndsAtUtc,
+            "a trial billed before it ends is not free");
+    }
+
+    /// <summary>
+    /// A trial that takes a card freezes no opening charge, because it takes no money.
+    /// </summary>
+    /// <remarks>
+    /// The inverse of what this asserted before, for the reason given on
+    /// <c>A_trial_that_demands_a_card_bills_for_the_first_time_when_it_ends</c>. The calendar case
+    /// is worth its own test because a calendar schedule prices an opening stub, and freezing that
+    /// stub's cost at signup would describe a charge nobody made — and describe it wrongly, since
+    /// the trial ends in a different part of the month than the day it started.
+    /// <para>
+    /// The next fee date is deliberately not asserted here: a calendar schedule's boundaries are
+    /// calendar firsts, so it falls on the 1st rather than on the trial's last day. That the
+    /// schedule anchors on the trial's end is asserted where it is visible, on the anniversary
+    /// cadence in <c>SubscriptionCreationServiceTests</c>.
+    /// </para>
+    /// </remarks>
     [Fact]
-    public async Task A_payment_required_trial_still_freezes_its_first_charge()
+    public async Task A_payment_required_trial_freezes_no_first_charge()
     {
         _plan.TrialDays = 14;
         _plan.TrialRequiresPaymentMethod = true;
 
         await Subscribe();
 
-        _created!.InitialChargeAmountMinor.Should().Be(2010);
-        _created.ProrationDays.Should().Be(7);
+        _created!.InitialChargeAmountMinor.Should().BeNull();
+        _created.ProrationDays.Should().BeNull();
+        _created.ProrationTotalDays.Should().BeNull();
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -463,22 +463,59 @@ public sealed class SubscriptionCreationServiceTests
     }
 
     /// <summary>
-    /// The regression this guards: a trial demanding a card is charged for its first period up
-    /// front, because the money path cannot hold a card without charging it. Billing again on
-    /// the trial's last day took the same money twice.
+    /// A trial that demands a card bills for the first time when it ends, exactly as a card-free
+    /// one does.
     /// </summary>
+    /// <remarks>
+    /// This test previously asserted the opposite, and its reason was true when it was written:
+    /// the money path could not hold a card without charging it, so a card-required trial paid for
+    /// its first period on day one and billing again at the trial's end took the same money twice.
+    /// Card setup separates the two — a card is stored and nothing is taken — so the charge that
+    /// used to happen at signup now happens once, at the end, and the schedule has to point there.
+    /// <para>
+    /// The double-charge it guarded against is still guarded, from the other side: nothing is
+    /// frozen as an opening charge, so there is no signup payment for the conversion to duplicate.
+    /// </para>
+    /// </remarks>
     [Fact]
-    public async Task A_trial_that_demands_a_card_is_not_billed_again_when_it_ends()
+    public async Task A_trial_that_demands_a_card_bills_for_the_first_time_when_it_ends()
     {
         _plan.TrialDays = 14;
         _plan.TrialRequiresPaymentMethod = true;
 
         await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
 
-        _created!.NextFeeBillingAtUtc.Should().NotBe(_created.Trial!.EndsAtUtc,
-            "the first period was already paid at signup");
-        _created.NextFeeBillingAtUtc.Should().Be(_created.CurrentPeriodEndUtc,
-            "the next fee falls when the period that was paid for runs out");
+        _created!.NextFeeBillingAtUtc.Should().Be(_created.Trial!.EndsAtUtc,
+            "the first paid period starts when the trial stops");
+        _created.InitialChargeAmountMinor.Should().BeNull(
+            "nothing was charged at signup, so there is no opening figure to freeze — and the " +
+            "renewal path reads this being unset as the trial not having converted yet");
+        // Non-nullable on the entity, so "never written" reads as false rather than as absent.
+        _created.InitialChargeProrated.Should().BeFalse();
+        _created.InitialChargeDiscountApplied.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// Neither trial mode is charged at signup, which is what makes checkout collect a card
+    /// instead of money.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task No_trial_is_charged_when_it_starts(bool requiresCard)
+    {
+        _plan.TrialDays = 14;
+        _plan.TrialRequiresPaymentMethod = requiresCard;
+
+        await Service().CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        SubscriptionAmountCalculator.InitialChargeAmountMinor(_created!)
+            .Should().Be(0, "a trial that bills on its first day is not a trial");
+
+        // The card is still a condition of starting when the plan asked for one; it is collected
+        // by a setup session rather than by taking a payment.
+        SubscriptionAmountCalculator.RequiresCardSetup(_created!)
+            .Should().Be(requiresCard);
     }
 
     [Fact]


### PR DESCRIPTION
**Server billing core, part 1 of the deferred-trial work.** The new `POST /payment-method/setup` endpoint, `Unpaid` recovery and client UI follow separately, as agreed.

## The defect

A trial that asked for a card was charged for its **whole first period on the day it started**. That was the only way to hold a card when it was written — the money path could not store one without taking money with it.

It has not been true since card setup landed. `StripeSetupSessionRequestFactory` opens a session in `mode=setup`, and `SubscriptionActivationProcessor` already adopts the card and moves `Incomplete → Trialing` with no charge. **Only the decision to charge was left behind.**

## What most of this spec already does

Worth stating plainly, because it shapes the change: setup-mode checkout, the off-session mandate, `pendingCheckout.purpose = "PaymentMethodSetup"`, the atomic `Incomplete → Trialing` transition, never recording a setup as the initial payment, `Unpaid` with reason `no_payment_method` at expiry, and consuming a discount period only when the charge actually received it — **all already exist and work.** The independence of `requirePaymentMethodUpfront` is already how `RequiresCardSetup` is written.

## Six changes, four of them load-bearing

**1. `SubscriptionAmountCalculator.cs`** — `InitialChargeAmountMinor` returns zero for any trial, not only a card-free one. Nothing payable then falls through to `RequiresCardSetup` (already true here) and checkout opens a setup session. *This one condition is the feature.* The rest is what stops it breaking something else.

**2. `SubscriptionCreationService.cs`** — no trial freezes an opening charge. That field is **also** the marker the renewal path reads as "this trial has not converted yet", so freezing a figure would have invented a charge nobody takes *and* permanently hidden the conversion from `TryResolveTrialConversion`.

**3. `SubscriptionCreationService.cs`** — `NextFeeBillingAtUtc` points at the trial's end for both modes.

> This is the one that would have shipped a new bug. It pointed at the *opening period's* end for a card-required trial, correct only while that period was paid at signup. A calendar-aligned monthly price opens with a stub ending **on the 1st**, so a 25 August signup trialing to 8 September would have been billed **a week into a free trial**. `ListDueForRenewalAsync` selects `Trialing` subscriptions on this date alone and applies no trial guard — the date is the only thing between a trial and an early charge.
>
> **Found by probing the real value, not by reading the code.** My reading said card-free and card-required now shared a path and were both fine. The probe said `card=False earlyCharge=False`, `card=True earlyCharge=True`.

**4. `SubscriptionCreationService.cs`** — the pending annual period is no longer frozen for a card-required trial, for the reason already documented for card-free ones: which month the trial ends in decides the year.

**5. `SubscriptionRenewalService.cs`** — `TryResolveTrialConversion` no longer requires a card-free trial.

**6. `SubscriptionActivationProcessor.cs`** — no charge invoice for a card-setup link. That call was unconditional and correct while such a trial was charged; the payment row behind a setup holds no money, and invoicing it would issue a document for a charge that never happened.

## Kept deliberately

The **zero-total trial document**, for both modes: the subscriber has entitlement granted on stated terms whether or not a card was taken. The spec said to create no document at trial signup; you chose to keep it. No charge is created either way.

## Tests

Two existing tests asserted the old behaviour and stated its reason (*"the money path cannot hold a card without charging it"*). Both **rewritten to the new intent rather than deleted**, keeping their double-charge guard from the other side: nothing is frozen at signup, so the conversion has no signup payment to duplicate.

Added: `No_trial_is_charged_when_it_starts` (both modes, asserting the card is still required where the plan asks), and `No_trial_is_billed_before_it_ends` (both modes, pinning change 3 — the trap above).

**3161 passed**, 4 failures in `SubscriptionSimulation*` permission guards, **confirmed pre-existing on clean `dev`** by stashing. `FinancialDocumentLedgerIntegrationTests` need a local mongod and were not run; they run in no CI workflow either.

## Not in this PR

`POST /api/subscriptions/{id}/payment-method/setup`, `Unpaid → recovery` charge-on-setup, the `GET current` recovery action, client copy and UI states, and docs. The client copy is currently **wrong on `dev`** — it tells the author a card-required trial is charged at signup, which this change makes false. Worth landing that soon after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
