### PR TITLE
Fix subscription worker mail reporter resolution

### DIFF
--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -36,6 +36,11 @@ public static class ApplicationServiceCollectionExtensions
         services.Configure<SubscriptionOptions>(
             configuration.GetSection(SubscriptionOptions.SectionName));
 
+        // A host may replace this with a controlled clock before registering the module. Keep a
+        // production default in the container for services whose clock is a required dependency,
+        // including the singleton mail-delivery reporter resolved by background work.
+        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+
         var simulationSection = configuration.GetSection(SubscriptionSimulationOptions.SectionName);
         services.Configure<SubscriptionSimulationOptions>(simulationSection);
 

--- a/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+using Moq;
 using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 
 namespace XUnitTest.Subscription;
@@ -73,6 +75,28 @@ public sealed class SubscriptionServiceRegistrationTests
         options.TenantIds.Should().BeEmpty(
             "nothing else discovers tenants, so an omitted tenant is silently skipped by " +
             "every background sweep");
+    }
+
+    [Fact]
+    public void Mail_delivery_reporter_resolves_with_the_default_system_clock()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterSubscriptionDomainServices(Configuration());
+
+        // Replace persistence so this is a composition test rather than a MongoDB test. The
+        // production failure happened while constructing the reporter, before persistence ran.
+        services.AddSingleton(Mock.Of<IMailDeliveryReportRepository>());
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true
+        });
+
+        provider.GetRequiredService<TimeProvider>()
+            .Should().BeSameAs(TimeProvider.System);
+        provider.GetRequiredService<IMailDeliveryReporter>()
+            .Should().BeOfType<MailDeliveryReporter>();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- register TimeProvider.System as the subscription module's overridable default clock
- allow hosts and tests to keep supplying a custom TimeProvider through TryAdd semantics
- add a DI composition regression that resolves the real MailDeliveryReporter

## Production failure
Every subscription work item failed before handler selection because resolving IEnumerable<ISubscriptionWorkHandler> constructed the financial-document delivery graph, which reached MailDeliveryReporter. Its required TimeProvider had no registration, so all work retried and eventually dead-lettered with InvalidOperationException.

## Verification
- focused registration, mail reporter, and dispatcher tests: 40 passed
- subscription namespace: 1375 passed; only the 4 pre-existing SubscriptionSimulation permission failures remain
- server projects compiled successfully during the test run

## Recovery
Dead-lettered SubscriptionBackgroundWork items must be requeued after deployment; restarting the worker alone does not revive them.