### PR TITLE
feat(subscription): explain campaign discounts on the buyer purchase preview [Phase 4/6]

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
@@ -67,6 +67,7 @@ const quote: SubscriptionPurchasePreview = {
   trialEndsAtUtc: null,
   requiresCardSetup: false,
   pendingAnnualPeriod: null,
+  campaign: null,
   blockers: [],
   quotedAtUtc: "2026-08-16T00:00:00Z",
   quoteValidUntilUtc: null,
@@ -260,5 +261,44 @@ describe("SubscribeDialog", () => {
     await waitFor(() => {
       expect(screen.getByText(/a card is required to start this subscription/)).toBeInTheDocument();
     });
+  });
+
+  it("explains a campaign discount and when standard pricing resumes", async () => {
+    previewSubscription.mockResolvedValue({
+      ...quote,
+      totalDueNowMinor: 0,
+      campaign: {
+        kind: "FreeOpeningCalendarPeriod",
+        description: "Your first calendar month is free. Standard pricing begins once this " +
+          "opening period ends.",
+        discountEndsAtUtc: "2026-09-01T00:00:00Z",
+        temporaryEntitlementKey: "seats",
+        temporaryEntitlementLimit: 1,
+      },
+    });
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscribe-quote-campaign")).toBeInTheDocument();
+    });
+
+    const panel = screen.getByTestId("subscribe-quote-campaign");
+    expect(panel.textContent).toContain("Your first calendar month is free");
+    expect(panel.textContent).toContain("seats limited to 1");
+  });
+
+  it("shows no campaign panel for an ordinary discount code", async () => {
+    previewSubscription.mockResolvedValue(quote);
+
+    renderDialog();
+    click(/^Preview$/);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("subscribe-quote")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("subscribe-quote-campaign")).not.toBeInTheDocument();
   });
 });

--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.tsx
@@ -311,6 +311,23 @@ export const SubscribeDialog = ({
                   Nothing is charged now, but a card is required to start this subscription.
                 </p>
               ) : null}
