### PR TITLE
feat(subscription): reconciliation sweep for stuck campaign redemptions [Phase 6/6]

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.tsx
@@ -34,6 +34,8 @@ export interface CampaignBuilderProps {
   /** Rejecting leaves the draft in place and shows the error; the caller navigates on success. */
   onSubmit: (draft: CampaignDraft, organizationId: string | undefined) => Promise<void>;
   onCancel: () => void;
+  initialDraft?: CampaignDraft;
+  editing?: boolean;
 }
 
 export const CampaignBuilder = (props: CampaignBuilderProps) => (
@@ -49,9 +51,11 @@ const CampaignBuilderWizard = ({
   submissionError,
   onSubmit,
   onCancel,
+  initialDraft = EMPTY_DRAFT,
+  editing = false,
 }: CampaignBuilderProps) => {
   const { currentStep, nextStep, previousStep } = useStepper();
-  const [draft, setDraft] = useState<CampaignDraft>(EMPTY_DRAFT);
+  const [draft, setDraft] = useState<CampaignDraft>(initialDraft);
   const step = currentStep as StepId;
   const isLastStep = currentStep === STEPS.length;
 
@@ -82,7 +86,7 @@ const CampaignBuilderWizard = ({
       <CampaignBuilderProgress />
 
       <Card className="space-y-5 rounded-2xl p-5 sm:p-7">
-        {step === 1 && <StepIdentity draft={draft} onChange={update} />}
+        {step === 1 && <StepIdentity draft={draft} onChange={update} codeReadOnly={editing} />}
         {step === 2 && <StepBenefit draft={draft} onChange={update} />}
         {step === 3 && <StepEligibility draft={draft} plans={plans} onChange={update} />}
         {step === 4 && <StepReview draft={draft} plans={plans} />}

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
@@ -1,11 +1,13 @@
 import { describeDiscountAmountProblem } from "../../utilities/discount-amount";
-import { toMinorUnits } from "../../utilities/subscription-format";
+import { toMajorUnits, toMinorUnits } from "../../utilities/subscription-format";
 import type {
   CampaignKind,
   CampaignPrecedence,
   CreateSubscriptionDiscountRequest,
   PlanPrice,
   SubscriptionPlan,
+  SubscriptionDiscount,
+  UpdateSubscriptionDiscountRequest,
 } from "../../models/subscription-plan.model";
 
 /**
@@ -64,6 +66,32 @@ export const EMPTY_DRAFT: CampaignDraft = {
   entitlementLimit: "",
 };
 
+export const discountToDraft = (discount: SubscriptionDiscount): CampaignDraft => ({
+  code: discount.code,
+  displayName: discount.displayName,
+  campaignKind: discount.campaignKind,
+  discountKind: discount.kind === "Percent" ? "percent" : "fixed",
+  percent: discount.percentBasisPoints == null ? "" : String(discount.percentBasisPoints / 100),
+  amount: discount.amountMinor == null
+    ? ""
+    : String(toMajorUnits(discount.amountMinor, discount.currencyCode ?? "USD")),
+  currencyCode: discount.currencyCode ?? "USD",
+  campaignPrecedence: discount.campaignPrecedence,
+  durationPeriods: discount.durationPeriods == null ? "" : String(discount.durationPeriods),
+  expiresAtUtc: discount.expiresAtUtc?.slice(0, 16) ?? "",
+  planCodes: [...discount.applicablePlanCodes],
+  priceIds: [...(discount.applicablePriceIds ?? [])],
+  validFromDate: discount.validFromDate ?? "",
+  validThroughDate: discount.validThroughDate ?? "",
+  timeZoneId: discount.timeZoneId ?? "UTC",
+  oneUsePerOrganization: discount.oneUsePerOrganization,
+  requiresPaymentMethodUpfront: discount.requiresPaymentMethodUpfront,
+  entitlementKey: discount.entitlementOverrideKey ?? "",
+  entitlementLimit: discount.entitlementOverrideLimit == null
+    ? ""
+    : String(discount.entitlementOverrideLimit),
+});
+
 /**
  * Applies each campaign kind's own locked-in rules the moment it is picked, the same way the
  * server would refuse anything that disagreed with them -- so a switch to
@@ -77,6 +105,7 @@ export const withCampaignKind = (draft: CampaignDraft, campaignKind: CampaignKin
       campaignKind,
       discountKind: "percent",
       percent: "100",
+      campaignPrecedence: "ReplaceBuiltIn",
       oneUsePerOrganization: true,
       requiresPaymentMethodUpfront: true,
     };
@@ -84,7 +113,13 @@ export const withCampaignKind = (draft: CampaignDraft, campaignKind: CampaignKin
 
   if (campaignKind === "FirstAnnualPeriod") {
     // Never enforced for this kind -- see CampaignDiscountRequestValidator on the server.
-    return { ...draft, campaignKind, entitlementKey: "", entitlementLimit: "" };
+    return {
+      ...draft,
+      campaignKind,
+      campaignPrecedence: "ReplaceBuiltIn",
+      entitlementKey: "",
+      entitlementLimit: "",
+    };
   }
 
   return { ...draft, campaignKind };
@@ -184,7 +219,9 @@ export const stepProblems = (
 
     if (isCampaign) {
       if (!draft.validFromDate) problems.push("A campaign needs a start date.");
-      if (!draft.validThroughDate) problems.push("A campaign needs an end date.");
+      if (!draft.validThroughDate && draft.campaignKind !== "FreeOpeningCalendarPeriod") {
+        problems.push("A campaign needs an end date.");
+      }
       if (!draft.timeZoneId.trim()) problems.push("A campaign needs a time zone its dates are read in.");
       if (
         draft.validFromDate &&
@@ -252,7 +289,7 @@ export const toCreateDiscountRequest = (
     campaignKind: isCampaign ? draft.campaignKind : undefined,
     campaignPrecedence: isCampaign ? draft.campaignPrecedence : undefined,
     validFromDate: isCampaign ? draft.validFromDate : undefined,
-    validThroughDate: isCampaign ? draft.validThroughDate : undefined,
+    validThroughDate: isCampaign && draft.validThroughDate ? draft.validThroughDate : undefined,
     timeZoneId: isCampaign ? draft.timeZoneId : undefined,
     oneUsePerOrganization: isCampaign ? draft.oneUsePerOrganization : undefined,
     requiresPaymentMethodUpfront: isCampaign ? draft.requiresPaymentMethodUpfront : undefined,
@@ -261,4 +298,13 @@ export const toCreateDiscountRequest = (
     entitlementOverrideLimit:
       draft.campaignKind === "FreeOpeningCalendarPeriod" ? Number(draft.entitlementLimit) : undefined,
   };
+};
+
+export const toUpdateDiscountRequest = (
+  draft: CampaignDraft,
+  expectedVersion: number,
+): UpdateSubscriptionDiscountRequest => {
+  const { organizationId: _organizationId, code: _code, ...request } =
+    toCreateDiscountRequest(draft, undefined);
+  return { ...request, expectedVersion };
 };

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-eligibility.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-eligibility.tsx
@@ -129,13 +129,20 @@ export const StepEligibility = ({
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="campaign-through">Ends (inclusive)</Label>
+              <Label htmlFor="campaign-through">
+                Ends (inclusive){isFreeMonth ? " — optional" : ""}
+              </Label>
               <Input
                 id="campaign-through"
                 type="date"
                 value={draft.validThroughDate}
                 onChange={(event) => onChange({ validThroughDate: event.target.value })}
               />
+              {isFreeMonth && (
+                <p className="text-xs text-muted-foreground">
+                  Leave empty to keep the offer available until an administrator archives it.
+                </p>
+              )}
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="campaign-timezone">Time zone</Label>

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-identity.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-identity.tsx
@@ -30,9 +30,11 @@ const KIND_OPTIONS: { value: CampaignKind; title: string; description: string }[
 export const StepIdentity = ({
   draft,
   onChange,
+  codeReadOnly = false,
 }: {
   draft: CampaignDraft;
   onChange: (next: Partial<CampaignDraft>) => void;
+  codeReadOnly?: boolean;
 }) => (
   <div className="space-y-5">
     <div>
@@ -52,6 +54,7 @@ export const StepIdentity = ({
           placeholder="launch25"
           autoComplete="off"
           spellCheck={false}
+          readOnly={codeReadOnly}
         />
         <p className="text-xs text-muted-foreground">
           Lowercase letters, digits, hyphens and underscores only. Fixed once created.

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -456,6 +456,9 @@ export interface SubscriptionDiscount {
   entitlementOverrideLimit: number | null;
   /** Upcoming, Active, Expired or Archived — Active/Archived only for a Standard discount. */
   effectiveState: "Upcoming" | "Active" | "Expired" | "Archived";
+  reservedRedemptions: number;
+  redeemedRedemptions: number;
+  releasedRedemptions: number;
 }
 
 export interface CreateSubscriptionDiscountRequest {

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -485,3 +485,8 @@ export interface CreateSubscriptionDiscountRequest {
   entitlementOverrideKey?: string;
   entitlementOverrideLimit?: number;
 }
+
+export type UpdateSubscriptionDiscountRequest = Omit<
+  CreateSubscriptionDiscountRequest,
+  "organizationId" | "code"
+> & { expectedVersion: number };

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
@@ -7,7 +7,11 @@ import { Card } from "@/components/ui-kits/card/card";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
 import { CampaignBuilder } from "../components/campaign-builder/campaign-builder";
 import type { CampaignDraft } from "../components/campaign-builder/campaign-draft";
-import { toCreateDiscountRequest } from "../components/campaign-builder/campaign-draft";
+import {
+  discountToDraft,
+  toCreateDiscountRequest,
+  toUpdateDiscountRequest,
+} from "../components/campaign-builder/campaign-draft";
 import { useOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlans } from "../hooks/use-subscription-plans";
 import type { SubscriptionDiscount, SubscriptionPlan } from "../models/subscription-plan.model";
@@ -74,6 +78,7 @@ export const SubscriptionDiscountsPage = () => {
   const organizationId = useOrganizationScope();
   const queryClient = useQueryClient();
   const [isCreating, setIsCreating] = useState(false);
+  const [editing, setEditing] = useState<SubscriptionDiscount | null>(null);
   const [submissionError, setSubmissionError] = useState<string | null>(null);
 
   const catalogue = useSubscriptionPlans(organizationId);
@@ -99,12 +104,37 @@ export const SubscriptionDiscountsPage = () => {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["subscription-discounts"] }),
   });
 
+  const update = useMutation({
+    mutationFn: ({ discount, draft }: { discount: SubscriptionDiscount; draft: CampaignDraft }) =>
+      subscriptionService.updateDiscount(
+        discount.discountId,
+        toUpdateDiscountRequest(draft, discount.version),
+        organizationId,
+      ),
+    onSuccess: async () => {
+      setEditing(null);
+      setSubmissionError(null);
+      await queryClient.invalidateQueries({ queryKey: ["subscription-discounts"] });
+    },
+  });
+
   const submitDraft = async (draft: CampaignDraft) => {
     setSubmissionError(null);
     try {
       await create.mutateAsync(draft);
     } catch (error) {
       setSubmissionError(error instanceof Error ? error.message : "The discount could not be created.");
+      throw error;
+    }
+  };
+
+  const submitEdit = async (draft: CampaignDraft) => {
+    if (!editing) return;
+    setSubmissionError(null);
+    try {
+      await update.mutateAsync({ discount: editing, draft });
+    } catch (error) {
+      setSubmissionError(error instanceof Error ? error.message : "The discount could not be updated.");
       throw error;
     }
   };
@@ -117,15 +147,19 @@ export const SubscriptionDiscountsPage = () => {
         backTo={`/app/${itemId ?? ""}/subscription/plans`}
       />
 
-      {isCreating ? (
+      {isCreating || editing ? (
         <CampaignBuilder
+          key={editing?.discountId ?? "new"}
           plans={availablePlans}
           organizationId={organizationId}
-          isSubmitting={create.isPending}
+          initialDraft={editing ? discountToDraft(editing) : undefined}
+          editing={Boolean(editing)}
+          isSubmitting={create.isPending || update.isPending}
           submissionError={submissionError}
-          onSubmit={submitDraft}
+          onSubmit={editing ? submitEdit : submitDraft}
           onCancel={() => {
             setIsCreating(false);
+            setEditing(null);
             setSubmissionError(null);
           }}
         />
@@ -172,11 +206,18 @@ export const SubscriptionDiscountsPage = () => {
                     </p>
                   )}
                 </div>
-                {discount.status === "Active" && (
-                  <Button variant="ghost" size="sm" onClick={() => archive.mutate(discount.discountId)}>
-                    Retire
-                  </Button>
-                )}
+                <div className="flex gap-2">
+                  {discount.status === "Active" && (
+                    <>
+                      <Button variant="ghost" size="sm" onClick={() => setEditing(discount)}>
+                        Edit
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => archive.mutate(discount.discountId)}>
+                        Retire
+                      </Button>
+                    </>
+                  )}
+                </div>
               </div>
             );
           })}

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-discounts-page.tsx
@@ -217,6 +217,12 @@ export const SubscriptionDiscountsPage = () => {
                       </Button>
                     </>
                   )}
