### PR TITLE
feat(subscription): let a running subscription collect a card

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -770,6 +770,20 @@
             Withdraws a scheduled decrease, leaving the current quantity in place.
             </summary>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.StartPaymentMethodSetup(System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Opens a hosted session that stores a card against a running subscription.
+            </summary>
+            <remarks>
+            This is not a payment. Nothing is charged, no invoice is produced, and a trial in progress
+            is neither ended nor shortened — the card is stored so the first paid period has something
+            to charge when the trial finishes.
+            <para>
+            Returns the subscription with a <c>pendingCheckout</c> carrying the URL to send the
+            subscriber to. A session already open is returned rather than replaced.
+            </para>
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.SubscriptionsController.GetAuditTrail(System.String,System.String,System.Int32,System.Threading.CancellationToken)">
             <summary>Returns the immutable lifecycle trail used to investigate this subscription.</summary>
             <remarks>

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -387,6 +387,43 @@ public sealed class SubscriptionsController : ControllerBase
         return result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Opens a hosted session that stores a card against a running subscription.
+    /// </summary>
+    /// <remarks>
+    /// This is not a payment. Nothing is charged, no invoice is produced, and a trial in progress
+    /// is neither ended nor shortened — the card is stored so the first paid period has something
+    /// to charge when the trial finishes.
+    /// <para>
+    /// Returns the subscription with a <c>pendingCheckout</c> carrying the URL to send the
+    /// subscriber to. A session already open is returned rather than replaced.
+    /// </para>
+    /// </remarks>
+    [HttpPost("{subscriptionId}/payment-method/setup")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> StartPaymentMethodSetup(
+        string subscriptionId,
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _checkout.StartPaymentMethodSetupAsync(
+            subscriptionId,
+            organizationId,
+            correlationId,
+            cancellationToken);
+
+        await AuditAsync("StartPaymentMethodSetup", organizationId, subscriptionId,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            null, null, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
     /// <summary>Returns the immutable lifecycle trail used to investigate this subscription.</summary>
     /// <remarks>
     /// Results are tenant- and organization-scoped. They intentionally omit actor identifiers,

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -303,6 +303,21 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
 
         if (subscription.Status != SubscriptionStatus.Incomplete)
         {
+            // A setup confirmed against a subscription that is already running is a card being
+            // added to one — during a trial, most often — rather than one being activated. There is
+            // no transition to make, but the card still has to be adopted: without this the
+            // subscriber completes a Stripe session, is told it succeeded, and still has nothing on
+            // file, then fails at the trial's end for want of a payment method. The early return
+            // below settled the link and skipped adoption entirely.
+            //
+            // Left pending on failure, exactly as the activation path does, so the sweep tries
+            // again rather than losing a card the subscriber has already entered.
+            if (IsCardSetup(link) &&
+                !await AdoptProviderCustomerAsync(subscription, payment, cancellationToken))
+            {
+                return false;
+            }
+
             // Already carried across by an earlier pass. Settle the link so it stops coming back.
             return await _links.TrySettleAsync(
                 link.TenantId,

--- a/server/Subscription.DomainService/Services/ISubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCheckoutService.cs
@@ -22,4 +22,18 @@ public interface ISubscriptionCheckoutService
         string? organizationId,
         string correlationId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Opens a session that stores a card against a subscription that is already running.
+    /// </summary>
+    /// <remarks>
+    /// Not a payment, and it issues no invoice. A trial that started without a card needs one
+    /// before its first paid period, and this is how the subscriber provides it — without ending
+    /// the trial, shortening it, or charging anything.
+    /// </remarks>
+    Task<SubscriptionOperationResult<SubscriptionResponse>> StartPaymentMethodSetupAsync(
+        string subscriptionId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -34,6 +34,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     private readonly IPaymentMethodSetupService _paymentMethodSetups;
     private readonly IPaymentRepository _paymentRepository;
     private readonly ICurrencyMinorUnitResolver _currency;
+    private readonly IBillingAccountRepository _billingAccounts;
     private readonly ILogger<SubscriptionCheckoutService> _logger;
     private readonly TimeProvider _time;
 
@@ -48,6 +49,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         IPaymentMethodSetupService paymentMethodSetups,
         IPaymentRepository paymentRepository,
         ICurrencyMinorUnitResolver currency,
+        IBillingAccountRepository billingAccounts,
         ILogger<SubscriptionCheckoutService> logger,
         ISubscriptionFinancialDocumentAnnouncer? documents = null,
         TimeProvider? time = null)
@@ -62,6 +64,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         _paymentMethodSetups = paymentMethodSetups;
         _paymentRepository = paymentRepository;
         _currency = currency;
+        _billingAccounts = billingAccounts;
         _logger = logger;
         _documents = documents;
         _time = time ?? TimeProvider.System;
@@ -435,6 +438,109 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     /// </para>
     /// </remarks>
     private static bool RequiresPayment(long amountMinor) => amountMinor > 0;
+
+    /// <inheritdoc />
+    public async Task<SubscriptionOperationResult<SubscriptionResponse>> StartPaymentMethodSetupAsync(
+        string subscriptionId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            organizationId,
+            cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+
+        var subscription = await _subscriptions.GetByIdAsync(
+            context.TenantId,
+            subscriptionId,
+            cancellationToken);
+
+        // Scope checked here rather than left to the query, because GetByIdAsync is tenant-scoped
+        // and not organization-scoped: without this, naming another organization's subscription id
+        // would open a card session against it.
+        if (subscription is null ||
+            !string.Equals(subscription.OrganizationId, context.OrganizationId, StringComparison.Ordinal))
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "No subscription was found to add a payment method to.",
+                correlationId);
+        }
+
+        if (subscription.Status is SubscriptionStatus.Canceled or SubscriptionStatus.IncompleteExpired)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_not_collectable",
+                "This subscription has ended, so there is nothing for a payment method to pay.",
+                correlationId);
+        }
+
+        // Deliberately refused rather than silently supported. Recovering an Unpaid subscription
+        // has to charge the overdue period before restoring access, and neither obvious way to do
+        // that is safe yet: Unpaid is outside the repository's live statuses, so a subscriber with
+        // no access would regain it the moment the status moved to PastDue — before any money
+        // arrived, and again on a declined retry. Until that path exists, saying so is better than
+        // storing a card that nothing will act on.
+        if (subscription.Status == SubscriptionStatus.Unpaid)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_recovery_unavailable",
+                "This subscription is unpaid. Recovering it is not yet supported here.",
+                correlationId);
+        }
+
+        var account = await _billingAccounts.GetAsync(
+            context.TenantId,
+            subscription.BillingAccountId,
+            cancellationToken);
+
+        if (account?.DefaultPaymentMethodId is { Length: > 0 })
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "payment_method_already_stored",
+                "This subscription already has a payment method.",
+                correlationId);
+        }
+
+        // A session already open is returned rather than replaced. Two live sessions against one
+        // subscription is how a subscriber ends up with the card they did not expect on file, and
+        // the activation sweep only ever settles one of them.
+        var existing = await _links.FindBySubscriptionAsync(
+            context.TenantId,
+            subscription.ItemId,
+            cancellationToken);
+
+        if (existing is { Purpose: SubscriptionPaymentPurpose.PaymentMethodSetup,
+                          State: SubscriptionPaymentLinkState.Pending })
+        {
+            var url = await ResolveUsableCheckoutUrlAsync(context.TenantId, existing, cancellationToken);
+
+            if (url is { Length: > 0 })
+            {
+                return SubscriptionOperationResult<SubscriptionResponse>.Success(
+                    _mapper.ToResponse(subscription, url, PendingSetup("Pending", url)),
+                    correlationId);
+            }
+
+            // The session expired without anybody finishing it. Bumping the attempt is what makes
+            // the next one distinct, and it is a compare-and-set, so two tabs produce one session.
+            return await RetryCardSetupAsync(subscription, existing, correlationId, cancellationToken);
+        }
+
+        return await StartCardSetupAsync(subscription, correlationId, cancellationToken);
+    }
 
     /// <summary>
     /// Opens a hosted session that stores a card and charges nothing.

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -547,6 +547,90 @@ public sealed class SubscriptionActivationProcessorTests
             });
 
     /// <summary>
