### PR TITLE
fix(subscription): stop telling authors a card-required trial charges at signup

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.test.tsx
@@ -32,23 +32,36 @@ const trialCardQuestion = () => screen.getByLabelText(/Require a card to start t
  * other moved with its control.
  */
 describe("the trial's card requirement", () => {
-  it("is on by default, and says the first period is charged", () => {
+  it("is on by default, and says the card is saved without a charge", () => {
     render(<Harness />);
 
     expect(trialCardQuestion()).toBeChecked();
-    // The consequence, not the setting: a card cannot be held without charging it, so requiring
-    // one turns the trial into an ordinary paid period with the allowances below.
-    expect(screen.getByText(/first period is charged at signup/i)).toBeInTheDocument();
+
+    // This said "the first period is charged at signup", and that was true: a card could not be
+    // held without taking money with it, so a trial that wanted one billed on day one. Card setup
+    // separated the two, and copy telling an author their trial charges immediately would now
+    // describe something the product does not do.
+    expect(screen.getByText(/saved now without a charge/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/first paid period is charged when the trial ends/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/charged at signup/i)).not.toBeInTheDocument();
   });
 
-  it("explains what a genuinely free trial leaves the product to do", async () => {
+  it("explains what a trial without a card leaves the product to do", async () => {
     const user = userEvent.setup();
     render(<Harness />);
 
     await user.click(trialCardQuestion());
 
     expect(trialCardQuestion()).not.toBeChecked();
-    expect(screen.getByText(/Genuinely free until the trial ends/i)).toBeInTheDocument();
+    expect(screen.getByText(/starts without a card/i)).toBeInTheDocument();
+
+    // The consequence worth stating: nothing stops the trial itself, but paid access cannot
+    // continue past it until a card exists.
+    expect(
+      screen.getByText(/required before paid access can continue/i),
+    ).toBeInTheDocument();
   });
 
   /**

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -144,10 +144,16 @@ export const StepTrial = () => {
                 </FormControl>
                 <FormLabel className="!m-0">Require a card to start the trial</FormLabel>
               </div>
+              {/*
+                Both branches describe a trial that is free until it ends. Requiring a card and
+                charging for the first period used to be the same act, because the money path could
+                not hold a card without taking money with it, and this copy said so. Card setup
+                separated them: the card is stored by a setup session that charges nothing.
+              */}
               <p className="text-xs text-muted-foreground">
                 {trialRequiresPaymentMethod
-                  ? "The first period is charged at signup — the payment path cannot hold a card without charging it. The trial then only governs the allowances below."
-                  : "Genuinely free until the trial ends, when the first charge is taken. Your product must collect a card before then, or that charge has nothing to bill."}
+                  ? "A card is saved now without a charge. The first paid period is charged when the trial ends."
+                  : "The trial starts without a card. A payment method is required before paid access can continue."}
               </p>
             </FormItem>
           )}


### PR DESCRIPTION
> **Merge after [#353](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/353).** This copy describes the behaviour #353 introduces. Landing it first would make the text wrong in the other direction.

## The problem

The plan builder tells an author who ticks *"Require a card to start the trial"*:

> The first period is charged at signup — the payment path cannot hold a card without charging it. The trial then only governs the allowances below.

True when written. Not true after #353, which makes every trial free until it ends.

## The new copy

| | |
|---|---|
| **Checked** | A card is saved now without a charge. The first paid period is charged when the trial ends. |
| **Unchecked** | The trial starts without a card. A payment method is required before paid access can continue. |

## Nothing else needed changing — worth saying, because it looked like it would

The spec also asks for the plan preview to show nothing due for either trial mode. **That already happens**, and it needs no client change:

- `subscribe-dialog.tsx` prints `"Nothing due now"` whenever `quote.totalDueNowMinor === 0`, and that figure is the server's `InitialChargeAmountMinor` — which #353 makes zero for both trial modes.
- Its `"Nothing is charged now, but a card is required to start this subscription."` line is already keyed on `quote.requiresCardSetup && totalDueNowMinor === 0`, which is exactly the card-required trial after #353.
- The trial invoice's `"Required up front" / "Not required"` is still accurate: a card *is* required up front, it is simply not charged.
- No e2e spec pins the old wording.

I checked each of these rather than changing them on the strength of the spec naming them.

## Tests

The two tests asserting the old copy are **updated, not deleted** — they moved to `step-pricing-model`/`step-trial` in #340 and still guard the same behaviour. One now also asserts `/charged at signup/i` is **absent**, so the claim cannot return without a failure.

- `plan-builder` suite: **103 passed**
- `tsc --noEmit`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