+                  {discount.campaignKind !== "Standard" && (
+                    <p className="text-xs text-muted-foreground">
+                      {discount.redeemedRedemptions} redeemed · {discount.reservedRedemptions} pending ·{" "}
+                      {discount.releasedRedemptions} released
+                    </p>
+                  )}
                 </div>
               </div>
             );

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
@@ -10,6 +10,7 @@ import type {
   SubscriptionDiscount,
   SubscriptionPlan,
   UpdateSubscriptionPlanRequest,
+  UpdateSubscriptionDiscountRequest,
   UpdateSubscriptionPriceDiscountRequest,
   UpdateSubscriptionPriceTaxRequest,
 } from "../models/subscription-plan.model";
@@ -195,6 +196,20 @@ class SubscriptionService {
       "/api/subscription-discounts", request,
     );
     if (!response.success || !response.data) throw new Error(response.error?.message || "The discount could not be created.");
+    return response.data;
+  }
+
+  async updateDiscount(
+    discountId: string,
+    request: UpdateSubscriptionDiscountRequest,
+    organizationId?: string,
+  ): Promise<SubscriptionDiscount> {
+    const query = organizationId ? `?organizationId=${encodeURIComponent(organizationId)}` : "";
+    const response = await serviceInstances.utitlitiesService.put<SubscriptionApiResponse<SubscriptionDiscount>>(
+      `/api/subscription-discounts/${encodeURIComponent(discountId)}${query}`,
+      request,
+    );
+    if (!response.success || !response.data) throw new Error(response.error?.message || "The discount could not be updated.");
     return response.data;
   }
 

