### PR TITLE
feat(subscription): record every mail with the payload that was sent

### DIFF
--- a/server/Subscription.DomainService/Entities/MailDeliveryReport.cs
+++ b/server/Subscription.DomainService/Entities/MailDeliveryReport.cs
@@ -1,0 +1,107 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One record of a mail being handed to the listener, with the payload that was handed over.
+/// </summary>
+/// <remarks>
+/// Written beside the mail rather than inside the thing being mailed. A financial document already
+/// carries its own <c>Delivery</c> block, but that block holds the current state of one document's
+/// one mail — it is overwritten on a resend, says nothing about usage-threshold mail, and never
+/// held what was actually sent. This is the append-only history: one row per handover, keeping the
+/// payload as it left.
+/// <para>
+/// Recording is deliberately best-effort and must never change what happens to the mail. Document
+/// delivery is at-most-once and guarded by a claim, so a report write that threw and bubbled up
+/// could release that claim and put a second invoice in somebody's inbox — the exact failure the
+/// claim exists to prevent. A report is worth strictly less than that guarantee.
+/// </para>
+/// </remarks>
+public sealed class MailDeliveryReport
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    public string TenantId { get; set; } = string.Empty;
+
+    /// <summary>Absent for tenant-wide mail, which is why it is nullable rather than empty.</summary>
+    public string? OrganizationId { get; set; }
+
+    public MailDeliveryReportSource Source { get; set; }
+
+    public MailDeliveryReportOutcome Outcome { get; set; }
+
+    /// <summary>
+    /// The thing being mailed about: a financial document id, or a subscription id for a usage
+    /// warning. Indexed, so "every mail we ever sent about this invoice" is one query.
+    /// </summary>
+    public string SubjectId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How a human names that subject — a document number, or the lifecycle event id. Carried
+    /// alongside the id because an operator reading this collection has the invoice number in
+    /// front of them and not a GUID.
+    /// </summary>
+    public string? SubjectReference { get; set; }
+
+    /// <summary>
+    /// The idempotency key the delivery service derives per document, when there is one. Usage
+    /// mail has none: it is not claimed and may legitimately be sent more than once.
+    /// </summary>
+    public string? MailMessageId { get; set; }
+
+    /// <summary>The listener queue the message was addressed to.</summary>
+    public string ConsumerName { get; set; } = string.Empty;
+
+    public string Purpose { get; set; } = string.Empty;
+
+    public string Language { get; set; } = string.Empty;
+
+    /// <summary>Recipients as they were sent — already trimmed and lowercased by the publisher.</summary>
+    public IReadOnlyList<string> To { get; set; } = [];
+
+    public IReadOnlyList<string> Cc { get; set; } = [];
+
+    public IReadOnlyList<string> Bcc { get; set; } = [];
+
+    /// <summary>Storage ids, not file contents. A rendered invoice is megabytes and lives in storage.</summary>
+    public IReadOnlyList<string> Attachments { get; set; } = [];
+
+    /// <summary>
+    /// The whole <c>SendMail</c> as JSON, exactly as published.
+    /// </summary>
+    /// <remarks>
+    /// The point of the collection. The fields above are duplicated out of this string so the
+    /// common questions are indexable and readable without parsing, but the payload is what
+    /// answers "what did the template actually receive" when a mail arrives wrong — a
+    /// <c>BodyDataContext</c> holding an empty plan name or a stale total cannot be reconstructed
+    /// from anything else after the fact.
+    /// </remarks>
+    public string PayloadJson { get; set; } = string.Empty;
+
+    /// <summary>SHA-256 of <see cref="PayloadJson"/>, for spotting two handovers that were identical.</summary>
+    public string PayloadHash { get; set; } = string.Empty;
+
+    public int PayloadLength { get; set; }
+
+    /// <summary>Set only when <see cref="Outcome"/> is <see cref="MailDeliveryReportOutcome.PublishFailed"/>.</summary>
+    public string? ErrorCode { get; set; }
+
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>Ties a report to the sweep or request that produced it, and to the work queue item.</summary>
+    public string? CorrelationId { get; set; }
+
+    public DateTime CreatedAtUtc { get; set; }
+
+    /// <summary>
+    /// When the TTL index removes this row.
+    /// </summary>
+    /// <remarks>
+    /// Always set, unlike the work queue's equivalent, because every row here is already finished
+    /// when it is written — there is no pending state that must survive. Payloads carry recipient
+    /// addresses and billing figures, so keeping them indefinitely would be accumulating personal
+    /// data for no stated purpose.
+    /// </remarks>
+    public DateTime PurgeAtUtc { get; set; }
+}

