### PR TITLE
Fix zero-amount payment-method setup callbacks

### DIFF
--- a/server/Payment.DomainService/Services/CheckoutResultValidator.cs
+++ b/server/Payment.DomainService/Services/CheckoutResultValidator.cs
@@ -22,11 +22,7 @@ public sealed class CheckoutResultValidator : ICheckoutResultValidator
         var expectedReference = payment.InitiationRequest?.Reference ??
                                 payment.ItemId;
 
-        if (!_minorUnitResolver.TryConvert(
-                payment.PreciseAmount,
-                payment.CurrencyCode,
-                out var expectedMinorUnits) ||
-            !string.Equals(
+        if (!string.Equals(
                 checkoutResult.Id,
                 payment.SessionId,
                 StringComparison.Ordinal) ||
@@ -34,6 +30,26 @@ public sealed class CheckoutResultValidator : ICheckoutResultValidator
                 checkoutResult.Reference,
                 expectedReference,
                 StringComparison.Ordinal))
+        {
+            return CheckoutResultValidationOutcome.Mismatch;
+        }
+
+        // A setup Checkout session stores a payment method but moves no money. Its payment
+        // record therefore has a deliberate zero amount, and Stripe does not return a charge
+        // amount for it. Validate the provider identity above, but do not send that zero through
+        // the financial amount validator, which correctly rejects non-positive payments.
+        if (string.Equals(
+                payment.PaymentFlow,
+                PaymentFlows.PaymentMethodSetup,
+                StringComparison.Ordinal))
+        {
+            return CheckoutResultValidationOutcome.Valid;
+        }
+
+        if (!_minorUnitResolver.TryConvert(
+                payment.PreciseAmount,
+                payment.CurrencyCode,
+                out var expectedMinorUnits))
         {
             return CheckoutResultValidationOutcome.Mismatch;
         }

--- a/server/XUnitTest/Payment/CheckoutResultValidatorTests.cs
+++ b/server/XUnitTest/Payment/CheckoutResultValidatorTests.cs
@@ -12,6 +12,70 @@ namespace XUnitTest.Payment;
 public sealed class CheckoutResultValidatorTests
 {
     [Fact]
+    public void Payment_method_setup_validates_identity_without_requiring_an_amount()
+    {
+        var minorUnits = new Mock<ICurrencyMinorUnitResolver>(MockBehavior.Strict);
+        var payment = new PaymentDetail
+        {
+            ItemId = "setup-payment-1",
+            SessionId = "setup-session-1",
+            PreciseAmount = 0,
+            CurrencyCode = "CHF",
+            PaymentFlow = PaymentFlows.PaymentMethodSetup,
+            InitiationRequest = new ProviderInitiationRequest
+            {
+                Reference = "setup-reference"
+            }
+        };
+        var result = new HostedCheckoutResult
+        {
+            Id = "setup-session-1",
+            Reference = "setup-reference",
+            Status = "completed"
+        };
+        var validator = new CheckoutResultValidator(minorUnits.Object);
+
+        validator.Validate(payment, result)
+            .Should().Be(CheckoutResultValidationOutcome.Valid);
+
+        minorUnits.VerifyNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData("another-session", "setup-reference")]
+    [InlineData("setup-session-1", "another-reference")]
+    public void Payment_method_setup_rejects_a_mismatched_session_or_reference(
+        string sessionId,
+        string reference)
+    {
+        var minorUnits = new Mock<ICurrencyMinorUnitResolver>(MockBehavior.Strict);
+        var payment = new PaymentDetail
+        {
+            ItemId = "setup-payment-1",
+            SessionId = "setup-session-1",
+            PreciseAmount = 0,
+            CurrencyCode = "CHF",
+            PaymentFlow = PaymentFlows.PaymentMethodSetup,
+            InitiationRequest = new ProviderInitiationRequest
+            {
+                Reference = "setup-reference"
+            }
+        };
+        var result = new HostedCheckoutResult
+        {
+            Id = sessionId,
+            Reference = reference,
+            Status = "completed"
+        };
+        var validator = new CheckoutResultValidator(minorUnits.Object);
+
+        validator.Validate(payment, result)
+            .Should().Be(CheckoutResultValidationOutcome.Mismatch);
+
+        minorUnits.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public void Checkout_result_uses_the_provider_reference_snapshot()
     {
         var minorUnits = new Mock<ICurrencyMinorUnitResolver>();


### PR DESCRIPTION
## Summary
- validate setup-mode Checkout results by session and provider reference without requiring a positive amount
- preserve amount and currency validation for real payment flows
- add regression coverage for valid and mismatched setup callbacks

## Cause
Payment-method setup records deliberately carry a zero amount. The shared checkout validator sent that zero through the financial minor-unit resolver, which rejects non-positive payments, so a valid Stripe setup callback returned payment_mismatch.

## Verification
- Payment test namespace: 1373 passed
- Focused checkout validator/callback/observation suite: 27 passed
- Server projects compiled successfully during the test build