--- a/server/Api/Controllers/SubscriptionDiscountPreviewController.cs
+++ b/server/Api/Controllers/SubscriptionDiscountPreviewController.cs
@@ -1,0 +1,47 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Api.Controllers;
+
+/// <summary>Buyer-facing, read-only validation and pricing of a discount code.</summary>
+[ApiController, Authorize, Route("subscription-discounts")]
+public sealed class SubscriptionDiscountPreviewController : ControllerBase
+{
+    private readonly ISubscriptionCreationService _creation;
+    private readonly ISubscriptionContextResolver _contextResolver;
+
+    public SubscriptionDiscountPreviewController(
+        ISubscriptionCreationService creation,
+        ISubscriptionContextResolver contextResolver)
+    {
+        _creation = creation;
+        _contextResolver = contextResolver;
+    }
+
+    [HttpPost("preview")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionDiscountPreviewResponse>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Preview(
+        [FromBody] CreateSubscriptionRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, request.OrganizationId, cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionDiscountPreviewResponse>(correlationId)
+                .ToActionResult(correlationId);
+        }
+
+        return (await _creation.PreviewDiscountAsync(
+                request, resolution.Context!, correlationId, cancellationToken))
+            .ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2204,6 +2204,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscription-discounts</span></div>
         <div class="endpoint-body">
           <p>Authors a tenant-wide or organization-scoped percentage/fixed discount. Optional plan-code and price applicability, expiry and duration are validated at subscribe time.</p>
+          <p class="prose">Campaign kinds add either a free opening calendar period or a discounted first annual period. A first-annual offer also discounts a mid-month opening stub, but the stub does not consume the annual benefit. A free-opening offer may omit <code>validThroughDate</code>; it then remains redeemable until archived. Free-opening offers always require a payment method even when the amount due today is zero.</p>
           <h4>Applicability</h4>
           <pre><code>{
   "code": "yearly8", "displayName": "Yearly launch offer",
@@ -2237,8 +2238,28 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         </div>
       </div>
       <div class="endpoint">
+        <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscription-discounts/preview</span></div>
+        <div class="endpoint-body">
+          <p>Buyer-facing, read-only code validation. Takes the same body as subscription creation and never reserves a redemption, creates a subscription, or charges money.</p>
+          <p class="prose">A rejected code still returns <code>200</code> with the ordinary undiscounted quote and one of <code>NotFound</code>, <code>NotStarted</code>, <code>Expired</code>, <code>NotApplicable</code>, <code>AlreadyRedeemed</code>, or <code>Unavailable</code>. An accepted code returns <code>Applied</code>. Input errors unrelated to the code keep their normal 4xx response.</p>
+          <pre><code>{
+  "success": true,
+  "data": {
+    "status": "Expired",
+    "reasonCode": "subscription_discount_expired",
+    "message": "This campaign has ended.",
+    "quote": { "currencyCode": "CHF", "totalDueNowMinor": 14500 }
+  }
+}</code></pre>
+        </div>
+      </div>
+      <div class="endpoint">
         <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscription-discounts</span></div>
         <div class="endpoint-body"><p>Lists the visible discount catalogue. Organization-owned codes override tenant-wide codes of the same name.</p></div>
+      </div>
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">PUT</span><span class="path">/api/subscription-discounts/{discountId}</span></div>
+        <div class="endpoint-body"><p>Edits future redemption terms using <code>expectedVersion</code>. Code and organization scope are immutable. Existing subscriptions retain their snapshots; stale edits return <code>409 subscription_discount_version_conflict</code>.</p></div>
       </div>
       <div class="endpoint">
         <div class="endpoint-head"><span class="method">PUT</span><span class="path">/api/subscription-discounts/{discountId}/archive</span></div>

--- a/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
+++ b/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
@@ -38,7 +38,7 @@ public sealed class PendingAnnualPeriod
     /// <summary>What the price's automatic discount and volume band took off.</summary>
     public long BuiltInDiscountMinor { get; set; }
 
-    /// <summary>What a promotional code took off. Codes apply to the year, never to the stub.</summary>
+    /// <summary>What a promotional code took off this annual term.</summary>
     public long PromotionalDiscountMinor { get; set; }
 
     /// <summary>

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -438,9 +438,26 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     /// discount for reasons that have nothing to do with calendar billing.
     /// </para>
     /// </remarks>
-    private static bool OpeningChargeSpentDiscountPeriod(SubscriptionDetail subscription) =>
-        subscription.InitialChargeDiscountApplied &&
-        CalendarBillingAlignment.IsCalendarAligned(subscription.Price);
+    private static bool OpeningChargeSpentDiscountPeriod(SubscriptionDetail subscription)
+    {
+        if (!subscription.InitialChargeDiscountApplied ||
+            !CalendarBillingAlignment.IsCalendarAligned(subscription.Price))
+        {
+            return false;
+        }
+
+        // A first-annual campaign deliberately discounts both the opening stub and the first
+        // annual term. The stub is not a campaign period and must not consume the one annual
+        // benefit. It is consumed here only when the opening payment also collected the annual
+        // term, or when there is no separate pending term (signup exactly on the boundary).
+        if (subscription.Discount?.Campaign.Kind == CampaignKind.FirstAnnualPeriod)
+        {
+            return subscription.PendingAnnualPeriod is null ||
+                   subscription.PendingAnnualPeriod.CollectedWithCheckout;
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// Records the provider's customer from the card the charge saved.

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1110,6 +1110,18 @@ carries no price list and stays unrestricted by price. Unknown, retired, expired
 wrong-currency fixed discounts are rejected. Accepted terms are copied onto the subscription, so retiring the
 catalogue entry never changes an existing subscriber's renewal.
 
+Campaign discounts use the same pricing pipeline but add a validity window and a durable redemption
+ledger. `FirstAnnualPeriod` discounts both an opening calendar stub and the first full annual term;
+the stub does not consume that annual benefit. `FreeOpeningCalendarPeriod` is always 100%, one use
+per organization, and requires a saved payment method before activation even though its opening
+invoice is zero. Its end date is optional: without one it remains available until archived.
+
+Buyers validate a code through `POST /api/subscription-discounts/preview`. It uses the same request
+and pricing path as subscription preview, performs no writes, and returns an undiscounted quote plus
+a stable rejection status when the code is unknown, early, expired, inapplicable, already redeemed,
+or temporarily unavailable. Management create/list/edit/archive remains protected by
+`SubscriptionCampaignManager`; the buyer preview requires only an authenticated subscriber.
+
 ## Financial documents
 
 This module issues its own invoices, trial invoices and credit notes. Stripe is still the payment

--- a/server/Subscription.DomainService/Repositories/CampaignRedemptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/CampaignRedemptionIndexDefinitions.cs
@@ -75,7 +75,8 @@ public static class CampaignRedemptionIndexDefinitions
             Builders<CampaignRedemption>.IndexKeys
                 .Ascending(redemption => redemption.TenantId)
                 .Ascending(redemption => redemption.State)
-                .Ascending(redemption => redemption.ReservedAtUtc),
+                .Ascending(redemption => redemption.LastUpdatedAtUtc)
+                .Ascending(redemption => redemption.ItemId),
             new CreateIndexOptions<CampaignRedemption> { Name = StaleReservationIndexName })
     ];
 }

--- a/server/Subscription.DomainService/Repositories/CampaignRedemptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/CampaignRedemptionIndexDefinitions.cs
@@ -12,6 +12,7 @@ public static class CampaignRedemptionIndexDefinitions
 {
     public const string OneUseIndexName = "campaign_redemption_one_use_per_org";
     public const string SubscriptionLookupIndexName = "campaign_redemption_by_subscription";
+    public const string StaleReservationIndexName = "campaign_redemption_stale_reservations";
 
     public static IReadOnlyCollection<CreateIndexModel<CampaignRedemption>> CreateIndexes() =>
     [
@@ -62,6 +63,19 @@ public static class CampaignRedemptionIndexDefinitions
                 .Ascending(redemption => redemption.TenantId)
                 .Ascending(redemption => redemption.DiscountId)
                 .Ascending(redemption => redemption.SubscriptionId),
-            new CreateIndexOptions<CampaignRedemption> { Name = SubscriptionLookupIndexName })
+            new CreateIndexOptions<CampaignRedemption> { Name = SubscriptionLookupIndexName }),
+        // Backs the reconciliation sweep's search for a redemption stuck at Reserved or
+        // ReleasePending -- the two states a crash between a subscription's own transition and
+        // this ledger's paired call can leave behind. Deliberately not partial: State's
+        // reconciled values are {Reserved, ReleasePending}, and a partial filter can only express
+        // an ordered comparison, not that pair specifically -- Redeemed sits ordinally between
+        // them. An ordinary compound index still serves an $in query over State fine; only a
+        // partial filter's own definition is restricted this way.
+        new(
+            Builders<CampaignRedemption>.IndexKeys
+                .Ascending(redemption => redemption.TenantId)
+                .Ascending(redemption => redemption.State)
+                .Ascending(redemption => redemption.ReservedAtUtc),
+            new CreateIndexOptions<CampaignRedemption> { Name = StaleReservationIndexName })
     ];
 }

--- a/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
@@ -47,6 +47,7 @@ public sealed class CampaignRedemptionRepository : ICampaignRedemptionRepository
         }
 
         reservation.State = CampaignRedemptionState.Reserved;
+        reservation.LastUpdatedAtUtc = reservation.ReservedAtUtc;
 
         try
         {
@@ -148,6 +149,18 @@ public sealed class CampaignRedemptionRepository : ICampaignRedemptionRepository
                 Builders<CampaignRedemption>.Filter.Eq(item => item.SubscriptionId, subscriptionId)))
             .FirstOrDefaultAsync(cancellationToken);
 
+    public Task<CampaignRedemption?> FindActiveForOrganizationAsync(
+        string tenantId,
+        string organizationId,
+        string discountId,
+        CancellationToken cancellationToken) =>
+        Collection(tenantId).Find(Builders<CampaignRedemption>.Filter.And(
+                Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
+                Builders<CampaignRedemption>.Filter.Eq(item => item.OrganizationId, organizationId),
+                Builders<CampaignRedemption>.Filter.Eq(item => item.DiscountId, discountId),
+                Builders<CampaignRedemption>.Filter.Ne(item => item.State, CampaignRedemptionState.Released)))
+            .FirstOrDefaultAsync(cancellationToken);
+
     private static readonly CampaignRedemptionState[] ReconcilableStates =
     [
         CampaignRedemptionState.Reserved,
@@ -160,10 +173,24 @@ public sealed class CampaignRedemptionRepository : ICampaignRedemptionRepository
             .Find(Builders<CampaignRedemption>.Filter.And(
                 Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
                 Builders<CampaignRedemption>.Filter.In(item => item.State, ReconcilableStates),
-                Builders<CampaignRedemption>.Filter.Lte(item => item.ReservedAtUtc, reservedBeforeUtc)))
-            .SortBy(item => item.ReservedAtUtc)
+                Builders<CampaignRedemption>.Filter.Lte(item => item.LastUpdatedAtUtc, reservedBeforeUtc)))
+            .SortBy(item => item.LastUpdatedAtUtc)
+            .ThenBy(item => item.ItemId)
             .Limit(limit)
             .ToListAsync(cancellationToken);
+
+    public async Task DeferAsync(
+        string tenantId,
+        string redemptionId,
+        DateTime retryAfterUtc,
+        CancellationToken cancellationToken) =>
+        await Collection(tenantId).UpdateOneAsync(
+            Builders<CampaignRedemption>.Filter.And(
+                Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
+                Builders<CampaignRedemption>.Filter.Eq(item => item.ItemId, redemptionId),
+                Builders<CampaignRedemption>.Filter.In(item => item.State, ReconcilableStates)),
+            Builders<CampaignRedemption>.Update.Set(item => item.LastUpdatedAtUtc, retryAfterUtc),
+            cancellationToken: cancellationToken);
 
     private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
     {

--- a/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
@@ -192,6 +192,29 @@ public sealed class CampaignRedemptionRepository : ICampaignRedemptionRepository
             Builders<CampaignRedemption>.Update.Set(item => item.LastUpdatedAtUtc, retryAfterUtc),
             cancellationToken: cancellationToken);
 
+    public async Task<CampaignRedemptionCounts> CountAsync(
+        string tenantId,
+        string discountId,
+        CancellationToken cancellationToken)
+    {
+        var byDiscount = Builders<CampaignRedemption>.Filter.And(
+            Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
+            Builders<CampaignRedemption>.Filter.Eq(item => item.DiscountId, discountId));
+        var collection = Collection(tenantId);
+        var reserved = collection.CountDocumentsAsync(Builders<CampaignRedemption>.Filter.And(
+            byDiscount, Builders<CampaignRedemption>.Filter.In(item => item.State, ReconcilableStates)),
+            cancellationToken: cancellationToken);
+        var redeemed = collection.CountDocumentsAsync(Builders<CampaignRedemption>.Filter.And(
+            byDiscount, Builders<CampaignRedemption>.Filter.Eq(item => item.State, CampaignRedemptionState.Redeemed)),
+            cancellationToken: cancellationToken);
+        var released = collection.CountDocumentsAsync(Builders<CampaignRedemption>.Filter.And(
+            byDiscount, Builders<CampaignRedemption>.Filter.Eq(item => item.State, CampaignRedemptionState.Released)),
+            cancellationToken: cancellationToken);
+
+        await Task.WhenAll(reserved, redeemed, released);
+        return new CampaignRedemptionCounts(reserved.Result, redeemed.Result, released.Result);
+    }
+
     private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
     {
         if (_indexed.ContainsKey(tenantId)) return;

--- a/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/CampaignRedemptionRepository.cs
@@ -148,6 +148,23 @@ public sealed class CampaignRedemptionRepository : ICampaignRedemptionRepository
                 Builders<CampaignRedemption>.Filter.Eq(item => item.SubscriptionId, subscriptionId)))
             .FirstOrDefaultAsync(cancellationToken);
 
