### PR TITLE
Add scheduled start times for standard discounts

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.test.tsx
@@ -78,6 +78,12 @@ describe("CampaignBuilder", () => {
 
     // Benefit: the default 10% carries through untouched.
     await screen.findByText(/What redeeming this discount takes off/);
+    fireEvent.change(screen.getByLabelText(/Starts at \(optional\)/), {
+      target: { value: "2026-10-01T09:30" },
+    });
+    fireEvent.change(screen.getByLabelText(/Expires at \(optional\)/), {
+      target: { value: "2026-10-31T18:00" },
+    });
     click(/^Next$/);
 
     // Eligibility: unrestricted is valid for a Standard discount.
@@ -91,6 +97,8 @@ describe("CampaignBuilder", () => {
     const [draft] = onSubmit.mock.calls[0]!;
     expect(draft.campaignKind).toBe("Standard");
     expect(draft.code).toBe("launch-25");
+    expect(draft.startsAtUtc).toBe("2026-10-01T09:30");
+    expect(draft.expiresAtUtc).toBe("2026-10-31T18:00");
   });
 
   it("locks a free-opening-period campaign's benefit and eligibility fields the moment it is picked", async () => {

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
@@ -165,6 +165,16 @@ describe("stepProblems", () => {
     expect(stepProblems(2, draft, plans)).toHaveLength(0);
   });
 
+  it("step 2 refuses a Standard discount whose expiry is not after its start", () => {
+    const draft = {
+      ...EMPTY_DRAFT,
+      startsAtUtc: "2026-10-31T18:00",
+      expiresAtUtc: "2026-10-01T09:30",
+    };
+
+    expect(stepProblems(2, draft, plans)).toContain("The discount must expire after it starts.");
+  });
+
   it("step 3 refuses a campaign with no price named", () => {
     const draft = withCampaignKind(EMPTY_DRAFT, "FirstAnnualPeriod");
 
@@ -259,6 +269,23 @@ describe("toCreateDiscountRequest", () => {
 
     expect(request.durationPeriods).toBeUndefined();
     expect(request.campaignKind).toBe("FirstAnnualPeriod");
+  });
+
+  it("converts a Standard discount start and expiry from local inputs to UTC instants", () => {
+    const startsAtUtc = "2026-10-01T09:30";
+    const expiresAtUtc = "2026-10-31T18:00";
+    const draft: CampaignDraft = {
+      ...EMPTY_DRAFT,
+      code: "october",
+      displayName: "October offer",
+      startsAtUtc,
+      expiresAtUtc,
+    };
+
+    const request = toCreateDiscountRequest(draft, undefined);
+
+    expect(request.startsAtUtc).toBe(new Date(startsAtUtc).toISOString());
+    expect(request.expiresAtUtc).toBe(new Date(expiresAtUtc).toISOString());
   });
 
   it("converts a fixed amount to minor units in the request currency", () => {

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
@@ -30,6 +30,7 @@ export interface CampaignDraft {
   campaignPrecedence: CampaignPrecedence;
   /** Standard only — a campaign's own duration is forced server-side and never authored here. */
   durationPeriods: string;
+  startsAtUtc: string;
   expiresAtUtc: string;
   planCodes: string[];
   priceIds: string[];
@@ -54,6 +55,7 @@ export const EMPTY_DRAFT: CampaignDraft = {
   currencyCode: "USD",
   campaignPrecedence: "BestDiscount",
   durationPeriods: "",
+  startsAtUtc: "",
   expiresAtUtc: "",
   planCodes: [],
   priceIds: [],
@@ -64,6 +66,13 @@ export const EMPTY_DRAFT: CampaignDraft = {
   requiresPaymentMethodUpfront: false,
   entitlementKey: "",
   entitlementLimit: "",
+};
+
+const toLocalDateTimeInput = (instant: string | null): string => {
+  if (!instant) return "";
+  const date = new Date(instant);
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 16);
 };
 
 export const discountToDraft = (discount: SubscriptionDiscount): CampaignDraft => ({
@@ -78,7 +87,8 @@ export const discountToDraft = (discount: SubscriptionDiscount): CampaignDraft =
   currencyCode: discount.currencyCode ?? "USD",
   campaignPrecedence: discount.campaignPrecedence,
   durationPeriods: discount.durationPeriods == null ? "" : String(discount.durationPeriods),
-  expiresAtUtc: discount.expiresAtUtc?.slice(0, 16) ?? "",
+  startsAtUtc: toLocalDateTimeInput(discount.startsAtUtc),
+  expiresAtUtc: toLocalDateTimeInput(discount.expiresAtUtc),
   planCodes: [...discount.applicablePlanCodes],
   priceIds: [...(discount.applicablePriceIds ?? [])],
   validFromDate: discount.validFromDate ?? "",
@@ -203,6 +213,16 @@ export const stepProblems = (
       }
     }
 
+    if (draft.campaignKind === "Standard") {
+      const starts = draft.startsAtUtc ? new Date(draft.startsAtUtc).getTime() : null;
+      const expires = draft.expiresAtUtc ? new Date(draft.expiresAtUtc).getTime() : null;
+      if (starts !== null && !Number.isFinite(starts)) problems.push("Enter a valid start date and time.");
+      if (expires !== null && !Number.isFinite(expires)) problems.push("Enter a valid expiry date and time.");
+      if (starts !== null && expires !== null && starts >= expires) {
+        problems.push("The discount must expire after it starts.");
+      }
+    }
+
     return problems;
   }
 
@@ -283,6 +303,7 @@ export const toCreateDiscountRequest = (
     // campaign kind silently overrides.
     durationPeriods:
       !isCampaign && draft.durationPeriods.trim() !== "" ? Number(draft.durationPeriods) : undefined,
+    startsAtUtc: !isCampaign && draft.startsAtUtc ? new Date(draft.startsAtUtc).toISOString() : undefined,
     expiresAtUtc: !isCampaign && draft.expiresAtUtc ? new Date(draft.expiresAtUtc).toISOString() : undefined,
     applicablePlanCodes: draft.planCodes,
     applicablePriceIds: draft.priceIds,

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
@@ -60,7 +60,7 @@ export const StepBenefit = ({
           A free opening month is always a full 100% reduction — nothing to set here.
         </p>
       ) : (
-        <div className="grid gap-5 sm:grid-cols-2">
+        <div className="grid gap-5 sm:grid-cols-3">
           <div className="space-y-1.5">
             <Label>Kind</Label>
             <Select
@@ -165,6 +165,16 @@ export const StepBenefit = ({
             />
           </div>
           <div className="space-y-1.5">
+            <Label htmlFor="campaign-start">Starts at (optional)</Label>
+            <Input
+              id="campaign-start"
+              type="datetime-local"
+              value={draft.startsAtUtc}
+              onChange={(event) => onChange({ startsAtUtc: event.target.value })}
+            />
+            <p className="text-xs text-muted-foreground">Leave empty to make the code available immediately.</p>
+          </div>
+          <div className="space-y-1.5">
             <Label htmlFor="campaign-expiry">Expires at (optional)</Label>
             <Input
               id="campaign-expiry"
@@ -172,6 +182,7 @@ export const StepBenefit = ({
               value={draft.expiresAtUtc}
               onChange={(event) => onChange({ expiresAtUtc: event.target.value })}
             />
+            <p className="text-xs text-muted-foreground">The code is unavailable at and after this instant.</p>
           </div>
         </div>
       )}

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-review.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-review.tsx
@@ -68,6 +68,9 @@ export const StepReview = ({
         {!isCampaign && draft.durationPeriods && (
           <Row label="Duration" value={`${draft.durationPeriods} billing periods`} />
         )}
+        {!isCampaign && draft.startsAtUtc && (
+          <Row label="Starts" value={new Date(draft.startsAtUtc).toLocaleString()} />
+        )}
         {!isCampaign && draft.expiresAtUtc && (
           <Row label="Expires" value={new Date(draft.expiresAtUtc).toLocaleString()} />
         )}

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -432,6 +432,7 @@ export interface SubscriptionDiscount {
   amountMinor: number | null;
   currencyCode: string | null;
   durationPeriods: number | null;
+  startsAtUtc: string | null;
   expiresAtUtc: string | null;
   applicablePlanCodes: string[];
   /** Absent on discounts stored before price restrictions existed, which are unrestricted by price. */
@@ -454,7 +455,7 @@ export interface SubscriptionDiscount {
   /** Set only for a `FreeOpeningCalendarPeriod` campaign — never honoured for any other kind. */
   entitlementOverrideKey: string | null;
   entitlementOverrideLimit: number | null;
-  /** Upcoming, Active, Expired or Archived — Active/Archived only for a Standard discount. */
+  /** Upcoming, Active, Expired or Archived. */
   effectiveState: "Upcoming" | "Active" | "Expired" | "Archived";
   reservedRedemptions: number;
   redeemedRedemptions: number;
@@ -470,6 +471,7 @@ export interface CreateSubscriptionDiscountRequest {
   amountMinor?: number;
   currencyCode?: string;
   durationPeriods?: number;
+  startsAtUtc?: string;
   expiresAtUtc?: string;
   applicablePlanCodes: string[];
   /** Narrows the plan list rather than replacing it: both have to match when both are given. */

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2264,6 +2264,7 @@ GET /api/subscription-discounts?organizationId=org-1</code></pre>
   "amountMinor": null,
   "currencyCode": null,
   "durationPeriods": null,
+  "startsAtUtc": null,
   "expiresAtUtc": null,
   "applicablePlanCodes": ["tier-1", "tier-2", "tier-3", "tier-4"],
   "applicablePriceIds": ["tier-1-yearly", "tier-2-yearly"],
@@ -2290,6 +2291,7 @@ GET /api/subscription-discounts?organizationId=org-1</code></pre>
     "amountMinor": null,
     "currencyCode": null,
     "durationPeriods": 1,
+    "startsAtUtc": null,
     "expiresAtUtc": null,
     "applicablePlanCodes": ["tier-1", "tier-2", "tier-3", "tier-4"],
     "applicablePriceIds": ["tier-1-yearly", "tier-2-yearly"],
@@ -2345,12 +2347,22 @@ GET /api/subscription-discounts?organizationId=org-1</code></pre>
   "kind": 0,
   "percentBasisPoints": 2500,
   "durationPeriods": 3,
+  "startsAtUtc": "2026-10-01T00:00:00Z",
   "expiresAtUtc": "2027-01-01T00:00:00Z",
   "applicablePlanCodes": ["tier-1"],
   "applicablePriceIds": [],
   "campaignKind": "Standard",
   "campaignPrecedence": "BestDiscount"
 }</code></pre>
+          <p class="prose">
+            <code>startsAtUtc</code> and <code>expiresAtUtc</code> are optional instants for a
+            Standard discount. A null start makes the code available immediately; a null expiry
+            keeps it available until it is retired. Before the start, subscription creation and
+            discount preview return <code>subscription_discount_not_started</code>; at or after the
+            expiry they return <code>subscription_discount_expired</code>. When both are present,
+            expiry must be strictly later than start. Existing discounts have a null start and keep
+            their previous behaviour.
+          </p>
           <h4>Applicability rules</h4>
           <p class="prose">
             The two lists <strong>narrow</strong> rather than offering two ways to qualify: when both
@@ -2413,6 +2425,7 @@ GET /api/subscription-discounts?organizationId=org-1</code></pre>
   "amountMinor": null,
   "currencyCode": null,
   "durationPeriods": null,
+  "startsAtUtc": null,
   "expiresAtUtc": null,
   "applicablePlanCodes": ["tier-1", "tier-2", "tier-3", "tier-4"],
   "applicablePriceIds": ["tier-1-yearly", "tier-2-yearly"],

--- a/server/Subscription.DomainService/Entities/DiscountTerms.cs
+++ b/server/Subscription.DomainService/Entities/DiscountTerms.cs
@@ -27,6 +27,9 @@ public sealed class DiscountTerms
     /// <summary>How many periods it applies to. Null runs for the life of the subscription.</summary>
     public int? DurationPeriods { get; set; }
 
+    /// <summary>The first instant this code may be redeemed. Null means immediately.</summary>
+    public DateTime? StartsAtUtc { get; set; }
+
     public DateTime? ExpiresAtUtc { get; set; }
 
     /// <summary>

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -583,7 +583,8 @@ turn suffixes that key per Stripe call (`:item`, `:invoice`, `:finalize`, `:pay`
 idempotency by endpoint, and the same raw key sent to four different endpoints in immediate
 succession is not something to trust silently.
 
-A discount reduces a renewal only while `DiscountTerms.DurationPeriods` and `ExpiresAtUtc` still
+A discount can be redeemed only once `DiscountTerms.StartsAtUtc` has been reached, and reduces a
+renewal only while `DiscountTerms.DurationPeriods` and `ExpiresAtUtc` still
 allow it; `SubscriptionDetail.DiscountPeriodsApplied` tracks how many periods it has already
 reduced, so an expired discount's absence is detected without re-deriving history from past
 charges.

--- a/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
@@ -12,6 +12,7 @@ public sealed class CreateDiscountRequest : ICampaignDiscountRequest
     public long? AmountMinor { get; set; }
     public string? CurrencyCode { get; set; }
     public int? DurationPeriods { get; set; }
+    public DateTime? StartsAtUtc { get; set; }
     public DateTime? ExpiresAtUtc { get; set; }
     public List<string> ApplicablePlanCodes { get; set; } = [];
     /// <summary>Empty is unrestricted by price. Narrows with the plan list, not instead of it.</summary>

--- a/server/Subscription.DomainService/Requests/ICampaignDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/ICampaignDiscountRequest.cs
@@ -16,6 +16,8 @@ public interface ICampaignDiscountRequest
     int? PercentBasisPoints { get; }
     long? AmountMinor { get; }
     string? CurrencyCode { get; }
+    DateTime? StartsAtUtc { get; }
+    DateTime? ExpiresAtUtc { get; }
     List<string> ApplicablePlanCodes { get; }
     List<string> ApplicablePriceIds { get; }
 

--- a/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
@@ -28,6 +28,7 @@ public sealed class UpdateDiscountRequest : ICampaignDiscountRequest
     public long? AmountMinor { get; set; }
     public string? CurrencyCode { get; set; }
     public int? DurationPeriods { get; set; }
+    public DateTime? StartsAtUtc { get; set; }
     public DateTime? ExpiresAtUtc { get; set; }
     public List<string> ApplicablePlanCodes { get; set; } = [];
     public List<string> ApplicablePriceIds { get; set; } = [];

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -11,6 +11,7 @@ public sealed class DiscountResponse
     public long? AmountMinor { get; init; }
     public string? CurrencyCode { get; init; }
     public int? DurationPeriods { get; init; }
+    public DateTime? StartsAtUtc { get; init; }
     public DateTime? ExpiresAtUtc { get; init; }
     public List<string> ApplicablePlanCodes { get; init; } = [];
     public List<string> ApplicablePriceIds { get; init; } = [];

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -89,6 +89,7 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
                 PercentBasisPoints = request.PercentBasisPoints,
                 AmountMinor = request.AmountMinor,
                 DurationPeriods = request.DurationPeriods,
+                StartsAtUtc = request.StartsAtUtc,
                 ExpiresAtUtc = request.ExpiresAtUtc
             },
             Campaign = campaign!
@@ -174,6 +175,7 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
             PercentBasisPoints = request.PercentBasisPoints,
             AmountMinor = request.AmountMinor,
             DurationPeriods = request.DurationPeriods,
+            StartsAtUtc = request.StartsAtUtc,
             ExpiresAtUtc = request.ExpiresAtUtc
         };
         existing.Campaign = campaign!;
@@ -527,7 +529,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         DisplayName = item.DisplayName, Kind = item.Terms.Kind.ToString(),
         PercentBasisPoints = item.Terms.PercentBasisPoints, AmountMinor = item.Terms.AmountMinor,
         CurrencyCode = item.CurrencyCode, DurationPeriods = item.Terms.DurationPeriods,
-        ExpiresAtUtc = item.Terms.ExpiresAtUtc, ApplicablePlanCodes = [.. item.ApplicablePlanCodes],
+        StartsAtUtc = item.Terms.StartsAtUtc, ExpiresAtUtc = item.Terms.ExpiresAtUtc,
+        ApplicablePlanCodes = [.. item.ApplicablePlanCodes],
         ApplicablePriceIds = [.. item.ApplicablePriceIds],
         Status = item.Status.ToString(),
         Version = item.Version,
@@ -554,9 +557,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
     /// written.
     /// </summary>
     /// <remarks>
-    /// A <see cref="CampaignKind.Standard"/> discount has no window, so it is Active whenever its
-    /// <see cref="CatalogueStatus"/> is, exactly as before this field existed -- Archived is the
-    /// only state a legacy discount can be told apart by.
+    /// A legacy <see cref="CampaignKind.Standard"/> discount whose start and expiry are both null
+    /// remains Active whenever its <see cref="CatalogueStatus"/> is.
     /// </remarks>
     private string EffectiveState(Discount item)
     {
@@ -565,12 +567,22 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
             return "Archived";
         }
 
+        var now = _time.GetUtcNow().UtcDateTime;
+
         if (item.Campaign.Kind == CampaignKind.Standard)
         {
+            if (item.Terms.StartsAtUtc is { } startsAt && now < startsAt)
+            {
+                return "Upcoming";
+            }
+
+            if (item.Terms.ExpiresAtUtc is { } expiresAt && now >= expiresAt)
+            {
+                return "Expired";
+            }
+
             return "Active";
         }
-
-        var now = _time.GetUtcNow().UtcDateTime;
 
         if (item.Campaign.RedeemableFromUtc is { } from && now < from)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -627,7 +627,16 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                 "The discount code does not exist or is retired.",
                 correlationId);
 
-        if (discount.Terms.ExpiresAtUtc is { } expiry && expiry <= _time.GetUtcNow().UtcDateTime)
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (discount.Terms.StartsAtUtc is { } startsAt && now < startsAt)
+            return SubscriptionOperationResult<DiscountTerms?>.Failure(
+                PaymentFailureKind.Validation,
+                "subscription_discount_not_started",
+                "The discount code has not started yet.",
+                correlationId);
+
+        if (discount.Terms.ExpiresAtUtc is { } expiry && expiry <= now)
             return SubscriptionOperationResult<DiscountTerms?>.Failure(
                 PaymentFailureKind.Validation,
                 "subscription_discount_expired",
@@ -639,8 +648,6 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // Standard discount's absent RedeemableFromUtc/UntilUtc as "always redeemable" is exactly
         // right for it. A campaign's own window only exists once Kind is not Standard, so this
         // check has nothing to do for every discount created before campaigns did.
-        var now = _time.GetUtcNow().UtcDateTime;
-
         if (discount.Campaign.Kind != CampaignKind.Standard)
         {
             if (discount.Campaign.RedeemableFromUtc is { } from && now < from)
@@ -703,6 +710,7 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
                     is CampaignKind.FreeOpeningCalendarPeriod or CampaignKind.FirstAnnualPeriod
                     ? 1
                     : terms.DurationPeriods,
+                StartsAtUtc = terms.StartsAtUtc,
                 ExpiresAtUtc = terms.ExpiresAtUtc,
                 // Copied so the restriction outlives the redemption. A plan change re-asks the same
                 // question, and it can only do so against terms that remember the answer.

--- a/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/CampaignDiscountRequestValidator.cs
@@ -37,6 +37,10 @@ public abstract class CampaignDiscountRequestValidator<T> : AbstractValidator<T>
         RuleFor(request => request).Must(request =>
             request.Kind != DiscountKind.FixedAmount || request.PercentBasisPoints is null)
             .WithMessage("A fixed discount cannot also define a percentage.");
+        RuleFor(request => request).Must(request =>
+                request.StartsAtUtc is null || request.ExpiresAtUtc is null ||
+                request.StartsAtUtc < request.ExpiresAtUtc)
+            .WithMessage("The discount must expire after it starts.");
 
         var isCampaign = (Func<T, bool>)(request => request.CampaignKind != CampaignKind.Standard);
 

--- a/server/XUnitTest/Subscription/CreateDiscountRequestValidatorTests.cs
+++ b/server/XUnitTest/Subscription/CreateDiscountRequestValidatorTests.cs
@@ -39,4 +39,20 @@ public sealed class CreateDiscountRequestValidatorTests
         });
         result.IsValid.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task A_discount_cannot_expire_at_or_before_its_start()
+    {
+        var instant = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var result = await _validator.ValidateAsync(new CreateDiscountRequest
+        {
+            Code = "launch25", DisplayName = "Launch", Kind = DiscountKind.Percent,
+            PercentBasisPoints = 2_500, StartsAtUtc = instant, ExpiresAtUtc = instant
+        });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(error =>
+            error.ErrorMessage == "The discount must expire after it starts.");
+    }
 }

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
@@ -452,10 +452,16 @@ public sealed class DiscountCatalogueServiceCampaignTests
                 It.IsAny<Discount>(), 3, It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
+        var request = UpdateRequest(expectedVersion: 3);
+        request.StartsAtUtc = DateTime.UtcNow.AddDays(1);
+        request.ExpiresAtUtc = DateTime.UtcNow.AddDays(10);
+
         var result = await Service().UpdateAsync(
-            stored.ItemId, UpdateRequest(expectedVersion: 3), null, "corr-1", CancellationToken.None);
+            stored.ItemId, request, null, "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
+        stored.Terms.StartsAtUtc.Should().Be(request.StartsAtUtc);
+        stored.Terms.ExpiresAtUtc.Should().Be(request.ExpiresAtUtc);
     }
 
     [Fact]
@@ -530,6 +536,35 @@ public sealed class DiscountCatalogueServiceCampaignTests
         var request = CampaignRequest(CampaignKind.FirstAnnualPeriod, [CalendarYearlyPriceId]);
         request.ValidFromDate = new DateOnly(2020, 1, 1);
         request.ValidThroughDate = new DateOnly(2020, 1, 31);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.EffectiveState.Should().Be("Expired");
+    }
+
+    [Fact]
+    public async Task A_standard_discount_before_its_start_reads_as_upcoming_and_returns_the_window()
+    {
+        var request = Request();
+        request.StartsAtUtc = DateTime.UtcNow.AddDays(1);
+        request.ExpiresAtUtc = DateTime.UtcNow.AddDays(10);
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.EffectiveState.Should().Be("Upcoming");
+        result.Value.StartsAtUtc.Should().Be(request.StartsAtUtc);
+        result.Value.ExpiresAtUtc.Should().Be(request.ExpiresAtUtc);
+        _created!.Terms.StartsAtUtc.Should().Be(request.StartsAtUtc);
+    }
+
+    [Fact]
+    public async Task A_standard_discount_past_its_expiry_reads_as_expired()
+    {
+        var request = Request();
+        request.StartsAtUtc = DateTime.UtcNow.AddDays(-10);
+        request.ExpiresAtUtc = DateTime.UtcNow.AddDays(-1);
 
         var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
 

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -232,6 +232,56 @@ public sealed class SubscriptionCreationServiceTests
     }
 
     [Fact]
+    public async Task A_standard_discount_before_its_start_is_refused()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "soon";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "soon", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms
+                {
+                    Code = "soon",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 2_500,
+                    StartsAtUtc = _time.GetUtcNow().UtcDateTime.AddMinutes(1)
+                }
+            });
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_discount_not_started");
+        _created.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_standard_discount_is_redeemable_at_its_exact_start_instant()
+    {
+        var request = NewRequest();
+        request.DiscountCode = "now";
+        _discounts.Setup(repository => repository.FindActiveByCodeAsync(
+                TenantId, OrganizationId, "now", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Discount
+            {
+                Terms = new DiscountTerms
+                {
+                    Code = "now",
+                    Kind = DiscountKind.Percent,
+                    PercentBasisPoints = 2_500,
+                    StartsAtUtc = _time.GetUtcNow().UtcDateTime
+                }
+            });
+
+        var result = await Service().CreateAsync(
+            request, Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Discount!.StartsAtUtc.Should().Be(_time.GetUtcNow().UtcDateTime);
+    }
+
+    [Fact]
     public async Task A_promotion_restricted_to_another_price_is_refused()
     {
         // A code authored for the yearly price, typed against the monthly one. Refused rather than


### PR DESCRIPTION
## Summary
- add optional startsAtUtc to standard discount create, update, storage, and responses
- refuse redemption before the start with subscription_discount_not_started
- report scheduled standard discounts as Upcoming and expired ones as Expired
- add a user-friendly Starts at field to the discount builder, including edit round-trip and Review display
- validate that expiry is strictly later than start on both client and server
- document request fields, boundary behavior, and backward compatibility

## Compatibility
Existing discounts deserialize startsAtUtc as null and remain available immediately. Existing campaign date behavior is unchanged; campaign kinds continue to use their date-and-time-zone validity window.

## Boundary semantics
- null start: available immediately
- now before start: not started
- now equal to start: redeemable
- now equal to or after expiry: expired

## Verification
- server targeted suite: 90 passed, 0 failed
- client campaign builder suites: 30 passed, 0 failed
- client type-check: clean
- diff check: clean