### PR TITLE
feat(subscription): charge and restore access when a lapsed trial recovers

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -590,21 +590,16 @@
             them one at a time invites a new street beside an old city on the next document issued.
             </remarks>
         </member>
+        <member name="T:Api.Controllers.SubscriptionDiscountPreviewController">
+            <summary>Buyer-facing, read-only validation and pricing of a discount code.</summary>
+        </member>
         <member name="T:Api.Controllers.SubscriptionDiscountsController">
             <remarks>
             Every action here manages the discount/campaign catalogue -- authoring, editing, retiring and
             listing it -- never redeeming one. A buyer applying a code at checkout goes through the
-            subscription endpoints instead, which is why this whole controller sits behind
-            <c>SubscriptionCampaignManager</c> rather than plain authentication: creating a discount that
-            is 100% off, or one that replaces a price's own automatic discount, is a commercial decision,
-            the same reasoning that scopes subscription background-work recovery to its own policy.
-            <para>
-            That policy has no effect until the identity provider maps a role to the
-            <c>subscription.campaign.manage</c> permission claim it requires -- until that mapping exists,
-            every caller is refused, including whoever manages discounts today under plain authentication.
-            This is a deployment precondition, not a code change: the mapping has to land before this
-            controller does, or discount authoring goes dark the moment it deploys.
-            </para>
+            subscription endpoints instead. Catalogue management currently requires authentication; a
+            dedicated campaign-management permission can be restored once the identity provider exposes
+            and assigns it consistently.
             </remarks>
         </member>
         <member name="T:Api.Controllers.SubscriptionMerchantProfileController">

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -49,6 +49,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     private readonly TimeProvider _time;
     private readonly ISubscriptionAuditTrail? _audit;
     private readonly ICampaignRedemptionRepository? _redemptions;
+    private readonly ISubscriptionRenewalService? _renewals;
 
     public SubscriptionActivationProcessor(
         ISubscriptionPaymentLinkRepository links,
@@ -62,7 +63,8 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         TimeProvider? time = null,
         ISubscriptionAuditTrail? audit = null,
         ISubscriptionFinancialDocumentAnnouncer? documents = null,
-        ICampaignRedemptionRepository? redemptions = null)
+        ICampaignRedemptionRepository? redemptions = null,
+        ISubscriptionRenewalService? renewals = null)
     {
         _links = links;
         _subscriptions = subscriptions;
@@ -76,6 +78,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         _audit = audit;
         _documents = documents;
         _redemptions = redemptions;
+        _renewals = renewals;
     }
 
     /// <summary>
@@ -319,6 +322,18 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                 !await AdoptProviderCustomerAsync(subscription, payment, cancellationToken))
             {
                 return false;
+            }
+
+            // The card just adopted is what an Unpaid subscription was missing, so this is the
+            // moment recovery becomes possible — not a moment later, and not left for a sweep
+            // that (correctly) never looks at an Unpaid subscription on its own. The link settles
+            // either way: it is a record that the card was stored, and it stored successfully
+            // whether or not the charge that follows is accepted.
+            if (IsCardSetup(link) &&
+                subscription.Status == SubscriptionStatus.Unpaid &&
+                _renewals is not null)
+            {
+                await _renewals.RecoverAsync(subscription, cancellationToken);
             }
 
             // Already carried across by an earlier pass. Settle the link so it stops coming back.

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -54,6 +54,20 @@ public interface ISubscriptionRepository
         string organizationId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// The organization's subscription that lost access for want of a payment method, if any.
+    /// </summary>
+    /// <remarks>
+    /// Not covered by <see cref="GetLiveAsync"/>, deliberately -- Unpaid grants nothing, which is
+    /// the whole point of the status. This exists so a client can still be told a subscription is
+    /// there and how to recover it, rather than reading the same "nothing" a tenant with no
+    /// subscription at all would see.
+    /// </remarks>
+    Task<SubscriptionDetail?> GetUnpaidAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken);
+
     Task<SubscriptionDetail?> GetByOrderIdAsync(
         string tenantId,
         string orderId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -117,6 +117,21 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
                     SubscriptionStatus.Incomplete)))
             .FirstOrDefaultAsync(cancellationToken);
 