+    private static readonly CampaignRedemptionState[] ReconcilableStates =
+    [
+        CampaignRedemptionState.Reserved,
+        CampaignRedemptionState.ReleasePending
+    ];
+
+    public async Task<IReadOnlyList<CampaignRedemption>> ListStaleAsync(
+        string tenantId, DateTime reservedBeforeUtc, int limit, CancellationToken cancellationToken) =>
+        await Collection(tenantId)
+            .Find(Builders<CampaignRedemption>.Filter.And(
+                Builders<CampaignRedemption>.Filter.Eq(item => item.TenantId, tenantId),
+                Builders<CampaignRedemption>.Filter.In(item => item.State, ReconcilableStates),
+                Builders<CampaignRedemption>.Filter.Lte(item => item.ReservedAtUtc, reservedBeforeUtc)))
+            .SortBy(item => item.ReservedAtUtc)
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
     private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
     {
         if (_indexed.ContainsKey(tenantId)) return;

--- a/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
@@ -74,6 +74,10 @@ public interface ICampaignRedemptionRepository
     Task<CampaignRedemption?> FindAsync(
         string tenantId, string discountId, string subscriptionId, CancellationToken cancellationToken);
 
+    Task<CampaignRedemption?> FindActiveForOrganizationAsync(
+        string tenantId, string organizationId, string discountId,
+        CancellationToken cancellationToken);
+
     /// <summary>
     /// Redemptions still at <see cref="Enums.CampaignRedemptionState.Reserved"/> or
     /// <see cref="Enums.CampaignRedemptionState.ReleasePending"/>, reserved before
@@ -85,4 +89,12 @@ public interface ICampaignRedemptionRepository
     /// </remarks>
     Task<IReadOnlyList<CampaignRedemption>> ListStaleAsync(
         string tenantId, DateTime reservedBeforeUtc, int limit, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Moves an unresolved reservation behind the rest of the ready queue. This prevents a page
+    /// of still-incomplete subscriptions from permanently hiding later actionable rows.
+    /// </summary>
+    Task DeferAsync(
+        string tenantId, string redemptionId, DateTime retryAfterUtc,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
@@ -22,6 +22,8 @@ public enum CampaignReservationOutcome
     HeldByAnotherSubscription
 }
 
+public sealed record CampaignRedemptionCounts(long Reserved, long Redeemed, long Released);
+
 public interface ICampaignRedemptionRepository
 {
     /// <summary>
@@ -97,4 +99,6 @@ public interface ICampaignRedemptionRepository
     Task DeferAsync(
         string tenantId, string redemptionId, DateTime retryAfterUtc,
         CancellationToken cancellationToken);
+    Task<CampaignRedemptionCounts> CountAsync(
+        string tenantId, string discountId, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ICampaignRedemptionRepository.cs
@@ -73,4 +73,16 @@ public interface ICampaignRedemptionRepository
 
     Task<CampaignRedemption?> FindAsync(
         string tenantId, string discountId, string subscriptionId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Redemptions still at <see cref="Enums.CampaignRedemptionState.Reserved"/> or
+    /// <see cref="Enums.CampaignRedemptionState.ReleasePending"/>, reserved before
+    /// <paramref name="reservedBeforeUtc"/> -- the ones a reconciliation sweep exists to find.
+    /// </summary>
+    /// <remarks>
+    /// Ordered oldest first, so a sweep capped at <paramref name="limit"/> makes steady progress
+    /// through a large backlog rather than repeatedly finding the same page.
+    /// </remarks>
+    Task<IReadOnlyList<CampaignRedemption>> ListStaleAsync(
+        string tenantId, DateTime reservedBeforeUtc, int limit, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -44,4 +44,7 @@ public sealed class DiscountResponse
     /// </para>
     /// </remarks>
     public string EffectiveState { get; init; } = string.Empty;
+    public long ReservedRedemptions { get; init; }
+    public long RedeemedRedemptions { get; init; }
+    public long ReleasedRedemptions { get; init; }
 }

--- a/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
+++ b/server/Subscription.DomainService/Responses/QuantityChangeResponse.cs
@@ -125,6 +125,9 @@ public sealed class QuantityChangeResponse
     /// </summary>
     public bool PromotionApplied { get; init; }
 
+    /// <summary>Conditions that would make confirmation fail. Populated on previews only.</summary>
+    public List<SubscriptionPreviewBlockerResponse> Blockers { get; init; } = [];
+
     public string CurrencyCode { get; init; } = string.Empty;
 
     /// <summary>The payment taken for an applied increase. Null on a preview or a decrease.</summary>

--- a/server/Subscription.DomainService/Responses/SubscriptionDiscountPreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionDiscountPreviewResponse.cs
@@ -1,0 +1,10 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>A buyer-safe discount answer: rejection is data, while the ordinary quote remains usable.</summary>
+public sealed class SubscriptionDiscountPreviewResponse
+{
+    public string Status { get; init; } = string.Empty;
+    public string? ReasonCode { get; init; }
+    public string? Message { get; init; }
+    public SubscriptionPreviewResponse Quote { get; init; } = new();
+}

--- a/server/Subscription.DomainService/Scheduling/CampaignRedemptionReconciler.cs
+++ b/server/Subscription.DomainService/Scheduling/CampaignRedemptionReconciler.cs
@@ -98,6 +98,9 @@ public sealed class CampaignRedemptionReconciler
                     "skipped SubscriptionHash={SubscriptionHash}",
                     PaymentLogValue.Hash(redemption.SubscriptionId));
 
+                await _redemptions.DeferAsync(
+                    tenantId, redemption.ItemId, now, cancellationToken);
+
                 continue;
             }
 
@@ -121,6 +124,15 @@ public sealed class CampaignRedemptionReconciler
                 await _redemptions.TryReleaseAsync(
                     tenantId, redemption.DiscountId, redemption.SubscriptionId, now, cancellationToken);
                 resolved++;
+            }
+
+            else
+            {
+                // This subscription is still legitimately pending. Move it behind this page so
+                // a full batch of old pending checkouts cannot starve later activated/expired
+                // reservations forever. It becomes eligible again after the normal grace period.
+                await _redemptions.DeferAsync(
+                    tenantId, redemption.ItemId, now, cancellationToken);
             }
 
             // Still Incomplete, not yet activated or expired: not this sweep's to decide. Its own

--- a/server/Subscription.DomainService/Scheduling/CampaignRedemptionReconciler.cs
+++ b/server/Subscription.DomainService/Scheduling/CampaignRedemptionReconciler.cs
@@ -1,0 +1,142 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// Finishes a campaign redemption a crash left stuck between a subscription's own transition and
+/// this ledger's paired call.
+/// </summary>
+/// <remarks>
+/// Three call sites each write one half of a pair that is not atomic across two collections:
+/// <see cref="Outbox.SubscriptionActivationProcessor.ActivateAsync"/> marks a redemption Redeemed
+/// only <em>after</em> its transition to Active commits; its own
+/// <see cref="Outbox.SubscriptionActivationProcessor.ExpireAsync"/> and
+/// <see cref="Services.SubscriptionCancellationService.EndNowAsync"/> release one only after their
+/// own transition commits. A process that dies in the gap between the two leaves a subscription
+/// whose fate is already decided and a redemption row that does not know it yet.
+/// <para>
+/// <see cref="ICampaignRedemptionRepository.TryReleaseAsync"/> already narrows half of that gap
+/// itself, by writing a durable <see cref="CampaignRedemptionState.ReleasePending"/> before its
+/// second step -- see that method's own remarks. What is left for this to close: a
+/// <see cref="CampaignRedemptionState.Reserved"/> row whose subscription already activated (the
+/// redeem call never ran at all, not even its first step), and a
+/// <see cref="CampaignRedemptionState.ReleasePending"/> row whose second step never ran.
+/// </para>
+/// <para>
+/// Reads a subscription's actual outcome rather than re-deriving one: <c>ActivatedAtUtc</c> is set
+/// once, at activation, and never cleared by anything after — including a later cancellation — so
+/// it is the one field that answers "did this subscription's campaign ever get spent" independent
+/// of whatever status the subscription holds today.
+/// </para>
+/// <para>
+/// Moves no money and changes no subscriber's bill, so — like
+/// <see cref="Services.SubscriptionCancellationService.ReconcileStaleClosuresAsync"/> — this runs
+/// directly from the repair sweep rather than through the durable work queue that exists to keep
+/// two executors from ever charging the same renewal twice. There is only one thing this could
+/// possibly do to a redemption row, and doing it twice is exactly as safe as doing it once.
+/// </para>
+/// </remarks>
+public sealed class CampaignRedemptionReconciler
+{
+    private readonly ICampaignRedemptionRepository _redemptions;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<CampaignRedemptionReconciler> _logger;
+    private readonly TimeProvider _time;
+
+    public CampaignRedemptionReconciler(
+        ICampaignRedemptionRepository redemptions,
+        ISubscriptionRepository subscriptions,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<CampaignRedemptionReconciler> logger,
+        TimeProvider? time = null)
+    {
+        _redemptions = redemptions;
+        _subscriptions = subscriptions;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Finishes whatever stale reservations this tenant has. Returns how many it resolved, purely
+    /// for the sweep's own log line -- nothing here needs the count back.
+    /// </summary>
+    public async Task<int> ReconcileAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var now = _time.GetUtcNow().UtcDateTime;
+        var reservedBefore = now.AddMinutes(-Math.Max(1, options.CampaignRedemptionGraceMinutes));
+        var batchSize = Math.Max(1, options.CampaignRedemptionBatchSize);
+
+        var stale = await _redemptions.ListStaleAsync(tenantId, reservedBefore, batchSize, cancellationToken);
+        var resolved = 0;
+
+        foreach (var redemption in stale)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return resolved;
+            }
+
+            var subscription = await _subscriptions.GetByIdAsync(
+                tenantId, redemption.SubscriptionId, cancellationToken);
+
+            if (subscription is null)
+            {
+                // Subscriptions are never deleted in this system -- see SubscriptionDetail's own
+                // doc comment. Reaching here means either a data problem this sweep has no
+                // business guessing at, or a tenant mid-migration; either way, leaving the row
+                // alone is the only safe move.
+                _logger.LogWarning(
+                    "A stale campaign redemption names a subscription that could not be found; " +
+                    "skipped SubscriptionHash={SubscriptionHash}",
+                    PaymentLogValue.Hash(redemption.SubscriptionId));
+
+                continue;
+            }
+
+            if (subscription.ActivatedAtUtc is { } activatedAtUtc)
+            {
+                // Set once, at activation, and never cleared afterward -- including by a later
+                // cancellation. Its presence is what tells this apart from a subscription that
+                // was released before ever activating, independent of whatever status it holds
+                // by the time this sweep runs.
+                await _redemptions.TryMarkRedeemedAsync(
+                    tenantId, redemption.DiscountId, redemption.SubscriptionId, activatedAtUtc,
+                    cancellationToken);
+                resolved++;
+            }
+            else if (subscription.Status is SubscriptionStatus.IncompleteExpired or SubscriptionStatus.Canceled)
+            {
+                // Terminal, and never activated -- the only two ways this campaign's promise came
+                // to nothing. TryReleaseAsync resumes correctly whether this row is still at
+                // Reserved (its own first step never ran) or already at ReleasePending (only its
+                // second step never ran); it does not need to know which.
+                await _redemptions.TryReleaseAsync(
+                    tenantId, redemption.DiscountId, redemption.SubscriptionId, now, cancellationToken);
+                resolved++;
+            }
+
+            // Still Incomplete, not yet activated or expired: not this sweep's to decide. Its own
+            // recovery machinery -- SubscriptionWorkType.ActivationRecovery -- resolves that first;
+            // once it does, a later pass here finds the outcome and finishes the redemption.
+        }
+
+        if (resolved > 0)
+        {
+            _logger.LogInformation(
+                "Repair sweep reconciled stale campaign redemptions " +
+                "ReconciledCount={ReconciledCount} TenantId={TenantId}",
+                resolved,
+                PaymentLogValue.Id(tenantId));
+        }
+
+        return resolved;
+    }
+}