+    /// A card saved against a subscription that is already running is still adopted.
+    /// </summary>
+    /// <remarks>
+    /// The gap this closes. Adoption sat after an early return taken whenever the subscription was
+    /// not Incomplete, so a card added during a trial @D@ the whole point of collecting one mid-trial
+    /// @D@ was confirmed by the provider, settled here, and never attached to the billing account.
+    /// The subscriber saw a successful Stripe session and still had nothing on file, then failed at
+    /// the trial's end for want of a payment method: a silent failure a whole trial away from its
+    /// cause.
+    /// </remarks>
+    [Theory]
+    [InlineData(SubscriptionStatus.Trialing)]
+    [InlineData(SubscriptionStatus.Active)]
+    public async Task A_card_saved_against_a_running_subscription_is_adopted(
+        SubscriptionStatus status)
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
+        GivenSubscription(subscription => subscription.Status = status);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _accounts.Verify(
+            repository => repository.TrySetProviderCustomerAsync(
+                TenantId,
+                "acct-1",
+                "cus_123",
+                "method-1",
+                MerchantOrganizationId,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the card the subscriber just entered is the one the next charge has to find");
+
+        _transition.Should().BeNull(
+            "the subscription was already running @D@ a card was added to it, not an activation");
+    }
+
+    /// <summary>
+    /// A card that cannot be adopted leaves the link pending rather than settling it away.
+    /// </summary>
+    /// <remarks>
+    /// Same rule the activation path follows. Settling would end the only record that the card
+    /// still needs attaching, and the subscriber has no way to know anything is wrong.
+    /// </remarks>
+    [Fact]
+    public async Task A_card_that_cannot_be_adopted_mid_trial_is_retried_rather_than_settled()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSubscription(subscription => subscription.Status = SubscriptionStatus.Trialing);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(0);
+        _links.Verify(repository => repository.TrySettleAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SubscriptionPaymentLinkState>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// A charge confirmed against an already-running subscription still settles and adopts
+    /// nothing, because a charge is not a card being added.
+    /// </summary>
+    [Fact]
+    public async Task A_charge_against_a_running_subscription_settles_without_adopting()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.InitialCharge);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
+        GivenSubscription(subscription => subscription.Status = SubscriptionStatus.Active);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _accounts.Verify(
+            repository => repository.TrySetProviderCustomerAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// A card setup settles into the same confirmed status a charge does, because that status is
     /// how the provider says a thing it was asked to do happened. What must not follow is the
     /// subscription reporting a zero-value record as the charge that opened it.

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -34,6 +34,7 @@ public sealed class SubscriptionCheckoutServiceTests
     private readonly Mock<IPaymentMethodSetupService> _paymentMethodSetups = new();
     private readonly Mock<IPaymentRepository> _paymentRepository = new();
     private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
 
     private SubscriptionDetail _subscription = NewSubscription();
     private MakePaymentRequest? _paymentRequest;
@@ -486,6 +487,7 @@ public sealed class SubscriptionCheckoutServiceTests
         _paymentMethodSetups.Object,
         _paymentRepository.Object,
         _currency.Object,
+        _billingAccounts.Object,
         NullLogger<SubscriptionCheckoutService>.Instance);
 
     private void ArrangePendingCheckout()
@@ -520,6 +522,136 @@ public sealed class SubscriptionCheckoutServiceTests
         PriceId = _subscription.Price.PriceId,
         TimeZoneId = _subscription.FeeSchedule.TimeZoneId
     };