+              {quote.campaign ? (
+                <div
+                  className="space-y-1 rounded-md border border-blocks-primary-300 bg-blocks-primary-50 p-2 text-blocks-primary-900"
+                  data-testid="subscribe-quote-campaign"
+                >
+                  <p>{quote.campaign.description}</p>
+                  <p className="text-xs">
+                    Standard pricing resumes {formatDate(quote.campaign.discountEndsAtUtc)}.
+                  </p>
+                  {quote.campaign.temporaryEntitlementKey ? (
+                    <p className="text-xs">
+                      {quote.campaign.temporaryEntitlementKey} limited to{" "}
+                      {quote.campaign.temporaryEntitlementLimit} while this offer runs.
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
               {quote.pendingAnnualPeriod ? (
                 <p className="text-xs text-muted-foreground">
                   Also buys the year starting {formatDate(quote.pendingAnnualPeriod.startUtc)}

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -151,6 +151,22 @@ export interface SubscriptionPreviewAnnualPeriod {
 }
 
 /**
+ * Why this quote is temporary, present only when the discount code applied is a platform
+ * campaign rather than an ordinary promotional code. Every other field on the preview already
+ * carries the right numbers for a campaign — this is only the "why" behind them.
+ */
+export interface SubscriptionPreviewCampaign {
+  kind: "FreeOpeningCalendarPeriod" | "FirstAnnualPeriod";
+  /** A short, ready-to-display sentence explaining the offer and when it ends. */
+  description: string;
+  /** The instant standard pricing resumes. */
+  discountEndsAtUtc: string;
+  /** Set only for a free-opening-period campaign that caps an entitlement while it runs. */
+  temporaryEntitlementKey: string | null;
+  temporaryEntitlementLimit: number | null;
+}
+
+/**
  * What subscribing would cost right now, and what would stand in the way — without subscribing.
  *
  * `totalDueNowMinor` is the exact figure a confirming subscribe call then charges: both read the
@@ -178,6 +194,8 @@ export interface SubscriptionPurchasePreview {
   /** Whether confirming will ask for a card even though nothing is due now. */
   requiresCardSetup: boolean;
   pendingAnnualPeriod: SubscriptionPreviewAnnualPeriod | null;
+  /** Null unless the discount code applied is a platform campaign. */
+  campaign: SubscriptionPreviewCampaign | null;
   /** Empty when nothing stands in the way of confirming. */
   blockers: SubscriptionPreviewBlocker[];
   /** The instant these figures were derived from. */

--- a/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
@@ -72,6 +72,20 @@ public sealed class SubscriptionPreviewResponse
     public SubscriptionPreviewAnnualPeriodResponse? PendingAnnualPeriod { get; init; }
 
     /// <summary>
+    /// Why this quote is temporary, when the discount code applied is a platform campaign rather
+    /// than an ordinary promotional code. Null for a Standard discount and for no discount at all.
+    /// </summary>
+    /// <remarks>
+    /// Every other field on this response already carries the right numbers for a campaign — the
+    /// same pricing pipeline prices one exactly as it prices an ordinary code. What is missing
+    /// without this is the "why": a buyer reading <see cref="TotalDueNowMinor"/> as zero, or
+    /// <see cref="NextRenewalAmountMinor"/> as a smaller figure than the price's own list amount,
+    /// has no way to tell from the numbers alone that either is temporary rather than the price
+    /// they will keep paying.
+    /// </remarks>
+    public SubscriptionPreviewCampaignResponse? Campaign { get; init; }
+
+    /// <summary>
     /// What would stop the confirm from succeeding, named rather than hidden behind a price the
     /// customer is then refused. Empty when nothing stands in the way.
     /// </summary>
@@ -102,6 +116,38 @@ public sealed class SubscriptionPreviewAnnualPeriodResponse
 
     /// <summary>Whether the year's amount is already included in <c>totalDueNowMinor</c>.</summary>
     public bool CollectedWithCheckout { get; init; }
+}
+
+/// <summary>
+/// The buyer-facing explanation for a campaign discount: what it is, and when the price it quoted
+/// stops applying.
+/// </summary>
+public sealed class SubscriptionPreviewCampaignResponse
+{
+    /// <summary>
+    /// <c>FreeOpeningCalendarPeriod</c> or <c>FirstAnnualPeriod</c> -- named rather than left for a
+    /// client to infer from the numbers, so a client that wants its own wording still knows which
+    /// campaign it is looking at.
+    /// </summary>
+    public string Kind { get; init; } = string.Empty;
+
+    /// <summary>A short, ready-to-display sentence explaining the offer and when it ends.</summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The instant standard pricing resumes -- the opening stub's end for a free calendar month,
+    /// or the discounted year's end for a first-annual-period campaign.
+    /// </summary>
+    public DateTime DiscountEndsAtUtc { get; init; }
+
+    /// <summary>
+    /// The entitlement a free-opening-period campaign temporarily caps, and the cap itself. Null
+    /// for a campaign that carries no override, and always null for a first-annual-period
+    /// campaign, which never carries one.
+    /// </summary>
+    public string? TemporaryEntitlementKey { get; init; }
+
+    public long? TemporaryEntitlementLimit { get; init; }
 }
 
 /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -1106,9 +1106,60 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                     TaxAmountMinor = annual.TaxAmountMinor,
                     CollectedWithCheckout = annual.CollectedWithCheckout
                 },
+            Campaign = BuildCampaignPreview(subscription),
             Blockers = blockers,
             QuotedAtUtc = subscription.CreatedAtUtc,
             QuoteValidUntilUtc = QuoteValidUntilUtc(subscription, timeZoneId)
+        };
+    }
+
+    /// <summary>
+    /// The buyer-facing explanation for a campaign discount, or null when there is none to explain
+    /// -- no discount at all, or an ordinary Standard one that needs no explaining because it never
+    /// stops applying on its own.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CampaignTerms.EntitlementOverride"/> is only ever honoured by
+    /// <see cref="EntitlementService"/> for <see cref="CampaignKind.FreeOpeningCalendarPeriod"/> --
+    /// see <c>EntitlementServiceCampaignTests</c>'s
+    /// <c>A_first_annual_period_campaign_never_overrides_an_entitlement_either</c>. Surfacing one
+    /// here for a <see cref="CampaignKind.FirstAnnualPeriod"/> campaign would describe a cap that
+    /// is never actually enforced, so it is read only for the kind that honours it.
+    /// </remarks>
+    private static SubscriptionPreviewCampaignResponse? BuildCampaignPreview(
+        SubscriptionDetail subscription)
+    {
+        if (subscription.Discount?.Campaign is not { Kind: var kind } campaign ||
+            kind == CampaignKind.Standard)
+        {
+            return null;
+        }
+
+        return kind switch
+        {
+            CampaignKind.FreeOpeningCalendarPeriod => new SubscriptionPreviewCampaignResponse
+            {
+                Kind = nameof(CampaignKind.FreeOpeningCalendarPeriod),
+                Description = "Your first calendar month is free. Standard pricing begins once " +
+                    "this opening period ends.",
+                // The same clock check EntitlementService and the plan/quantity-change lock read
+                // for this campaign kind -- the opening period is over exactly when this passes.
+                DiscountEndsAtUtc = subscription.CurrentPeriodEndUtc,
+                TemporaryEntitlementKey = campaign.EntitlementOverride?.EntitlementKey,
+                TemporaryEntitlementLimit = campaign.EntitlementOverride?.Limit
+            },
+            CampaignKind.FirstAnnualPeriod => new SubscriptionPreviewCampaignResponse
+            {
+                Kind = nameof(CampaignKind.FirstAnnualPeriod),
+                Description = "This discount applies to your first year only. Standard pricing " +
+                    "resumes at your first renewal.",
+                // The discounted year's own end where one is still pending (a mid-month signup,
+                // priced but not yet open); otherwise the current period already *is* that year,
+                // opened on the calendar boundary itself, and CurrentPeriodEndUtc already names it.
+                DiscountEndsAtUtc = subscription.PendingAnnualPeriod?.EndUtc
+                    ?? subscription.CurrentPeriodEndUtc
+            },
+            _ => null
         };
     }
 

--- a/server/XUnitTest/Subscription/SubscriptionPreviewCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPreviewCampaignTests.cs
@@ -1,0 +1,257 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using Subscription.DomainService.Validators;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Phase 4: the buyer-facing explanation a purchase preview attaches to a campaign discount.
+/// </summary>
+/// <remarks>
+/// <c>POST /subscriptions/preview</c> already prices a campaign code exactly as a real signup
+/// would -- it shares <c>BuildSubscriptionAsync</c> with <see cref="SubscriptionCreationService.CreateAsync"/>
+/// wholesale, so there is only one pricing path to get right, and Phase 1 through 3b's own tests
+/// already cover it. What a preview response could not do until now is say *why* a figure is
+/// temporary: a buyer reading a zero due-now or a discounted renewal has no way to tell from the
+/// numbers alone that either reverts. This suite is entirely about that explanation, not the
+/// pricing underneath it.
+/// </remarks>
+public sealed class SubscriptionPreviewCampaignTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionCatalogueRepository> _catalogue = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDiscountRepository> _discounts = new();
+    private readonly Mock<IBillingAccountRepository> _accounts = new();
+    private readonly Mock<ISubscriptionBillingProfileGuard> _billingProfile = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 14, 10, 0, 0, TimeSpan.Zero));
+
+    public SubscriptionPreviewCampaignTests()
+    {
+        _billingProfile
+            .Setup(guard => guard.MissingFieldsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _billingProfile
+            .Setup(guard => guard.ContactDefaultsAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingContactDefaults("Ada Byron", "billing@northwind.example"));
+
+        _catalogue
+            .Setup(repository => repository.FindPlanByCodeAsync(
+                TenantId, OrganizationId, "professional", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPlan());
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-monthly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewMonthlyPrice());
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-yearly", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewCalendarYearlyPrice());
+
+        _accounts
+            .Setup(repository => repository.GetOrCreateAndReconcileAsync(
+                It.IsAny<BillingAccount>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingAccount account, CancellationToken _) => account);
+
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+    }
+
+    [Fact]
+    public async Task A_standard_discounts_preview_carries_no_campaign_explanation()
+    {
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "launch25", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms
+                {
+                    Code = "launch25", Kind = DiscountKind.Percent, PercentBasisPoints = 2_500
+                }
+            });
+
+        var request = NewRequest("price-monthly");
+        request.DiscountCode = "launch25";
+
+        var result = await Service().PreviewAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Campaign.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_free_opening_period_previews_its_own_explanation_and_entitlement_cap()
+    {
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "free1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ItemId = "discount-free1",
+                Version = 1,
+                Terms = new DiscountTerms
+                {
+                    Code = "free1", Kind = DiscountKind.Percent, PercentBasisPoints = 10_000
+                },
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FreeOpeningCalendarPeriod,
+                    EntitlementOverride = new CampaignEntitlementOverride
+                    {
+                        EntitlementKey = "seats", Limit = 1
+                    },
+                    RedeemableFromUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    RedeemableUntilUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                }
+            });
+
+        var request = NewRequest("price-monthly");
+        request.DiscountCode = "free1";
+
+        var result = await Service().PreviewAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var campaign = result.Value!.Campaign;
+        campaign.Should().NotBeNull();
+        campaign!.Kind.Should().Be("FreeOpeningCalendarPeriod");
+        campaign.Description.Should().NotBeNullOrWhiteSpace();
+        // The same instant the confirm's own subscription would carry as CurrentPeriodEndUtc --
+        // read back rather than recomputed, so this cannot name a different boundary than the one
+        // the entitlement override and the change-lock actually read.
+        campaign.DiscountEndsAtUtc.Should().Be(result.Value.PeriodEndUtc);
+        campaign.TemporaryEntitlementKey.Should().Be("seats");
+        campaign.TemporaryEntitlementLimit.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_first_annual_period_preview_names_the_discounted_years_own_end_not_the_stubs()
+    {
+        _discounts
+            .Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "annual1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                ItemId = "discount-annual1",
+                Version = 1,
+                Terms = new DiscountTerms
+                {
+                    Code = "annual1", Kind = DiscountKind.Percent, PercentBasisPoints = 1_500
+                },
+                ApplicablePriceIds = ["price-yearly"],
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.FirstAnnualPeriod,
+                    RedeemableFromUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                    RedeemableUntilUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+                }
+            });
+
+        var request = NewRequest("price-yearly");
+        request.DiscountCode = "annual1";
+
+        var result = await Service().PreviewAsync(request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var campaign = result.Value!.Campaign;
+        campaign.Should().NotBeNull();
+        campaign!.Kind.Should().Be("FirstAnnualPeriod");
+        // The buyer signed up mid-month, so PeriodEndUtc on the response is the STUB's end -- the
+        // discount instead ends when the discounted year it also bought ends, which is what a
+        // buyer actually needs to know standard pricing resumes at.
+        result.Value.PendingAnnualPeriod.Should().NotBeNull();
+        campaign.DiscountEndsAtUtc.Should().Be(result.Value.PendingAnnualPeriod!.EndUtc);
+        campaign.DiscountEndsAtUtc.Should().NotBe(result.Value.PeriodEndUtc);
+        // FirstAnnualPeriod never carries an entitlement override -- nothing to describe here even
+        // though the field exists on the response shape.
+        campaign.TemporaryEntitlementKey.Should().BeNull();
+    }
+
+    private SubscriptionCreationService Service() => new(
+        _catalogue.Object,
+        _subscriptions.Object,
+        _discounts.Object,
+        _accounts.Object,
+        new CreateSubscriptionRequestValidator(),
+        NullLogger<SubscriptionCreationService>.Instance,
+        _time,
+        billingProfile: _billingProfile.Object);
+
+    private static SubscriptionContext Context() =>
+        new(TenantId, OrganizationId, "actor-1", "user-1");
+
+    private static CreateSubscriptionRequest NewRequest(string priceId) => new()
+    {
+        PlanCode = "professional",
+        PriceId = priceId,
+        TimeZoneId = "Europe/Zurich",
+        Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 1 }]
+    };
+
+    private static Plan NewPlan() => new()
+    {
+        ItemId = "plan-1",
+        TenantId = TenantId,
+        Code = "professional",
+        DisplayName = "Professional",
+        Status = CatalogueStatus.Active,
+        Version = 3,
+        Entitlements =
+        [
+            new PlanEntitlement { Key = "seats", LimitKind = EntitlementLimitKind.Count, Limit = 5 }
+        ],
+        QuantityItems =
+        [
+            new PlanQuantityItem { ItemKey = "seat", UnitLabel = "seat", DefaultQuantity = 1 }
+        ]
+    };
+
+    private static Price NewMonthlyPrice() => new()
+    {
+        ItemId = "price-monthly",
+        TenantId = TenantId,
+        PlanId = "plan-1",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 8_900,
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        QuantityItemKey = "seat",
+        Status = CatalogueStatus.Active
+    };
+
+    /// <summary>A signup on 14 August 2026 -- mid-month, so this cadence always has a stub.</summary>
+    private static Price NewCalendarYearlyPrice() => new()
+    {
+        ItemId = "price-yearly",
+        TenantId = TenantId,
+        PlanId = "plan-1",
+        CurrencyCode = "CHF",
+        UnitAmountMinor = 96_000,
+        Interval = BillingInterval.Year,
+        IntervalCount = 1,
+        BillingAlignment = BillingAlignment.CalendarMonth,
+        CalendarStubBasePriceId = "price-monthly",
+        CalendarStubBaseUnitAmountMinor = 8_900,
+        QuantityItemKey = "seat",
+        Status = CatalogueStatus.Active
+    };
+}


