### PR TITLE
feat(subscription): admin campaign authoring wizard [Phase 5/6]

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder-progress.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder-progress.tsx
@@ -1,0 +1,81 @@
+import { Check } from "lucide-react";
+import { useStepper } from "@/components/stepper/stepper-provider";
+import { cn } from "@/lib/utils";
+
+/**
+ * The four-step progress bar for {@link CampaignBuilder}. A smaller cousin of
+ * `plan-builder/plan-builder-progress.tsx` — same interaction and visual language, without that
+ * one's sticky-scroll and live-preview-panel treatment, which this shorter wizard has no room or
+ * need for.
+ */
+export const CampaignBuilderProgress = () => {
+  const { completedSteps, currentStep, getSteps, goToStep, totalSteps } = useStepper();
+  const steps = getSteps();
+
+  return (
+    <section
+      aria-label="Discount creation progress"
+      className="rounded-2xl border border-blocks-primary-100 bg-card/95 px-4 py-4 shadow-sm sm:px-6 sm:py-5"
+    >
+      <p className="mb-4 text-sm font-medium text-foreground">
+        Step {currentStep} of {totalSteps}
+      </p>
+
+      <ol className="grid grid-cols-4">
+        {steps.map((step, index) => {
+          const isCurrent = currentStep === step.id;
+          const isComplete = completedSteps.includes(step.id);
+          const canNavigate = isCurrent || step.id === 1 || completedSteps.includes(step.id - 1);
+
+          return (
+            <li
+              key={step.id}
+              className={cn(
+                "relative min-w-0",
+                index < steps.length - 1 &&
+                  "after:absolute after:left-[calc(50%+1.25rem)] after:right-[calc(-50%+1.25rem)] after:top-4 after:h-0.5 after:bg-border after:content-['']",
+                index < steps.length - 1 && isComplete && "after:bg-blocks-primary-500",
+              )}
+            >
+              <button
+                type="button"
+                onClick={() => goToStep(step.id)}
+                disabled={!canNavigate}
+                aria-current={isCurrent ? "step" : undefined}
+                className="group relative z-10 flex w-full flex-col items-center gap-2 text-center disabled:cursor-not-allowed"
+              >
+                <span
+                  className={cn(
+                    "flex h-8 w-8 items-center justify-center rounded-full border bg-card text-xs font-bold text-muted-foreground transition-all duration-200",
+                    isCurrent &&
+                      "border-blocks-primary-600 bg-blocks-primary-600 text-white ring-4 ring-blocks-primary-100",
+                    isComplete &&
+                      !isCurrent &&
+                      "border-blocks-primary-500 bg-blocks-primary-50 text-blocks-primary-700",
+                    canNavigate &&
+                      !isCurrent &&
+                      "group-hover:border-blocks-primary-400 group-hover:text-blocks-primary-700",
+                  )}
+                >
+                  {isComplete && !isCurrent ? <Check className="h-4 w-4" /> : step.id}
+                </span>
+                <span
+                  className={cn(
+                    "hidden max-w-full truncate text-xs font-medium text-muted-foreground transition-colors sm:block",
+                    (isCurrent || isComplete) && "text-foreground",
+                  )}
+                >
+                  {step.title}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+
+      <p className="mt-3 text-center text-sm font-medium text-foreground sm:hidden">
+        {steps[currentStep - 1]?.title}
+      </p>
+    </section>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../../models/subscription-plan.model";
+import { CampaignBuilder } from "./campaign-builder";
+import type { CampaignDraft } from "./campaign-draft";
+
+const plan: SubscriptionPlan = {
+  planId: "plan-1",
+  code: "pro",
+  displayName: "Pro",
+  description: null,
+  entitlements: [{ key: "seats", limitKind: "Count", limit: 5, meterKey: null, unitLabel: "seat" }],
+  prices: [
+    {
+      priceId: "price-monthly-calendar",
+      currencyCode: "USD",
+      unitAmountMinor: 1_000,
+      interval: "Month",
+      intervalCount: 1,
+      billingAlignment: "CalendarMonth",
+      quantityItemKey: null,
+    },
+    {
+      priceId: "price-monthly-anniversary",
+      currencyCode: "USD",
+      unitAmountMinor: 1_000,
+      interval: "Month",
+      intervalCount: 1,
+      billingAlignment: "Anniversary",
+      quantityItemKey: null,
+    },
+  ],
+} as unknown as SubscriptionPlan;
+
+const click = (name: RegExp) => fireEvent.click(screen.getByRole("button", { name }));
+
+const renderBuilder = (onSubmit = vi.fn<(draft: CampaignDraft) => Promise<void>>()) => {
+  const onCancel = vi.fn();
+  render(
+    <CampaignBuilder
+      plans={[plan]}
+      organizationId="org-1"
+      isSubmitting={false}
+      submissionError={null}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    />,
+  );
+  return { onSubmit, onCancel };
+};
+
+describe("CampaignBuilder", () => {
+  it("blocks advancing past Identity until a code and display name are entered", () => {
+    renderBuilder();
+
+    expect(screen.getByRole("button", { name: /^Next$/ })).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Code/), { target: { value: "launch-25" } });
+    fireEvent.change(screen.getByLabelText(/Display name/), { target: { value: "Launch" } });
+
+    expect(screen.getByRole("button", { name: /^Next$/ })).toBeEnabled();
+  });
+
+  it("cancels from the first step instead of going back", () => {
+    const { onCancel } = renderBuilder();
+
+    click(/^Cancel$/);
+
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("walks a Standard discount through all four steps and submits it unchanged by any campaign rule", async () => {
+    const { onSubmit } = renderBuilder();
+
+    fireEvent.change(screen.getByLabelText(/Code/), { target: { value: "launch-25" } });
+    fireEvent.change(screen.getByLabelText(/Display name/), { target: { value: "Launch offer" } });
+    click(/^Next$/);
+
+    // Benefit: the default 10% carries through untouched.
+    await screen.findByText(/What redeeming this discount takes off/);
+    click(/^Next$/);
+
+    // Eligibility: unrestricted is valid for a Standard discount.
+    await screen.findByText(/redeemed in/);
+    click(/^Next$/);
+
+    await screen.findByText(/Check everything before creating/);
+    click(/^Create discount$/);
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    const [draft] = onSubmit.mock.calls[0]!;
+    expect(draft.campaignKind).toBe("Standard");
+    expect(draft.code).toBe("launch-25");
+  });
+
+  it("locks a free-opening-period campaign's benefit and eligibility fields the moment it is picked", async () => {
+    renderBuilder();
+
+    fireEvent.change(screen.getByLabelText(/Code/), { target: { value: "free1" } });
+    fireEvent.change(screen.getByLabelText(/Display name/), { target: { value: "Free month" } });
+    fireEvent.click(screen.getByLabelText(/Free opening month/));
+    click(/^Next$/);
+
+    await screen.findByText(/always a full 100% reduction/);
+    // Next is enabled without touching anything else -- the kind change already locked the
+    // reduction to something valid.
+    expect(screen.getByRole("button", { name: /^Next$/ })).toBeEnabled();
+    click(/^Next$/);
+
+    // Eligibility: only the calendar-aligned monthly price is offered, and the campaign is
+    // blocked until one is picked plus the entitlement is named.
+    await screen.findByText(/redeemed in/);
+    expect(screen.queryByText(/price-monthly-anniversary/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Next$/ })).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText(/Restrict to pro/));
+    fireEvent.change(screen.getByLabelText(/Starts/), { target: { value: "2026-01-01" } });
+    fireEvent.change(screen.getByLabelText(/Ends \(inclusive\)/), { target: { value: "2026-12-31" } });
+    fireEvent.change(screen.getByLabelText(/Temporary entitlement/), { target: { value: "seats" } });
+    fireEvent.change(screen.getByLabelText(/Temporary limit/), { target: { value: "1" } });
+
+    expect(screen.getByRole("button", { name: /^Next$/ })).toBeEnabled();
+
+    const oneUseSwitch = screen.getByLabelText(/One redemption per organization/);
+    expect(oneUseSwitch).toBeDisabled();
+    expect(oneUseSwitch).toHaveAttribute("data-state", "checked");
+  });
+
+  it("shows the submission error returned by the caller without losing the draft", () => {
+    render(
+      <CampaignBuilder
+        plans={[plan]}
+        organizationId="org-1"
+        isSubmitting={false}
+        submissionError="A discount with that code already exists."
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent("A discount with that code already exists.");
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.tsx
@@ -1,0 +1,133 @@
+import { ArrowLeft, ArrowRight, Check, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import StepperProviderComponent, { useStepper } from "@/components/stepper/stepper-provider";
+import type { Steps } from "@/components/stepper/stepper-models";
+import type { SubscriptionPlan } from "../../models/subscription-plan.model";
+import { CampaignBuilderProgress } from "./campaign-builder-progress";
+import {
+  EMPTY_DRAFT,
+  stepProblems,
+  toCreateDiscountRequest,
+  withCampaignKind,
+  type CampaignDraft,
+  type StepId,
+} from "./campaign-draft";
+import { StepBenefit } from "./step-benefit";
+import { StepEligibility } from "./step-eligibility";
+import { StepIdentity } from "./step-identity";
+import { StepReview } from "./step-review";
+
+const STEPS: Steps = [
+  { id: 1, title: "Identity" },
+  { id: 2, title: "Benefit" },
+  { id: 3, title: "Eligibility" },
+  { id: 4, title: "Review" },
+];
+
+export interface CampaignBuilderProps {
+  plans: SubscriptionPlan[];
+  organizationId: string | undefined;
+  isSubmitting: boolean;
+  submissionError: string | null;
+  /** Rejecting leaves the draft in place and shows the error; the caller navigates on success. */
+  onSubmit: (draft: CampaignDraft, organizationId: string | undefined) => Promise<void>;
+  onCancel: () => void;
+}
+
+export const CampaignBuilder = (props: CampaignBuilderProps) => (
+  <StepperProviderComponent steps={STEPS}>
+    <CampaignBuilderWizard {...props} />
+  </StepperProviderComponent>
+);
+
+const CampaignBuilderWizard = ({
+  plans,
+  organizationId,
+  isSubmitting,
+  submissionError,
+  onSubmit,
+  onCancel,
+}: CampaignBuilderProps) => {
+  const { currentStep, nextStep, previousStep } = useStepper();
+  const [draft, setDraft] = useState<CampaignDraft>(EMPTY_DRAFT);
+  const step = currentStep as StepId;
+  const isLastStep = currentStep === STEPS.length;
+
+  const update = (next: Partial<CampaignDraft>) => {
+    // Picking a new offer type locks in that kind's own rules immediately (a full 100% reduction
+    // and its two required flags for a free month, a cleared entitlement override for a
+    // first-year discount) -- see withCampaignKind. Every other field is a plain merge.
+    setDraft((current) =>
+      next.campaignKind !== undefined ? withCampaignKind(current, next.campaignKind) : { ...current, ...next },
+    );
+  };
+
+  const problems = stepProblems(step, draft, plans);
+  const canAdvance = problems.length === 0;
+
+  const submit = async () => {
+    if (stepProblems(1, draft, plans).length > 0 ||
+        stepProblems(2, draft, plans).length > 0 ||
+        stepProblems(3, draft, plans).length > 0) {
+      return;
+    }
+
+    await onSubmit(draft, organizationId);
+  };
+
+  return (
+    <div className="space-y-5">
+      <CampaignBuilderProgress />
+
+      <Card className="space-y-5 rounded-2xl p-5 sm:p-7">
+        {step === 1 && <StepIdentity draft={draft} onChange={update} />}
+        {step === 2 && <StepBenefit draft={draft} onChange={update} />}
+        {step === 3 && <StepEligibility draft={draft} plans={plans} onChange={update} />}
+        {step === 4 && <StepReview draft={draft} plans={plans} />}
+
+        {!isLastStep && problems.length > 0 && (
+          <ul className="space-y-1 rounded-md border border-destructive/20 bg-destructive/5 p-3 text-xs text-destructive">
+            {problems.map((problem) => (
+              <li key={problem}>{problem}</li>
+            ))}
+          </ul>
+        )}
+
+        {submissionError && (
+          <div
+            role="alert"
+            className="rounded-md border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm font-medium text-destructive"
+          >
+            {submissionError}
+          </div>
+        )}
+
+        <div className="flex justify-between border-t pt-5">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={currentStep === 1 ? onCancel : previousStep}
+            disabled={isSubmitting}
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {currentStep === 1 ? "Cancel" : "Back"}
+          </Button>
+
+          {isLastStep ? (
+            <Button type="button" onClick={submit} disabled={isSubmitting}>
+              {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Check className="mr-2 h-4 w-4" />}
+              {isSubmitting ? "Creating…" : "Create discount"}
+            </Button>
+          ) : (
+            <Button type="button" onClick={nextStep} disabled={!canAdvance}>
+              Next
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import type { SubscriptionPlan } from "../../models/subscription-plan.model";
+import {
+  EMPTY_DRAFT,
+  canSubmit,
+  eligiblePrices,
+  stepProblems,
+  toCreateDiscountRequest,
+  withCampaignKind,
+  type CampaignDraft,
+} from "./campaign-draft";
+
+const plan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan =>
+  ({
+    planId: "plan-1",
+    code: "pro",
+    displayName: "Pro",
+    description: null,
+    entitlements: [{ key: "seats", limitKind: "Count", limit: 5, meterKey: null, unitLabel: "seat" }],
+    prices: [
+      {
+        priceId: "price-anniversary-month",
+        currencyCode: "USD",
+        unitAmountMinor: 1_000,
+        interval: "Month",
+        intervalCount: 1,
+        billingAlignment: "Anniversary",
+        quantityItemKey: null,
+      },
+      {
+        priceId: "price-calendar-month",
+        currencyCode: "USD",
+        unitAmountMinor: 1_000,
+        interval: "Month",
+        intervalCount: 1,
+        billingAlignment: "CalendarMonth",
+        quantityItemKey: null,
+      },
+      {
+        priceId: "price-calendar-year",
+        currencyCode: "USD",
+        unitAmountMinor: 10_000,
+        interval: "Year",
+        intervalCount: 1,
+        billingAlignment: "CalendarMonth",
+        calendarStubBasePriceId: "price-calendar-month",
+        calendarStubBaseUnitAmountMinor: 1_000,
+        quantityItemKey: null,
+      },
+      {
+        priceId: "price-calendar-year-no-stub",
+        currencyCode: "USD",
+        unitAmountMinor: 10_000,
+        interval: "Year",
+        intervalCount: 1,
+        billingAlignment: "CalendarMonth",
+        quantityItemKey: null,
+      },
+      {
+        priceId: "price-anniversary-year",
+        currencyCode: "USD",
+        unitAmountMinor: 10_000,
+        interval: "Year",
+        intervalCount: 1,
+        billingAlignment: "Anniversary",
+        quantityItemKey: null,
+      },
+    ],
+    ...overrides,
+  }) as unknown as SubscriptionPlan;
+
+describe("withCampaignKind", () => {
+  it("locks a free-opening-period campaign to a full 100% reduction and its two required flags", () => {
+    const draft = withCampaignKind(
+      { ...EMPTY_DRAFT, percent: "25" },
+      "FreeOpeningCalendarPeriod",
+    );
+
+    expect(draft.discountKind).toBe("percent");
+    expect(draft.percent).toBe("100");
+    expect(draft.oneUsePerOrganization).toBe(true);
+    expect(draft.requiresPaymentMethodUpfront).toBe(true);
+  });
+
+  it("clears any entitlement override when switching to first-annual-period", () => {
+    const draft = withCampaignKind(
+      { ...EMPTY_DRAFT, entitlementKey: "seats", entitlementLimit: "1" },
+      "FirstAnnualPeriod",
+    );
+
+    expect(draft.entitlementKey).toBe("");
+    expect(draft.entitlementLimit).toBe("");
+  });
+
+  it("leaves an ordinary field untouched when switching to Standard", () => {
+    const draft = withCampaignKind({ ...EMPTY_DRAFT, percent: "25" }, "Standard");
+
+    expect(draft.percent).toBe("25");
+  });
+});
+
+describe("eligiblePrices", () => {
+  const plans = [plan()];
+
+  it("offers every price for a Standard discount", () => {
+    expect(eligiblePrices("Standard", plans)).toHaveLength(5);
+  });
+
+  it("offers only calendar-aligned monthly prices for a free-opening-period campaign", () => {
+    const result = eligiblePrices("FreeOpeningCalendarPeriod", plans);
+
+    expect(result.map(({ price }) => price.priceId)).toEqual(["price-calendar-month"]);
+  });
+
+  it("offers only calendar-aligned yearly prices with a stub base for a first-annual-period campaign", () => {
+    const result = eligiblePrices("FirstAnnualPeriod", plans);
+
+    // Excludes the anniversary year and the calendar year with no stub base configured -- both
+    // would silently mis-discount at redemption if this campaign kind were authored against them.
+    expect(result.map(({ price }) => price.priceId)).toEqual(["price-calendar-year"]);
+  });
+});
+
+describe("stepProblems", () => {
+  const plans = [plan()];
+  const validCampaign = (): CampaignDraft =>
+    withCampaignKind(
+      {
+        ...EMPTY_DRAFT,
+        code: "annual15",
+        displayName: "15% off year one",
+        priceIds: ["price-calendar-year"],
+        validFromDate: "2026-01-01",
+        validThroughDate: "2026-12-31",
+      },
+      "FirstAnnualPeriod",
+    );
+
+  it("step 1 refuses an empty code or display name", () => {
+    expect(stepProblems(1, EMPTY_DRAFT, plans)).not.toHaveLength(0);
+  });
+
+  it("step 1 refuses a code with characters the server would reject", () => {
+    const draft = { ...EMPTY_DRAFT, code: "Launch 25!", displayName: "Launch" };
+
+    expect(stepProblems(1, draft, plans).some((problem) => problem.includes("lowercase"))).toBe(true);
+  });
+
+  it("step 1 accepts a valid code and display name", () => {
+    const draft = { ...EMPTY_DRAFT, code: "launch-25", displayName: "Launch" };
+
+    expect(stepProblems(1, draft, plans)).toHaveLength(0);
+  });
+
+  it("step 2 refuses a partial reduction for a free-opening-period campaign", () => {
+    const draft = withCampaignKind({ ...EMPTY_DRAFT, percent: "100" }, "FreeOpeningCalendarPeriod");
+    const partial = { ...draft, percent: "50" };
+
+    expect(stepProblems(2, partial, plans).some((problem) => problem.includes("100%"))).toBe(true);
+  });
+
+  it("step 2 accepts a locked free-opening-period campaign", () => {
+    const draft = withCampaignKind(EMPTY_DRAFT, "FreeOpeningCalendarPeriod");
+
+    expect(stepProblems(2, draft, plans)).toHaveLength(0);
+  });
+
+  it("step 3 refuses a campaign with no price named", () => {
+    const draft = withCampaignKind(EMPTY_DRAFT, "FirstAnnualPeriod");
+
+    expect(stepProblems(3, draft, plans).some((problem) => problem.includes("at least one price"))).toBe(
+      true,
+    );
+  });
+
+  it("step 3 does not require a price for a Standard discount", () => {
+    expect(stepProblems(3, EMPTY_DRAFT, plans)).toHaveLength(0);
+  });
+
+  it("step 3 refuses a campaign window that ends before it starts", () => {
+    const draft = { ...validCampaign(), validFromDate: "2026-12-31", validThroughDate: "2026-01-01" };
+
+    expect(stepProblems(3, draft, plans).some((problem) => problem.includes("end before it starts"))).toBe(
+      true,
+    );
+  });
+
+  it("step 3 accepts a fully-filled first-annual-period campaign", () => {
+    expect(stepProblems(3, validCampaign(), plans)).toHaveLength(0);
+  });
+
+  it("step 3 refuses a free-opening-period campaign with no entitlement named", () => {
+    const draft = withCampaignKind(
+      { ...EMPTY_DRAFT, priceIds: ["price-calendar-month"], validFromDate: "2026-1-1", validThroughDate: "2026-2-1" },
+      "FreeOpeningCalendarPeriod",
+    );
+
+    expect(
+      stepProblems(3, draft, plans).some((problem) => problem.includes("temporarily caps")),
+    ).toBe(true);
+  });
+
+  it("step 3 refuses an entitlement key the plan does not grant", () => {
+    const draft = withCampaignKind(
+      {
+        ...EMPTY_DRAFT,
+        priceIds: ["price-calendar-month"],
+        planCodes: ["pro"],
+        validFromDate: "2026-1-1",
+        validThroughDate: "2026-2-1",
+        entitlementKey: "nonexistent",
+        entitlementLimit: "1",
+      },
+      "FreeOpeningCalendarPeriod",
+    );
+
+    expect(stepProblems(3, draft, plans).some((problem) => problem.includes("nonexistent"))).toBe(true);
+  });
+});
+
+describe("canSubmit", () => {
+  const plans = [plan()];
+
+  it("is false for the empty draft", () => {
+    expect(canSubmit(EMPTY_DRAFT, plans)).toBe(false);
+  });
+
+  it("is true once every one of the first three steps is satisfied", () => {
+    const draft: CampaignDraft = {
+      ...EMPTY_DRAFT,
+      code: "launch-25",
+      displayName: "Launch offer",
+    };
+
+    expect(canSubmit(draft, plans)).toBe(true);
+  });
+});
+
+describe("toCreateDiscountRequest", () => {
+  it("omits every campaign field for a Standard discount", () => {
+    const draft: CampaignDraft = { ...EMPTY_DRAFT, code: "launch-25", displayName: "Launch" };
+
+    const request = toCreateDiscountRequest(draft, "org-1");
+
+    expect(request.campaignKind).toBeUndefined();
+    expect(request.campaignPrecedence).toBeUndefined();
+    expect(request.validFromDate).toBeUndefined();
+    expect(request.oneUsePerOrganization).toBeUndefined();
+    expect(request.entitlementOverrideKey).toBeUndefined();
+  });
+
+  it("never sends a duration for a campaign, even if one was left over from Standard", () => {
+    const draft = withCampaignKind(
+      { ...EMPTY_DRAFT, code: "annual15", displayName: "Year one", durationPeriods: "3" },
+      "FirstAnnualPeriod",
+    );
+
+    const request = toCreateDiscountRequest(draft, undefined);
+
+    expect(request.durationPeriods).toBeUndefined();
+    expect(request.campaignKind).toBe("FirstAnnualPeriod");
+  });
+
+  it("converts a fixed amount to minor units in the request currency", () => {
+    const draft: CampaignDraft = {
+      ...EMPTY_DRAFT,
+      code: "flat10",
+      displayName: "Ten off",
+      discountKind: "fixed",
+      amount: "10",
+      currencyCode: "USD",
+    };
+
+    const request = toCreateDiscountRequest(draft, undefined);
+
+    expect(request.amountMinor).toBe(1_000);
+    expect(request.percentBasisPoints).toBeUndefined();
+  });
+
+  it("sends the entitlement override only for a free-opening-period campaign", () => {
+    const draft = withCampaignKind(
+      {
+        ...EMPTY_DRAFT,
+        code: "free1",
+        displayName: "Free month",
+        entitlementKey: "seats",
+        entitlementLimit: "1",
+      },
+      "FreeOpeningCalendarPeriod",
+    );
+
+    const request = toCreateDiscountRequest(draft, undefined);
+
+    expect(request.entitlementOverrideKey).toBe("seats");
+    expect(request.entitlementOverrideLimit).toBe(1);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
@@ -1,0 +1,264 @@
+import { describeDiscountAmountProblem } from "../../utilities/discount-amount";
+import { toMinorUnits } from "../../utilities/subscription-format";
+import type {
+  CampaignKind,
+  CampaignPrecedence,
+  CreateSubscriptionDiscountRequest,
+  PlanPrice,
+  SubscriptionPlan,
+} from "../../models/subscription-plan.model";
+
+/**
+ * Everything the four-step wizard collects, in the units a human types them in — cents become
+ * minor units, dates become ISO strings, only at {@link toCreateDiscountRequest}.
+ *
+ * One flat object rather than one per step: a later step's validity can depend on an earlier
+ * step's answer (the campaign kind picked in Identity decides most of what Benefit and
+ * Eligibility even show), so splitting the state the same way the steps are split would mean
+ * threading cross-step reads back through step boundaries for no benefit.
+ */
+export interface CampaignDraft {
+  code: string;
+  displayName: string;
+  campaignKind: CampaignKind;
+  discountKind: "percent" | "fixed";
+  percent: string;
+  amount: string;
+  currencyCode: string;
+  campaignPrecedence: CampaignPrecedence;
+  /** Standard only — a campaign's own duration is forced server-side and never authored here. */
+  durationPeriods: string;
+  expiresAtUtc: string;
+  planCodes: string[];
+  priceIds: string[];
+  /** Local calendar dates, "yyyy-MM-dd" — campaign kinds only. */
+  validFromDate: string;
+  validThroughDate: string;
+  timeZoneId: string;
+  oneUsePerOrganization: boolean;
+  requiresPaymentMethodUpfront: boolean;
+  /** FreeOpeningCalendarPeriod only — refused by the server for any other kind. */
+  entitlementKey: string;
+  entitlementLimit: string;
+}
+
+export const EMPTY_DRAFT: CampaignDraft = {
+  code: "",
+  displayName: "",
+  campaignKind: "Standard",
+  discountKind: "percent",
+  percent: "10",
+  amount: "",
+  currencyCode: "USD",
+  campaignPrecedence: "BestDiscount",
+  durationPeriods: "",
+  expiresAtUtc: "",
+  planCodes: [],
+  priceIds: [],
+  validFromDate: "",
+  validThroughDate: "",
+  timeZoneId: Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+  oneUsePerOrganization: false,
+  requiresPaymentMethodUpfront: false,
+  entitlementKey: "",
+  entitlementLimit: "",
+};
+
+/**
+ * Applies each campaign kind's own locked-in rules the moment it is picked, the same way the
+ * server would refuse anything that disagreed with them -- so a switch to
+ * FreeOpeningCalendarPeriod cannot leave behind a 25% rate or a cleared "requires payment method"
+ * toggle that Benefit and Eligibility would otherwise have to notice and correct on their own.
+ */
+export const withCampaignKind = (draft: CampaignDraft, campaignKind: CampaignKind): CampaignDraft => {
+  if (campaignKind === "FreeOpeningCalendarPeriod") {
+    return {
+      ...draft,
+      campaignKind,
+      discountKind: "percent",
+      percent: "100",
+      oneUsePerOrganization: true,
+      requiresPaymentMethodUpfront: true,
+    };
+  }
+
+  if (campaignKind === "FirstAnnualPeriod") {
+    // Never enforced for this kind -- see CampaignDiscountRequestValidator on the server.
+    return { ...draft, campaignKind, entitlementKey: "", entitlementLimit: "" };
+  }
+
+  return { ...draft, campaignKind };
+};
+
+/** Only a price this campaign kind could ever be redeemed against is worth offering. */
+export const eligiblePrices = (
+  campaignKind: CampaignKind,
+  plans: SubscriptionPlan[],
+): { plan: SubscriptionPlan; price: PlanPrice }[] => {
+  const all = plans.flatMap((plan) => plan.prices.map((price) => ({ plan, price })));
+
+  if (campaignKind === "Standard") {
+    return all;
+  }
+
+  if (campaignKind === "FreeOpeningCalendarPeriod") {
+    return all.filter(
+      ({ price }) => price.interval === "Month" && price.billingAlignment === "CalendarMonth",
+    );
+  }
+
+  // FirstAnnualPeriod: a calendar-aligned year with a stub base actually configured -- otherwise
+  // it falls back to an anniversary year at runtime, which this campaign kind cannot price
+  // correctly. Mirrors DiscountCatalogueService.CheckCadence exactly.
+  return all.filter(
+    ({ price }) =>
+      price.interval === "Year" &&
+      price.billingAlignment === "CalendarMonth" &&
+      (price.calendarStubBaseUnitAmountMinor ?? 0) > 0,
+  );
+};
+
+export type StepId = 1 | 2 | 3 | 4;
+
+/** Every reason this step cannot yet be left. Empty means it can. */
+export const stepProblems = (
+  step: StepId,
+  draft: CampaignDraft,
+  plans: SubscriptionPlan[],
+): string[] => {
+  if (step === 1) {
+    const problems: string[] = [];
+
+    if (!draft.code.trim()) {
+      problems.push("Enter a code.");
+    } else if (!/^[a-z0-9_-]+$/.test(draft.code.trim())) {
+      problems.push("Code may only contain lowercase letters, digits, hyphens and underscores.");
+    }
+
+    if (!draft.displayName.trim()) {
+      problems.push("Enter a display name.");
+    }
+
+    return problems;
+  }
+
+  if (step === 2) {
+    const problems: string[] = [];
+
+    if (draft.discountKind === "percent") {
+      const percent = Number(draft.percent);
+      if (draft.percent.trim() === "" || !Number.isFinite(percent) || percent <= 0 || percent > 100) {
+        problems.push("Percent off must be between 0 and 100.");
+      }
+      if (draft.campaignKind === "FreeOpeningCalendarPeriod" && percent !== 100) {
+        problems.push("A free-opening-period campaign must be a full 100% reduction.");
+      }
+    } else {
+      if (draft.campaignKind === "FreeOpeningCalendarPeriod") {
+        problems.push("A free-opening-period campaign cannot be a fixed amount — it must be 100% off.");
+      }
+      const amountProblem = describeDiscountAmountProblem(draft.amount, draft.currencyCode);
+      if (amountProblem) problems.push(amountProblem);
+    }
+
+    if (draft.campaignKind === "Standard" && draft.durationPeriods.trim() !== "") {
+      const duration = Number(draft.durationPeriods);
+      if (!Number.isInteger(duration) || duration <= 0) {
+        problems.push("Duration in billing periods must be a whole number greater than zero.");
+      }
+    }
+
+    return problems;
+  }
+
+  if (step === 3) {
+    const problems: string[] = [];
+    const isCampaign = draft.campaignKind !== "Standard";
+
+    if (isCampaign && draft.priceIds.length === 0) {
+      problems.push(
+        "This campaign kind needs at least one price named — it prices a specific price's " +
+          "opening period or first annual period, not a plan in general.",
+      );
+    }
+
+    if (isCampaign) {
+      if (!draft.validFromDate) problems.push("A campaign needs a start date.");
+      if (!draft.validThroughDate) problems.push("A campaign needs an end date.");
+      if (!draft.timeZoneId.trim()) problems.push("A campaign needs a time zone its dates are read in.");
+      if (
+        draft.validFromDate &&
+        draft.validThroughDate &&
+        draft.validThroughDate < draft.validFromDate
+      ) {
+        problems.push("The campaign cannot end before it starts.");
+      }
+    }
+
+    if (draft.campaignKind === "FreeOpeningCalendarPeriod") {
+      if (!draft.entitlementKey.trim()) {
+        problems.push("A free-opening-period campaign must name the entitlement it temporarily caps.");
+      }
+      const limit = Number(draft.entitlementLimit);
+      if (draft.entitlementLimit.trim() === "" || !Number.isFinite(limit) || limit <= 0) {
+        problems.push("The temporary entitlement limit must be a positive number.");
+      }
+      const plan = plans.find((candidate) => draft.planCodes.includes(candidate.code)) ??
+        plans.find((candidate) =>
+          draft.priceIds.some((priceId) =>
+            candidate.prices.some((price) => price.priceId === priceId)));
+      const entitlement = plan?.entitlements.find(
+        (candidate) => candidate.key === draft.entitlementKey.trim(),
+      );
+      if (plan && draft.entitlementKey.trim() && !entitlement) {
+        problems.push(`The plan '${plan.code}' has no entitlement '${draft.entitlementKey.trim()}'.`);
+      }
+    }
+
+    return problems;
+  }
+
+  return [];
+};
+
+export const canSubmit = (draft: CampaignDraft, plans: SubscriptionPlan[]): boolean =>
+  ([1, 2, 3] as const).every((step) => stepProblems(step, draft, plans).length === 0);
+
+/** The exact request `POST /api/subscription-discounts` expects — units converted here, once. */
+export const toCreateDiscountRequest = (
+  draft: CampaignDraft,
+  organizationId: string | undefined,
+): CreateSubscriptionDiscountRequest => {
+  const isCampaign = draft.campaignKind !== "Standard";
+
+  return {
+    organizationId,
+    code: draft.code.trim(),
+    displayName: draft.displayName.trim(),
+    kind: draft.discountKind === "percent" ? 0 : 1,
+    percentBasisPoints:
+      draft.discountKind === "percent" ? Math.round(Number(draft.percent) * 100) : undefined,
+    amountMinor:
+      draft.discountKind === "fixed" ? toMinorUnits(Number(draft.amount), draft.currencyCode) : undefined,
+    currencyCode: draft.discountKind === "fixed" ? draft.currencyCode : undefined,
+    // A campaign's own duration is forced server-side regardless of what is sent, so nothing here
+    // ever claims to set one — sending it would suggest an author-controlled figure that a
+    // campaign kind silently overrides.
+    durationPeriods:
+      !isCampaign && draft.durationPeriods.trim() !== "" ? Number(draft.durationPeriods) : undefined,
+    expiresAtUtc: !isCampaign && draft.expiresAtUtc ? new Date(draft.expiresAtUtc).toISOString() : undefined,
+    applicablePlanCodes: draft.planCodes,
+    applicablePriceIds: draft.priceIds,
+    campaignKind: isCampaign ? draft.campaignKind : undefined,
+    campaignPrecedence: isCampaign ? draft.campaignPrecedence : undefined,
+    validFromDate: isCampaign ? draft.validFromDate : undefined,
+    validThroughDate: isCampaign ? draft.validThroughDate : undefined,
+    timeZoneId: isCampaign ? draft.timeZoneId : undefined,
+    oneUsePerOrganization: isCampaign ? draft.oneUsePerOrganization : undefined,
+    requiresPaymentMethodUpfront: isCampaign ? draft.requiresPaymentMethodUpfront : undefined,
+    entitlementOverrideKey:
+      draft.campaignKind === "FreeOpeningCalendarPeriod" ? draft.entitlementKey.trim() : undefined,
+    entitlementOverrideLimit:
+      draft.campaignKind === "FreeOpeningCalendarPeriod" ? Number(draft.entitlementLimit) : undefined,
+  };
+};

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
@@ -1,0 +1,187 @@
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui-kits/select/select";
+import { SUBSCRIPTION_CURRENCY_OPTIONS } from "../../constants/subscription.constants";
+import { describeDiscountAmountProblem } from "../../utilities/discount-amount";
+import {
+  exampleMinorAmount,
+  minorUnitStep,
+} from "../../utilities/subscription-format";
+import type { CampaignPrecedence } from "../../models/subscription-plan.model";
+import type { CampaignDraft } from "./campaign-draft";
+
+const PRECEDENCE_OPTIONS: { value: CampaignPrecedence; label: string; description: string }[] = [
+  {
+    value: "BestDiscount",
+    label: "Best discount wins",
+    description: "Whichever reduction is larger — this campaign's, or the price's own — never both.",
+  },
+  {
+    value: "ReplaceBuiltIn",
+    label: "Replace the price's own discount",
+    description: "This campaign's reduction only, for as long as it applies — even if smaller.",
+  },
+  {
+    value: "Stack",
+    label: "Stack on top",
+    description: "Both reductions combined, capped at 100% of the price.",
+  },
+];
+
+export const StepBenefit = ({
+  draft,
+  onChange,
+}: {
+  draft: CampaignDraft;
+  onChange: (next: Partial<CampaignDraft>) => void;
+}) => {
+  const isFreeMonth = draft.campaignKind === "FreeOpeningCalendarPeriod";
+  const isCampaign = draft.campaignKind !== "Standard";
+  const amountMessage =
+    draft.discountKind === "fixed" && draft.amount.trim() !== ""
+      ? describeDiscountAmountProblem(draft.amount, draft.currencyCode)
+      : null;
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-lg font-semibold">Benefit</h2>
+        <p className="mt-1 text-sm text-muted-foreground">What redeeming this discount takes off.</p>
+      </div>
+
+      {isFreeMonth ? (
+        <p className="rounded-md border border-blocks-primary-200 bg-blocks-primary-50 p-3 text-sm text-blocks-primary-900">
+          A free opening month is always a full 100% reduction — nothing to set here.
+        </p>
+      ) : (
+        <div className="grid gap-5 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label>Kind</Label>
+            <Select
+              value={draft.discountKind}
+              onValueChange={(value) => onChange({ discountKind: value as "percent" | "fixed" })}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="percent">Percentage</SelectItem>
+                <SelectItem value="fixed">Fixed amount</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {draft.discountKind === "percent" ? (
+            <div className="space-y-1.5">
+              <Label htmlFor="campaign-percent">Percent off</Label>
+              <Input
+                id="campaign-percent"
+                type="number"
+                min={0.01}
+                max={100}
+                value={draft.percent}
+                onChange={(event) => onChange({ percent: event.target.value })}
+              />
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <Label htmlFor="campaign-amount">Amount off ({draft.currencyCode})</Label>
+                <Input
+                  id="campaign-amount"
+                  type="number"
+                  min={0}
+                  step={minorUnitStep(draft.currencyCode)}
+                  placeholder={exampleMinorAmount(draft.currencyCode)}
+                  value={draft.amount}
+                  onChange={(event) => onChange({ amount: event.target.value })}
+                  aria-invalid={amountMessage !== null}
+                  aria-describedby={amountMessage ? "campaign-amount-problem" : undefined}
+                />
+                {amountMessage && (
+                  <p id="campaign-amount-problem" className="mt-1 text-xs text-destructive">
+                    {amountMessage}
+                  </p>
+                )}
+              </div>
+              <div>
+                <Label htmlFor="campaign-currency">Currency</Label>
+                <Select value={draft.currencyCode} onValueChange={(value) => onChange({ currencyCode: value })}>
+                  <SelectTrigger id="campaign-currency">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SUBSCRIPTION_CURRENCY_OPTIONS.map((currency) => (
+                      <SelectItem key={currency.code} value={currency.code}>
+                        {currency.code} — {currency.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {isCampaign ? (
+        <div className="space-y-2">
+          <Label>How it meets the price's own discount</Label>
+          <Select
+            value={draft.campaignPrecedence}
+            onValueChange={(value) => onChange({ campaignPrecedence: value as CampaignPrecedence })}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PRECEDENCE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {PRECEDENCE_OPTIONS.find((option) => option.value === draft.campaignPrecedence)?.description}
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-5 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="campaign-duration">Duration in billing periods (optional)</Label>
+            <Input
+              id="campaign-duration"
+              type="number"
+              min={1}
+              value={draft.durationPeriods}
+              onChange={(event) => onChange({ durationPeriods: event.target.value })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="campaign-expiry">Expires at (optional)</Label>
+            <Input
+              id="campaign-expiry"
+              type="datetime-local"
+              value={draft.expiresAtUtc}
+              onChange={(event) => onChange({ expiresAtUtc: event.target.value })}
+            />
+          </div>
+        </div>
+      )}
+
+      {isCampaign && !isFreeMonth && (
+        <p className="text-xs text-muted-foreground">
+          This offer expires itself — a first-year discount stops after the first annual period,
+          automatically. There is no duration to set.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-eligibility.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-eligibility.tsx
@@ -1,0 +1,226 @@
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import { Switch } from "@/components/ui-kits/switch/switch";
+import type { SubscriptionPlan } from "../../models/subscription-plan.model";
+import { formatPrice } from "../../utilities/subscription-format";
+import { eligiblePrices, type CampaignDraft } from "./campaign-draft";
+
+const toggle = (values: string[], value: string) =>
+  values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value];
+
+export const StepEligibility = ({
+  draft,
+  plans,
+  onChange,
+}: {
+  draft: CampaignDraft;
+  plans: SubscriptionPlan[];
+  onChange: (next: Partial<CampaignDraft>) => void;
+}) => {
+  const isCampaign = draft.campaignKind !== "Standard";
+  const isFreeMonth = draft.campaignKind === "FreeOpeningCalendarPeriod";
+
+  // Restricted to plans that actually offer a price this campaign kind could ever price — an
+  // author choosing from anything wider would only find out it cannot be redeemed once Review
+  // refuses to submit, or worse, after it is saved.
+  const candidatePrices = eligiblePrices(draft.campaignKind, plans);
+  const candidatePlanCodes = [...new Set(candidatePrices.map(({ plan }) => plan.code))];
+  const selectablePlans = plans.filter(
+    (plan) => !isCampaign || candidatePlanCodes.includes(plan.code),
+  );
+  const selectablePrices = candidatePrices.filter(
+    ({ plan }) => draft.planCodes.length === 0 || draft.planCodes.includes(plan.code),
+  );
+
+  const planForEntitlement =
+    plans.find((plan) => draft.planCodes.includes(plan.code)) ??
+    plans.find((plan) =>
+      draft.priceIds.some((priceId) => plan.prices.some((price) => price.priceId === priceId)));
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-lg font-semibold">Eligibility</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          What this discount applies to, and the window it can be redeemed in.
+        </p>
+      </div>
+
+      <fieldset className="space-y-1">
+        <legend className="text-sm font-medium">
+          Plans {isCampaign ? "" : "(optional)"}
+        </legend>
+        <p className="text-xs text-muted-foreground">
+          {isCampaign
+            ? "Only plans with a price this offer can actually price are listed."
+            : "Leave every box clear to allow any plan."}
+        </p>
+        <div className="max-h-32 space-y-1 overflow-y-auto rounded-md border p-2">
+          {selectablePlans.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              {isCampaign
+                ? "No plan has a price this offer type can be redeemed against yet."
+                : "No plans authored yet."}
+            </p>
+          )}
+          {selectablePlans.map((plan) => (
+            <label key={plan.planId} className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={draft.planCodes.includes(plan.code)}
+                onCheckedChange={() => {
+                  const next = toggle(draft.planCodes, plan.code);
+                  onChange({
+                    planCodes: next,
+                    priceIds: draft.priceIds.filter((priceId) =>
+                      candidatePrices
+                        .filter(({ plan: candidate }) => next.length === 0 || next.includes(candidate.code))
+                        .some(({ price }) => price.priceId === priceId)),
+                  });
+                }}
+                aria-label={`Restrict to ${plan.displayName}`}
+              />
+              <span>
+                {plan.displayName} <code className="text-xs">{plan.code}</code>
+              </span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <fieldset className="space-y-1">
+        <legend className="text-sm font-medium">
+          Prices {isCampaign ? "" : "(optional)"}
+        </legend>
+        <p className="text-xs text-muted-foreground">
+          {isCampaign
+            ? "This offer prices a specific price's opening period, not a plan in general — name at least one."
+            : "Narrows to one cadence or currency — a yearly-only offer, for instance."}
+        </p>
+        <div className="max-h-32 space-y-1 overflow-y-auto rounded-md border p-2">
+          {selectablePrices.length === 0 && (
+            <p className="text-xs text-muted-foreground">No prices to choose from.</p>
+          )}
+          {selectablePrices.map(({ plan, price }) => (
+            <label key={price.priceId} className="flex items-center gap-2 text-sm">
+              <Checkbox
+                checked={draft.priceIds.includes(price.priceId)}
+                onCheckedChange={() => onChange({ priceIds: toggle(draft.priceIds, price.priceId) })}
+                aria-label={`Restrict to ${plan.code} ${formatPrice(price)}`}
+              />
+              <span>
+                {plan.code} · {formatPrice(price)}
+              </span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {isCampaign && (
+        <>
+          <div className="grid gap-5 sm:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="campaign-from">Starts</Label>
+              <Input
+                id="campaign-from"
+                type="date"
+                value={draft.validFromDate}
+                onChange={(event) => onChange({ validFromDate: event.target.value })}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="campaign-through">Ends (inclusive)</Label>
+              <Input
+                id="campaign-through"
+                type="date"
+                value={draft.validThroughDate}
+                onChange={(event) => onChange({ validThroughDate: event.target.value })}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="campaign-timezone">Time zone</Label>
+              <Input
+                id="campaign-timezone"
+                value={draft.timeZoneId}
+                onChange={(event) => onChange({ timeZoneId: event.target.value })}
+                placeholder="Europe/Zurich"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-3 rounded-md border p-3">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">One redemption per organization</p>
+                {isFreeMonth && (
+                  <p className="text-xs text-muted-foreground">Required for a free-opening-period campaign.</p>
+                )}
+              </div>
+              <Switch
+                checked={draft.oneUsePerOrganization}
+                onCheckedChange={(checked) => onChange({ oneUsePerOrganization: checked === true })}
+                disabled={isFreeMonth}
+                aria-label="One redemption per organization"
+              />
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Requires a payment method before activation</p>
+                {isFreeMonth && (
+                  <p className="text-xs text-muted-foreground">Required for a free-opening-period campaign.</p>
+                )}
+              </div>
+              <Switch
+                checked={draft.requiresPaymentMethodUpfront}
+                onCheckedChange={(checked) => onChange({ requiresPaymentMethodUpfront: checked === true })}
+                disabled={isFreeMonth}
+                aria-label="Requires a payment method before activation"
+              />
+            </div>
+          </div>
+        </>
+      )}
+
+      {isFreeMonth && (
+        <div className="grid gap-5 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="campaign-entitlement-key">Temporary entitlement</Label>
+            <Input
+              id="campaign-entitlement-key"
+              list="campaign-entitlement-options"
+              value={draft.entitlementKey}
+              onChange={(event) => onChange({ entitlementKey: event.target.value })}
+              placeholder="seats"
+            />
+            {planForEntitlement && (
+              <datalist id="campaign-entitlement-options">
+                {planForEntitlement.entitlements
+                  .filter((entitlement) => entitlement.limitKind === "Count")
+                  .map((entitlement) => (
+                    <option key={entitlement.key} value={entitlement.key} />
+                  ))}
+              </datalist>
+            )}
+            <p className="text-xs text-muted-foreground">
+              The count entitlement this offer temporarily caps while the free month runs.
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="campaign-entitlement-limit">Temporary limit</Label>
+            <Input
+              id="campaign-entitlement-limit"
+              type="number"
+              min={1}
+              value={draft.entitlementLimit}
+              onChange={(event) => onChange({ entitlementLimit: event.target.value })}
+              placeholder="1"
+            />
+            <p className="text-xs text-muted-foreground">
+              Cannot exceed the plan's own limit for this entitlement.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-identity.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-identity.tsx
@@ -1,0 +1,101 @@
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui-kits/radio-group/radio-group";
+import type { CampaignKind } from "../../models/subscription-plan.model";
+import type { CampaignDraft } from "./campaign-draft";
+
+const KIND_OPTIONS: { value: CampaignKind; title: string; description: string }[] = [
+  {
+    value: "Standard",
+    title: "Standard discount",
+    description: "An ordinary percentage or fixed reduction. No date window, no redemption limit.",
+  },
+  {
+    value: "FreeOpeningCalendarPeriod",
+    title: "Free opening month",
+    description:
+      "100% off a calendar-aligned monthly price's opening period only — signup to the next " +
+      "calendar-month boundary — paired with a temporary entitlement cap. One redemption per " +
+      "organization, and requires a card upfront.",
+  },
+  {
+    value: "FirstAnnualPeriod",
+    title: "First-year discount",
+    description:
+      "Discounts a calendar-aligned yearly price's first full annual period only. A renewal past " +
+      "that reverts to the price's own rate automatically — no expiry date to manage.",
+  },
+];
+
+export const StepIdentity = ({
+  draft,
+  onChange,
+}: {
+  draft: CampaignDraft;
+  onChange: (next: Partial<CampaignDraft>) => void;
+}) => (
+  <div className="space-y-5">
+    <div>
+      <h2 className="text-lg font-semibold">Identity</h2>
+      <p className="mt-1 text-sm text-muted-foreground">
+        What this discount is called, and what kind of offer it is.
+      </p>
+    </div>
+
+    <div className="grid gap-5 sm:grid-cols-2">
+      <div className="space-y-1.5">
+        <Label htmlFor="campaign-code">Code</Label>
+        <Input
+          id="campaign-code"
+          value={draft.code}
+          onChange={(event) => onChange({ code: event.target.value })}
+          placeholder="launch25"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p className="text-xs text-muted-foreground">
+          Lowercase letters, digits, hyphens and underscores only. Fixed once created.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="campaign-name">Display name</Label>
+        <Input
+          id="campaign-name"
+          value={draft.displayName}
+          onChange={(event) => onChange({ displayName: event.target.value })}
+          placeholder="Launch offer"
+        />
+      </div>
+    </div>
+
+    <div className="space-y-2">
+      <Label>Offer type</Label>
+      <RadioGroup
+        value={draft.campaignKind}
+        onValueChange={(value) => onChange({ campaignKind: value as CampaignKind })}
+        className="gap-3"
+      >
+        {KIND_OPTIONS.map((option) => (
+          <label
+            key={option.value}
+            htmlFor={`campaign-kind-${option.value}`}
+            className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 text-sm has-[:checked]:border-blocks-primary-400 has-[:checked]:bg-blocks-primary-50"
+          >
+            <RadioGroupItem
+              value={option.value}
+              id={`campaign-kind-${option.value}`}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="font-medium">{option.title}</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">
+                {option.description}
+              </span>
+            </span>
+          </label>
+        ))}
+      </RadioGroup>
+    </div>
+  </div>
+);

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-review.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-review.tsx
@@ -1,0 +1,117 @@
+import type { ReactNode } from "react";
+import type { SubscriptionPlan } from "../../models/subscription-plan.model";
+import { formatMoney, formatPrice, toMinorUnits } from "../../utilities/subscription-format";
+import type { CampaignDraft } from "./campaign-draft";
+
+const Row = ({ label, value }: { label: string; value: ReactNode }) => (
+  <div className="flex items-baseline justify-between gap-4 py-1.5">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="text-right font-medium">{value}</span>
+  </div>
+);
+
+const KIND_LABEL: Record<CampaignDraft["campaignKind"], string> = {
+  Standard: "Standard discount",
+  FreeOpeningCalendarPeriod: "Free opening month",
+  FirstAnnualPeriod: "First-year discount",
+};
+
+export const StepReview = ({
+  draft,
+  plans,
+}: {
+  draft: CampaignDraft;
+  plans: SubscriptionPlan[];
+}) => {
+  const restrictedPrices = draft.priceIds
+    .map((priceId) => {
+      const match = plans
+        .flatMap((plan) => plan.prices.map((price) => ({ plan, price })))
+        .find((candidate) => candidate.price.priceId === priceId);
+      return match ? `${match.plan.code} · ${formatPrice(match.price)}` : priceId;
+    })
+    .join(", ");
+
+  const isCampaign = draft.campaignKind !== "Standard";
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-lg font-semibold">Review</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Check everything before creating this discount — the code cannot be changed afterward.
+        </p>
+      </div>
+
+      <div className="divide-y rounded-md border px-3">
+        <Row label="Code" value={<code>{draft.code || "—"}</code>} />
+        <Row label="Display name" value={draft.displayName || "—"} />
+        <Row label="Offer type" value={KIND_LABEL[draft.campaignKind]} />
+        <Row
+          label="Reduction"
+          value={
+            draft.discountKind === "percent"
+              ? `${draft.percent || "0"}% off`
+              : `${formatMoney(toMinorUnits(Number(draft.amount || 0), draft.currencyCode), draft.currencyCode)} off`
+          }
+        />
+        {isCampaign && (
+          <Row
+            label="Meets the price's own discount"
+            value={
+              { BestDiscount: "Best discount wins", ReplaceBuiltIn: "Replaces it", Stack: "Stacks on top" }[
+                draft.campaignPrecedence
+              ]
+            }
+          />
+        )}
+        {!isCampaign && draft.durationPeriods && (
+          <Row label="Duration" value={`${draft.durationPeriods} billing periods`} />
+        )}
+        {!isCampaign && draft.expiresAtUtc && (
+          <Row label="Expires" value={new Date(draft.expiresAtUtc).toLocaleString()} />
+        )}
+        <Row
+          label="Applies to"
+          value={
+            restrictedPrices || draft.planCodes.length > 0
+              ? restrictedPrices || draft.planCodes.join(", ")
+              : "Any plan and price"
+          }
+        />
+        {isCampaign && (
+          <>
+            <Row
+              label="Redeemable window"
+              value={`${draft.validFromDate || "—"} to ${draft.validThroughDate || "—"} (${
+                draft.timeZoneId || "—"
+              })`}
+            />
+            <Row label="One use per organization" value={draft.oneUsePerOrganization ? "Yes" : "No"} />
+            <Row
+              label="Requires payment method upfront"
+              value={draft.requiresPaymentMethodUpfront ? "Yes" : "No"}
+            />
+          </>
+        )}
+        {draft.campaignKind === "FreeOpeningCalendarPeriod" && (
+          <Row
+            label="Temporary entitlement cap"
+            value={
+              draft.entitlementKey
+                ? `${draft.entitlementKey} → ${draft.entitlementLimit || "—"}`
+                : "—"
+            }
+          />
+        )}
+      </div>
+
+      {isCampaign && (
+        <p className="rounded-md border border-blocks-primary-200 bg-blocks-primary-50 p-3 text-xs text-blocks-primary-900">
+          This offer expires and reverts to standard pricing on its own — there is nothing to
+          schedule or remember to turn off.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -403,6 +403,25 @@ export interface UpdateSubscriptionPriceTaxRequest {
   taxMode?: "Exclusive" | "Inclusive";
 }
 
+/**
+ * What a discount is, beyond the ordinary percentage or fixed reduction: which billing periods it
+ * is allowed to touch, and what else happens alongside the reduction.
+ *
+ * `Standard` is what every discount authored before campaigns existed reads back as — no window,
+ * no redemption ledger entry, no entitlement override.
+ */
+export type CampaignKind = "Standard" | "FirstAnnualPeriod" | "FreeOpeningCalendarPeriod";
+
+/** How a campaign's reduction interacts with a price's own automatic and volume discounts. */
+export type CampaignPrecedence = "BestDiscount" | "ReplaceBuiltIn" | "Stack";
+
+/**
+ * `CampaignKind` and `CampaignPrecedence` are the one exception to the request-enums-as-numbers
+ * rule at the top of this file: both carry `[JsonConverter(typeof(JsonStringEnumConverter))]` on
+ * the server, so they serialize as their string names in *every* direction — request bodies
+ * included. Sending the underlying integer for either fails model binding the same way sending
+ * the string would for `kind` (`DiscountKind`), which carries no such attribute.
+ */
 export interface SubscriptionDiscount {
   discountId: string;
   organizationId: string | null;
@@ -418,6 +437,25 @@ export interface SubscriptionDiscount {
   /** Absent on discounts stored before price restrictions existed, which are unrestricted by price. */
   applicablePriceIds?: string[];
   status: "Active" | "Archived";
+  /** Read back on every response so a subsequent edit can be sent as an expected version. */
+  version: number;
+  campaignKind: CampaignKind;
+  campaignPrecedence: CampaignPrecedence;
+  /** The local dates a campaign authored them in, present only for a non-Standard campaign. */
+  validFromDate: string | null;
+  validThroughDate: string | null;
+  /** The zone `validFromDate`/`validThroughDate` are read in. */
+  timeZoneId: string | null;
+  /** The same window, converted to UTC instants — what redemption actually checks against. */
+  redeemableFromUtc: string | null;
+  redeemableUntilUtc: string | null;
+  oneUsePerOrganization: boolean;
+  requiresPaymentMethodUpfront: boolean;
+  /** Set only for a `FreeOpeningCalendarPeriod` campaign — never honoured for any other kind. */
+  entitlementOverrideKey: string | null;
+  entitlementOverrideLimit: number | null;
+  /** Upcoming, Active, Expired or Archived — Active/Archived only for a Standard discount. */
+  effectiveState: "Upcoming" | "Active" | "Expired" | "Archived";
 }
 
 export interface CreateSubscriptionDiscountRequest {
@@ -433,4 +471,17 @@ export interface CreateSubscriptionDiscountRequest {
   applicablePlanCodes: string[];
   /** Narrows the plan list rather than replacing it: both have to match when both are given. */
   applicablePriceIds: string[];
+  /** Omit entirely for a Standard discount — the server default is the same as omitting it. */
+  campaignKind?: CampaignKind;
+  campaignPrecedence?: CampaignPrecedence;
+  /** Local calendar dates, e.g. "2026-01-01" — required together whenever campaignKind is set. */
+  validFromDate?: string;
+  validThroughDate?: string;
+  /** Required whenever validFromDate/validThroughDate are set. */
+  timeZoneId?: string;
+  oneUsePerOrganization?: boolean;
+  requiresPaymentMethodUpfront?: boolean;
+  /** FreeOpeningCalendarPeriod only — refused by the server for any other campaign kind. */
+  entitlementOverrideKey?: string;
+  entitlementOverrideLimit?: number;
 }

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
@@ -1,26 +1,18 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams } from "react-router";
+import { Badge } from "@/components/ui-kits/badge/badge";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
-import { Input } from "@/components/ui-kits/input/input";
-import { Label } from "@/components/ui-kits/label/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui-kits/select/select";
-import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
+import { CampaignBuilder } from "../components/campaign-builder/campaign-builder";
+import type { CampaignDraft } from "../components/campaign-builder/campaign-draft";
+import { toCreateDiscountRequest } from "../components/campaign-builder/campaign-draft";
 import { useOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlans } from "../hooks/use-subscription-plans";
-import type { SubscriptionPlan } from "../models/subscription-plan.model";
+import type { SubscriptionDiscount, SubscriptionPlan } from "../models/subscription-plan.model";
 import { subscriptionService } from "../services/subscription.service";
-import { SUBSCRIPTION_CURRENCY_OPTIONS } from "../constants/subscription.constants";
-import { describeDiscountAmountProblem } from "../utilities/discount-amount";
-import {
-  exampleMinorAmount,
-  formatMoney,
-  formatPrice,
-  minorUnitStep,
-  toMinorUnits,
-} from "../utilities/subscription-format";
+import { formatMoney, formatPrice } from "../utilities/subscription-format";
 
 /**
  * What a discount applies to, in one line.
@@ -56,199 +48,141 @@ const describeApplicability = (
   return `Restricted to ${parts.join(" and ")}.`;
 };
 
+/** A campaign's own window and rules, in one line — absent for a Standard discount. */
+const describeCampaign = (discount: SubscriptionDiscount): string | null => {
+  if (discount.campaignKind === "Standard") return null;
+
+  const kindLabel =
+    discount.campaignKind === "FreeOpeningCalendarPeriod" ? "Free opening month" : "First-year discount";
+  const window =
+    discount.validFromDate && discount.validThroughDate
+      ? `${discount.validFromDate} – ${discount.validThroughDate}`
+      : null;
+
+  return [kindLabel, window].filter(Boolean).join(" · ");
+};
+
+const EFFECTIVE_STATE_VARIANT: Record<SubscriptionDiscount["effectiveState"], "default" | "secondary" | "outline"> = {
+  Active: "default",
+  Upcoming: "secondary",
+  Expired: "outline",
+  Archived: "outline",
+};
+
 export const SubscriptionDiscountsPage = () => {
   const { itemId } = useParams();
   const organizationId = useOrganizationScope();
   const queryClient = useQueryClient();
-  const [code, setCode] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [percent, setPercent] = useState("10");
-  const [kind, setKind] = useState<"percent" | "fixed">("percent");
-  const [amount, setAmount] = useState("");
-  const [currencyCode, setCurrencyCode] = useState("USD");
-  const [durationPeriods, setDurationPeriods] = useState("");
-  const [expiresAtUtc, setExpiresAtUtc] = useState("");
-  const [planCodes, setPlanCodes] = useState<string[]>([]);
-  const [priceIds, setPriceIds] = useState<string[]>([]);
-
-  // Null when the amount is sendable. Only asked of a fixed discount: a percentage has no
-  // currency and no amount to be wrong about.
-  const amountProblem =
-    kind === "fixed" ? describeDiscountAmountProblem(amount, currencyCode) : null;
-
-  // Shown only once there is something to correct. An empty field is already visibly empty, and
-  // colouring it red before anybody has typed reads as a mistake they have not made yet — while
-  // the button stays disabled either way.
-  const amountMessage = amount.trim() === "" ? null : amountProblem;
+  const [isCreating, setIsCreating] = useState(false);
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
 
   const catalogue = useSubscriptionPlans(organizationId);
   const availablePlans = catalogue.data ?? [];
-
-  // Only the prices of the plans that are actually restricted to. A discount aimed at one plan and
-  // a price belonging to another can never match, and offering that pair invites authoring it.
-  const selectablePrices = availablePlans
-    .filter((plan) => planCodes.length === 0 || planCodes.includes(plan.code))
-    .flatMap((plan) => plan.prices.map((price) => ({ plan, price })));
-
-  const toggle = (values: string[], value: string) =>
-    values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value];
 
   const discounts = useQuery({
     queryKey: ["subscription-discounts", organizationId],
     queryFn: () => subscriptionService.listDiscounts(organizationId),
   });
+
   const create = useMutation({
-    mutationFn: () => subscriptionService.createDiscount({
-      organizationId,
-      code: code.trim(),
-      displayName: displayName.trim(),
-      kind: kind === "percent" ? 0 : 1,
-      percentBasisPoints: kind === "percent" ? Math.round(Number(percent) * 100) : undefined,
-      // The only place this figure changes units. The field holds what the author typed; the API
-      // has always wanted minor units and still does.
-      amountMinor: kind === "fixed" ? toMinorUnits(Number(amount), currencyCode) : undefined,
-      currencyCode: kind === "fixed" ? currencyCode : undefined,
-      durationPeriods: durationPeriods ? Number(durationPeriods) : undefined,
-      expiresAtUtc: expiresAtUtc ? new Date(expiresAtUtc).toISOString() : undefined,
-      applicablePlanCodes: planCodes,
-      // Both lists narrow, so an empty one is "unrestricted by that" rather than "matches nothing".
-      applicablePriceIds: priceIds,
-    }),
+    mutationFn: (draft: CampaignDraft) =>
+      subscriptionService.createDiscount(toCreateDiscountRequest(draft, organizationId)),
     onSuccess: async () => {
-      setCode(""); setDisplayName(""); setAmount(""); setPlanCodes([]); setPriceIds([]);
+      setIsCreating(false);
+      setSubmissionError(null);
       await queryClient.invalidateQueries({ queryKey: ["subscription-discounts"] });
     },
   });
+
   const archive = useMutation({
     mutationFn: (discountId: string) => subscriptionService.archiveDiscount(discountId, organizationId),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["subscription-discounts"] }),
   });
 
+  const submitDraft = async (draft: CampaignDraft) => {
+    setSubmissionError(null);
+    try {
+      await create.mutateAsync(draft);
+    } catch (error) {
+      setSubmissionError(error instanceof Error ? error.message : "The discount could not be created.");
+      throw error;
+    }
+  };
+
   return (
     <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
       <SubscriptionPlanPageHeader
         title="Subscription discounts"
-        description="Reusable discount codes are validated at signup and copied onto each subscription."
+        description="Reusable discount codes and time-boxed campaigns are validated at signup and copied onto each subscription."
         backTo={`/app/${itemId ?? ""}/subscription/plans`}
       />
-      <Card className="space-y-4 rounded-xl">
-        <h2 className="font-semibold">Create discount</h2>
-        <div className="grid gap-3 sm:grid-cols-2">
-          <div><Label htmlFor="discount-code">Code</Label><Input id="discount-code" value={code} onChange={(event) => setCode(event.target.value)} placeholder="launch25" /></div>
-          <div><Label htmlFor="discount-name">Display name</Label><Input id="discount-name" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Launch offer" /></div>
-          <div><Label>Kind</Label><Select value={kind} onValueChange={(value) => setKind(value as "percent" | "fixed")}><SelectTrigger><SelectValue /></SelectTrigger><SelectContent><SelectItem value="percent">Percentage</SelectItem><SelectItem value="fixed">Fixed amount</SelectItem></SelectContent></Select></div>
-          {kind === "percent" ? <div><Label htmlFor="discount-percent">Percent off</Label><Input id="discount-percent" type="number" min={0.01} max={100} value={percent} onChange={(event) => setPercent(event.target.value)} /></div> : <div className="grid grid-cols-2 gap-2">
-              <div>
-                <Label htmlFor="discount-amount">Amount off ({currencyCode})</Label>
-                <Input
-                  id="discount-amount"
-                  type="number"
-                  min={0}
-                  step={minorUnitStep(currencyCode)}
-                  placeholder={exampleMinorAmount(currencyCode)}
-                  value={amount}
-                  onChange={(event) => setAmount(event.target.value)}
-                  aria-invalid={amountMessage !== null}
-                  aria-describedby={amountMessage ? "discount-amount-problem" : undefined}
-                />
-                {/* Named here rather than left to the disabled button, which says that something
-                    is wrong without saying what. */}
-                {amountMessage && (
-                  <p id="discount-amount-problem" className="mt-1 text-xs text-destructive">
-                    {amountMessage}
-                  </p>
-                )}
-              </div>
-              <div>
-                <Label htmlFor="discount-currency">Currency</Label>
-                {/* A list rather than three free characters. The exponent decides how many
-                    decimals the amount may carry, and a currency nothing knows the exponent of
-                    would be assumed to have two — wrong for yen, and wrong by a factor of ten
-                    for dinars. */}
-                <Select value={currencyCode} onValueChange={setCurrencyCode}>
-                  <SelectTrigger id="discount-currency">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {SUBSCRIPTION_CURRENCY_OPTIONS.map((currency) => (
-                      <SelectItem key={currency.code} value={currency.code}>
-                        {currency.code} — {currency.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>}
-          <fieldset className="space-y-1">
-            <legend className="text-sm font-medium">Plans (optional)</legend>
-            <p className="text-xs text-muted-foreground">Leave every box clear to allow any plan.</p>
-            <div className="max-h-32 space-y-1 overflow-y-auto rounded-md border p-2">
-              {availablePlans.length === 0 && (
-                <p className="text-xs text-muted-foreground">No plans authored yet.</p>
-              )}
-              {availablePlans.map((plan) => (
-                <label key={plan.planId} className="flex items-center gap-2 text-sm">
-                  <Checkbox
-                    checked={planCodes.includes(plan.code)}
-                    onCheckedChange={() => {
-                      const next = toggle(planCodes, plan.code);
-                      setPlanCodes(next);
-                      // Prices belonging to a plan that is no longer selected cannot match anything,
-                      // so they are dropped rather than left in a state nobody can see or undo.
-                      setPriceIds((current) =>
-                        current.filter((priceId) =>
-                          availablePlans
-                            .filter((candidate) =>
-                              next.length === 0 || next.includes(candidate.code))
-                            .some((candidate) =>
-                              candidate.prices.some((price) => price.priceId === priceId)),
-                        ),
-                      );
-                    }}
-                    aria-label={`Restrict to ${plan.displayName}`}
-                  />
-                  <span>{plan.displayName} <code className="text-xs">{plan.code}</code></span>
-                </label>
-              ))}
-            </div>
-          </fieldset>
-          <fieldset className="space-y-1">
-            <legend className="text-sm font-medium">Prices (optional)</legend>
-            <p className="text-xs text-muted-foreground">
-              Narrows to one cadence or currency — a yearly-only offer, for instance.
+
+      {isCreating ? (
+        <CampaignBuilder
+          plans={availablePlans}
+          organizationId={organizationId}
+          isSubmitting={create.isPending}
+          submissionError={submissionError}
+          onSubmit={submitDraft}
+          onCancel={() => {
+            setIsCreating(false);
+            setSubmissionError(null);
+          }}
+        />
+      ) : (
+        <Card className="flex items-center justify-between gap-4 rounded-xl p-5">
+          <div>
+            <h2 className="font-semibold">Create a discount</h2>
+            <p className="text-sm text-muted-foreground">
+              An ordinary code, a free opening month, or a first-year offer — four short steps.
             </p>
-            <div className="max-h-32 space-y-1 overflow-y-auto rounded-md border p-2">
-              {selectablePrices.length === 0 && (
-                <p className="text-xs text-muted-foreground">No prices to choose from.</p>
-              )}
-              {selectablePrices.map(({ plan, price }) => (
-                <label key={price.priceId} className="flex items-center gap-2 text-sm">
-                  <Checkbox
-                    checked={priceIds.includes(price.priceId)}
-                    onCheckedChange={() => setPriceIds(toggle(priceIds, price.priceId))}
-                    aria-label={`Restrict to ${plan.code} ${formatPrice(price)}`}
-                  />
-                  <span>{plan.code} · {formatPrice(price)}</span>
-                </label>
-              ))}
-            </div>
-          </fieldset>
-          <div><Label htmlFor="discount-duration">Duration in billing periods (optional)</Label><Input id="discount-duration" type="number" min={1} value={durationPeriods} onChange={(event) => setDurationPeriods(event.target.value)} /></div>
-          <div><Label htmlFor="discount-expiry">Expires at (optional)</Label><Input id="discount-expiry" type="datetime-local" value={expiresAtUtc} onChange={(event) => setExpiresAtUtc(event.target.value)} /></div>
-        </div>
-        {create.error && <p className="text-sm text-destructive">{create.error.message}</p>}
-        <Button disabled={!code.trim() || !displayName.trim() || amountProblem !== null || create.isPending} onClick={() => create.mutate()}>{create.isPending ? "Creating…" : "Create discount"}</Button>
-      </Card>
+          </div>
+          <Button onClick={() => setIsCreating(true)}>New discount</Button>
+        </Card>
+      )}
+
       <Card className="rounded-xl p-0">
         <div className="border-b p-4 font-semibold">Discount catalogue</div>
         <div className="divide-y">
-          {(discounts.data ?? []).map((discount) => (
-            <div key={discount.discountId} className="flex items-center justify-between gap-4 p-4">
-              <div><p className="font-medium">{discount.displayName} <code className="text-xs">{discount.code}</code></p><p className="text-xs text-muted-foreground">{discount.percentBasisPoints ? `${discount.percentBasisPoints / 100}% off` : `${formatMoney(discount.amountMinor ?? 0, discount.currencyCode ?? "USD")} off`} · {discount.status}</p><p className="text-xs text-muted-foreground">{describeApplicability(discount.applicablePlanCodes, discount.applicablePriceIds, availablePlans)}</p></div>
-              {discount.status === "Active" && <Button variant="ghost" size="sm" onClick={() => archive.mutate(discount.discountId)}>Retire</Button>}
-            </div>
-          ))}
-          {!discounts.isLoading && !(discounts.data?.length) && <p className="p-4 text-sm text-muted-foreground">No discounts authored yet.</p>}
+          {(discounts.data ?? []).map((discount) => {
+            const campaignSummary = describeCampaign(discount);
+
+            return (
+              <div key={discount.discountId} className="flex items-center justify-between gap-4 p-4">
+                <div>
+                  <p className="flex items-center gap-2 font-medium">
+                    {discount.displayName} <code className="text-xs">{discount.code}</code>
+                    <Badge variant={EFFECTIVE_STATE_VARIANT[discount.effectiveState]}>
+                      {discount.effectiveState}
+                    </Badge>
+                    {campaignSummary && <Badge variant="secondary">{campaignSummary}</Badge>}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {discount.percentBasisPoints
+                      ? `${discount.percentBasisPoints / 100}% off`
+                      : `${formatMoney(discount.amountMinor ?? 0, discount.currencyCode ?? "USD")} off`}{" "}
+                    · {discount.status}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {describeApplicability(discount.applicablePlanCodes, discount.applicablePriceIds, availablePlans)}
+                  </p>
+                  {discount.entitlementOverrideKey && (
+                    <p className="text-xs text-muted-foreground">
+                      Temporarily caps {discount.entitlementOverrideKey} at {discount.entitlementOverrideLimit}.
+                    </p>
+                  )}
+                </div>
+                {discount.status === "Active" && (
+                  <Button variant="ghost" size="sm" onClick={() => archive.mutate(discount.discountId)}>
+                    Retire
+                  </Button>
+                )}
+              </div>
+            );
+          })}
+          {!discounts.isLoading && !(discounts.data?.length) && (
+            <p className="p-4 text-sm text-muted-foreground">No discounts authored yet.</p>
+          )}
         </div>
       </Card>
     </main>

--- a/server/Subscription.DomainService/Entities/Discount.cs
+++ b/server/Subscription.DomainService/Entities/Discount.cs
@@ -109,14 +109,6 @@ public sealed class CampaignTerms
     public bool OneUsePerOrganization { get; set; }
 
     /// <summary>
-    /// For <see cref="CampaignKind.FirstAnnualPeriod"/>: whether the campaign's reduction also
-    /// applies to a calendar-aligned yearly price's opening stub, in addition to the first full
-    /// annual period. The stub never consumes the campaign on its own -- only the annual period
-    /// does -- regardless of this flag.
-    /// </summary>
-    public bool ApplyToOpeningStub { get; set; }
-
-    /// <summary>
     /// Whether activating a subscription under this campaign requires a stored payment method,
     /// even on a plan that does not otherwise require one upfront. A campaign that sets this
     /// overrides the plan's own <c>RequirePaymentMethodUpfront</c> for the duration it applies --

--- a/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
@@ -30,7 +30,6 @@ public sealed class CreateDiscountRequest : ICampaignDiscountRequest
     public string? TimeZoneId { get; set; }
 
     public bool OneUsePerOrganization { get; set; }
-    public bool ApplyToOpeningStub { get; set; }
     public bool RequiresPaymentMethodUpfront { get; set; }
     public string? EntitlementOverrideKey { get; set; }
     public long? EntitlementOverrideLimit { get; set; }

--- a/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
@@ -38,7 +38,6 @@ public sealed class UpdateDiscountRequest : ICampaignDiscountRequest
     public DateOnly? ValidThroughDate { get; set; }
     public string? TimeZoneId { get; set; }
     public bool OneUsePerOrganization { get; set; }
-    public bool ApplyToOpeningStub { get; set; }
     public bool RequiresPaymentMethodUpfront { get; set; }
     public string? EntitlementOverrideKey { get; set; }
     public long? EntitlementOverrideLimit { get; set; }

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -27,7 +27,6 @@ public sealed class DiscountResponse
     public DateTime? RedeemableFromUtc { get; init; }
     public DateTime? RedeemableUntilUtc { get; init; }
     public bool OneUsePerOrganization { get; init; }
-    public bool ApplyToOpeningStub { get; init; }
     public bool RequiresPaymentMethodUpfront { get; init; }
     public string? EntitlementOverrideKey { get; init; }
     public long? EntitlementOverrideLimit { get; init; }

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -252,8 +252,6 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
             RedeemableFromUtc = redeemableFromUtc,
             RedeemableUntilUtc = redeemableUntilUtc,
             OneUsePerOrganization = request.OneUsePerOrganization,
-            ApplyToOpeningStub = request is CreateDiscountRequest { ApplyToOpeningStub: true } or
-                UpdateDiscountRequest { ApplyToOpeningStub: true },
             RequiresPaymentMethodUpfront = request.RequiresPaymentMethodUpfront,
             EntitlementOverride = request.EntitlementOverrideKey is { Length: > 0 } key
                 ? new CampaignEntitlementOverride
@@ -498,7 +496,6 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         RedeemableFromUtc = item.Campaign.RedeemableFromUtc,
         RedeemableUntilUtc = item.Campaign.RedeemableUntilUtc,
         OneUsePerOrganization = item.Campaign.OneUsePerOrganization,
-        ApplyToOpeningStub = item.Campaign.ApplyToOpeningStub,
         RequiresPaymentMethodUpfront = item.Campaign.RequiresPaymentMethodUpfront,
         EntitlementOverrideKey = item.Campaign.EntitlementOverride?.EntitlementKey,
         EntitlementOverrideLimit = item.Campaign.EntitlementOverride?.Limit,

--- a/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
@@ -94,19 +94,18 @@ public abstract class CampaignDiscountRequestValidator<T> : AbstractValidator<T>
             .WithMessage("The temporary entitlement limit must be a positive number.")
             .When(request => request.CampaignKind == CampaignKind.FreeOpeningCalendarPeriod);
 
-        // Both present or both absent, for every other campaign kind — half of a pair is not a
-        // request that can mean anything, and silently ignoring the one that is there would hide
-        // a caller's mistake rather than refuse it.
+        // EntitlementService honours an override for FreeOpeningCalendarPeriod only -- see
+        // EntitlementServiceCampaignTests' A_first_annual_period_campaign_never_overrides_an_
+        // entitlement_either. Accepting one here for FirstAnnualPeriod would store a value that
+        // validates cleanly and then does nothing, the same silent-no-op shape the removed
+        // ApplyToOpeningStub flag had. Refused instead, at the one point an author can still
+        // notice and drop it.
         RuleFor(request => request).Must(request =>
-                (request.EntitlementOverrideKey is null) == (request.EntitlementOverrideLimit is null))
+                request.EntitlementOverrideKey is null && request.EntitlementOverrideLimit is null)
             .WithMessage(
-                "An entitlement override needs both a key and a limit, or neither.")
-            .When(request => request.CampaignKind != CampaignKind.FreeOpeningCalendarPeriod);
-        RuleFor(request => request.EntitlementOverrideLimit).GreaterThan(0)
-            .WithMessage("The temporary entitlement limit must be a positive number.")
-            .When(request =>
-                request.CampaignKind != CampaignKind.FreeOpeningCalendarPeriod &&
-                request.EntitlementOverrideLimit is not null);
+                "A first-annual-period campaign cannot carry a temporary entitlement override -- " +
+                "it is never enforced for this campaign kind.")
+            .When(request => request.CampaignKind == CampaignKind.FirstAnnualPeriod);
 
         // A non-campaign discount carries none of this. Refused rather than silently dropped, so a
         // caller who set a campaign field on a Standard discount finds out, instead of the field

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
@@ -282,6 +282,25 @@ public sealed class DiscountCatalogueServiceCampaignTests
         result.IsSuccess.Should().BeTrue();
     }
 
+    /// <summary>
+    /// EntitlementService only ever honours an override for FreeOpeningCalendarPeriod -- see
+    /// EntitlementServiceCampaignTests. Accepting one here would store a value that validates
+    /// cleanly and then is silently never enforced, the same shape the removed ApplyToOpeningStub
+    /// flag had.
+    /// </summary>
+    [Fact]
+    public async Task A_first_annual_period_campaign_refuses_a_temporary_entitlement_override()
+    {
+        var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [CalendarYearlyPriceId]);
+        request.EntitlementOverrideKey = "seats";
+        request.EntitlementOverrideLimit = 1;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_discount_invalid");
+    }
+
     [Fact]
     public async Task A_free_opening_period_campaign_refuses_a_price_that_is_not_calendar_aligned()
     {


### PR DESCRIPTION
Phase 5/6 of campaign discount management. A four-step wizard (Identity / Benefit / Eligibility / Review) for authoring a discount, Standard or campaign, replacing the single-form page that only ever knew how to create a Standard one.

## Two real gaps closed before building the UI that would have exposed them

Building the authoring form meant deciding what to show for every field the server request accepts, which surfaced two fields that validate cleanly and then do nothing:

1. **`Discount.Campaign.ApplyToOpeningStub`** — scaffolded in Phase 1 for a "discount the stub too" design that Phase 3b's investigation and the user's own explicit choice ("annual period only") superseded. Never read anywhere in the pricing pipeline. Removed outright rather than exposed as a checkbox that would silently do nothing when checked — nothing depends on it, since nothing built on it has merged yet.
2. A **`FirstAnnualPeriod`** campaign could carry an entitlement override that validated fine and was stored, but `EntitlementService` only ever honours one for `FreeOpeningCalendarPeriod` (proven by `EntitlementServiceCampaignTests`). Same silent-no-op shape as (1). Closed in `CampaignDiscountRequestValidator`: `FirstAnnualPeriod` now refuses an entitlement override outright.

Both would otherwise have needed a wizard step to either lie about what a toggle does, or omit it inconsistently with what the request technically accepted — building the UI is what surfaced them.

## Server

- `ApplyToOpeningStub` removed end to end (`Discount.cs`, `Create/UpdateDiscountRequest.cs`, `DiscountResponse.cs`, `DiscountCatalogueService.cs`).
- `CampaignDiscountRequestValidator`: `FirstAnnualPeriod` + an entitlement override → `subscription_discount_invalid`.

## Client

- `models/subscription-plan.model.ts` — `SubscriptionDiscount`/`CreateSubscriptionDiscountRequest` gain the full campaign surface. Documented explicitly: `CampaignKind`/`CampaignPrecedence` are the one exception to this file's own "request enums are numbers" convention — both carry `[JsonConverter(typeof(JsonStringEnumConverter))]` on the server, so they serialize as strings in a request body too, unlike `DiscountKind`.
- `components/campaign-builder/` (new) — `campaign-draft.ts` holds the wizard's state and every rule, pure and unit-tested on its own: `withCampaignKind` locks in a kind's rules the moment it's picked (a free month forces 100%/one-use/requires-payment; a first-year discount clears any leftover entitlement override); `eligiblePrices` filters to only a price this campaign kind could ever be redeemed against, mirroring `DiscountCatalogueService.CheckCadence`'s server-side cadence rules; `stepProblems` mirrors the validator per step so Next is disabled with a reason instead of deferring every mistake to a failed submit. The four step components + orchestrator follow `plan-builder/`'s established stepper pattern, without that module's sticky-scroll/live-preview machinery this shorter wizard doesn't need.
- `pages/subscription-discounts-page.tsx` — the old inline single-form card is replaced by the wizard behind a "New discount" button; the catalogue list now shows a campaign's kind, window, effective state, and entitlement cap — all newly available on the response but never rendered until now.

## Tests

- `campaign-draft.test.ts` (23 tests) — per-kind locking, cadence filtering, per-step validation, request-building.
- `campaign-builder.test.tsx` (5 tests) — navigation gating, cancel, a full Standard walkthrough, a Free Month kind-switch locking its fields and narrowing the price picker, a submission error shown without losing the draft.
- One new `DiscountCatalogueServiceCampaignTests` case for the closed entitlement-override gap.

## Verification

- Server: `dotnet test --filter "FullyQualifiedName!~Integration"`: 3216/3217 non-flaky tests passed (a `PeriodicPingBackgroundServiceTests` case failed once under full-suite load, passed 20/20 in isolation — pre-existing timing flakiness, unrelated to anything here), same 4 pre-existing baseline failures, 1 unrelated skip.
- Client: `npx vitest run` (full suite): **323 files, 2334 tests passed**. `npx tsc -b`: clean.

## Remaining phase

6/2b — reconciliation-sweep worker for the redemption ledger's crash window.

## Merge order

Based on `feat/campaign-buyer-preview` (#354) → `feat/campaign-annual-yearly-pricing` (#352) → `feat/campaign-free-month-pricing` (#351) → `feat/campaign-discounts-redemption-ledger` (#350) → `feat/campaign-discounts-data-model` (#349). Merge in that order, retargeting each PR's base as the prior one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
