### PR TITLE
Fix flat-price unit amount on subscription invoices

### DIFF
--- a/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
@@ -1440,7 +1440,18 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
             ];
         }
 
-        if (terms.QuantityItems.Count == 0)
+        // Quantity items can describe capacity without pricing it. A flat-fee plan commonly carries
+        // a seat/user item for entitlement enforcement while the selected price has no
+        // QuantityItemKey; SubscriptionQuantityBuilder correctly snapshots that item's unit amount
+        // as zero. Treating its presence as proof of per-unit billing produced an invoice line at
+        // CHF 0.00 beside a non-zero subtotal. Only items that actually carry money belong in the
+        // financial line table. If none do, this is a flat-price plan regardless of its capacity
+        // metadata and the plan price is the unit price.
+        var pricedItems = terms.QuantityItems
+            .Where(item => item.UnitAmountMinor != 0)
+            .ToList();
+
+        if (pricedItems.Count == 0)
         {
             return
             [
@@ -1457,7 +1468,7 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
         // Per item, and the amounts are the undiscounted product of quantity and unit price —
         // discounts appear once, as their own figures, rather than being smeared across lines where
         // they would round differently and stop adding up.
-        return terms.QuantityItems
+        return pricedItems
             .Select(item => new FinancialDocumentLine
             {
                 Description = $"{terms.Subject.PlanName} — {item.UnitLabel}",

--- a/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
@@ -792,6 +792,35 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
     }
 
     [Fact]
+    public async Task A_flat_price_with_an_unpriced_capacity_item_prints_the_plan_unit_price()
+    {
+        // Capacity metadata is not a billed quantity. The production defect carried one user item
+        // at zero because the price had no QuantityItemKey, then rendered that zero beside the
+        // correctly charged flat subtotal.
+        Subscribed(subscription => subscription.QuantityItems =
+        [
+            new SubscriptionQuantityItem
+            {
+                ItemKey = "lawyer-seat",
+                UnitLabel = "Lawyer seat",
+                Quantity = 1,
+                UnitAmountMinor = 0
+            }
+        ]);
+        SettledRenewal();
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        var line = document!.Lines.Should().ContainSingle().Subject;
+        line.Description.Should().Be("Pro");
+        line.ItemKey.Should().BeNull();
+        line.Quantity.Should().Be(1);
+        line.UnitAmountMinor.Should().Be(100_000);
+        line.AmountMinor.Should().Be(document.Amounts.GrossSubtotalMinor);
+    }
+
+    [Fact]
     public async Task The_recorded_obligation_names_who_acted_even_if_they_are_since_unknown()
     {
         var subscription = Subscribed();


### PR DESCRIPTION
## Summary
- Render the authoritative flat plan price when quantity items are unpriced capacity metadata.
- Keep genuinely priced quantity-item invoice lines unchanged.
- Add a regression test for a flat-fee plan with an unpriced user-capacity item.

## Root cause
The issuer treated the presence of any quantity item as proof of per-item pricing. Flat-fee plans can carry zero-priced quantity items solely for capacity enforcement, so their invoice line showed CHF 0.00 even though the document totals correctly used the flat price.

## Verification
- SubscriptionFinancialDocumentIssuerTests: 36 passed, 0 failed.
- git diff --check clean.