### PR TITLE
fix(subscription): prefill Stripe checkout's email from the billing profile

### DIFF
--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -465,6 +465,28 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     /// </remarks>
     private static bool RequiresPayment(long amountMinor) => amountMinor > 0;
 
+    /// <summary>
+    /// The address Stripe should prefill, read from the billing account rather than asked of the
+    /// caller.
+    /// </summary>
+    /// <remarks>
+    /// Set once, at signup, from the billing profile's own contact -- see
+    /// SubscriptionCreationService's BillingEmail assignment -- so by the time a subscription can
+    /// be charged or asked to collect a card, this is already the address on file. Read here
+    /// rather than threaded through from the caller because ChargeAsync and StartCardSetupAsync
+    /// are reached from more than one entry point, some of which have never had a reason to know
+    /// the billing account until now.
+    /// </remarks>
+    private async Task<string?> BillingEmailAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        var account = await _billingAccounts.GetAsync(
+            subscription.TenantId, subscription.BillingAccountId, cancellationToken);
+
+        return account?.BillingEmail is { Length: > 0 } email ? email : null;
+    }
+
     /// <summary>Whether a card is actually stored, read from the account rather than assumed.</summary>
     private async Task<bool> HasStoredPaymentMethodAsync(
         string tenantId,
@@ -590,7 +612,10 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                 CurrencyCode = subscription.CurrencyCode,
                 OrderId = subscription.OrderId,
                 Description = $"{subscription.Plan.DisplayName} subscription",
-                CustomerOrganizationId = subscription.OrganizationId
+                CustomerOrganizationId = subscription.OrganizationId,
+                // Same reason ChargeAsync carries it: prefilled once here rather than typed twice
+                // -- once on the billing profile, again on Stripe's own page.
+                CustomerEmail = await BillingEmailAsync(subscription, cancellationToken)
             },
             SubscriptionConstants.PaymentMethodSetupKeyFor(
                 subscription.ItemId,
@@ -713,6 +738,10 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                 OrderId = subscription.OrderId,
                 Description = $"{subscription.Plan.DisplayName} subscription",
                 CustomerOrganizationId = subscription.OrganizationId,
+                // Stripe uses this to prefill the checkout page's email field. Without it the
+                // subscriber -- whose address the billing profile already collected a step
+                // earlier -- has to type it again on the provider's own page.
+                CustomerEmail = await BillingEmailAsync(subscription, cancellationToken),
                 // The renewal in a month charges this card with nobody present, which the
                 // provider only permits if the mandate was established when it was saved.
                 SavePaymentMethod = true

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -598,6 +598,8 @@ public sealed class SubscriptionCheckoutServiceTests
                 TenantId, subscription.ItemId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(subscription);
 
+    private CreatePaymentMethodSetupRequest? _setupRequest;
+
     private void GivenSetupSessionOpens(string url = "https://checkout.stripe.com/setup") =>
         _paymentMethodSetups
             .Setup(service => service.CreateSetupAsync(
@@ -605,6 +607,8 @@ public sealed class SubscriptionCheckoutServiceTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
+            .Callback<CreatePaymentMethodSetupRequest, string, string, CancellationToken>(
+                (request, _, _, _) => _setupRequest = request)
             .ReturnsAsync(PaymentOperationResult.Success(
                 new PaymentResponse
                 {
@@ -612,6 +616,42 @@ public sealed class SubscriptionCheckoutServiceTests
                     RedirectUrl = url
                 },
                 "corr-1"));
+
+    // ---- Prefilling Stripe's own page with what the billing profile already collected ---------
+    //
+    // Both CustomerEmail fields exist on the requests to the payment module and were never set --
+    // neither the charge nor the card-setup session carried them, so Stripe's checkout page asked
+    // the subscriber to type an address the billing profile had already collected a step earlier.
+
+    [Fact]
+    public async Task The_initial_charge_carries_the_billing_email_for_stripe_to_prefill()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, _subscription.BillingAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount { BillingEmail = "maya@example.com" });
+
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        _paymentRequest!.CustomerEmail.Should().Be("maya@example.com");
+    }
+
+    [Fact]
+    public async Task A_missing_billing_email_leaves_the_field_unset_rather_than_sending_empty()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, _subscription.BillingAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount { BillingEmail = null });
+
+        await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        // Not empty string: Stripe's own form-encoding helper only omits a field for a literal
+        // null, and an empty customer_email is a value the provider can reject outright.
+        _paymentRequest!.CustomerEmail.Should().BeNull();
+    }
 
     [Fact]
     public async Task A_trialing_subscription_can_add_a_card_without_being_charged()

--- a/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
+++ b/server/XUnitTest/Subscription/ZeroAmountCardSetupTests.cs
@@ -212,6 +212,25 @@ public sealed class ZeroAmountCardSetupTests
             SubscriptionConstants.PaymentMethodSetupKeyFor(_subscription.ItemId, 0));
     }
 
+    /// <summary>
+    /// The card-setup session carries the billing profile's own email, so Stripe's page opens
+    /// with it already filled in rather than asking the subscriber to type an address the
+    /// billing profile collected a step earlier.
+    /// </summary>
+    [Fact]
+    public async Task The_setup_session_carries_the_billing_email_for_stripe_to_prefill()
+    {
+        _subscription.Plan.RequirePaymentMethodUpfront = true;
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, _subscription.BillingAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount { BillingEmail = "maya@example.com" });
+
+        await Subscribe();
+
+        _setupRequest!.CustomerEmail.Should().Be("maya@example.com");
+    }
+
     [Fact]
     public async Task A_provider_that_cannot_collect_a_card_leaves_the_subscription_recoverable()
     {


### PR DESCRIPTION
## Two things asked, one gap

**Payment methods prefilled** already worked and needed nothing — both requests already name the Stripe customer (`providerPayerReference`, resolved from stored payment methods by shopper reference) whenever one exists, which is what makes Stripe show cards already saved against them.

**Email prefilled** did not. `CustomerEmail` exists on both `MakePaymentRequest` and `CreatePaymentMethodSetupRequest`, and both provider factories already forward it to Stripe as `customer_email` — but neither call site in `SubscriptionCheckoutService` ever set it. A first-time subscriber has always had to retype an address the billing profile collected a step earlier.

## The fix

New `BillingEmailAsync` reads `BillingAccount.BillingEmail` — populated once at signup from the resolved billing contact — and wires it into both `ChargeAsync` (the initial charge) and `StartCardSetupAsync` (the card-only session, reached from signup, from adding a card mid-trial, and from Unpaid recovery).

Only matters for a shopper Stripe hasn't seen before. Once `providerPayerReference` is known, Stripe reads the email off its own Customer record and this is moot — which is also why the fix is scoped to these two call sites rather than every place a request gets built.

A missing billing email leaves the field genuinely unset (`StripeForm.Add` only omits a literal `null`) rather than sending an empty string, which Stripe can reject outright.

## Verification

- Confirmed against the reverted fix first: exactly the two new tests fail, nothing else.
- `SubscriptionCheckoutServiceTests` + `ZeroAmountCardSetupTests`: 48 passed.
- Full non-integration suite: **3285 passed**. The 4 `SubscriptionSimulation*` failures are pre-existing; `SubscriptionWorkDispatcherTests`' one failure confirmed a load flake, 18/18 alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