+    public async Task<SubscriptionDetail?> GetUnpaidAsync(
+        string tenantId,
+        string organizationId,
+        CancellationToken cancellationToken) =>
+        await Subscriptions(tenantId)
+            .Find(Builders<SubscriptionDetail>.Filter.And(
+                TenantFilter(tenantId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.OrganizationId,
+                    organizationId),
+                Builders<SubscriptionDetail>.Filter.Eq(
+                    subscription => subscription.Status,
+                    SubscriptionStatus.Unpaid)))
+            .FirstOrDefaultAsync(cancellationToken);
+
     public async Task<SubscriptionDetail?> GetByOrderIdAsync(
         string tenantId,
         string orderId,

--- a/server/Subscription.DomainService/Services/ISubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionRenewalService.cs
@@ -6,4 +6,17 @@ namespace Subscription.DomainService.Services;
 public interface ISubscriptionRenewalService
 {
     Task RenewAsync(SubscriptionDetail subscription, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Charges the overdue first period of a trial that went Unpaid for want of a card, now that
+    /// one has been supplied.
+    /// </summary>
+    /// <remarks>
+    /// Only ever called for a subscription already Unpaid — anything else reaches this by caller
+    /// error, and charging a live subscription through a path meant for one that lost access would
+    /// be worse than refusing. On success the subscription moves straight to Active, the same
+    /// compare-and-set a renewal uses; on decline it stays exactly where it was rather than
+    /// entering the dunning schedule, which is a live status.
+    /// </remarks>
+    Task RecoverAsync(SubscriptionDetail subscription, CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -415,6 +415,22 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                 correlationId);
         }
 
+        // Unpaid grants nothing, so GetLiveAsync above never finds it — but it is a subscription
+        // the caller still has, and one they can still act on. Without this it read exactly like no
+        // subscription at all, which left no way for a client to offer the one thing that fixes it:
+        // saving a card through POST .../payment-method/setup.
+        subscription = await _subscriptions.GetUnpaidAsync(
+            context.TenantId,
+            context.OrganizationId,
+            cancellationToken);
+
+        if (subscription is not null)
+        {
+            return SubscriptionOperationResult<SubscriptionResponse>.Success(
+                _mapper.ToResponse(subscription),
+                correlationId);
+        }
+
         // No subscription is an answer, not a failure. This used to be a 404, which says the
         // endpoint is not there: a client cannot tell that from a bad route, a revoked path or a
         // typo, so every caller had to special-case one status code to read an ordinary "not yet".
@@ -485,20 +501,11 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                 correlationId);
         }
 