--- a/server/Subscription.DomainService/Enums/MailDeliveryReportOutcome.cs
+++ b/server/Subscription.DomainService/Enums/MailDeliveryReportOutcome.cs
@@ -1,0 +1,29 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// What became of one handover to the mail listener.
+/// </summary>
+/// <remarks>
+/// Deliberately not "Delivered". Nothing here observes an inbox: the furthest this side can see is
+/// that the broker accepted the message. Whether it was rendered, submitted to SES, accepted,
+/// bounced or filtered is recorded by the mail service on the other side of the queue, and a report
+/// that said "Delivered" would be claiming knowledge this process does not have.
+/// </remarks>
+public enum MailDeliveryReportOutcome
+{
+    /// <summary>The broker accepted the message. Nothing beyond that is claimed.</summary>
+    Published = 0,
+
+    /// <summary>
+    /// The publish threw. The message may still have gone out — an acknowledgement can be lost on
+    /// the way back — which is why the delivery service treats this as unknown rather than as a
+    /// failure to retry.
+    /// </summary>
+    PublishFailed = 1,
+
+    /// <summary>
+    /// Never handed over: a guard refused first, e.g. a document with no billing contact, or a
+    /// claim already taken by an earlier attempt.
+    /// </summary>
+    NotAttempted = 2
+}

--- a/server/Subscription.DomainService/Enums/MailDeliveryReportSource.cs
+++ b/server/Subscription.DomainService/Enums/MailDeliveryReportSource.cs
@@ -1,0 +1,18 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Which of the two mail publishers a report came from.
+/// </summary>
+/// <remarks>
+/// Named rather than inferred from whichever subject field happens to be populated: a reader
+/// filtering the collection wants "every invoice mail" without knowing that an invoice is the one
+/// that carries a document number.
+/// </remarks>
+public enum MailDeliveryReportSource
+{
+    /// <summary>An invoice, credit note or receipt, from the financial document delivery sweep.</summary>
+    FinancialDocument = 0,
+
+    /// <summary>A usage allowance warning, from the lifecycle event consumer.</summary>
+    UsageThreshold = 1
+}