### PR DESCRIPTION
Phase 4/6 of campaign discount management. The buyer-facing "what would this cost" surface for a campaign discount code.

## Scope, decided with the user before writing anything

`POST /subscriptions/preview` already prices a campaign discount code exactly as a real signup would — it shares `BuildSubscriptionAsync` wholesale with `SubscriptionCreationService.CreateAsync`, so the redeemable-window check, the cadence rules, and the `DurationPeriods`-forced pricing from Phases 1–3b already apply to a preview with zero new code.

What was actually missing, confirmed with the user rather than assumed, was narrower than "a preview API": **the response has no way to say a figure is temporary.** A buyer reading `totalDueNowMinor` as zero, or a discounted `nextRenewalAmountMinor`, cannot tell from the numbers alone that either reverts. A second, code-only endpoint for checking a campaign before a plan is chosen was considered and explicitly deferred as unnecessary for now.

## Server

- `Responses/SubscriptionPreviewResponse.cs` — new `SubscriptionPreviewCampaignResponse`: `Kind`, a ready-to-display `Description`, `DiscountEndsAtUtc`, and the temporary entitlement key/limit (`FreeOpeningCalendarPeriod` only). New nullable `Campaign` field on the preview response.
- `Services/SubscriptionCreationService.cs` — `BuildCampaignPreview` reads back what `ApplyPeriods`/`ResolveDiscountAsync` already computed on the in-memory subscription; nothing is recomputed, so this cannot describe a discount differently than the one actually priced.
  - `FreeOpeningCalendarPeriod`: `DiscountEndsAtUtc` is `CurrentPeriodEndUtc` — the same clock boundary `EntitlementService` and the plan/quantity-change lock already read for this campaign kind.
  - `FirstAnnualPeriod`: `DiscountEndsAtUtc` is `PendingAnnualPeriod.EndUtc` where a stub is pending, falling back to `CurrentPeriodEndUtc` for a signup landing exactly on the calendar boundary. Never surfaces an entitlement override — this campaign kind never honours one (see `EntitlementServiceCampaignTests`).
  - Standard discount or no discount: `Campaign` is null.

