### PR TITLE
Report the correct renewal date for prepaid annual terms

### DIFF
--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2599,6 +2599,14 @@ POST /api/subscriptions
             number.
           </p>
           <p class="prose">
+            <code>nextRenewalAtUtc</code> is the next date money is due, not merely the next
+            internal period boundary. For a calendar-aligned yearly price collected up front, a
+            mid-month signup buys both the opening stub and the full year: the first of the next
+            month opens that already-paid year, while <code>nextRenewalAtUtc</code> is one year
+            later. When the annual amount is configured for collection at the boundary instead,
+            the first of the next month remains the next renewal date.
+          </p>
+          <p class="prose">
             <code>quoteValidUntilUtc</code> is the earliest instant this quote's proration could
             no longer hold — the next local midnight in the request's own <code>timeZoneId</code>,
             since a day fraction is the only figure here that moves with the clock. It is

--- a/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
@@ -49,8 +49,9 @@ public sealed class SubscriptionPreviewResponse
     public DateTime PeriodEndUtc { get; init; }
 
     /// <summary>
-    /// When the next charge falls — the trial's end for a card-free trial, otherwise this
-    /// period's own end.
+    /// When the next charge falls — the trial's end for a card-free trial, the end of an annual
+    /// term collected with checkout, otherwise this period's own end. A boundary that merely opens
+    /// an already-paid annual term is deliberately not reported as a renewal.
     /// </summary>
     public DateTime? NextRenewalAtUtc { get; init; }
 

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -1202,7 +1202,13 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
             TotalDays = subscription.ProrationTotalDays,
             PeriodStartUtc = subscription.CurrentPeriodStartUtc,
             PeriodEndUtc = subscription.CurrentPeriodEndUtc,
-            NextRenewalAtUtc = subscription.NextFeeBillingAtUtc,
+            // The first is still a worker boundary: it opens the annual period after the stub.
+            // It is not a renewal when that year is included in the checkout total. Exposing the
+            // internal boundary as money due would tell the buyer that the year just paid for is
+            // charged again on the day it starts.
+            NextRenewalAtUtc = annualBundled
+                ? annual!.EndUtc
+                : subscription.NextFeeBillingAtUtc,
             // The same call SubscriptionResponseMapper uses for an existing subscription's
             // RecurringAmountMinor, so a quote and a live subscription describe a renewal
             // identically.

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -50,7 +50,12 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
                 .ToList(),
             CurrentPeriodStartUtc = subscription.CurrentPeriodStartUtc,
             CurrentPeriodEndUtc = subscription.CurrentPeriodEndUtc,
-            NextPaymentAtUtc = subscription.NextFeeBillingAtUtc,
+            // A prepaid pending year still needs processing at its start boundary, but no money is
+            // taken there. Report the next actual payment at the end of the bought year while the
+            // repository keeps NextFeeBillingAtUtc for the worker transition.
+            NextPaymentAtUtc = subscription.PendingAnnualPeriod is { IsPrepaid: true } prepaidAnnual
+                ? prepaidAnnual.EndUtc
+                : subscription.NextFeeBillingAtUtc,
             TrialEndsAtUtc = subscription.Trial?.EndsAtUtc,
             CancelAtPeriodEnd = subscription.CancelAtPeriodEnd,
             CanceledAtUtc = subscription.CanceledAtUtc,

--- a/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAnnualChargeTimingTests.cs
@@ -128,6 +128,23 @@ public sealed class CalendarAnnualChargeTimingTests
             "the stub is still the period they hold — the year has not started");
     }
 