--- a/server/Subscription.DomainService/Repositories/IMailDeliveryReportRepository.cs
+++ b/server/Subscription.DomainService/Repositories/IMailDeliveryReportRepository.cs
@@ -1,0 +1,24 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// Stores and reads the mail delivery history.
+/// </summary>
+public interface IMailDeliveryReportRepository
+{
+    /// <summary>Appends one report. Never updates an existing row.</summary>
+    Task AddAsync(MailDeliveryReport report, CancellationToken cancellationToken);
+
+    /// <summary>Every mail sent about one subject, newest first.</summary>
+    Task<IReadOnlyList<MailDeliveryReport>> ForSubjectAsync(
+        string tenantId,
+        string subjectId,
+        CancellationToken cancellationToken);
+
+    /// <summary>The most recent mail for a tenant, newest first.</summary>
+    Task<IReadOnlyList<MailDeliveryReport>> RecentAsync(
+        string tenantId,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/MailDeliveryReportIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/MailDeliveryReportIndexDefinitions.cs
@@ -1,0 +1,59 @@
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// The indexes behind the three questions this collection is opened to answer.
+/// </summary>
+public static class MailDeliveryReportIndexDefinitions
+{
+    public const string SubjectIndexName = "mail_report_by_subject";
+    public const string RecentIndexName = "mail_report_by_tenant_created";
+    public const string MessageIndexName = "mail_report_by_message_id";
+    public const string PurgeIndexName = "ttl_mail_report_purge_at";
+
+    public static IReadOnlyCollection<CreateIndexModel<MailDeliveryReport>> CreateIndexes() =>
+    [
+        // "Every mail we ever sent about this invoice", which is the question an operator arrives
+        // with. Newest first, because a resend is what they are usually looking for.
+        new(
+            Builders<MailDeliveryReport>.IndexKeys
+                .Ascending(report => report.TenantId)
+                .Ascending(report => report.SubjectId)
+                .Descending(report => report.CreatedAtUtc),
+            new CreateIndexOptions { Name = SubjectIndexName }),
+
+        // "What has gone out lately", for a tenant, without scanning the collection.
+        new(
+            Builders<MailDeliveryReport>.IndexKeys
+                .Ascending(report => report.TenantId)
+                .Descending(report => report.CreatedAtUtc),
+            new CreateIndexOptions { Name = RecentIndexName }),
+
+        // Not unique, deliberately. A document's message id is stable across a deliberate resend,
+        // so two rows sharing one is the honest record of it having been sent twice on purpose.
+        // Made unique, the second send would fail to record and the history would show one mail
+        // where two went out.
+        new(
+            Builders<MailDeliveryReport>.IndexKeys
+                .Ascending(report => report.TenantId)
+                .Ascending(report => report.MailMessageId),
+            new CreateIndexOptions
+            {
+                Name = MessageIndexName,
+                Sparse = true
+            }),
+
+        // Retention. Every row is final when written, so unlike the work queue's TTL there is no
+        // pending state to keep alive by leaving this null -- PurgeAtUtc is always set, and
+        // ExpireAfter zero means "remove when that moment passes".
+        new(
+            Builders<MailDeliveryReport>.IndexKeys.Ascending(report => report.PurgeAtUtc),
+            new CreateIndexOptions
+            {
+                Name = PurgeIndexName,
+                ExpireAfter = TimeSpan.Zero
+            })
+    ];
+}

--- a/server/Subscription.DomainService/Repositories/MailDeliveryReportRepository.cs
+++ b/server/Subscription.DomainService/Repositories/MailDeliveryReportRepository.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// The Mongo-backed store behind <see cref="IMailDeliveryReportRepository"/>.
+/// </summary>
+/// <remarks>
+/// Insert-only. There is no update path and no upsert: a report describes one handover that either
+/// happened or did not, and editing it after the fact would make the history less trustworthy than
+/// the <c>Delivery</c> block it exists to complement, which is overwritten on every resend.
+/// </remarks>
+public sealed class MailDeliveryReportRepository : IMailDeliveryReportRepository
+{
+    private const int MaxLimit = 500;
+
+    private readonly IDbContextProvider _db;
+    private readonly ConcurrentDictionary<string, byte> _indexed = new();
+
+    public MailDeliveryReportRepository(IDbContextProvider db) => _db = db;
+
+    public async Task AddAsync(MailDeliveryReport report, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        await EnsureIndexesAsync(report.TenantId, cancellationToken);
+
+        await Collection(report.TenantId)
+            .InsertOneAsync(report, options: null, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<MailDeliveryReport>> ForSubjectAsync(
+        string tenantId,
+        string subjectId,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        return await Collection(tenantId)
+            .Find(report => report.TenantId == tenantId && report.SubjectId == subjectId)
+            .SortByDescending(report => report.CreatedAtUtc)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<MailDeliveryReport>> RecentAsync(
+        string tenantId,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        return await Collection(tenantId)
+            .Find(report => report.TenantId == tenantId)
+            .SortByDescending(report => report.CreatedAtUtc)
+            .Limit(Math.Clamp(limit, 1, MaxLimit))
+            .ToListAsync(cancellationToken);
+    }
+
+    private IMongoCollection<MailDeliveryReport> Collection(string tenantId) =>
+        SubscriptionCollections.Of<MailDeliveryReport>(
+            _db, tenantId, SubscriptionCollections.MailDeliveryReports);
+
+    // Created once per tenant per process, the same way every other repository here does it. The
+    // dictionary is the guard: index creation is idempotent in MongoDB but not free, and this runs
+    // on a path that fires once per mail.
+    private async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (!_indexed.TryAdd(tenantId, 0))
+        {
+            return;
+        }
+
+        try
+        {
+            await Collection(tenantId).Indexes.CreateManyAsync(
+                MailDeliveryReportIndexDefinitions.CreateIndexes(), cancellationToken);
+        }
+        catch
+        {
+            // Left to be retried by the next call rather than swallowed for the life of the
+            // process: a transient failure here would otherwise leave this tenant permanently
+            // unindexed, and the collection is read by operators during an incident.
+            _indexed.TryRemove(tenantId, out _);
+            throw;
+        }
+    }
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -41,6 +41,12 @@ internal static class SubscriptionCollections
     public const string UsagePeriodClaims = "SubscriptionUsagePeriodClaims";
     public const string CampaignRedemptions = "SubscriptionCampaignRedemptions";
 
+    /// <summary>
+    /// Append-only record of every mail handed to the listener, payload included. Separate from the
+    /// documents it reports on, because it also covers mail that has no document behind it.
+    /// </summary>
+    public const string MailDeliveryReports = "SubscriptionMailDeliveryReports";
+
     public static IMongoCollection<TDocument> Of<TDocument>(
         IDbContextProvider dbContextProvider,
         string tenantId,

--- a/server/Subscription.DomainService/Services/IMailDeliveryReporter.cs
+++ b/server/Subscription.DomainService/Services/IMailDeliveryReporter.cs
@@ -1,0 +1,65 @@
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Messaging;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Records what was handed to the mail listener.
+/// </summary>
+/// <remarks>
+/// Every method is best-effort and none of them throws. Callers sit on the mail path, where document
+/// delivery is at-most-once behind a claim: an exception escaping this would unwind a send that had
+/// already happened and could put a second invoice in somebody's inbox. Reporting is worth less than
+/// that guarantee, so it fails quietly and says so in the log.
+/// </remarks>
+public interface IMailDeliveryReporter
+{
+    /// <summary>
+    /// Records one handover and its outcome.
+    /// </summary>
+    /// <param name="request">What was sent, to whom, about what, and how it went.</param>
+    /// <param name="cancellationToken">
+    /// Honoured for the write, but a cancelled write is still not an error here: the mail's own
+    /// outcome is already decided by the time this is called.
+    /// </param>
+    Task RecordAsync(MailDeliveryReportRequest request, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// One report to write.
+/// </summary>
+/// <remarks>
+/// A record rather than a long parameter list: two of these fields are optional in one direction and
+/// mandatory in the other (a document has a message id and a number; a usage warning has neither),
+/// and positional arguments made that easy to get wrong at the call site.
+/// </remarks>
+public sealed record MailDeliveryReportRequest
+{
+    public required string TenantId { get; init; }
+
+    public string? OrganizationId { get; init; }
+
+    public required MailDeliveryReportSource Source { get; init; }
+
+    public required MailDeliveryReportOutcome Outcome { get; init; }
+
+    public required string SubjectId { get; init; }
+
+    public string? SubjectReference { get; init; }
+
+    public string? MailMessageId { get; init; }
+
+    public required string ConsumerName { get; init; }
+
+    /// <summary>
+    /// The payload as published. Null when nothing was built because a guard refused first, which
+    /// is a report worth keeping — "no billing contact" is exactly what an operator is looking for.
+    /// </summary>
+    public SendMail? Payload { get; init; }
+
+    public string? ErrorCode { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public string? CorrelationId { get; init; }
+}

--- a/server/Subscription.DomainService/Services/MailDeliveryReporter.cs
+++ b/server/Subscription.DomainService/Services/MailDeliveryReporter.cs
@@ -1,0 +1,120 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Messaging;
+using Subscription.DomainService.Repositories;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Writes the mail delivery history, and never lets writing it break the mail.
+/// </summary>
+public sealed class MailDeliveryReporter : IMailDeliveryReporter
+{
+    /// <summary>
+    /// How long a report is kept.
+    /// </summary>
+    /// <remarks>
+    /// Long enough to answer "what did we send that customer last quarter" during a billing
+    /// dispute, and short enough that recipient addresses and billing figures are not kept
+    /// indefinitely for no stated purpose. The TTL index enforces it; nothing sweeps.
+    /// </remarks>
+    public static readonly TimeSpan Retention = TimeSpan.FromDays(90);
+
+    // Written for a human reading the collection during an incident, not for a machine: indented,
+    // and without the escaping that turns every address in a payload into an unreadable string.
+    private static readonly JsonSerializerOptions PayloadFormat = new()
+    {
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
+    private readonly IMailDeliveryReportRepository _reports;
+    private readonly TimeProvider _time;
+    private readonly ILogger<MailDeliveryReporter> _logger;
+
+    public MailDeliveryReporter(
+        IMailDeliveryReportRepository reports,
+        TimeProvider time,
+        ILogger<MailDeliveryReporter> logger)
+    {
+        _reports = reports;
+        _time = time;
+        _logger = logger;
+    }
+
+    public async Task RecordAsync(
+        MailDeliveryReportRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        try
+        {
+            var now = _time.GetUtcNow().UtcDateTime;
+            var payloadJson = request.Payload is null
+                ? string.Empty
+                : JsonSerializer.Serialize(request.Payload, PayloadFormat);
+
+            await _reports.AddAsync(
+                new MailDeliveryReport
+                {
+                    TenantId = request.TenantId,
+                    OrganizationId = request.OrganizationId,
+                    Source = request.Source,
+                    Outcome = request.Outcome,
+                    SubjectId = request.SubjectId,
+                    SubjectReference = request.SubjectReference,
+                    MailMessageId = request.MailMessageId,
+                    ConsumerName = request.ConsumerName,
+                    Purpose = request.Payload?.Purpose ?? string.Empty,
+                    Language = request.Payload?.Language ?? string.Empty,
+                    To = [.. request.Payload?.To ?? []],
+                    Cc = [.. request.Payload?.Cc ?? []],
+                    Bcc = [.. request.Payload?.Bcc ?? []],
+                    Attachments = [.. request.Payload?.Attachments ?? []],
+                    PayloadJson = payloadJson,
+                    PayloadHash = Hash(payloadJson),
+                    PayloadLength = payloadJson.Length,
+                    ErrorCode = request.ErrorCode,
+                    ErrorMessage = request.ErrorMessage,
+                    CorrelationId = request.CorrelationId,
+                    CreatedAtUtc = now,
+                    PurgeAtUtc = now.Add(Retention)
+                },
+                cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            // Deliberately swallowed, including cancellation. The mail's outcome was decided before
+            // this was called, and rethrowing would unwind a send that already happened -- on the
+            // document path that means releasing a claim and risking a duplicate invoice. What is
+            // lost is a row in a history collection, which is why this is logged loudly enough to
+            // notice and quiet enough to ignore at three in the morning.
+            _logger.LogWarning(
+                exception,
+                "A mail delivery report could not be written; the mail itself is unaffected " +
+                "Source={Source} Outcome={Outcome} SubjectReference={SubjectReference}",
+                request.Source,
+                request.Outcome,
+                PaymentLogValue.Label(request.SubjectReference ?? request.SubjectId));
+        }
+    }
+
+    private static string Hash(string payloadJson)
+    {
+        if (payloadJson.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return Convert
+            .ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payloadJson)))
+            .ToLower(CultureInfo.InvariantCulture);
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentDeliveryService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentDeliveryService.cs
@@ -22,6 +22,7 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
     private readonly IFinancialDocumentLogoResolver _logo;
     private readonly ICurrencyMinorUnitResolver _currency;
     private readonly IMessageClient _messages;
+    private readonly IMailDeliveryReporter? _mailReports;
     private readonly IOptions<SubscriptionOptions> _options;
     private readonly ILogger<SubscriptionFinancialDocumentDeliveryService> _logger;
     private readonly TimeProvider _time;
@@ -35,6 +36,7 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
         IMessageClient messages,
         IOptions<SubscriptionOptions> options,
         ILogger<SubscriptionFinancialDocumentDeliveryService> logger,
+        IMailDeliveryReporter? mailReports = null,
         TimeProvider? time = null)
     {
         _documents = documents;
@@ -45,6 +47,10 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
         _messages = messages;
         _options = options;
         _logger = logger;
+        // Optional so that a caller which does not care about the history -- every existing test,
+        // for one -- is not forced to supply one. Absent, nothing is recorded and the mail behaves
+        // exactly as it did before this existed.
+        _mailReports = mailReports;
         _time = time ?? TimeProvider.System;
     }
 
@@ -405,6 +411,15 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
                 "download DocumentNumber={DocumentNumber}",
                 PaymentLogValue.Label(document.DocumentNumber));
 
+            await ReportAsync(
+                document,
+                payload: null,
+                mailMessageId: null,
+                MailDeliveryReportOutcome.NotAttempted,
+                errorCode: "document_mail_no_recipient",
+                errorMessage: "The document has no billing contact address.",
+                cancellationToken);
+
             return MailOutcome.NoRecipient;
         }
 
@@ -433,6 +448,16 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
                 "DocumentNumber={DocumentNumber} MessageId={MessageId}",
                 PaymentLogValue.Label(document.DocumentNumber),
                 PaymentLogValue.Label(messageId));
+
+            await ReportAsync(
+                document,
+                payload: null,
+                messageId,
+                MailDeliveryReportOutcome.NotAttempted,
+                errorCode: "document_mail_claim_taken",
+                errorMessage:
+                    "An earlier attempt claimed this mail and never recorded its outcome.",
+                cancellationToken);
 
             return MailOutcome.OutcomeUnknown;
         }
@@ -487,21 +512,25 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
             ["PeriodEnd"] = document.Period.LocalEnd
         };
 
+        // Built before the send rather than inline, so the report can carry the very object that
+        // was published instead of a reconstruction of it.
+        var payload = new SendMail
+        {
+            To = [recipient.Trim().ToLowerInvariant()],
+            Purpose = PurposeFor(document.DocumentType),
+            Language = SubscriptionConstants.DefaultMailLanguage,
+            Attachments = [storageId],
+            SubjectDataContext = new Dictionary<string, string>(context),
+            BodyDataContext = context
+        };
+
         try
         {
             await _messages.SendToConsumerAsync(
                 new ConsumerMessage<SendMail>
                 {
                     ConsumerName = SubscriptionConstants.MailQueue,
-                    Payload = new SendMail
-                    {
-                        To = [recipient.Trim().ToLowerInvariant()],
-                        Purpose = PurposeFor(document.DocumentType),
-                        Language = SubscriptionConstants.DefaultMailLanguage,
-                        Attachments = [storageId],
-                        SubjectDataContext = new Dictionary<string, string>(context),
-                        BodyDataContext = context
-                    }
+                    Payload = payload
                 });
         }
         catch (Exception exception) when (exception is not OperationCanceledException)
@@ -518,8 +547,26 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
                 PaymentLogValue.Label(document.DocumentNumber),
                 PaymentLogValue.Label(messageId));
 
+            await ReportAsync(
+                document,
+                payload,
+                messageId,
+                MailDeliveryReportOutcome.PublishFailed,
+                errorCode: "document_mail_publish_failed",
+                errorMessage: exception.Message,
+                cancellationToken);
+
             return MailOutcome.OutcomeUnknown;
         }
+
+        await ReportAsync(
+            document,
+            payload,
+            messageId,
+            MailDeliveryReportOutcome.Published,
+            errorCode: null,
+            errorMessage: null,
+            cancellationToken);
 
         return MailOutcome.Published;
     }
@@ -602,4 +649,38 @@ public sealed class SubscriptionFinancialDocumentDeliveryService :
 
         return $"{(safe.Length == 0 ? "document" : safe[..Math.Min(safe.Length, 60)])}.pdf";
     }
+
+    /// <summary>
+    /// Writes one line of mail history, and never affects the mail.
+    /// </summary>
+    /// <remarks>
+    /// The reporter already swallows its own failures; this also tolerates not having one at all,
+    /// which is how every existing caller and test constructs this service. Nothing above may
+    /// depend on the outcome of this call.
+    /// </remarks>
+    private Task ReportAsync(
+        SubscriptionFinancialDocument document,
+        SendMail? payload,
+        string? mailMessageId,
+        MailDeliveryReportOutcome outcome,
+        string? errorCode,
+        string? errorMessage,
+        CancellationToken cancellationToken) =>
+        _mailReports?.RecordAsync(
+            new MailDeliveryReportRequest
+            {
+                TenantId = document.TenantId,
+                OrganizationId = document.OrganizationId,
+                Source = MailDeliveryReportSource.FinancialDocument,
+                Outcome = outcome,
+                SubjectId = document.ItemId,
+                SubjectReference = document.DocumentNumber,
+                MailMessageId = mailMessageId,
+                ConsumerName = SubscriptionConstants.MailQueue,
+                Payload = payload,
+                ErrorCode = errorCode,
+                ErrorMessage = errorMessage,
+                CorrelationId = document.CorrelationId
+            },
+            cancellationToken) ?? Task.CompletedTask;
 }