## Client

- `models/subscription-simulation.model.ts` — new `SubscriptionPreviewCampaign` type; plain passthrough, no service-layer mapping needed.
- `components/subscribe-dialog.tsx` — a short explanatory panel in the existing purchase-preview card, shown only when `campaign` is set: the description, when standard pricing resumes, and the temporary entitlement cap where one applies.

## Tests

- `SubscriptionPreviewCampaignTests` (new): Standard discount → no `Campaign`; `FreeOpeningCalendarPeriod`'s `DiscountEndsAtUtc` matches the response's own `PeriodEndUtc` plus the entitlement cap; `FirstAnnualPeriod`'s `DiscountEndsAtUtc` matches `PendingAnnualPeriod.EndUtc` and deliberately differs from `PeriodEndUtc`, with no entitlement key.
- `subscribe-dialog.test.tsx` — the panel renders when present, is absent for an ordinary/no discount.

## Verification

- Server: `dotnet test --filter "FullyQualifiedName!~Integration"`: **3216 passed**, same 4 pre-existing baseline failures, 1 unrelated skip.
- Client: `npx vitest run` (full suite): **321 files, 2306 tests passed**. `npx tsc -b`: clean.

## Remaining phases

5 (admin authoring UI), 6/2b (reconciliation-sweep worker).

## Merge order

Based on `feat/campaign-annual-yearly-pricing` (#352) → `feat/campaign-free-month-pricing` (#351) → `feat/campaign-discounts-redemption-ledger` (#350) → `feat/campaign-discounts-data-model` (#349). Merge in that order, retargeting each PR's base as the prior one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