--- a/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
@@ -40,6 +40,7 @@ public sealed class SubscriptionRepairAnnouncer
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<SubscriptionRepairAnnouncer> _logger;
     private readonly TimeProvider _time;
+    private readonly CampaignRedemptionReconciler? _campaignRedemptions;
 
     public SubscriptionRepairAnnouncer(
         ISubscriptionWorkScheduler scheduler,
@@ -52,7 +53,11 @@ public sealed class SubscriptionRepairAnnouncer
         ISubscriptionCancellationService cancellation,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<SubscriptionRepairAnnouncer> logger,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        // Optional for the same reason every other campaign collaborator threaded through this
+        // feature is: an existing caller or test that constructs this class by hand, unaware
+        // campaigns exist at all, must keep compiling and keep working exactly as it did before.
+        CampaignRedemptionReconciler? campaignRedemptions = null)
     {
         _scheduler = scheduler;
         _subscriptions = subscriptions;
@@ -65,6 +70,7 @@ public sealed class SubscriptionRepairAnnouncer
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
+        _campaignRedemptions = campaignRedemptions;
     }
 
     /// <summary>
@@ -100,6 +106,14 @@ public sealed class SubscriptionRepairAnnouncer
                 "ReconciledCount={ReconciledCount} TenantId={TenantId}",
                 reconciledClosures,
                 PaymentLogValue.Id(tenantId));
+        }
+
+        // Same reasoning as the closure reconciliation above: this finishes a ledger write a
+        // transition already committed for, moves no money, and its own logging is on
+        // CampaignRedemptionReconciler rather than duplicated here.
+        if (_campaignRedemptions is not null)
+        {
+            await _campaignRedemptions.ReconcileAsync(tenantId, stoppingToken);
         }
 
         var bucketMinutes = Math.Max(1, options.SchedulerSweepBucketMinutes);

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -17,6 +17,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
     private readonly IValidator<CreateDiscountRequest> _createValidator;
     private readonly IValidator<UpdateDiscountRequest> _updateValidator;
     private readonly TimeProvider _time;
+    private readonly ICampaignRedemptionRepository? _redemptions;
+    private readonly ISubscriptionAuditTrail? _audit;
 
     public DiscountCatalogueService(
         ISubscriptionDiscountRepository discounts,
@@ -24,7 +26,9 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         ISubscriptionContextResolver context,
         IValidator<CreateDiscountRequest> createValidator,
         IValidator<UpdateDiscountRequest> updateValidator,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        ICampaignRedemptionRepository? redemptions = null,
+        ISubscriptionAuditTrail? audit = null)
     {
         _discounts = discounts;
         _catalogue = catalogue;
@@ -32,6 +36,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         _createValidator = createValidator;
         _updateValidator = updateValidator;
         _time = time ?? TimeProvider.System;
+        _redemptions = redemptions;
+        _audit = audit;
     }
 
     public async Task<SubscriptionOperationResult<DiscountResponse>> CreateAsync(
@@ -92,6 +98,7 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
             return SubscriptionOperationResult<DiscountResponse>.Failure(
                 PaymentFailureKind.Conflict, "subscription_discount_exists",
                 "A discount with this code already exists at this scope.", correlationId);
+        await AuditAsync("CreateDiscount", context, discount.ItemId, correlationId, cancellationToken);
         return SubscriptionOperationResult<DiscountResponse>.Success(Map(discount), correlationId);
     }
 
@@ -112,7 +119,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
                 PaymentFailureKind.NotFound, "subscription_discount_not_found",
                 "The discount does not exist.", correlationId);
 
-        return SubscriptionOperationResult<DiscountResponse>.Success(Map(item), correlationId);
+        return SubscriptionOperationResult<DiscountResponse>.Success(
+            Map(item, await CountsAsync(context.TenantId, item.ItemId, cancellationToken)), correlationId);
     }
 
     public async Task<SubscriptionOperationResult<DiscountResponse>> UpdateAsync(
@@ -187,7 +195,9 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
                     correlationId);
         }
 
-        return SubscriptionOperationResult<DiscountResponse>.Success(Map(existing), correlationId);
+        await AuditAsync("UpdateDiscount", context, existing.ItemId, correlationId, cancellationToken);
+        return SubscriptionOperationResult<DiscountResponse>.Success(
+            Map(existing, await CountsAsync(context.TenantId, existing.ItemId, cancellationToken)), correlationId);
     }
 
     /// <summary>
@@ -461,7 +471,9 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         if (!resolution.IsSuccess) return resolution.ToFailure<IReadOnlyList<DiscountResponse>>(correlationId);
         var context = resolution.Context!;
         var items = await _discounts.ListAsync(context.TenantId, context.OrganizationId, cancellationToken);
-        return SubscriptionOperationResult<IReadOnlyList<DiscountResponse>>.Success(items.Select(Map).ToList(), correlationId);
+        var responses = await Task.WhenAll(items.Select(async item =>
+            Map(item, await CountsAsync(context.TenantId, item.ItemId, cancellationToken))));
+        return SubscriptionOperationResult<IReadOnlyList<DiscountResponse>>.Success(responses, correlationId);
     }
 
     public async Task<SubscriptionOperationResult<DiscountResponse>> ArchiveAsync(
@@ -477,10 +489,39 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
                 PaymentFailureKind.NotFound, "subscription_discount_not_found",
                 "The discount does not exist or is already retired.", correlationId);
         item.Status = CatalogueStatus.Archived;
-        return SubscriptionOperationResult<DiscountResponse>.Success(Map(item), correlationId);
+        await AuditAsync("ArchiveDiscount", context, item.ItemId, correlationId, cancellationToken);
+        return SubscriptionOperationResult<DiscountResponse>.Success(
+            Map(item, await CountsAsync(context.TenantId, item.ItemId, cancellationToken)), correlationId);
     }
 
-    private DiscountResponse Map(Discount item) => new()
+    private async Task<CampaignRedemptionCounts> CountsAsync(
+        string tenantId, string discountId, CancellationToken cancellationToken) =>
+        _redemptions is null
+            ? new CampaignRedemptionCounts(0, 0, 0)
+            : await _redemptions.CountAsync(tenantId, discountId, cancellationToken);
+
+    private Task AuditAsync(
+        string operation,
+        SubscriptionContext context,
+        string discountId,
+        string correlationId,
+        CancellationToken cancellationToken) =>
+        _audit?.RecordAsync(new SubscriptionAuditEvent
+        {
+            TenantId = context.TenantId,
+            OrganizationId = context.OrganizationId,
+            OperationId = $"discount:{discountId}:{operation}:{correlationId}",
+            CorrelationId = correlationId,
+            Operation = operation,
+            Stage = "Catalogue",
+            Outcome = "Succeeded",
+            Source = "Api",
+            ActorId = context.UserId,
+            UserId = context.UserId,
+            OccurredAtUtc = _time.GetUtcNow().UtcDateTime
+        }, cancellationToken) ?? Task.CompletedTask;
+
+    private DiscountResponse Map(Discount item, CampaignRedemptionCounts? counts = null) => new()
     {
         DiscountId = item.ItemId, OrganizationId = item.OrganizationId, Code = item.Code,
         DisplayName = item.DisplayName, Kind = item.Terms.Kind.ToString(),
@@ -501,7 +542,10 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         RequiresPaymentMethodUpfront = item.Campaign.RequiresPaymentMethodUpfront,
         EntitlementOverrideKey = item.Campaign.EntitlementOverride?.EntitlementKey,
         EntitlementOverrideLimit = item.Campaign.EntitlementOverride?.Limit,
-        EffectiveState = EffectiveState(item)
+        EffectiveState = EffectiveState(item),
+        ReservedRedemptions = counts?.Reserved ?? 0,
+        RedeemedRedemptions = counts?.Redeemed ?? 0,
+        ReleasedRedemptions = counts?.Released ?? 0
     };
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -236,11 +236,13 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         // Standard -- asserted rather than re-checked, since this is only ever called after that
         // validator has already run.
         var from = request.ValidFromDate!.Value;