--- a/server/Subscription.DomainService/Services/UsageThresholdEmailService.cs
+++ b/server/Subscription.DomainService/Services/UsageThresholdEmailService.cs
@@ -3,6 +3,7 @@ using Blocks.Genesis;
 using Microsoft.Extensions.Logging;
 using Payment.DomainService.Utilities;
 using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Messaging;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Utilities;
@@ -18,17 +19,22 @@ public sealed class UsageThresholdEmailService : IUsageThresholdEmailService
     private readonly IBillingAccountRepository _billingAccounts;
     private readonly IMessageClient _messageClient;
     private readonly ILogger<UsageThresholdEmailService> _logger;
+    private readonly IMailDeliveryReporter? _mailReports;
 
     public UsageThresholdEmailService(
         ISubscriptionRepository subscriptions,
         IBillingAccountRepository billingAccounts,
         IMessageClient messageClient,
-        ILogger<UsageThresholdEmailService> logger)
+        ILogger<UsageThresholdEmailService> logger,
+        IMailDeliveryReporter? mailReports = null)
     {
         _subscriptions = subscriptions;
         _billingAccounts = billingAccounts;
         _messageClient = messageClient;
         _logger = logger;
+        // Optional for the same reason as on the document path: absent, nothing is recorded and
+        // the mail behaves exactly as it did before.
+        _mailReports = mailReports;
     }
 
     public async Task SendAsync(
@@ -92,19 +98,45 @@ public sealed class UsageThresholdEmailService : IUsageThresholdEmailService
             ["Limit"] = limit
         };
 
