### PR TITLE
feat(subscription): surface the three deferred-trial CTAs and fix the docs

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { SimulatedSubscription } from "../models/subscription-simulation.model";
+import { CurrentSubscriptionCard } from "./current-subscription-card";
+
+/**
+ * The three moments the deferred-trial spec asks for, and the one rule that governs all of
+ * them: a card session is never mistaken for a payment, and never offered twice at once.
+ */
+const baseSubscription: SimulatedSubscription = {
+  subscriptionId: "sub-1",
+  status: "Trialing",
+  planCode: "professional",
+  planName: "Professional",
+  currencyCode: "CHF",
+  unitAmountMinor: 8_900,
+  interval: "Month",
+  intervalCount: 1,
+  displayPriceNote: null,
+  quantities: [],
+  currentPeriodStartUtc: "2026-08-01T00:00:00Z",
+  currentPeriodEndUtc: "2026-09-01T00:00:00Z",
+  nextPaymentAtUtc: null,
+  trialEndsAtUtc: "2026-09-08T00:00:00Z",
+  cancelAtPeriodEnd: false,
+  canceledAtUtc: null,
+  pendingQuantityChange: null,
+  currentTier: null,
+  recurringAmountMinor: 8_900,
+  checkoutUrl: null,
+  pendingCheckout: null,
+  hasPaymentMethod: null,
+  version: 1,
+};
+
+const noop = () => undefined;
+
+const renderCard = (subscription: SimulatedSubscription) =>
+  render(
+    <CurrentSubscriptionCard
+      subscription={subscription}
+      isLoading={false}
+      isError={false}
+      error={null}
+      scopeLabel="Acme"
+      onRetry={noop}
+      onCancel={noop}
+      onChangePlan={noop}
+      onChangeQuantity={noop}
+      onCancelPendingQuantityChange={noop}
+      isCancelingPendingQuantityChange={false}
+      onViewAuditTrail={noop}
+      onAddPaymentMethod={noop}
+      isStartingPaymentMethodSetup={false}
+    />,
+  );
+
+describe("CurrentSubscriptionCard payment-method actions", () => {
+  it("offers to add a payment method during a card-free trial that has none", () => {
+    renderCard({ ...baseSubscription, status: "Trialing", hasPaymentMethod: false });
+
+    expect(screen.getByRole("button", { name: /add payment method/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /complete card setup/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /continue subscription/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers nothing once a card is already on file", () => {
+    // The case status alone cannot tell apart from the one above: a card-required trial that
+    // already collected one, or a card-free trial where the subscriber added one voluntarily.
+    renderCard({ ...baseSubscription, status: "Trialing", hasPaymentMethod: true });
+
+    expect(
+      screen.queryByRole("button", { name: /add payment method/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still offers to cancel an unpaid subscription, not only to recover it", () => {
+    // The server has always allowed cancelling anything short of Canceled/IncompleteExpired.
+    // Unpaid was simply never returned by GetCurrentAsync before #360, so this had no chance to
+    // matter until the card started showing Unpaid subscriptions at all.
+    renderCard({ ...baseSubscription, status: "Unpaid", hasPaymentMethod: false });
+
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeInTheDocument();
+  });
+
+  it("offers to recover an unpaid subscription by adding a card", () => {
+    renderCard({ ...baseSubscription, status: "Unpaid", hasPaymentMethod: false });
+
+    expect(
+      screen.getByRole("button", { name: /add card and continue subscription/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^add payment method$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("surfaces an open card session instead of offering to start a second one", () => {
+    // Whichever of the three cases opened it -- the session already open always wins, so a
+    // subscriber part-way through Stripe sees where to finish rather than a button that would
+    // open a competing one.
+    renderCard({
+      ...baseSubscription,
+      status: "Unpaid",
+      hasPaymentMethod: false,
+      pendingCheckout: {
+        purpose: "PaymentMethodSetup",
+        state: "Pending",
+        errorCode: null,
+        checkoutUrl: "https://checkout.stripe.com/setup-1",
+      },
+    });
+
+    const link = screen.getByRole("link", { name: /complete card setup/i });
+    expect(link).toHaveAttribute("href", "https://checkout.stripe.com/setup-1");
+    expect(
+      screen.queryByRole("button", { name: /add card and continue subscription/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the incomplete card-required trial's own setup session the same way", () => {
+    renderCard({
+      ...baseSubscription,
+      status: "Incomplete",
+      hasPaymentMethod: null,
+      pendingCheckout: {
+        purpose: "PaymentMethodSetup",
+        state: "Pending",
+        errorCode: null,
+        checkoutUrl: "https://checkout.stripe.com/setup-2",
+      },
+    });
+
+    expect(screen.getByRole("link", { name: /complete card setup/i })).toHaveAttribute(
+      "href",
+      "https://checkout.stripe.com/setup-2",
+    );
+  });
+
+  it("calls the handler rather than navigating directly, so the caller controls the request", () => {
+    const onAddPaymentMethod = vi.fn();
+
+    render(
+      <CurrentSubscriptionCard
+        subscription={{ ...baseSubscription, status: "Trialing", hasPaymentMethod: false }}
+        isLoading={false}
+        isError={false}
+        error={null}
+        scopeLabel="Acme"
+        onRetry={noop}
+        onCancel={noop}
+        onChangePlan={noop}
+        onChangeQuantity={noop}
+        onCancelPendingQuantityChange={noop}
+        isCancelingPendingQuantityChange={false}
+        onViewAuditTrail={noop}
+        onAddPaymentMethod={onAddPaymentMethod}
+        isStartingPaymentMethodSetup={false}
+      />,
+    );
+
+    screen.getByRole("button", { name: /add payment method/i }).click();
+
+    expect(onAddPaymentMethod).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the action while a setup session is being opened", () => {
+    render(
+      <CurrentSubscriptionCard
+        subscription={{ ...baseSubscription, status: "Unpaid", hasPaymentMethod: false }}
+        isLoading={false}
+        isError={false}
+        error={null}
+        scopeLabel="Acme"
+        onRetry={noop}
+        onCancel={noop}
+        onChangePlan={noop}
+        onChangeQuantity={noop}
+        onCancelPendingQuantityChange={noop}
+        isCancelingPendingQuantityChange={false}
+        onViewAuditTrail={noop}
+        onAddPaymentMethod={noop}
+        isStartingPaymentMethodSetup
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /add card and continue subscription/i }),
+    ).toBeDisabled();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, CalendarClock, ExternalLink, History, Inbox } from "lucide-react";
+import { AlertCircle, CalendarClock, CreditCard, ExternalLink, History, Inbox } from "lucide-react";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
@@ -23,7 +23,11 @@ const describeTier = (tier: QuantityDiscountTier) => {
     : `${range} band \u00b7 no discount`;
 };
 
-const CANCELABLE_STATUSES = new Set(["Incomplete", "Trialing", "Active", "PastDue"]);
+// Unpaid included since #360 made it visible here at all -- before then it was never returned by
+// GetCurrentAsync, so this set only had to name the statuses that were ever reachable on screen.
+// The server has always accepted cancelling Unpaid (anything short of Canceled/IncompleteExpired);
+// a subscriber offered nothing but "recover" here had no way to walk away instead.
+const CANCELABLE_STATUSES = new Set(["Incomplete", "Trialing", "Active", "PastDue", "Unpaid"]);
 // Incomplete has not paid yet, so it is not eligible to change plan — the doc has you continue
 // or cancel that checkout instead.
 const CHANGEABLE_STATUSES = new Set(["Trialing", "Active", "PastDue"]);
@@ -41,6 +45,8 @@ export const CurrentSubscriptionCard = ({
   onCancelPendingQuantityChange,
   isCancelingPendingQuantityChange,
   onViewAuditTrail,
+  onAddPaymentMethod,
+  isStartingPaymentMethodSetup,
 }: {
   subscription: SimulatedSubscription | null | undefined;
   isLoading: boolean;
@@ -54,6 +60,9 @@ export const CurrentSubscriptionCard = ({
   onCancelPendingQuantityChange: () => void;
   isCancelingPendingQuantityChange: boolean;
   onViewAuditTrail: () => void;
+  /** Opens a card-collection session. Never a payment -- see the button labels below. */
+  onAddPaymentMethod: () => void;
+  isStartingPaymentMethodSetup: boolean;
 }) => {
   if (isLoading) {
     return <Skeleton className="h-28 w-full rounded-xl" />;
@@ -88,6 +97,23 @@ export const CurrentSubscriptionCard = ({
     );
   }
 
+  // A session already open -- from any of the three cases below -- always wins over starting a
+  // new one, so a subscriber part-way through Stripe sees where to finish it rather than a button
+  // that would open a second, competing session.
+  const pendingSetupUrl = subscription.pendingCheckout?.checkoutUrl ?? null;
+
+  // Card-free trial that has not added one yet. hasPaymentMethod is read from the account, not
+  // guessed from the status: a card-required trial reaching Trialing already collected one, and a
+  // card-free trial may have added one voluntarily, so status alone cannot say whether this is
+  // still owed.
+  const canAddPaymentMethod =
+    !pendingSetupUrl &&
+    subscription.status === "Trialing" &&
+    subscription.hasPaymentMethod === false;
+
+  // Lost paid access for want of a card, and this is the one thing that gets it back.
+  const canRecover = !pendingSetupUrl && subscription.status === "Unpaid";
+
   return (
     <Card className="rounded-xl p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -119,6 +145,38 @@ export const CurrentSubscriptionCard = ({
                 Continue checkout
                 <ExternalLink className="ml-2 h-3.5 w-3.5" />
               </a>
+            </Button>
+          )}
+          {/*
+            A card session, never a payment -- distinct from "Continue checkout" above, which is
+            money. Three different moments land on the same button: an incomplete card-required
+            trial's own signup session resuming, and a session either of the two calls below just
+            opened.
+          */}
+          {pendingSetupUrl && (
+            <Button size="sm" asChild>
+              <a href={pendingSetupUrl} target="_blank" rel="noreferrer">
+                <CreditCard className="mr-2 h-3.5 w-3.5" />
+                Complete card setup
+                <ExternalLink className="ml-2 h-3.5 w-3.5" />
+              </a>
+            </Button>
+          )}
+          {canAddPaymentMethod && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onAddPaymentMethod}
+              disabled={isStartingPaymentMethodSetup}
+            >
+              <CreditCard className="mr-2 h-3.5 w-3.5" />
+              Add payment method
+            </Button>
+          )}
+          {canRecover && (
+            <Button size="sm" onClick={onAddPaymentMethod} disabled={isStartingPaymentMethodSetup}>
+              <CreditCard className="mr-2 h-3.5 w-3.5" />
+              Add card and continue subscription
             </Button>
           )}
           {CHANGEABLE_STATUSES.has(subscription.status) && subscription.quantities.length > 0 && (

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-start-payment-method-setup.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-start-payment-method-setup.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/**
+ * Opens a card-collection session against an existing subscription and hands back the checkout
+ * URL to send the subscriber to.
+ *
+ * Not a payment. Nothing here charges anything or produces an invoice -- it stores a card, and
+ * what happens next (nothing, for a trial in progress; an immediate charge, for a recovering
+ * Unpaid subscription) is decided server-side by the subscription's own status once the provider
+ * confirms the setup, not by this call.
+ */
+export const useStartPaymentMethodSetup = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      organizationId,
+    }: {
+      subscriptionId: string;
+      organizationId?: string;
+    }) => subscriptionSimulationService.startPaymentMethodSetup(subscriptionId, organizationId),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -70,6 +70,13 @@ export interface SimulatedSubscription {
     errorCode: string | null;
     checkoutUrl: string | null;
   } | null;
+  /**
+   * Whether a card is already on file, where the server actually checked -- undefined everywhere
+   * it did not. `GET current` is the one place this is populated: a Trialing subscription whose
+   * trial never demanded a card may have one anyway (added voluntarily) or may still need the
+   * "Add payment method" action, and status alone cannot tell those two apart.
+   */
+  hasPaymentMethod?: boolean | null;
   version: number;
 }
 

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -30,6 +30,7 @@ import { ChangeQuantityDialog } from "../components/change-quantity-dialog";
 import { CloseUsagePeriodDialog } from "../components/close-usage-period-dialog";
 import { DataConsoleDialog } from "../components/data-console-dialog";
 import { useCancelPendingQuantityChange } from "../hooks/use-quantity-change";
+import { useStartPaymentMethodSetup } from "../hooks/use-start-payment-method-setup";
 import { CurrentSubscriptionCard } from "../components/current-subscription-card";
 import { PaymentOutcomeDialog } from "../components/payment-outcome-dialog";
 import { RunDueJobsDialog } from "../components/run-due-jobs-dialog";
@@ -115,6 +116,40 @@ export const SubscriptionSimulationPage = () => {
   };
 
   const cancelPendingQuantity = useCancelPendingQuantityChange();
+  const startPaymentMethodSetup = useStartPaymentMethodSetup();
+
+  /**
+   * Stores a card against the subscription that already exists -- never a payment, whichever of
+   * the three cases the card is offering it for. The session opened is surfaced by the card
+   * re-rendering `pendingCheckout` once this invalidates the query, the same way a fresh signup's
+   * own checkout URL already appears.
+   */
+  const addPaymentMethod = async () => {
+    if (!currentSubscription) {
+      return;
+    }
+
+    try {
+      await startPaymentMethodSetup.mutateAsync({
+        subscriptionId: currentSubscription.subscriptionId,
+        organizationId: organizationScope,
+      });
+
+      toast({
+        title: "Card setup ready",
+        description:
+          "Open the checkout link from the current subscription card above. No charge has " +
+          "been made.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "The card could not be added",
+        description:
+          error instanceof Error ? error.message : "Reload and try again.",
+      });
+    }
+  };
 
   /**
    * Withdraws a scheduled reduction. Reported as a toast rather than inline, because the control
@@ -212,6 +247,8 @@ export const SubscriptionSimulationPage = () => {
             onCancelPendingQuantityChange={withdrawScheduledQuantityChange}
             isCancelingPendingQuantityChange={cancelPendingQuantity.isPending}
             onViewAuditTrail={() => setIsViewingAuditTrail(true)}
+            onAddPaymentMethod={addPaymentMethod}
+            isStartingPaymentMethodSetup={startPaymentMethodSetup.isPending}
           />
         </div>
       </Card>

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -159,6 +159,39 @@ class SubscriptionSimulationService {
     }
   }
 
+  /**
+   * Opens a hosted session that stores a card against a subscription that already exists --
+   * never a payment. Works during a card-free trial (adding one voluntarily), an incomplete
+   * card-required trial (resuming or retrying its own setup), and an Unpaid subscription
+   * (recovering it): the server tells these apart by the subscription's own status, and this
+   * call is the same for all three.
+   */
+  async startPaymentMethodSetup(
+    subscriptionId: string,
+    organizationId?: string,
+  ): Promise<SimulatedSubscription> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+
+    try {
+      const response = await serviceInstances.utitlitiesService.post<
+        SimulationApiResponse<SimulatedSubscription>
+      >(
+        `${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/payment-method/setup${query}`,
+        {},
+      );
+
+      if (!response.success || !response.data) {
+        throw operationError(response, "The payment method could not be set up.");
+      }
+
+      return response.data;
+    } catch (error) {
+      throw operationError(error, "The payment method could not be set up.");
+    }
+  }
+
   async cancel(request: CancelSubscriptionRequest): Promise<SimulatedSubscription> {
     const query = new URLSearchParams();
     query.set("immediately", String(request.immediately));

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -968,12 +968,15 @@
         a later signup sees the new rule.
       </p>
       <div class="callout">
-        <strong>A card-free trial's first paid cycle is anchored on <code>trialEndsAtUtc</code>,
-        whichever kind produced it.</strong> A 25 August signup on a one-month anniversary trial is
-        first charged 25 September; the same signup on an end-of-month trial is first charged 1
-        September. A calendar-aligned price still renews on its own calendar boundaries — the trial
-        only decides <em>when</em> the first charge happens, charging the stub up to the next
-        boundary and renewing normally from there.
+        <strong>Every trial's first paid cycle is anchored on <code>trialEndsAtUtc</code>,
+        whichever kind produced it — whether or not the trial required a card.</strong> A 25
+        August signup on a one-month anniversary trial is first charged 25 September; the same
+        signup on an end-of-month trial is first charged 1 September. A calendar-aligned price
+        still renews on its own calendar boundaries — the trial only decides <em>when</em> the
+        first charge happens, charging the stub up to the next boundary and renewing normally
+        from there. See <a href="#branches">§2</a>: a trial with <code>trialRequiresPaymentMethod:
+        true</code> collects a card at signup and is not charged for it — the first money moves
+        here, at the trial's end, exactly as a card-free trial's does.
       </div>
       <p>
         <strong>A trial grant replaces a meter's allowance
@@ -1317,25 +1320,27 @@ stateDiagram-v2
 
       <h3>2 · Card required, or genuinely free</h3>
       <p>
-        When there <em>is</em> something to charge, <code>trialRequiresPaymentMethod: true</code>
-        charges the first period at signup and the trial then governs the allowances rather than
-        the price. With <code>false</code> the trial is free and the response carries
-        <strong>no <code>checkoutUrl</code></strong>.
+        A trial is never charged at signup, whichever way <code>trialRequiresPaymentMethod</code>
+        is set. What it decides is whether a card is <em>collected</em> before the trial starts —
+        collecting one is not the same act as charging for a period, and the two used to be
+        conflated because the money path once had no way to hold a card without taking money with
+        it. It does now: a card-setup checkout stores one and charges nothing.
       </p>
       <p>
-        When the opening amount is <strong>zero</strong> — a free plan, a fully discounted first
-        period, a card-free trial — a card can still be required, and collecting one is no longer
-        the same thing as charging for a period. Either
+        The opening amount is what actually decides whether the subscriber sees a payment
+        checkout or a card-only one. It is <strong>always zero</strong> for a trial — that is what
+        makes it a trial — and can also be zero outside one, for a free plan or a fully discounted
+        first period. A card can still be required in that zero case: either
         <code>requirePaymentMethodUpfront: true</code> on the plan or a trial with
-        <code>trialRequiresPaymentMethod: true</code> is enough:
+        <code>trialRequiresPaymentMethod: true</code> is enough.
       </p>
       <div class="table-wrap">
         <table>
           <thead><tr><th>Opening amount</th><th>Card required</th><th>What the subscriber gets</th></tr></thead>
           <tbody>
-            <tr><td>&gt; 0</td><td class="type">—</td><td class="prose">A payment checkout. <code>Incomplete</code> until the charge is confirmed.</td></tr>
+            <tr><td>&gt; 0</td><td class="type">—</td><td class="prose">A payment checkout. <code>Incomplete</code> until the charge is confirmed. Never a trial — see above.</td></tr>
             <tr><td>0</td><td class="type">no</td><td class="prose">Nothing to visit. <code>Active</code> (or <code>Trialing</code>) immediately, <code>checkoutUrl: null</code>.</td></tr>
-            <tr><td>0</td><td class="type">yes</td><td class="prose">A <strong>card-setup</strong> checkout. <code>Incomplete</code> with a <code>checkoutUrl</code> until the card is stored.</td></tr>
+            <tr><td>0</td><td class="type">yes</td><td class="prose">A <strong>card-setup</strong> checkout. <code>Incomplete</code> with a <code>checkoutUrl</code> until the card is stored — then <code>Active</code> or <code>Trialing</code>.</td></tr>
           </tbody>
         </table>
       </div>
@@ -1346,6 +1351,19 @@ stateDiagram-v2
         not from the card. Access is granted only once the provider confirms the card was stored,
         which is the same rule a paid signup follows and for the same reason: a browser returning
         from a redirect is not evidence.
+      </p>
+      <p class="prose">
+        A trial's first paid period is always charged when the trial ends, whichever way
+        <code>trialRequiresPaymentMethod</code> was set — see the <a href="#trial">Trial</a>
+        callout. A card-required trial that has one on file is charged automatically. A card-free
+        trial with none on file at that moment loses access instead: it moves to
+        <code>Unpaid</code>, and stays there until a card is supplied through
+        <a href="#api-setup"><code>POST .../payment-method/setup</code></a> — the same endpoint
+        that lets a subscriber add a card to <em>any</em> running subscription voluntarily,
+        mid-trial, before the deadline forces the question. Supplying one during
+        <code>Unpaid</code> charges the overdue period immediately and restores access only if
+        that charge succeeds; a decline leaves the subscription exactly where it was, open to
+        another attempt.
       </p>
       <p>
         The response looks exactly like a paid one:
@@ -2437,7 +2455,10 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <code>status: "Incomplete"</code> and the still-valid <code>checkoutUrl</code> when one
             is available. For card-only setup, <code>pendingCheckout</code> distinguishes
             <code>Pending</code>, <code>Failed</code>, and <code>Expired</code>; only Pending carries
-            a usable URL. It does not return <code>Unpaid</code> or ended subscriptions.
+            a usable URL. An <code>Unpaid</code> subscription is also returned — it grants nothing,
+            but it is still there and still recoverable, and this is how a client finds out to offer
+            that rather than reading it as no subscription at all. It does not return ended
+            subscriptions.
           </p>
           <p class="prose">
             <code>quantities</code> is what the subscriber holds and is paying for now.
@@ -2447,6 +2468,16 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <code>recurringAmountMinor</code> is what the next renewal costs at the quantity, band and
             discount in force, and <code>currentTier</code> the band it selects; take both from here
             rather than multiplying <code>unitAmountMinor</code> in the browser.
+          </p>
+          <p class="prose">
+            <code>hasPaymentMethod</code> is read from the account, not guessed from
+            <code>status</code>: a card-required trial reaching <code>Trialing</code> already
+            collected one, and a card-free trial may have added one voluntarily through
+            <a href="#api-setup"><code>POST .../payment-method/setup</code></a> — status alone
+            cannot tell either apart from a trial that still needs the prompt. <code>null</code>
+            means it was not applicable to check, which does not happen for a subscription this
+            endpoint actually returns; treat it as <code>false</code> only where it is genuinely
+            not <code>true</code>.
           </p>
           <h4>Query</h4>
           <p>
@@ -2480,6 +2511,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
     "recurringAmountMinor": 300,
     "checkoutUrl": null,
     "pendingCheckout": null,
+    "hasPaymentMethod": true,
     "version": 2
   },
   "error": null,
@@ -2517,6 +2549,74 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
               about something absent.
             </p>
           </div>
+        </div>
+      </div>
+
+      <div class="endpoint" id="api-setup">
+        <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscriptions/{subscriptionId}/payment-method/setup</span></div>
+        <div class="endpoint-body">
+          <p>
+            Stores a card against a subscription that already exists. <strong>Not a payment</strong>
+            — the same rule as the card-setup checkout at signup (see <a href="#branches">§2</a>):
+            nothing is charged, no payment or invoice is produced by this call itself, and it
+            appears in neither payment nor invoice history.
+          </p>
+          <p class="prose">
+            Three moments land on this one endpoint, told apart by the subscription's own status
+            rather than by anything the caller sends:
+          </p>
+          <div class="table-wrap">
+            <table>
+              <thead><tr><th>Status</th><th>What supplying a card does</th></tr></thead>
+              <tbody>
+                <tr><td><code>Trialing</code></td><td class="prose">Stores it. Does not end the trial, shorten it, or charge anything — the trial runs exactly as it would have. Refused with <code>payment_method_already_stored</code> if one is already on file.</td></tr>
+                <tr><td><code>Incomplete</code> (card-required trial's own setup)</td><td class="prose">Returns the same pending session rather than opening a second one, or opens a fresh one if the last has expired.</td></tr>
+                <tr><td><code>Unpaid</code></td><td class="prose">Stores it, then charges the overdue first period immediately. Access is restored only if that charge succeeds — a decline leaves the subscription exactly <code>Unpaid</code>, open to another attempt, never granted early.</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="prose">
+            <code>Canceled</code> and <code>IncompleteExpired</code> are refused with
+            <code>subscription_not_collectable</code> — there is nothing left for a card to pay
+            for.
+          </p>
+          <h4>Query</h4>
+          <p>
+            <code>organizationId</code> is optional, following the same rule as
+            <a href="#api-current"><code>GET .../current</code></a>: ordinary callers always
+            resolve to their own organization, and only the platform console may name another.
+          </p>
+          <h4>Sample response</h4>
+          <pre><code>{
+  "success": true,
+  "data": {
+    "subscriptionId": "97b6de84-…",
+    "status": "Trialing",
+    "checkoutUrl": null,
+    "pendingCheckout": {
+      "purpose": "PaymentMethodSetup",
+      "state": "Pending",
+      "errorCode": null,
+      "checkoutUrl": "https://checkout.stripe.com/…"
+    }
+  },
+  "error": null,
+  "meta": { "correlationId": "0HN…", "timestampUtc": "…", "replayed": false }
+}</code></pre>
+          <p class="prose">
+            The subscription's status does not change here — it is <code>Trialing</code> before
+            this call and <code>Trialing</code> in the response above. What changed is
+            <code>pendingCheckout</code>, exactly the shape the signup-time card setup uses.
+            <code>GET .../current</code> keeps returning a usable <code>checkoutUrl</code> from it
+            until the session is finished, expires, or is abandoned for a fresh one.
+          </p>
+          <h4>Returns</h4>
+          <p>
+            <code>200</code> · <code>404</code> not found, or not the caller's ·
+            <code>409</code> <code>subscription_not_collectable</code> ended ·
+            <code>409</code> <code>payment_method_already_stored</code> ·
+            <code>401</code> unauthenticated.
+          </p>
         </div>
       </div>
 

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -178,6 +178,20 @@ public sealed class SubscriptionResponse
     /// <summary>The non-financial checkout that must finish before access is granted.</summary>
     public PendingCheckoutResponse? PendingCheckout { get; init; }
 
+    /// <summary>
+    /// Whether a payment method is already on file, where that was actually checked -- null
+    /// everywhere it was not.
+    /// </summary>
+    /// <remarks>
+    /// Populated by <c>GET /subscriptions/current</c>, the one place a client has to decide
+    /// whether to offer adding a card at all: a Trialing subscription whose trial never demanded
+    /// one may already have a card if the subscriber added one voluntarily, or may still need
+    /// this call's own CTA. Status alone cannot tell those apart, and null rather than false
+    /// elsewhere is deliberate -- a bare <c>bool</c> defaulting to false would read as "no card"
+    /// on a response that never checked, which is a wrong answer wearing a right one's shape.
+    /// </remarks>
+    public bool? HasPaymentMethod { get; init; }
+
     public int Version { get; init; }
 }
 

--- a/server/Subscription.DomainService/Services/ISubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionResponseMapper.cs
@@ -8,5 +8,6 @@ public interface ISubscriptionResponseMapper
     SubscriptionResponse ToResponse(
         SubscriptionDetail subscription,
         string? checkoutUrl = null,
-        PendingCheckoutResponse? pendingCheckout = null);
+        PendingCheckoutResponse? pendingCheckout = null,
+        bool? hasPaymentMethod = null);
 }

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -387,7 +387,10 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         if (subscription is not null)
         {
             return SubscriptionOperationResult<SubscriptionResponse>.Success(
-                _mapper.ToResponse(subscription),
+                _mapper.ToResponse(
+                    subscription,
+                    hasPaymentMethod: await HasStoredPaymentMethodAsync(
+                        context.TenantId, subscription.BillingAccountId, cancellationToken)),
                 correlationId);
         }
 
@@ -426,8 +429,15 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
 
         if (subscription is not null)
         {
+            // Computed rather than assumed false. Unpaid ordinarily has no card by definition, but
+            // a card adopted moments ago by RecoverAsync's own transition can be visible here
+            // before that transition's status write has -- reading it for real means this can
+            // never claim "no card" about a subscription that already has one.
             return SubscriptionOperationResult<SubscriptionResponse>.Success(
-                _mapper.ToResponse(subscription),
+                _mapper.ToResponse(
+                    subscription,
+                    hasPaymentMethod: await HasStoredPaymentMethodAsync(
+                        context.TenantId, subscription.BillingAccountId, cancellationToken)),
                 correlationId);
         }
 
@@ -454,6 +464,17 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     /// </para>
     /// </remarks>
     private static bool RequiresPayment(long amountMinor) => amountMinor > 0;
+
+    /// <summary>Whether a card is actually stored, read from the account rather than assumed.</summary>
+    private async Task<bool> HasStoredPaymentMethodAsync(
+        string tenantId,
+        string billingAccountId,
+        CancellationToken cancellationToken)
+    {
+        var account = await _billingAccounts.GetAsync(tenantId, billingAccountId, cancellationToken);
+
+        return account?.DefaultPaymentMethodId is { Length: > 0 };
+    }
 
     /// <inheritdoc />
     public async Task<SubscriptionOperationResult<SubscriptionResponse>> StartPaymentMethodSetupAsync(

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -14,7 +14,8 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
     public SubscriptionResponse ToResponse(
         SubscriptionDetail subscription,
         string? checkoutUrl = null,
-        PendingCheckoutResponse? pendingCheckout = null)
+        PendingCheckoutResponse? pendingCheckout = null,
+        bool? hasPaymentMethod = null)
     {
         ArgumentNullException.ThrowIfNull(subscription);
 
@@ -103,6 +104,7 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
                 : null,
             CheckoutUrl = checkoutUrl,
             PendingCheckout = pendingCheckout,
+            HasPaymentMethod = hasPaymentMethod,
             Version = subscription.Version
         };
     }

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -418,6 +418,36 @@ public sealed class SubscriptionCheckoutServiceTests
     }
 
     /// <summary>
+    /// Whether a card is on file is answered for real, not assumed from the status.
+    /// </summary>
+    /// <remarks>
+    /// A card-required trial reaching Trialing already has one -- collecting it is the only way
+    /// there. A card-free trial that added one voluntarily also does. Status alone cannot tell
+    /// either apart from a trial that still needs the CTA, so this is read from the account.
+    /// </remarks>
+    [Theory]
+    [InlineData("method-1", true)]
+    [InlineData(null, false)]
+    public async Task Current_reports_whether_a_card_is_actually_on_file(
+        string? storedMethodId, bool expected)
+    {
+        _subscription.Status = SubscriptionStatus.Trialing;
+        _subscription.BillingAccountId = "acct-1";
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_subscription);
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, "acct-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount { DefaultPaymentMethodId = storedMethodId });
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.Value!.HasPaymentMethod.Should().Be(expected);
+    }
+
+    /// <summary>
     /// An Unpaid subscription is answered as itself, not read as no subscription at all.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
> **Diff scope:** based on [#360](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/360)'s head, so this shows only the new work. **Merge order: #353 → #358 → #360 → this.**

Client and documentation piece of the deferred-trial spec. Closes out the four remaining items: the three subscriber-page CTAs, and the docs `#353`/`#360` made false.

## There is no end-customer subscriber portal in this repo

Worth stating before the diff, because it shapes it. Everything under `client/app` touching subscriptions is either plan/discount/profile **authoring**, or `subscription-simulation` — a QA console, gated behind its own permission, that is the *only* surface in this codebase actually driving a real subscription end to end (create, checkout, cancel, change plan). That console is where these CTAs are implemented. If a production subscriber portal exists, it's outside this repository — I confirmed this by searching every route and directory rather than assuming.

## Three CTAs, one precedence rule

1. **A card session already open always wins** — `pendingCheckout.checkoutUrl` renders "Complete card setup" linking to it. Covers an incomplete card-required trial's own signup session *and* a session either action below just opened — a subscriber mid-Stripe sees where to finish, never a button that would open a competing session.
2. **`Unpaid`** → "Add card and continue subscription".
3. **`Trialing` with no card on file** → "Add payment method".

## Case 3 needed a field that didn't exist

Status alone can't say whether a `Trialing` subscription already has a card: a card-required trial reaching `Trialing` collected one to get there; a card-free trial may have added one voluntarily through the same endpoint. Neither is distinguishable from "still needs the CTA" without asking the billing account.

New `SubscriptionResponse.HasPaymentMethod` — **`bool?`, not `bool`**. Nullable deliberately: a bare `false` populated everywhere would be misread as "definitely no card" on responses (a cancellation, a plan change) that never checked it. Populated only by `GET current`, the one place the client needs it, read from the account rather than inferred from status.

## Also fixed, found while building this

**`CANCELABLE_STATUSES` never included `Unpaid`.** The server has always allowed cancelling anything short of `Canceled`/`IncompleteExpired` — `Unpaid` simply couldn't appear on this card before #360 made `GetCurrentAsync` return it, so the gap had no way to matter until now. A subscriber offered nothing but "recover" had no way to walk away instead.

## Documentation

The integration guide's Branches section stated the pre-#353 model as current fact:

> "`trialRequiresPaymentMethod: true` charges the first period at signup and the trial then governs the allowances rather than the price."

False since #353. Its opening-amount table had no row for what a card-required trial actually produces now (a card-setup checkout at zero, not a payment checkout). Rewritten, along with:

- The Trial section's callout — was card-free-trial-only, is now every trial.
- `GET current`'s doc — claimed *"It does not return `Unpaid`"*, which #360 changed; added `hasPaymentMethod` to the sample response and its own explanation.
- A new reference block for `POST .../payment-method/setup`, which had no documentation at all since the endpoint is new in #358.

## Verification

- Full server suite: **3267 passed** — the 4 `SubscriptionSimulation*` permission-guard failures confirmed pre-existing.
- Full client suite: **2342 passed, 324 files, zero failures** — including `create-payment-provider-page`, which failed transiently under load in an earlier run of this same session and was confirmed clean both alone and in this full run.
- 8 new `current-subscription-card` tests (all three CTAs, precedence, the disabled state, the handler contract, the restored cancel option) and 2 `HasPaymentMethod` tests, written against the real implementation and run, not inspected.
- Doc HTML verified structurally: every new anchor resolves, `<div>` tags balance (167/167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
