### PR TITLE
fix(subscription): stop the plan builder's own preview saying a trial charges at signup

### DIFF
--- a/client/app/cross-modules/utilities/subscription/utilities/trial-duration-label.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/trial-duration-label.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { describeTrialSentence } from "./trial-duration-label";
+
+/**
+ * The sentence that reads "Charged at signup" in production right now, on the plan builder's own
+ * preview -- a third place saying this independently of step-trial.tsx (fixed in #355) and this
+ * file's own card-free branch, which was already correct. Every trial is free until it ends since
+ * #353; a card being collected up front is a condition of starting, not a charge.
+ */
+describe("describeTrialSentence", () => {
+  it("does not claim a card-required trial is charged at signup", () => {
+    const sentence = describeTrialSentence({
+      trialDurationKind: "Days",
+      trialDurationCount: 14,
+      trialRequiresPaymentMethod: true,
+    });
+
+    expect(sentence).not.toMatch(/charged at signup/i);
+    expect(sentence).toMatch(/first charge is taken when the trial ends/i);
+    expect(sentence).toContain("14 days");
+  });
+
+  it("still describes a card-free trial as free until the first charge", () => {
+    const sentence = describeTrialSentence({
+      trialDurationKind: "Days",
+      trialDurationCount: 14,
+      trialRequiresPaymentMethod: false,
+    });
+
+    expect(sentence).toBe("Free for 14 days, then the first charge is taken.");
+  });
+
+  it("says a card is saved for the anniversary-month cadence too", () => {
+    const sentence = describeTrialSentence({
+      trialDurationKind: "AnniversaryMonths",
+      trialDurationCount: 1,
+      trialRequiresPaymentMethod: true,
+    });
+
+    expect(sentence).toContain("1 month");
+    expect(sentence).toMatch(/card is saved now/i);
+  });
+
+  it("says a card is saved for the end-of-calendar-month cadence too", () => {
+    const sentence = describeTrialSentence({
+      trialDurationKind: "EndOfCalendarMonth",
+      trialDurationCount: null,
+      trialRequiresPaymentMethod: true,
+    });
+
+    expect(sentence).toBe(
+      "A card is saved now, free until the end of the calendar month, then the first charge is " +
+        "taken when the trial ends.",
+    );
+  });
+
+  it("returns null for a plan with no trial", () => {
+    expect(
+      describeTrialSentence({
+        trialDurationKind: null,
+        trialDurationCount: null,
+        trialRequiresPaymentMethod: true,
+      }),
+    ).toBeNull();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/trial-duration-label.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/trial-duration-label.ts
@@ -26,7 +26,7 @@ export const describeTrialDuration = (plan: TrialDuration): string | null => {
 };
 
 /**
- * A full sentence describing when the trial ends and what happens then — for the plan summary
+ * A full sentence describing when the trial ends and what happens then -- for the plan summary
  * card, where the badge's short label is not enough context.
  */
 export const describeTrialSentence = (
@@ -45,7 +45,14 @@ export const describeTrialSentence = (
     return null;
   }
 
+  const freeSpan = plan.trialDurationKind === "EndOfCalendarMonth" ? span : `for ${span}`;
+
+  // Both branches describe a trial that is free until it ends -- a card being collected up front
+  // is a condition of starting, not a charge. This read "Charged at signup" for the card-required
+  // case until it was caught live in the plan builder's own preview: the third place this sentence
+  // was written independently of step-trial.tsx (#355) and trial-duration-label.ts's own
+  // card-required branch, and the only one still saying so after #353 made it false.
   return plan.trialRequiresPaymentMethod
-    ? `Charged at signup; the trial (${span}) governs the allowances, not the price.`
-    : `Free ${plan.trialDurationKind === "EndOfCalendarMonth" ? span : `for ${span}`}, then the first charge is taken.`;
+    ? `A card is saved now, free ${freeSpan}, then the first charge is taken when the trial ends.`
+    : `Free ${freeSpan}, then the first charge is taken.`;
 };


### PR DESCRIPTION
**Live on `dev` right now**, caught in the actual plan-builder screen: a card-required trial's preview panel reads

> "Charged at signup; the trial (1 days) governs the allowances, not the price."

False since #353 — every trial is free until it ends, whether or not it collects a card.

## Why #355 didn't catch this

`describeTrialSentence` in `trial-duration-label.ts` is a **third** place saying this, independent of the two #355 fixed. It exists specifically to feed `plan-summary-card.tsx` — a component #355 never touched, because #355 fixed exactly the one component (`step-trial.tsx`) it edited. Three places said the same false thing; two got fixed.

## The fix

Card-free branch is untouched — it already said the true thing (`"Free for 14 days, then the first charge is taken."`). Card-required branch now reads:

> "A card is saved now, free for 14 days, then the first charge is taken when the trial ends."

Same fact `step-trial.tsx`'s checkbox already states, same words.

## Tests

None existed for this file. Added 5, covering both branches across all three trial-duration kinds plus the no-trial case. **Confirmed against the reverted wording first** — 3 fail on the old text, 2 pass unchanged since the card-free branch was never wrong.

## Verification

- `trial-duration-label.test.ts` + `plan-summary-card.test.tsx`: 16 passed
- Broader subscription client suite: **477 passed, 38 files**
- `tsc --noEmit`, `eslint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