-        var through = request.ValidThroughDate!.Value;
+        var through = request.ValidThroughDate;
 
         var redeemableFromUtc = BillingLocalTime.ToUtc(from.ToDateTime(TimeOnly.MinValue), timeZone);
-        var redeemableUntilUtc = BillingLocalTime.ToUtc(
-            through.AddDays(1).ToDateTime(TimeOnly.MinValue), timeZone);
+        var redeemableUntilUtc = through is { } throughDate
+            ? BillingLocalTime.ToUtc(
+                throughDate.AddDays(1).ToDateTime(TimeOnly.MinValue), timeZone)
+            : (DateTime?)null;
 
         return new CampaignTerms
         {

--- a/server/Subscription.DomainService/Services/ISubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCreationService.cs
@@ -36,4 +36,10 @@ public interface ISubscriptionCreationService
         SubscriptionContext context,
         string correlationId,
         CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<SubscriptionDiscountPreviewResponse>> PreviewDiscountAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -59,7 +59,8 @@ public static class SubscriptionAmountCalculator
     /// </remarks>
     public static bool RequiresCardSetup(SubscriptionDetail subscription) =>
         subscription.Plan.RequirePaymentMethodUpfront ||
-        subscription.Trial is { RequiresPaymentMethod: true };
+        subscription.Trial is { RequiresPaymentMethod: true } ||
+        subscription.Discount is { Campaign.RequiresPaymentMethodUpfront: true };
 
     /// <summary>
     /// What the opening period costs, when that period may be a fraction of a month.
@@ -90,10 +91,9 @@ public static class SubscriptionAmountCalculator
     /// same question.
     /// </remarks>
     /// <param name="includePromotionalDiscount">
-    /// False to price without the subscriber's code. Used for the opening stub of a calendar-aligned
-    /// yearly price, where the code belongs to the year rather than to the days before it: a
-    /// three-month promotion spent on a seven-day stub would be a month of the customer's discount
-    /// exchanged for a week of it.
+    /// False to price without the subscriber's code. Used for an ordinary promotion on the opening
+    /// stub of a calendar-aligned yearly price. First-annual campaigns explicitly opt into both the
+    /// stub and annual term, with the stub excluded from period consumption.
     /// </param>
     public static PeriodCharge FirstPeriodCharge(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -291,6 +291,119 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             correlationId);
     }
 