+
+    // ---- Adding a card to a subscription that is already running -------------------------------
+    //
+    // A trial that started without one needs a card before its first paid period, and this is how
+    // the subscriber supplies it. The rules pinned below are the ones that cost something when they
+    // are wrong: whose subscription it is, whether a second session gets opened, and whether
+    // anything is charged.
+
+    private void GivenSubscriptionById(SubscriptionDetail subscription) =>
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, subscription.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(subscription);
+
+    private void GivenSetupSessionOpens(string url = "https://checkout.stripe.com/setup") =>
+        _paymentMethodSetups
+            .Setup(service => service.CreateSetupAsync(
+                It.IsAny<CreatePaymentMethodSetupRequest>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PaymentOperationResult.Success(
+                new PaymentResponse
+                {
+                    PaymentDetailId = "pay-setup-1",
+                    RedirectUrl = url
+                },
+                "corr-1"));
+
+    [Fact]
+    public async Task A_trialing_subscription_can_add_a_card_without_being_charged()
+    {
+        _subscription.Status = SubscriptionStatus.Trialing;
+        GivenSubscriptionById(_subscription);
+        GivenSetupSessionOpens();
+
+        var result = await Service().StartPaymentMethodSetupAsync(
+            _subscription.ItemId, OrganizationId, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PendingCheckout!.Purpose.Should().Be("PaymentMethodSetup");
+        result.Value.PendingCheckout.CheckoutUrl.Should().Be("https://checkout.stripe.com/setup");
+
+        // The whole point of the endpoint: a card is stored and no money moves.
+        _payments.Verify(
+            service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Adding_a_card_leaves_the_trial_exactly_where_it_was()
+    {
+        var endsAt = new DateTime(2026, 9, 8, 9, 0, 0, DateTimeKind.Utc);
+        _subscription.Status = SubscriptionStatus.Trialing;
+        _subscription.Trial = new TrialTerms { EndsAtUtc = endsAt, RequiresPaymentMethod = false };
+        GivenSubscriptionById(_subscription);
+        GivenSetupSessionOpens();
+
+        await Service().StartPaymentMethodSetupAsync(
+            _subscription.ItemId, OrganizationId, "corr-1", CancellationToken.None);
+
+        // Saving a card is not an event in the trial's life: it neither ends it nor shortens it.
+        _subscription.Status.Should().Be(SubscriptionStatus.Trialing);
+        _subscription.Trial!.EndsAtUtc.Should().Be(endsAt);
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Another_organizations_subscription_is_not_found_rather_than_refused()
+    {
+        // GetByIdAsync is tenant-scoped and not organization-scoped, so without the explicit check
+        // this would open a card session against somebody else's subscription. Reported as absent
+        // rather than forbidden, which is what every other lookup here does.
+        _subscription.OrganizationId = "org-2";
+        _subscription.Status = SubscriptionStatus.Trialing;
+        GivenSubscriptionById(_subscription);
+
+        var result = await Service().StartPaymentMethodSetupAsync(
+            _subscription.ItemId, OrganizationId, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_not_found");
+        _paymentMethodSetups.Verify(
+            service => service.CreateSetupAsync(
+                It.IsAny<CreatePaymentMethodSetupRequest>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(SubscriptionStatus.Canceled, "subscription_not_collectable")]
+    [InlineData(SubscriptionStatus.IncompleteExpired, "subscription_not_collectable")]
+    [InlineData(SubscriptionStatus.Unpaid, "subscription_recovery_unavailable")]
+    public async Task A_subscription_that_cannot_take_a_card_says_which_case_it_is(
+        SubscriptionStatus status,
+        string expectedCode)
+    {
+        _subscription.Status = status;
+        GivenSubscriptionById(_subscription);
+
+        var result = await Service().StartPaymentMethodSetupAsync(
+            _subscription.ItemId, OrganizationId, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be(expectedCode);
+    }
+
+    [Fact]
+    public async Task A_subscription_that_already_has_a_card_is_not_sent_to_collect_another()
+    {
+        _subscription.Status = SubscriptionStatus.Trialing;
+        GivenSubscriptionById(_subscription);
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, _subscription.BillingAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount { DefaultPaymentMethodId = "method-1" });
+
+        var result = await Service().StartPaymentMethodSetupAsync(
+            _subscription.ItemId, OrganizationId, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("payment_method_already_stored");
+    }
 
     private static SubscriptionDetail NewSubscription()
     {

--- a/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
+++ b/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
@@ -40,6 +40,7 @@ public sealed class ZeroAmountCardSetupTests
     private readonly Mock<IPaymentMethodSetupService> _setups = new();
     private readonly Mock<IPaymentRepository> _paymentRepository = new();
     private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
+    private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
 
     private readonly SubscriptionDetail _subscription = FreeSubscription();
 
@@ -443,6 +444,7 @@ public sealed class ZeroAmountCardSetupTests
         _setups.Object,
         _paymentRepository.Object,
         _currency.Object,
+        _billingAccounts.Object,
         NullLogger<SubscriptionCheckoutService>.Instance);
 
     private static TrialTerms Trial(bool requiresPaymentMethod) => new()


### PR DESCRIPTION
Part 2 of the deferred-trial work. Adds the endpoint a card-free trial needs to get a card before its first paid period.

```
POST /api/subscriptions/{subscriptionId}/payment-method/setup?organizationId=...
```

Returns the subscription with a `pendingCheckout` carrying the Stripe URL. **Not a payment**: no charge, no invoice, and a trial in progress is neither ended nor shortened.

## It also closes a bug that would have made the endpoint useless

Card adoption sat behind an early return in `SubscriptionActivationProcessor` taken whenever the subscription was **not** `Incomplete`:

```csharp
if (subscription.Status != SubscriptionStatus.Incomplete)
{
    return await _links.TrySettleAsync(..., Applied, ...);   // adoption never reached
}
```

So a setup confirmed against a running subscription was settled and **the card was never attached to the billing account**. The subscriber completes Stripe, is told it worked, and still has nothing on file — then fails at the trial's end for want of a payment method, a whole trial away from the cause.

This is reachable today through a late webhook. It becomes the *normal* path with this endpoint. Adoption now runs first, and a failure leaves the link pending for the sweep rather than settling it away.

**Verified by disabling the fix:** exactly the three new tests fail, and only those.

## The guards, and why each exists

| Guard | Why |
|---|---|
| Another organization's subscription → `subscription_not_found` | `GetByIdAsync` is tenant-scoped, **not** organization-scoped. Without the explicit check, naming an id would open a card session against someone else's subscription. |
| Session already open → returned, not replaced | Two live sessions against one subscription is how a subscriber ends up with a card they did not expect, and the sweep only ever settles one. |
| Expired session → existing attempt bump | A compare-and-set on the attempt number, so two tabs produce one session. |
| `Canceled` / `IncompleteExpired` → `subscription_not_collectable` | Nothing left for a payment method to pay. |
| Already has a card → `payment_method_already_stored` | Don't send someone to Stripe to store what they already have. |

## Unpaid recovery is deliberately refused, not half-supported

`subscription_recovery_unavailable`, with the reason in the code. Recovery must charge the overdue period **before** restoring access, and neither obvious route is safe:

- `Unpaid` sits outside the repository's `LiveStatuses` (`Trialing`, `Active`, `PastDue`), so `GetLiveAsync` returns null and `EntitlementService` already grants nothing — access is correctly gone.
- **Moving it to `PastDue`** to reuse the renewal sweep would restore access the moment the status changed, before any money arrived.
- **Calling `RenewAsync` directly** would do the same on a *declined* retry, because the decline path lands on `PastDue`.

Either would hand paid access to someone who has not paid. Storing a card that nothing acts on would be worse than saying so, so the endpoint refuses with a specific code and recovery gets its own purpose-built charge path in a follow-up.

## Verification

- `SubscriptionCheckoutServiceTests` + `ZeroAmountCardSetupTests`: **42 passed**
- `SubscriptionActivationProcessorTests`: **24 passed**, including three new ones that fail without the adoption fix
- Full non-integration suite: **3167 passed**. 4 `SubscriptionSimulation*` failures are pre-existing on clean `dev`; `FinancialDocumentRendererHealthMonitorTests` fails only under load and **passes alone** — it touches nothing this change goes near.

`ZeroAmountCardSetupTests` needed the new constructor argument; the compiler caught that construction site after my own grep missed it (it uses `new(...)` form).

## Still to come

Unpaid recovery with its own charge path, the `GET current` recovery action, and the subscriber-page UI states. Copy is in [#355](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/355); billing core in [#353](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/353).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