-        // Deliberately refused rather than silently supported. Recovering an Unpaid subscription
-        // has to charge the overdue period before restoring access, and neither obvious way to do
-        // that is safe yet: Unpaid is outside the repository's live statuses, so a subscriber with
-        // no access would regain it the moment the status moved to PastDue — before any money
-        // arrived, and again on a declined retry. Until that path exists, saying so is better than
-        // storing a card that nothing will act on.
-        if (subscription.Status == SubscriptionStatus.Unpaid)
-        {
-            return Failure(
-                PaymentFailureKind.Conflict,
-                "subscription_recovery_unavailable",
-                "This subscription is unpaid. Recovering it is not yet supported here.",
-                correlationId);
-        }
+        // Unpaid is deliberately allowed through to the same session a trial uses to add a card.
+        // The confirmation this session produces goes through SubscriptionActivationProcessor,
+        // which charges the overdue period the moment the card is adopted and only then restores
+        // access -- see RecoverAsync and its own guard against a decline granting access through
+        // PastDue.
 
         var account = await _billingAccounts.GetAsync(
             context.TenantId,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -71,6 +71,36 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
     /// <summary>Optional for the reason the scheduler beside it is: a renewal must not need one.</summary>
     private readonly ISubscriptionFinancialDocumentAnnouncer? _documents;
 
+    /// <inheritdoc />
+    public Task RecoverAsync(SubscriptionDetail subscription, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        if (subscription.Status != SubscriptionStatus.Unpaid)
+        {
+            // Called from exactly one place: a card confirmed against a subscription that is
+            // already Unpaid. Anything else reaching here is a caller mistake, and this exists
+            // specifically because charging a subscription through the wrong entry point is the
+            // one failure mode that costs real money -- so it is refused rather than guessed at.
+            _logger.LogWarning(
+                "RecoverAsync called for a subscription that is not Unpaid TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} Status={Status}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(subscription.Status.ToString()));
+
+            return Task.CompletedTask;
+        }
+
+        // Everything after this point is the same charge, the same idempotency key derivation, and
+        // the same compare-and-set transition an ordinary renewal uses -- reused rather than
+        // duplicated so this money follows one set of rules, not two. What makes it safe to reuse
+        // for a subscription that lost access is the pair of fixes above it: the period and price
+        // are anchored on the trial's own end regardless of how long the subscription sat Unpaid,
+        // and a decline here leaves Unpaid alone instead of granting access through PastDue.
+        return RenewAsync(subscription, cancellationToken);
+    }
+
     public async Task RenewAsync(
         SubscriptionDetail subscription,
         CancellationToken cancellationToken)
@@ -104,12 +134,27 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             return;
         }
 
-        // Which instant the period being charged belongs to. Normally now — but a card-free trial
-        // converting is charged for the period its *trial ended* in, however late this sweep runs.
-        // Anchoring on the clock instead would skip the days between the trial's end and today,
-        // and those are days the subscriber was entitled to and nobody billed.
+        // Which instant the period being charged belongs to. Normally now — but a trial converting
+        // for the first time is charged for the period its *trial ended* in, however late this
+        // runs. Anchoring on the clock instead would skip the days between the trial's end and
+        // today, and those are days the subscriber was entitled to and nobody billed.
         var converting = TryResolveTrialConversion(subscription, now, out var trialEndUtc, out var stub);
-        var periodAnchorUtc = converting ? trialEndUtc : now;
+
+        // The calendar case above covers a price with a variable-length opening stub. A price
+        // billed on its own anniversary has no stub — its first paid period is simply the whole
+        // period the schedule's own anchor already sits at, which is the trial's end (the schedule
+        // was built that way). That makes "now" a safe stand-in only while this runs promptly, and
+        // it does not run promptly for a subscription that sat Unpaid until somebody came back
+        // with a card: TryGetPeriod(schedule, now) would then resolve whatever period "now" falls
+        // in, silently skipping the one actually owed, and price it at whatever is live today
+        // rather than what was quoted when the trial ended.
+        var firstConversionUtc = subscription.Trial is { EndsAtUtc: var trialEndsAtUtc } &&
+            subscription.InitialChargeAmountMinor is null &&
+            trialEndsAtUtc <= now
+                ? trialEndsAtUtc
+                : (DateTime?)null;
+
+        var periodAnchorUtc = converting ? trialEndUtc : firstConversionUtc ?? now;
 
         if (!BillingPeriodCalculator.TryGetPeriod(
                 subscription.FeeSchedule,
@@ -170,10 +215,11 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         // Priced at the instant the period being charged *began*, not the instant this sweep runs.
         // Whether a promotion is still live depends on the clock, so pricing a conversion from
         // "now" would charge a subscriber who was mid-promotion when their trial ended the
-        // undiscounted amount purely because a worker was held up — and would make the same
-        // contractual period cost two different figures depending on sweep latency. Only the
-        // conversion moves it; an ordinary renewal begins at the boundary it is running on.
-        var pricingInstantUtc = converting ? trialEndUtc : now;
+        // undiscounted amount purely because a worker was held up, or because they were Unpaid for
+        // a week before adding a card — and would make the same contractual period cost two
+        // different figures depending on when this happened to run. Only a first conversion moves
+        // it; an ordinary renewal begins at the boundary it is running on.
+        var pricingInstantUtc = converting ? trialEndUtc : firstConversionUtc ?? now;
 
         // The year a calendar-aligned yearly subscription bought at signup, now due to open. Its
         // amount was frozen with the quote and is not re-derived here — the boundary is a month
@@ -608,6 +654,42 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         CancellationToken cancellationToken)
     {
         var maxAttempts = Math.Max(1, _options.CurrentValue.DunningMaxAttempts);
+
+        if (subscription.Status == SubscriptionStatus.Unpaid)
+        {
+            // Stays Unpaid rather than advancing to PastDue, which is a live status —
+            // TryGetLiveAsync and the entitlement it feeds both grant access to it, so moving an
+            // Unpaid subscription there on a decline would restore paid access to somebody who
+            // just failed to pay for it.
+            //
+            // The attempt count still advances, in an Unpaid-to-Unpaid write of its own. The next
+            // charge's idempotency key is derived from it, and leaving it still would give a
+            // second attempt — from a genuinely different card the subscriber added after this one
+            // was declined — the identical key the first attempt used, so the gateway would replay
+            // the stale decline instead of trying the new card at all.
+            await ApplyTransitionAsync(
+                subscription,
+                SubscriptionStatus.Unpaid,
+                SubscriptionStatus.Unpaid,
+                periodKey,
+                attemptNumber,
+                new SubscriptionTransition(SubscriptionStatus.Unpaid, SubscriptionStatus.Unpaid)
+                {
+                    DunningAttemptCount = attemptNumber,
+                    Event = _events.CreateRenewalOutcome(
+                        subscription,
+                        SubscriptionConstants.SubscriptionRenewalFailed,
+                        periodKey,
+                        attemptNumber,
+                        subscription.CorrelationId)
+                },
+                cancellationToken);
+
+            await AuditAsync(subscription, "StateApplied", "Failed", "recovery_charge_declined",
+                null, null, attemptNumber, cancellationToken);
+
+            return;
+        }
 
         if (subscription.Status != SubscriptionStatus.PastDue)
         {

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -9,6 +9,7 @@ using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 using XUnitTest.Payment;
 
@@ -547,6 +548,56 @@ public sealed class SubscriptionActivationProcessorTests
             });
 
     /// <summary>
+    /// A card confirmed for an Unpaid subscription triggers the recovery charge immediately.
+    /// </summary>
+    /// <remarks>
+    /// The card just adopted is the one thing an Unpaid subscription was missing, so this is the
+    /// moment recovery becomes possible -- not a moment later, and not left for a sweep that
+    /// (correctly) never looks at an Unpaid subscription on its own initiative.
+    /// </remarks>
+    [Fact]
+    public async Task A_card_confirmed_for_an_unpaid_subscription_triggers_recovery()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
+        GivenSubscription(subscription => subscription.Status = SubscriptionStatus.Unpaid);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _renewals.Verify(
+            service => service.RecoverAsync(
+                It.Is<SubscriptionDetail>(s => s.ItemId == "sub-1"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// A card confirmed for a Trialing subscription never triggers a charge.
+    /// </summary>
+    /// <remarks>
+    /// Saving a card mid-trial and recovering a lapsed one share the same adoption code, and only
+    /// one of them is meant to charge anything. Pinned because a mistake here would charge a
+    /// trial the moment it added a card, which is exactly what deferred trial charging exists to
+    /// prevent.
+    /// </remarks>
+    [Fact]
+    public async Task A_card_confirmed_mid_trial_does_not_trigger_a_charge()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
+        GivenSubscription(subscription => subscription.Status = SubscriptionStatus.Trialing);
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _renewals.Verify(
+            service => service.RecoverAsync(
+                It.IsAny<SubscriptionDetail>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// A card saved against a subscription that is already running is still adopted.
     /// </summary>
     /// <remarks>
@@ -703,6 +754,8 @@ public sealed class SubscriptionActivationProcessorTests
         _transition!.NewStatus.Should().Be(SubscriptionStatus.IncompleteExpired);
     }
 
+    private readonly Mock<ISubscriptionRenewalService> _renewals = new();
+
     private SubscriptionActivationProcessor Processor() => new(
         _links.Object,
         _subscriptions.Object,
@@ -712,7 +765,8 @@ public sealed class SubscriptionActivationProcessorTests
         _storedMethods.Object,
         new SubscriptionOptionsMonitorStub(new SubscriptionOptions()),
         NullLogger<SubscriptionActivationProcessor>.Instance,
-        _time);
+        _time,
+        renewals: _renewals.Object);
 
     private static SubscriptionDetail NewSubscription() => new()
     {

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -418,6 +418,38 @@ public sealed class SubscriptionCheckoutServiceTests
     }
 
     /// <summary>
+    /// An Unpaid subscription is answered as itself, not read as no subscription at all.
+    /// </summary>
+    /// <remarks>
+    /// Unpaid grants nothing, so GetLiveAsync never finds it -- but it is a subscription the caller
+    /// still has, and one they can still recover. Before this it fell all the way through to the
+    /// same empty answer a tenant with no subscription at all would get, leaving no way for a
+    /// client to offer the one thing that fixes it.
+    /// </remarks>
+    [Fact]
+    public async Task Current_reports_an_unpaid_subscription_rather_than_reading_it_as_none()
+    {
+        _subscription.Status = SubscriptionStatus.Unpaid;
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+        _subscriptions
+            .Setup(repository => repository.GetIncompleteAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail?)null);
+        _subscriptions
+            .Setup(repository => repository.GetUnpaidAsync(
+                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_subscription);
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Unpaid));
+    }
+
+    /// <summary>
     /// An organization with no subscription is answered, not refused.
     /// </summary>
     /// <remarks>
@@ -620,7 +652,6 @@ public sealed class SubscriptionCheckoutServiceTests
     [Theory]
     [InlineData(SubscriptionStatus.Canceled, "subscription_not_collectable")]
     [InlineData(SubscriptionStatus.IncompleteExpired, "subscription_not_collectable")]
-    [InlineData(SubscriptionStatus.Unpaid, "subscription_recovery_unavailable")]
     public async Task A_subscription_that_cannot_take_a_card_says_which_case_it_is(
         SubscriptionStatus status,
         string expectedCode)
@@ -634,6 +665,30 @@ public sealed class SubscriptionCheckoutServiceTests
         result.IsSuccess.Should().BeFalse();
         result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
         result.ErrorCode.Should().Be(expectedCode);
+    }
+
+    /// <summary>
+    /// Unpaid can open a card session, now that a card confirmed against it is actually acted on.
+    /// </summary>
+    /// <remarks>
+    /// This used to be refused with subscription_recovery_unavailable, and the refusal was correct
+    /// at the time: nothing charged the overdue period once a card arrived, so storing one would
+    /// have done nothing. SubscriptionActivationProcessor now charges it the moment the card is
+    /// adopted, through SubscriptionRenewalService.RecoverAsync, so the session this opens leads
+    /// somewhere.
+    /// </remarks>
+    [Fact]
+    public async Task An_unpaid_subscription_can_open_a_recovery_session()
+    {
+        _subscription.Status = SubscriptionStatus.Unpaid;
+        GivenSubscriptionById(_subscription);
+        GivenSetupSessionOpens();
+
+        var result = await Service().StartPaymentMethodSetupAsync(
+            _subscription.ItemId, OrganizationId, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PendingCheckout!.Purpose.Should().Be("PaymentMethodSetup");
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
@@ -536,6 +536,123 @@ public sealed class SubscriptionRenewalServiceTests
         charged.DiscountCombination.Should().BeNull();
     }
 
+    // ---- Recovering an Unpaid trial once a card is finally supplied --------------------------
+    //
+    // RecoverAsync exists for exactly one moment: a card confirmed against a subscription that
+    // already lost access for want of one. What is pinned below is what makes reusing RenewAsync
+    // safe for that moment rather than dangerous -- the anchor a late recovery prices against, and
+    // what a declined recovery attempt must not do.
+
+    private static SubscriptionDetail NewUnconvertedTrial(DateTime trialEndsAtUtc) => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Unpaid,
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+        Price = new PriceSnapshot { CurrencyCode = "CHF", UnitAmountMinor = 8_900 },
+        // Anniversary billing, not calendar-aligned -- the case that has no stub of its own and
+        // therefore no help from TryResolveTrialConversion's calendar-only branch. #353 anchors the
+        // schedule at the trial's own end, which is what a correct recovery has to reproduce even
+        // when it runs long after that instant.
+        FeeSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = trialEndsAtUtc,
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = trialEndsAtUtc.Day
+        },
+        Trial = new TrialTerms { EndsAtUtc = trialEndsAtUtc, RequiresPaymentMethod = false },
+        InitialChargeAmountMinor = null
+    };
+
+    [Fact]
+    public async Task Recovering_a_trial_that_lapsed_weeks_ago_still_charges_the_period_it_owes()
+    {
+        // The trial ended 1 January; the card arrives 20 February, seven weeks later. A recovery
+        // anchored on "now" would resolve whatever period February falls in and skip the one
+        // actually owed -- this is the trap #353 caught for the prompt case and this closes for the
+        // late one.
+        var trialEndsAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        _time.Advance(new DateTimeOffset(2026, 2, 20, 9, 0, 0, TimeSpan.Zero) - _time.GetUtcNow());
+        var subscription = NewUnconvertedTrial(trialEndsAtUtc);
+
+        await Service().RecoverAsync(subscription, CancellationToken.None);
+
+        _transition!.CurrentPeriodStartUtc.Should().Be(trialEndsAtUtc,
+            "the period owed is the one right after the trial, not whichever one 20 February falls in");
+        _transition.CurrentPeriodEndUtc.Should().Be(new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+        _charge!.AmountMinor.Should().Be(8_900, "a whole period at the quoted price, not a stub");
+    }
+
+    [Fact]
+    public async Task A_successful_recovery_moves_straight_to_active()
+    {
+        var subscription = NewUnconvertedTrial(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        await Service().RecoverAsync(subscription, CancellationToken.None);
+
+        _transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Unpaid);
+        _transition.NewStatus.Should().Be(SubscriptionStatus.Active);
+    }
+
+    [Fact]
+    public async Task A_declined_recovery_stays_unpaid_rather_than_reaching_pastdue()
+    {
+        // The trap: PastDue is a live status. ApplyFailureAsync's ordinary branch would have moved
+        // any non-PastDue subscription there on a decline, which for Unpaid means granting paid
+        // access to somebody whose card was just refused.
+        Decline();
+        var subscription = NewUnconvertedTrial(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        await Service().RecoverAsync(subscription, CancellationToken.None);
+
+        _transition!.ExpectedStatus.Should().Be(SubscriptionStatus.Unpaid);
+        _transition.NewStatus.Should().Be(SubscriptionStatus.Unpaid);
+        _transition.NewStatus.Should().NotBe(SubscriptionStatus.PastDue);
+    }
+
+    [Fact]
+    public async Task A_second_recovery_after_a_decline_is_not_replayed_as_the_first_ones_result()
+    {
+        // The attempt count is what the charge's idempotency key is derived from. Left unmoved by a
+        // declined recovery, a second attempt -- from a genuinely different card the subscriber
+        // supplied afterward -- would derive the identical key the first attempt used, and the
+        // gateway would hand back the stale decline instead of trying the new card at all.
+        Decline();
+        var subscription = NewUnconvertedTrial(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        await Service().RecoverAsync(subscription, CancellationToken.None);
+
+        _transition!.DunningAttemptCount.Should().Be(
+            1, "so the next attempt's idempotency key is not the one this decline already used");
+    }
+
+    [Fact]
+    public async Task RecoverAsync_refuses_a_subscription_that_is_not_unpaid()
+    {
+        // Called from exactly one place. Anything reaching this method for a live subscription is
+        // a caller mistake, and charging it through the wrong entry point is the failure mode this
+        // guard exists to rule out entirely rather than trust every future caller to avoid.
+        var subscription = NewSubscription(SubscriptionStatus.Active);
+
+        await Service().RecoverAsync(subscription, CancellationToken.None);
+
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private static SubscriptionDetail NewSubscription(SubscriptionStatus status) => new()
     {
         ItemId = "sub-1",


### PR DESCRIPTION
> **Diff scope:** based on `stacked-base/unpaid-trial-recovery`, a marker pushed at the exact point [#353](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/353) and [#358](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/358) combine — so this diff is only the new work, not theirs restated. **Merge order: #353 → #358 → this.** None of it is meaningful without both: #353 makes a trial free until it ends (so Unpaid-for-no-card exists at all), #358 gives a subscriber a way to add a card afterward.

Closes the last gap. A card confirmed against an `Unpaid` subscription now charges the overdue first period and, **only on success**, restores access. Before this, `RecoverAsync` did not exist — #358 explicitly refused `Unpaid` at the endpoint, correctly, because neither obvious way to wire it was safe yet.

## Two correctness fixes make reusing `RenewAsync` safe here

**1. The period and price are anchored on the trial's own end for *any* trial that never converted, not only a calendar-aligned one.**

The calendar branch already did this for its variable-length stub. An anniversary price has no stub — its first paid period is simply the whole period the schedule's own anchor sits at, which #353 set to the trial's end. Pricing from "now" is safe only while this runs *promptly*, and recovery by construction does not: the subscriber has to notice, come back, and add a card. Late enough, `TryGetPeriod` resolves whichever period "now" falls in and **silently skips the one actually owed**, pricing it at whatever is live today instead of what was quoted when the trial ended.

Verified by reverting the anchor: exactly `Recovering_a_trial_that_lapsed_weeks_ago_still_charges_the_period_it_owes` fails.

**2. A decline during `Unpaid` no longer reaches `PastDue`.**

`ApplyFailureAsync`'s existing branch moves any non-`PastDue` subscription there on a decline — correct for an ordinary renewal, and dangerous here: `PastDue` is a **live status**, so this would have restored paid access to somebody whose card was just refused. Recorded as failed, left `Unpaid`.

Its attempt count still advances, in its own `Unpaid → Unpaid` write — otherwise a second attempt from a genuinely different card (added after the first was declined) would derive the *identical* idempotency key the first attempt used, and the gateway would replay the stale decline instead of trying the new card.

Verified the same way: disabling either half fails exactly the test built for it.

## `RecoverAsync` refuses anything not already `Unpaid`

A thin, self-guarding wrapper around `RenewAsync`. Charging a subscription through the wrong entry point is the one mistake here that costs real money, so it's ruled out at the one place that can enforce it rather than trusted to every future caller.

## Wired at the exact moment a card is adopted

In `SubscriptionActivationProcessor`, for any setup confirmed against a non-`Incomplete` subscription: `Unpaid` triggers recovery, `Trialing` does not. The same adoption code point serves both "a card added mid-trial" and "a card recovering a lapsed trial," and only one of those is ever meant to charge anything. Verified both directions — the negative test guards against a mistake here charging a trial the moment it adds a card, which is exactly what #353 exists to prevent.

## Two things this corrects from earlier in the stack

- **#358's refusal is removed.** `subscription_recovery_unavailable` was correct when written and is now the wrong answer, since recovery exists.
- **`GET current` no longer reads `Unpaid` as "no subscription."** `GetLiveAsync` excludes `Unpaid` by design (it grants nothing), and the fallback chain stopped there — an `Unpaid` subscriber got the identical response as a tenant that never subscribed, with no way for a client to offer the fix. New `GetUnpaidAsync` repository method; `GetCurrentAsync` now returns it as itself.

## Verification

- `SubscriptionRenewalServiceTests`, `SubscriptionActivationProcessorTests`, `SubscriptionCheckoutServiceTests`: **78 passed**, including 5 new tests each individually confirmed to fail when its specific fix is reverted.
- Full non-integration suite on the stacked branch: **3264 passed**. Remaining failures are the pre-existing `SubscriptionSimulation*` permission guards and one `PeriodicPingBackgroundServiceTests` case confirmed load-flaky (passes alone, 20/20).

## Deliberately out of scope

No `UnpaidReason` field distinguishing "never had a card" from "dunning exhausted" — both currently read as `Status: "Unpaid"`, and the recovery mechanics are identical either way, so the client can use one CTA for both. Client-side UI states, snapshot fields on the recorded charge beyond what `ApplySuccessAsync` already writes, and documentation are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