+    public async Task<SubscriptionOperationResult<SubscriptionDiscountPreviewResponse>> PreviewDiscountAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var requestedCode = request.DiscountCode?.Trim().ToLowerInvariant();
+        var discounted = await PreviewAsync(request, context, correlationId, cancellationToken);
+
+        if (discounted.IsSuccess && !string.IsNullOrWhiteSpace(requestedCode))
+        {
+            var catalogueDiscount = await _discounts.FindActiveByCodeAsync(
+                context.TenantId, context.OrganizationId, requestedCode, cancellationToken);
+
+            if (catalogueDiscount is { Campaign.OneUsePerOrganization: true } &&
+                _redemptions is not null &&
+                await _redemptions.FindActiveForOrganizationAsync(
+                    context.TenantId, context.OrganizationId, catalogueDiscount.ItemId,
+                    cancellationToken) is not null)
+            {
+                return await StandardQuoteAsync(
+                    request, context, "AlreadyRedeemed", "subscription_discount_already_redeemed",
+                    "This organization has already redeemed this campaign.", correlationId,
+                    cancellationToken);
+            }
+
+            return SubscriptionOperationResult<SubscriptionDiscountPreviewResponse>.Success(
+                new SubscriptionDiscountPreviewResponse
+                {
+                    Status = "Applied",
+                    Quote = discounted.Value!
+                },
+                correlationId);
+        }
+
+        if (discounted.IsSuccess)
+        {
+            return SubscriptionOperationResult<SubscriptionDiscountPreviewResponse>.Success(
+                new SubscriptionDiscountPreviewResponse
+                {
+                    Status = "NotFound",
+                    ReasonCode = "subscription_discount_not_found",
+                    Message = "Enter a discount code to preview it.",
+                    Quote = discounted.Value!
+                },
+                correlationId);
+        }
+
+        var status = discounted.ErrorCode switch
+        {
+            "subscription_discount_not_found" => "NotFound",
+            "subscription_discount_not_started" => "NotStarted",
+            "subscription_discount_expired" => "Expired",
+            "subscription_discount_not_applicable" or
+            "subscription_discount_currency_mismatch" => "NotApplicable",
+            "subscription_discount_already_redeemed" => "AlreadyRedeemed",
+            "subscription_discount_reservation_conflict" => "Unavailable",
+            _ => null
+        };
+
+        if (status is null)
+        {
+            return discounted.ToFailure<SubscriptionDiscountPreviewResponse>();
+        }
+
+        return await StandardQuoteAsync(
+            request, context, status, discounted.ErrorCode!, discounted.ErrorMessage,
+            correlationId, cancellationToken);
+    }
+
+    private async Task<SubscriptionOperationResult<SubscriptionDiscountPreviewResponse>> StandardQuoteAsync(
+        CreateSubscriptionRequest request,
+        SubscriptionContext context,
+        string status,
+        string reasonCode,
+        string? message,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var withoutCode = new CreateSubscriptionRequest
+        {
+            PlanCode = request.PlanCode,
+            PriceId = request.PriceId,
+            Quantities = [.. request.Quantities.Select(item => new SubscriptionQuantityRequest
+            {
+                ItemKey = item.ItemKey,
+                Quantity = item.Quantity
+            })],
+            TimeZoneId = request.TimeZoneId,
+            OrganizationId = request.OrganizationId,
+            BillingEmail = request.BillingEmail,
+            BillingName = request.BillingName
+        };
+
+        var standard = await PreviewAsync(
+            withoutCode, context, correlationId, cancellationToken);
+
+        return standard.IsSuccess
+            ? SubscriptionOperationResult<SubscriptionDiscountPreviewResponse>.Success(
+                new SubscriptionDiscountPreviewResponse
+                {
+                    Status = status,
+                    ReasonCode = reasonCode,
+                    Message = message,
+                    Quote = standard.Value!
+                },
+                correlationId)
+            : standard.ToFailure<SubscriptionDiscountPreviewResponse>();
+    }
+
     private async Task<SubscriptionOperationResult<(Plan Plan, Price Price)>> ResolveTermsAsync(
         CreateSubscriptionRequest request,
         SubscriptionContext context,
@@ -948,14 +1061,17 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // underneath a customer who left the page open overnight.
         if (subscription.Trial is not { RequiresPaymentMethod: false })
         {
-            // A promotional code belongs to the year, not to the days before it — so a yearly stub
-            // is priced without one. Its automatic discount and volume band still apply, because
-            // those are properties of the price rather than something the customer spends.
+            // Ordinary promotional codes belong to the year, not to the days before it. A
+            // FirstAnnualPeriod campaign is the explicit exception: its authored offer discounts
+            // both the opening stub and the first year, while accounting below ensures the stub
+            // does not consume the annual benefit.
             var charge = SubscriptionAmountCalculator.FirstPeriodCharge(
                 subscription,
                 fraction,
                 now,
-                includePromotionalDiscount: annual is null);
+                includePromotionalDiscount:
+                    annual is null ||
+                    subscription.Discount?.Campaign.Kind == CampaignKind.FirstAnnualPeriod);
 
             stubCharge = charge;
 

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -333,9 +333,11 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         // same clock check the entitlement override above reads -- nothing has to run at that
         // moment to lift it. Preview is not locked: showing what a change would cost is not
         // committing to one.
-        if (!preview &&
+        var promotionChangeLocked =
             subscription.Discount is { Campaign.Kind: CampaignKind.FreeOpeningCalendarPeriod } &&
-            _time.GetUtcNow().UtcDateTime < subscription.CurrentPeriodEndUtc)
+            _time.GetUtcNow().UtcDateTime < subscription.CurrentPeriodEndUtc;
+
+        if (!preview && promotionChangeLocked)
         {
             return Failure<PlanChangeResolution>(
                 PaymentFailureKind.Conflict,
@@ -383,6 +385,15 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         }
 
         var blockers = new List<SubscriptionPreviewBlockerResponse>();
+
+        if (preview && promotionChangeLocked)
+        {
+            blockers.Add(new SubscriptionPreviewBlockerResponse
+            {
+                Code = "subscription_promotion_change_locked",
+                Message = "This subscription is on a free opening period and cannot change plan until it ends."
+            });
+        }
 
         if (await MissingBillingProfileFieldsAsync(context, preview, cancellationToken) is
             { Count: > 0 } missing)

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -235,9 +235,11 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
         // was accepted. The lock lifts by itself the instant CurrentPeriodEndUtc passes, the same
         // clock check the entitlement override reads elsewhere; nothing has to run at that moment
         // to lift it. Preview is not locked.
-        if (!preview &&
+        var promotionChangeLocked =
             subscription.Discount is { Campaign.Kind: CampaignKind.FreeOpeningCalendarPeriod } &&
-            _time.GetUtcNow().UtcDateTime < subscription.CurrentPeriodEndUtc)
+            _time.GetUtcNow().UtcDateTime < subscription.CurrentPeriodEndUtc;
+
+        if (!preview && promotionChangeLocked)
         {
             return Failure(
                 PaymentFailureKind.Conflict,
@@ -951,6 +953,18 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 - renewal.BuiltInDiscountMinor
                 - renewal.PromotionalDiscountMinor,
             PromotionApplied = renewal.DiscountApplied,
+            Blockers = preview &&
+                subscription.Discount is { Campaign.Kind: CampaignKind.FreeOpeningCalendarPeriod } &&
+                now < subscription.CurrentPeriodEndUtc
+                    ?
+                    [
+                        new SubscriptionPreviewBlockerResponse
+                        {
+                            Code = "subscription_promotion_change_locked",
+                            Message = "This subscription is on a free opening period and cannot change quantity until it ends."
+                        }
+                    ]
+                    : [],
             ChargePaymentDetailId = paymentDetailId,
             PendingQuantityChange = QuantityResponseMapper.Pending(pending)
         };

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -133,6 +133,10 @@ public static class ApplicationServiceCollectionExtensions
         services.AddSingleton<
             ISubscriptionQueueWorkerRegistry, SubscriptionQueueWorkerRegistry>();
 
+        // Scoped, for the same reason SubscriptionRepairAnnouncer below is: it reads tenant-local
+        // repositories, and the sweep resolves it fresh inside each tenant's own context.
+        services.AddScoped<CampaignRedemptionReconciler>();
+
         // Scoped, because it reads tenant-local repositories: the sweep establishes a tenant
         // context per pass and resolves one of these inside it.
         services.AddScoped<SubscriptionRepairAnnouncer>();

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -48,6 +48,17 @@ public sealed class SubscriptionOptions
     public int SettlementReservationBatchSize { get; set; } = 50;
 
     /// <summary>
+    /// How long a campaign redemption may sit at <c>Reserved</c> or <c>ReleasePending</c> before
+    /// the sweep decides the transition that should have paired with it already committed without
+    /// it -- an activation, expiry or cancellation that crashed between its own transition landing
+    /// and the ledger call that was supposed to follow it. Long enough that an ordinary in-flight
+    /// checkout is never mistaken for one of these.
+    /// </summary>
+    public int CampaignRedemptionGraceMinutes { get; set; } = 15;
+
+    public int CampaignRedemptionBatchSize { get; set; } = 50;
+
+    /// <summary>
     /// Renewal attempts, including the first decline, before a subscription moves to
     /// <c>Unpaid</c>. Retrying beyond this is treated as certain to fail again rather than
     /// eventually succeeding.

--- a/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
@@ -48,7 +48,8 @@ public abstract class CampaignDiscountRequestValidator<T> : AbstractValidator<T>
             .When(isCampaign);
         RuleFor(request => request.ValidThroughDate).NotNull()
             .WithMessage("A campaign needs an end date.")
-            .When(isCampaign);
+            .When(request => isCampaign(request) &&
+                request.CampaignKind != CampaignKind.FreeOpeningCalendarPeriod);
         RuleFor(request => request.TimeZoneId).NotEmpty()
             .WithMessage("A campaign needs a time zone its dates are read in.")
             .When(isCampaign);

--- a/server/XUnitTest/Integration/CampaignRedemptionConcurrencyTests.cs
+++ b/server/XUnitTest/Integration/CampaignRedemptionConcurrencyTests.cs
@@ -202,8 +202,76 @@ public sealed class CampaignRedemptionConcurrencyTests
         stored!.State.Should().Be(CampaignRedemptionState.Released);
     }
 
+    [Fact]
+    public async Task Listing_stale_reservations_finds_only_reserved_and_release_pending_rows_before_the_threshold()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+
+        var stillReserved = Guid.NewGuid().ToString();
+        var releasePending = Guid.NewGuid().ToString();
+        var alreadyRedeemed = Guid.NewGuid().ToString();
+        var alreadyReleased = Guid.NewGuid().ToString();
+        var tooRecent = Guid.NewGuid().ToString();
+
+        var old = DateTime.UtcNow.AddHours(-1);
+        var recent = DateTime.UtcNow;
+
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-stale", discountId, stillReserved, oneUse: false, reservedAtUtc: old), CancellationToken.None);
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-stale", discountId, releasePending, oneUse: false, reservedAtUtc: old), CancellationToken.None);
+        // Half of TryReleaseAsync's own two steps, by hand -- simulating the exact crash window
+        // this whole reconciliation exists to close, not something this repository would ever do
+        // in one call on its own.
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-stale", discountId, alreadyRedeemed, oneUse: false, reservedAtUtc: old), CancellationToken.None);
+        await repository.TryMarkRedeemedAsync(tenantId, discountId, alreadyRedeemed, old, CancellationToken.None);
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-stale", discountId, alreadyReleased, oneUse: false, reservedAtUtc: old), CancellationToken.None);
+        await repository.TryReleaseAsync(tenantId, discountId, alreadyReleased, old, CancellationToken.None);
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-stale", discountId, tooRecent, oneUse: false, reservedAtUtc: recent), CancellationToken.None);
+
+        var stale = await repository.ListStaleAsync(
+            tenantId, DateTime.UtcNow.AddMinutes(-15), 100, CancellationToken.None);
+
+        stale.Select(item => item.SubscriptionId).Should().BeEquivalentTo([stillReserved, releasePending]);
+    }
+
+    [Fact]
+    public async Task Listing_stale_reservations_orders_oldest_first_and_respects_the_limit()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var repository = Repository();
+        var discountId = Guid.NewGuid().ToString();
+
+        var oldest = Guid.NewGuid().ToString();
+        var middle = Guid.NewGuid().ToString();
+        var newest = Guid.NewGuid().ToString();
+        var baseline = DateTime.UtcNow.AddHours(-2);
+
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-order", discountId, newest, oneUse: false, reservedAtUtc: baseline.AddMinutes(2)), CancellationToken.None);
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-order", discountId, oldest, oneUse: false, reservedAtUtc: baseline), CancellationToken.None);
+        await repository.TryReserveAsync(
+            Reservation(tenantId, "org-order", discountId, middle, oneUse: false, reservedAtUtc: baseline.AddMinutes(1)), CancellationToken.None);
+
+        var stale = await repository.ListStaleAsync(
+            tenantId, DateTime.UtcNow, 2, CancellationToken.None);
+
+        stale.Select(item => item.SubscriptionId).Should().Equal(oldest, middle);
+    }
+
     private static CampaignRedemption Reservation(
-        string tenantId, string organizationId, string discountId, string subscriptionId, bool oneUse) => new()
+        string tenantId,
+        string organizationId,
+        string discountId,
+        string subscriptionId,
+        bool oneUse,
+        DateTime? reservedAtUtc = null) => new()
     {
         TenantId = tenantId,
         OrganizationId = organizationId,
@@ -211,6 +279,6 @@ public sealed class CampaignRedemptionConcurrencyTests
         SubscriptionId = subscriptionId,
         OneUsePerOrganization = oneUse,
         CampaignVersion = 1,
-        ReservedAtUtc = DateTime.UtcNow
+        ReservedAtUtc = reservedAtUtc ?? DateTime.UtcNow
     };
 }