+        var payload = new SendMail
+        {
+            To = [account.BillingEmail.Trim().ToLowerInvariant()],
+            Purpose = SubscriptionConstants.UsageThresholdMailPurpose,
+            Language = SubscriptionConstants.DefaultMailLanguage,
+            SubjectDataContext = new Dictionary<string, string>(context),
+            BodyDataContext = context
+        };
+
         await _messageClient.SendToConsumerAsync(
             new ConsumerMessage<SendMail>
             {
                 ConsumerName = SubscriptionConstants.MailQueue,
-                Payload = new SendMail
-                {
-                    To = [account.BillingEmail.Trim().ToLowerInvariant()],
-                    Purpose = SubscriptionConstants.UsageThresholdMailPurpose,
-                    Language = SubscriptionConstants.DefaultMailLanguage,
-                    SubjectDataContext = new Dictionary<string, string>(context),
-                    BodyDataContext = context
-                }
+                Payload = payload
             });
+
+        // Recorded after the send, and only on success. A throw above belongs to the caller, which
+        // retries the whole lifecycle event -- recording an attempt here would put a row in the
+        // history for a mail that is about to be sent again.
+        if (_mailReports is not null)
+        {
+            await _mailReports.RecordAsync(
+                new MailDeliveryReportRequest
+                {
+                    TenantId = lifecycleEvent.TenantId,
+                    OrganizationId = subscription.OrganizationId,
+                    Source = MailDeliveryReportSource.UsageThreshold,
+                    Outcome = MailDeliveryReportOutcome.Published,
+                    SubjectId = lifecycleEvent.SubscriptionId,
+                    SubjectReference = lifecycleEvent.EventId,
+                    // No message id: usage warnings are not claimed and the same threshold may
+                    // legitimately warn more than once.
+                    MailMessageId = null,
+                    ConsumerName = SubscriptionConstants.MailQueue,
+                    Payload = payload,
+                    CorrelationId = lifecycleEvent.EventId
+                },
+                cancellationToken);
+        }
 
         _logger.LogInformation(
             "Usage threshold email queued TenantHash={TenantHash} " +

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -85,6 +85,9 @@ public static class ApplicationServiceCollectionExtensions
             ICampaignRedemptionRepository,
             CampaignRedemptionRepository>();
         services.AddSingleton<
+            IMailDeliveryReportRepository,
+            MailDeliveryReportRepository>();
+        services.AddSingleton<
             ISubscriptionBillingProfileRepository,
             SubscriptionBillingProfileRepository>();
         services.AddSingleton<
@@ -285,6 +288,8 @@ public static class ApplicationServiceCollectionExtensions
             ISubscriptionUsageOveragePreviewService,
             SubscriptionUsageOveragePreviewService>();
         services.AddScoped<IUsageThresholdEvaluator, UsageThresholdEvaluator>();
+        // Singleton to match the repository it wraps, and because it holds no per-request state.
+        services.AddSingleton<IMailDeliveryReporter, MailDeliveryReporter>();
         services.AddScoped<IUsageThresholdEmailService, UsageThresholdEmailService>();
         services.AddScoped<
             ISubscriptionActivationProcessor,

--- a/server/XUnitTest/Subscription/MailDeliveryReporterTests.cs
+++ b/server/XUnitTest/Subscription/MailDeliveryReporterTests.cs
@@ -1,0 +1,207 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Messaging;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+public sealed class MailDeliveryReporterTests
+{
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 30, 7, 12, 48, TimeSpan.Zero);
+
+    private readonly Mock<IMailDeliveryReportRepository> _reports = new();
+
+    [Fact]
+    public async Task Keeps_the_payload_as_it_was_published()
+    {
+        var written = CaptureWrite();
+
+        await Reporter().RecordAsync(Request(Payload()), CancellationToken.None);
+
+        written.Value.Should().NotBeNull();
+
+        // The point of the collection: the body context is recoverable verbatim. An invoice that
+        // arrives with an empty plan name cannot be diagnosed from anything else after the fact.
+        var round = JsonSerializer.Deserialize<SendMail>(written.Value!.PayloadJson);
+
+        round.Should().NotBeNull();
+        round!.To.Should().Equal("owner@example.com");
+        round.Purpose.Should().Be("subscription-invoice");
+        round.Attachments.Should().Equal("storage-1");
+        round.BodyDataContext["Total"].Should().Be("USD 49.00");
+        round.BodyDataContext["PlanName"].Should().Be("Professional");
+    }
+
+    [Fact]
+    public async Task Copies_out_the_fields_worth_querying_without_parsing_the_payload()
+    {
+        var written = CaptureWrite();
+
+        await Reporter().RecordAsync(Request(Payload()), CancellationToken.None);
+
+        written.Value!.TenantId.Should().Be("tenant-1");
+        written.Value.SubjectReference.Should().Be("INV-2026-000039");
+        written.Value.MailMessageId.Should().Be("document-mail:doc-1");
+        written.Value.Outcome.Should().Be(MailDeliveryReportOutcome.Published);
+        written.Value.Source.Should().Be(MailDeliveryReportSource.FinancialDocument);
+        written.Value.To.Should().Equal("owner@example.com");
+        written.Value.Attachments.Should().Equal("storage-1");
+        written.Value.PayloadLength.Should().Be(written.Value.PayloadJson.Length);
+        written.Value.PayloadHash.Should().HaveLength(64);
+        written.Value.CreatedAtUtc.Should().Be(Now.UtcDateTime);
+    }
+
+    [Fact]
+    public async Task Sets_a_purge_date_so_addresses_are_not_kept_indefinitely()
+    {
+        var written = CaptureWrite();
+
+        await Reporter().RecordAsync(Request(Payload()), CancellationToken.None);
+
+        written.Value!.PurgeAtUtc.Should().Be(
+            Now.UtcDateTime.Add(MailDeliveryReporter.Retention));
+    }
+
+    [Fact]
+    public async Task Records_a_refusal_that_never_built_a_payload()
+    {
+        var written = CaptureWrite();
+
+        // "No billing contact" is exactly the row an operator is looking for, so a report with
+        // nothing to serialize is still worth writing.
+        await Reporter().RecordAsync(
+            Request(payload: null) with
+            {
+                Outcome = MailDeliveryReportOutcome.NotAttempted,
+                ErrorCode = "document_mail_no_recipient"
+            },
+            CancellationToken.None);
+
+        written.Value!.Outcome.Should().Be(MailDeliveryReportOutcome.NotAttempted);
+        written.Value.ErrorCode.Should().Be("document_mail_no_recipient");
+        written.Value.PayloadJson.Should().BeEmpty();
+        written.Value.PayloadHash.Should().BeEmpty();
+        written.Value.To.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Never_lets_a_failed_write_reach_the_caller()
+    {
+        _reports
+            .Setup(r => r.AddAsync(It.IsAny<MailDeliveryReport>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("mongo is unreachable"));
+
+        // The guarantee the whole feature depends on. The document mail path is at-most-once
+        // behind a claim, so an exception escaping here would unwind a send that already happened
+        // and put a second invoice in somebody's inbox.
+        var recording = async () =>
+            await Reporter().RecordAsync(Request(Payload()), CancellationToken.None);
+
+        await recording.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Swallows_cancellation_too()
+    {
+        _reports
+            .Setup(r => r.AddAsync(It.IsAny<MailDeliveryReport>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        // Cancellation is not special here: the mail's outcome was decided before this was called,
+        // so there is nothing left to abandon and rethrowing would still risk the duplicate.
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        var recording = async () =>
+            await Reporter().RecordAsync(Request(Payload()), cancelled.Token);
+
+        await recording.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Hashes_identical_payloads_alike_and_different_ones_apart()
+    {
+        var hashes = new List<string>();
+        _reports
+            .Setup(r => r.AddAsync(It.IsAny<MailDeliveryReport>(), It.IsAny<CancellationToken>()))
+            .Callback<MailDeliveryReport, CancellationToken>(
+                (report, _) => hashes.Add(report.PayloadHash))
+            .Returns(Task.CompletedTask);
+
+        var reporter = Reporter();
+        await reporter.RecordAsync(Request(Payload()), CancellationToken.None);
+        await reporter.RecordAsync(Request(Payload()), CancellationToken.None);
+
+        var different = Payload();
+        different.BodyDataContext["Total"] = "USD 59.00";
+        await reporter.RecordAsync(Request(different), CancellationToken.None);
+
+        hashes[0].Should().Be(hashes[1]);
+        hashes[2].Should().NotBe(hashes[0]);
+    }
+
+    private sealed class Captured
+    {
+        public MailDeliveryReport? Value { get; set; }
+    }
+
+    private Captured CaptureWrite()
+    {
+        var captured = new Captured();
+
+        _reports
+            .Setup(r => r.AddAsync(It.IsAny<MailDeliveryReport>(), It.IsAny<CancellationToken>()))
+            .Callback<MailDeliveryReport, CancellationToken>(
+                (report, _) => captured.Value = report)
+            .Returns(Task.CompletedTask);
+
+        return captured;
+    }
+
+    private MailDeliveryReporter Reporter() =>
+        new(_reports.Object,
+            new ControlledTimeProvider(Now),
+            NullLogger<MailDeliveryReporter>.Instance);
+
+    private static SendMail Payload()
+    {
+        var context = new Dictionary<string, string>
+        {
+            ["PlanName"] = "Professional",
+            ["Total"] = "USD 49.00",
+            ["DocumentNumber"] = "INV-2026-000039"
+        };
+
+        return new SendMail
+        {
+            To = ["owner@example.com"],
+            Purpose = "subscription-invoice",
+            Language = "en-US",
+            Attachments = ["storage-1"],
+            SubjectDataContext = new Dictionary<string, string>(context),
+            BodyDataContext = context
+        };
+    }
+
+    private static MailDeliveryReportRequest Request(SendMail? payload) =>
+        new()
+        {
+            TenantId = "tenant-1",
+            OrganizationId = "org-1",
+            Source = MailDeliveryReportSource.FinancialDocument,
+            Outcome = MailDeliveryReportOutcome.Published,
+            SubjectId = "doc-1",
+            SubjectReference = "INV-2026-000039",
+            MailMessageId = "document-mail:doc-1",
+            ConsumerName = "blocks_email_listener",
+            Payload = payload,
+            CorrelationId = "sweep-1"
+        };
+}


### PR DESCRIPTION
## Why

A financial document already carries a `Delivery` block, but it holds the current state of **one document's one mail**: overwritten on a resend, silent about usage-threshold mail, and it never held what was actually handed over.

So when an invoice arrives with an empty plan name or a stale total, the thing that would explain it — the `BodyDataContext` the template was given — is gone. This came out of a live investigation where the question "what did we actually send?" had no answer anywhere in the system.

## What

`SubscriptionMailDeliveryReports`: append-only, one row per handover to the mail listener, tenant-scoped like every other subscription collection.

| | |
|---|---|
| `PayloadJson` | the whole `SendMail` as published — indented, unescaped, readable during an incident |
| `PayloadHash` / `PayloadLength` | SHA-256, so two identical handovers are recognisable |
| `To` / `Cc` / `Bcc` / `Attachments` / `Purpose` / `Language` | copied out so the common questions are indexable without parsing |
| `SubjectId` + `SubjectReference` | document id and its number — an operator arrives with `INV-2026-000039`, not a GUID |
| `MailMessageId`, `Outcome`, `ErrorCode`, `ErrorMessage`, `CorrelationId` | |

Indexes: by subject (newest first), by tenant recency, sparse on message id, and a TTL on `PurgeAtUtc`.

## Three decisions worth overruling if you disagree

**Both publishers, not just invoices.** `UsageThresholdEmailService` also publishes `SendMail`; a "mail delivery report" that silently covered half the mail would be worse than none.

**Refusals recorded, not only sends.** `document_mail_no_recipient` and `document_mail_claim_taken` existed as log lines only. Those are precisely the rows you go looking for when mail is missing — the claim-taken case in particular is invisible today and never retries by design.

**90-day TTL.** Payloads carry recipient addresses and billing figures; keeping them indefinitely is accumulating personal data for no stated purpose. `MailDeliveryReporter.Retention` is one constant if billing disputes need longer.

## The constraint that shaped it

**Recording is best-effort and cannot affect the mail.** The reporter swallows every exception, including cancellation, and both publishers take it as an optional dependency (absent, nothing is recorded and behaviour is identical to before).

This is not defensiveness for its own sake. Document delivery is at-most-once behind a claim, so an exception escaping the reporter would unwind a send that **had already happened** — putting a second invoice in somebody's inbox, which is the exact failure the claim exists to prevent. A history row is worth less than that guarantee.

Two tests pin it: `Never_lets_a_failed_write_reach_the_caller` and `Swallows_cancellation_too`.

The message-id index is deliberately **not** unique, for the same reason: a deliberate resend reuses the id, and a unique index would make the second send fail to record — showing one mail where two went out.

## Verification

- 7 new tests pass; the 18 existing delivery and usage-threshold tests still pass (25 together after merging `dev`).
- Full unit suite: **3252 passed, 4 failed** — the four are the pre-existing `SubscriptionSimulationGuard` permission failures on `dev`, untouched by this change.
- `Subscription.DomainService` builds clean.

Note that **no CI job runs server unit tests on a PR**, so none of the above will be re-run by this PR's checks. That gap is why the four pre-existing failures went unnoticed, and a `server-pr-validation` workflow is drafted but blocked on them.

## Not included

No read API. The collection is queryable directly, which is what an operator needs during an incident; an endpoint can follow once the shape has proven itself against real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