+    [Fact]
+    public async Task At_checkout_preview_reports_the_end_of_the_bought_year_as_the_next_renewal()
+    {
+        _price = CalendarPrice(CalendarAnnualChargeTiming.AtCheckout);
+
+        var preview = await Service().PreviewAsync(
+            Request(),
+            new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1"),
+            "corr-preview",
+            CancellationToken.None);
+
+        preview.IsSuccess.Should().BeTrue(preview.ErrorCode ?? "preview should succeed");
+        preview.Value!.PendingAnnualPeriod!.CollectedWithCheckout.Should().BeTrue();
+        preview.Value.NextRenewalAtUtc.Should().Be(LocalMidnight(2027, 9, 1),
+            "September 2026 only opens the year included in totalDueNow; it charges nothing");
+    }
+
     /// <summary>
     /// The two calendar modes charge different totals now and identical totals overall. That is the
     /// only difference between them, and it is worth asserting as one statement.
@@ -270,20 +287,22 @@ public sealed class CalendarAnnualChargeTimingTests
     private async Task Subscribe(string? discountCode = null)
     {
         var result = await Service().CreateAsync(
-            new CreateSubscriptionRequest
-            {
-                PlanCode = "tier-2",
-                PriceId = "price-yearly",
-                TimeZoneId = Zurich,
-                DiscountCode = discountCode,
-                Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 1 }]
-            },
+            Request(discountCode),
             new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1"),
             "corr-1",
             CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue(result.ErrorCode ?? "creation should succeed");
     }
+
+    private static CreateSubscriptionRequest Request(string? discountCode = null) => new()
+    {
+        PlanCode = "tier-2",
+        PriceId = "price-yearly",
+        TimeZoneId = Zurich,
+        DiscountCode = discountCode,
+        Quantities = [new SubscriptionQuantityRequest { ItemKey = "seat", Quantity = 1 }]
+    };
 
     private void GivenDiscount(DiscountTerms terms) =>
         _discounts

--- a/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
@@ -107,6 +107,42 @@ public sealed class SubscriptionResponseMapperTests
     }
 
     [Fact]
+    public void A_prepaid_pending_year_reports_its_end_as_the_next_payment()
+    {
+        var subscription = NewSubscription(10);
+        subscription.NextFeeBillingAtUtc = PeriodEnd;
+        subscription.PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = PeriodEnd,
+            EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            IsPrepaid = true
+        };
+
+        var response = _mapper.ToResponse(subscription);
+
+        response.NextPaymentAtUtc.Should().Be(subscription.PendingAnnualPeriod.EndUtc,
+            "the earlier worker boundary opens an annual term that has already been paid for");
+    }
+
+    [Fact]
+    public void An_unpaid_pending_year_reports_its_start_as_the_next_payment()
+    {
+        var subscription = NewSubscription(10);
+        subscription.NextFeeBillingAtUtc = PeriodEnd;
+        subscription.PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = PeriodEnd,
+            EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            IsPrepaid = false
+        };
+
+        var response = _mapper.ToResponse(subscription);
+
+        response.NextPaymentAtUtc.Should().Be(PeriodEnd,
+            "a year configured for boundary collection is still owed when it starts");
+    }
+
+    [Fact]
     public void An_effective_cancellation_reports_when_access_actually_ended()
     {
         var subscription = NewSubscription(10);


### PR DESCRIPTION
## Summary
- report the end of an annual term as nextRenewalAtUtc when the opening stub and year are collected together
- report the same date through nextPaymentAtUtc after checkout has actually settled the pending year
- preserve September 1, 2026 as the internal worker boundary and as the payment date for annual terms configured for boundary collection
- document the buyer-facing date semantics

## Root cause
NextFeeBillingAtUtc serves two jobs internally: it wakes the worker at the stub boundary and normally identifies the next charge. For an annual term collected upfront, the stub boundary only opens an already-paid year. Preview exposed that internal processing date as a renewal, making the UI say the customer would pay again on September 1, 2026.

## Verification
- CalendarAnnualChargeTimingTests and SubscriptionResponseMapperTests: 20 passed, 0 failed
- coverage includes upfront annual collection and pay-at-boundary annual collection
- git diff --check clean