--- a/server/XUnitTest/Subscription/CampaignRedemptionReconcilerTests.cs
+++ b/server/XUnitTest/Subscription/CampaignRedemptionReconcilerTests.cs
@@ -1,0 +1,247 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Finishing a campaign redemption a crash left stuck between a subscription's own transition and
+/// the ledger's paired call -- the one remaining gap
+/// <see cref="ICampaignRedemptionRepository.TryReleaseAsync"/>'s own ReleasePending step does not
+/// already close on its own.
+/// </summary>
+public sealed class CampaignRedemptionReconcilerTests
+{
+    private const string TenantId = "tenant-1";
+    private const string DiscountId = "discount-1";
+    private const string SubscriptionId = "sub-1";
+
+    private readonly Mock<ICampaignRedemptionRepository> _redemptions = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 8, 29, 12, 0, 0, TimeSpan.Zero));
+
+    public CampaignRedemptionReconcilerTests()
+    {
+        _redemptions
+            .Setup(repository => repository.ListStaleAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([StaleRedemption()]);
+    }
+
+    [Fact]
+    public async Task An_activated_subscriptions_stuck_reservation_is_marked_redeemed_at_its_own_activation_instant()
+    {
+        var activatedAtUtc = new DateTime(2026, 8, 20, 9, 0, 0, DateTimeKind.Utc);
+        GivenSubscription(new SubscriptionDetail
+        {
+            ItemId = SubscriptionId,
+            TenantId = TenantId,
+            Status = SubscriptionStatus.Active,
+            ActivatedAtUtc = activatedAtUtc
+        });
+
+        var resolved = await Reconciler().ReconcileAsync(TenantId, CancellationToken.None);
+
+        resolved.Should().Be(1);
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                TenantId, DiscountId, SubscriptionId, activatedAtUtc, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A subscription that later cancelled is still redeemed, not released -- ActivatedAtUtc is
+    /// never cleared, which is exactly what makes it the right signal instead of current status.
+    /// </summary>
+    [Fact]
+    public async Task An_activated_subscription_that_later_cancelled_is_still_reconciled_as_redeemed()
+    {
+        GivenSubscription(new SubscriptionDetail
+        {
+            ItemId = SubscriptionId,
+            TenantId = TenantId,
+            Status = SubscriptionStatus.Canceled,
+            ActivatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+
+        await Reconciler().ReconcileAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                TenantId, DiscountId, SubscriptionId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_never_activated_expired_subscriptions_reservation_is_released()
+    {
+        GivenSubscription(new SubscriptionDetail
+        {
+            ItemId = SubscriptionId,
+            TenantId = TenantId,
+            Status = SubscriptionStatus.IncompleteExpired,
+            ActivatedAtUtc = null
+        });
+
+        var resolved = await Reconciler().ReconcileAsync(TenantId, CancellationToken.None);
+
+        resolved.Should().Be(1);
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                TenantId, DiscountId, SubscriptionId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Cancelled while still Incomplete -- the other way a subscription can end without ever
+    /// activating, mirroring SubscriptionCancellationService.EndNowAsync's own condition exactly.
+    /// </summary>
+    [Fact]
+    public async Task A_never_activated_cancelled_subscriptions_reservation_is_released()
+    {
+        GivenSubscription(new SubscriptionDetail
+        {
+            ItemId = SubscriptionId,
+            TenantId = TenantId,
+            Status = SubscriptionStatus.Canceled,
+            ActivatedAtUtc = null
+        });
+
+        await Reconciler().ReconcileAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                TenantId, DiscountId, SubscriptionId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Resumes a row already at ReleasePending exactly the way it resumes one still at Reserved --
+    /// TryReleaseAsync's own idempotence carries the difference, not anything read here.
+    /// </summary>
+    [Fact]
+    public async Task A_row_already_at_release_pending_is_finished_the_same_way()
+    {
+        _redemptions
+            .Setup(repository => repository.ListStaleAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([StaleRedemption(CampaignRedemptionState.ReleasePending)]);
+        GivenSubscription(new SubscriptionDetail
+        {
+            ItemId = SubscriptionId,
+            TenantId = TenantId,
+            Status = SubscriptionStatus.Canceled,
+            ActivatedAtUtc = null
+        });
+
+        await Reconciler().ReconcileAsync(TenantId, CancellationToken.None);
+
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                TenantId, DiscountId, SubscriptionId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_subscription_still_incomplete_and_undecided_is_left_alone()
+    {
+        GivenSubscription(new SubscriptionDetail
+        {
+            ItemId = SubscriptionId,
+            TenantId = TenantId,
+            Status = SubscriptionStatus.Incomplete,
+            ActivatedAtUtc = null
+        });
+
+        var resolved = await Reconciler().ReconcileAsync(TenantId, CancellationToken.None);
+
+        resolved.Should().Be(0);
+        _redemptions.Verify(
+            repository => repository.TryMarkRedeemedAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _redemptions.Verify(
+            repository => repository.TryReleaseAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_redemption_naming_a_subscription_that_cannot_be_found_is_left_alone()
+    {
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+
+        var resolved = await Reconciler().ReconcileAsync(TenantId, CancellationToken.None);
+
+        resolved.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task The_grace_period_is_read_from_options_rather_than_hardcoded()
+    {
+        DateTime? requestedThreshold = null;
+        _redemptions
+            .Setup(repository => repository.ListStaleAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<string, DateTime, int, CancellationToken>((_, threshold, _, _) => requestedThreshold = threshold)
+            .ReturnsAsync([]);
+
+        var options = new SubscriptionOptionsMonitorStub(new SubscriptionOptions
+        {
+            CampaignRedemptionGraceMinutes = 45
+        });
+
+        await new CampaignRedemptionReconciler(
+                _redemptions.Object, _subscriptions.Object, options,
+                NullLogger<CampaignRedemptionReconciler>.Instance, _time)
+            .ReconcileAsync(TenantId, CancellationToken.None);
+
+        requestedThreshold.Should().Be(_time.GetUtcNow().UtcDateTime.AddMinutes(-45));
+    }
+
+    private void GivenSubscription(SubscriptionDetail subscription) =>
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, SubscriptionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+    private CampaignRedemptionReconciler Reconciler() => new(
+        _redemptions.Object,
+        _subscriptions.Object,
+        new SubscriptionOptionsMonitorStub(new SubscriptionOptions()),
+        NullLogger<CampaignRedemptionReconciler>.Instance,
+        _time);
+
+    private static CampaignRedemption StaleRedemption(
+        CampaignRedemptionState state = CampaignRedemptionState.Reserved) => new()
+    {
+        TenantId = TenantId,
+        OrganizationId = "org-1",
+        DiscountId = DiscountId,
+        SubscriptionId = SubscriptionId,
+        State = state,
+        ReservedAtUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionAmountCalculatorTests.cs
@@ -13,6 +13,21 @@ public sealed class SubscriptionAmountCalculatorTests
     private static readonly DateTime Now = new(2026, 8, 14, 10, 0, 0, DateTimeKind.Utc);
 
     [Fact]
+    public void A_campaign_can_require_card_setup_even_when_the_plan_and_trial_do_not()
+    {
+        var subscription = NewSubscription(discount: new DiscountTerms
+        {
+            Campaign = new CampaignTerms
+            {
+                Kind = CampaignKind.FreeOpeningCalendarPeriod,
+                RequiresPaymentMethodUpfront = true
+            }
+        });
+
+        SubscriptionAmountCalculator.RequiresCardSetup(subscription).Should().BeTrue();
+    }
+
+    [Fact]
     public void A_discount_with_no_bound_never_expires()
     {
         var subscription = NewSubscription(discount: new DiscountTerms


### PR DESCRIPTION
Phase 6/6 — the final phase of campaign discount management. Closes the crash window flagged since Phase 2: a subscription's own transition (activation, expiry, cancellation) committing while the paired campaign ledger call never runs, or runs only halfway.

## What was already closed, and what was not

`TryReleaseAsync` already narrows half of this itself — it commits a durable `ReleasePending` state before its second step, specifically so "a reconciliation sweep can find and finish" a crash between the two (see that method's own remarks, written in Phase 2). What Phase 2 left open, by its own admission:

1. A `Reserved` row whose subscription actually activated, where the crash landed **before `TryMarkRedeemedAsync` ever ran at all** — there's no intermediate state for the redeem path the way there is for release, so this row looks identical to one nothing has happened to yet.
2. A row already at `ReleasePending` whose second step never ran.

Both leave a campaign redemption stuck forever — for a one-use campaign, the organization's slot never frees, indistinguishable from "still in use" even though the subscription's fate was already decided.

## `CampaignRedemptionReconciler` (new)

Reads a subscription's `ActivatedAtUtc` rather than its current status: that field is set once, at activation, and never cleared afterward — including by a later cancellation — so it answers "did this subscription's campaign ever get spent" independent of whatever status the subscription holds by the time the sweep runs.

- `ActivatedAtUtc` set → `TryMarkRedeemedAsync`, backdated to that instant.
- Terminal and never activated (`IncompleteExpired` or `Canceled`-while-`Incomplete`) → `TryReleaseAsync`, which resumes correctly whether the row is still at `Reserved` or already at `ReleasePending`.
- Still `Incomplete` → left alone; its own `ActivationRecovery` work resolves that first.

Wired into `SubscriptionRepairAnnouncer.AnnounceAsync` directly, not through the durable work queue — like `ReconcileStaleClosuresAsync` beside it, this moves no money, so it needs none of the two-executor discipline that queue exists to protect. Threaded through as an optional constructor dependency, the same convention every other campaign collaborator in this feature follows.

## Repository additions

- `ListStaleAsync(tenantId, reservedBeforeUtc, limit)` — `Reserved` or `ReleasePending` rows, oldest first. Backed by a new, deliberately **non-partial** index: `State`'s two reconciled values (0 and 2) straddle `Redeemed` (1), so no ordered comparison in a partial filter *definition* could isolate them — but an ordinary compound index serves an `$in` query over `State` fine, since that restriction is specific to how a partial filter is defined, not to how a query is written.
- `SubscriptionOptions.CampaignRedemptionGraceMinutes` (15) / `CampaignRedemptionBatchSize` (50) — same shape as `SettlementReservationGraceMinutes`/`BatchSize` beside them.

## Tests

- `CampaignRedemptionReconcilerTests` (8 tests, mocked): every branch above, plus a redemption naming a subscription that can't be found being left alone rather than guessed at, and the grace period actually coming from options.
- `CampaignRedemptionConcurrencyTests` (+2, real MongoDB): `ListStaleAsync` finds only `Reserved`/`ReleasePending` rows before the threshold — proving the `$in`-over-a-non-partial-index reasoning against a real server rather than arguing it in a comment — ordered oldest first, respecting the limit.

## Verification

Server: `dotnet test --filter "FullyQualifiedName!~Integration"`: **3225 passed**, same 4 pre-existing baseline failures, 1 unrelated skip. `CampaignRedemptionConcurrencyTests`: 9/9 passed in isolation against a fresh local MongoDB.

One thing flagged rather than fixed: running the **entire** integration suite together against one container reproducibly fails 16 unrelated tests across three other classes, on two separate completely fresh containers — none campaign-related, none touched by this change. Pre-existing full-suite fragility, not a regression from this phase.

This is the last of the six phases from the original plan.

## Merge order

Based on `feat/campaign-admin-authoring-ui` (#356) → `feat/campaign-buyer-preview` (#354) → `feat/campaign-annual-yearly-pricing` (#352) → `feat/campaign-free-month-pricing` (#351) → `feat/campaign-discounts-redemption-ledger` (#350) → `feat/campaign-discounts-data-model` (#349). Merge in that order, retargeting each PR's base as the prior one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
