### PR TITLE
feat(subscription): expose overage terms on GET /subscriptions/current

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
@@ -83,6 +83,8 @@ const subscription: SimulatedSubscription = {
   unitAmountMinor: 10_000,
   interval: "Month",
   intervalCount: 1,
+  usageInterval: "Month",
+  usageIntervalCount: 1,
   displayPriceNote: null,
   quantities: [],
   currentPeriodStartUtc: "2026-08-01T00:00:00Z",

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
@@ -95,6 +95,7 @@ const subscription: SimulatedSubscription = {
   currentTier: null,
   recurringAmountMinor: 10_000,
   checkoutUrl: null,
+  meters: [],
   version: 1,
 };
 

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
@@ -39,6 +39,8 @@ const subscription: SimulatedSubscription = {
   unitAmountMinor: 14_500,
   interval: "Month",
   intervalCount: 1,
+  usageInterval: "Month",
+  usageIntervalCount: 1,
   displayPriceNote: null,
   quantities: [{ itemKey: "user", quantity: 4, unitLabel: "user" }],
   currentPeriodStartUtc: "2026-08-01T00:00:00Z",

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
@@ -51,6 +51,7 @@ const subscription: SimulatedSubscription = {
   currentTier: { minimumQuantity: 1, maximumQuantity: 4, discountBasisPoints: 0 },
   recurringAmountMinor: 58_000,
   checkoutUrl: null,
+  meters: [],
   version: 7,
 };
 

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
@@ -30,6 +30,7 @@ const baseSubscription: SimulatedSubscription = {
   checkoutUrl: null,
   pendingCheckout: null,
   hasPaymentMethod: null,
+  meters: [],
   version: 1,
 };
 

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
@@ -16,6 +16,8 @@ const baseSubscription: SimulatedSubscription = {
   unitAmountMinor: 8_900,
   interval: "Month",
   intervalCount: 1,
+  usageInterval: "Month",
+  usageIntervalCount: 1,
   displayPriceNote: null,
   quantities: [],
   currentPeriodStartUtc: "2026-08-01T00:00:00Z",

--- a/client/app/cross-modules/utilities/subscription-simulation/components/estimate-usage-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/estimate-usage-dialog.test.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MeterTerms, UsageOveragePreviewResult } from "../models/subscription-simulation.model";
+
+const previewUsageOverage = vi.fn();
+
+vi.mock("../services/subscription-simulation.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../services/subscription-simulation.service")
+  >("../services/subscription-simulation.service");
+
+  return {
+    ...actual,
+    subscriptionSimulationService: {
+      previewUsageOverage: (...args: unknown[]) => previewUsageOverage(...args),
+    },
+  };
+});
+
+import { EstimateUsageDialog } from "./estimate-usage-dialog";
+
+const meter: MeterTerms = {
+  meterKey: "screening",
+  displayName: "Screenings",
+  unitLabel: "screening",
+  includedQuantity: 150,
+  resetPolicy: "Periodic",
+  carryForwardCap: null,
+  overageAllowed: true,
+  overagePricing: {
+    currencyCode: "CHF",
+    tiers: [
+      { upToQuantity: 100, unitAmount: "1.00" },
+      { upToQuantity: null, unitAmount: "0.80" },
+    ],
+  },
+};
+
+const previewResult: UsageOveragePreviewResult = {
+  meterKey: "screening",
+  unitLabel: "screening",
+  currencyCode: "CHF",
+  periodKey: "2026-08",
+  periodStartUtc: "2026-08-01T00:00:00Z",
+  periodEndUtc: "2026-09-01T00:00:00Z",
+  calculatedAtUtc: "2026-08-16T12:00:00Z",
+  includedQuantity: 150,
+  currentUsage: 140,
+  currentOverage: 0,
+  additionalQuantity: 20,
+  projectedUsage: 160,
+  projectedOverage: 10,
+  currentCharge: { grossMinor: 0, automaticDiscountMinor: 0, netMinor: 0, taxMinor: 0, totalMinor: 0 },
+  additionalCharge: {
+    grossMinor: 1_000,
+    automaticDiscountMinor: 0,
+    netMinor: 1_000,
+    taxMinor: 77,
+    totalMinor: 1_077,
+  },
+  projectedPeriodCharge: {
+    grossMinor: 12_000,
+    automaticDiscountMinor: 0,
+    netMinor: 12_000,
+    taxMinor: 924,
+    totalMinor: 12_924,
+  },
+  additionalTierBreakdown: [
+    { fromOverageQuantity: 0, toOverageQuantity: 10, units: 10, unitAmountMinor: 100, amountMinor: 1_000 },
+  ],
+  discount: { automaticBasisPoints: 0, promotionalCodeApplied: false },
+  tax: { rateBasisPoints: 770, mode: "Exclusive" },
+  writesUsage: false,
+  chargesPayment: false,
+  finalChargeDependsOnActualPeriodEndUsage: true,
+};
+
+const renderDialog = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <EstimateUsageDialog
+        meter={meter}
+        organizationId="org-1"
+        open
+        onOpenChange={() => {}}
+      />
+    </QueryClientProvider>,
+  );
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EstimateUsageDialog", () => {
+  it("does not call the preview for a zero or fractional quantity", async () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/additional screenings to estimate/i), {
+      target: { value: "0" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^estimate$/i }));
+
+    expect(screen.getByText(/whole number of additional units greater than zero/i)).toBeInTheDocument();
+    expect(previewUsageOverage).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText(/additional screenings to estimate/i), {
+      target: { value: "2.5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^estimate$/i }));
+
+    expect(previewUsageOverage).not.toHaveBeenCalled();
+  });
+
+  it("calls the preview with a positive whole-number quantity", async () => {
+    previewUsageOverage.mockResolvedValue(previewResult);
+
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/additional screenings to estimate/i), {
+      target: { value: "20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^estimate$/i }));
+
+    await waitFor(() =>
+      expect(previewUsageOverage).toHaveBeenCalledWith({
+        meterKey: "screening",
+        additionalQuantity: 20,
+        organizationId: "org-1",
+      }),
+    );
+  });
+
+  it("displays the discount, tax and totals the preview reports", async () => {
+    previewUsageOverage.mockResolvedValue(previewResult);
+
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/additional screenings to estimate/i), {
+      target: { value: "20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^estimate$/i }));
+
+    await waitFor(() => expect(screen.getByText(/10.77/)).toBeInTheDocument());
+    expect(screen.getByText(/7\.7%, Exclusive/)).toBeInTheDocument();
+  });
+
+  it("states that previewing neither records usage nor charges payment, and that the final invoice may differ", async () => {
+    previewUsageOverage.mockResolvedValue(previewResult);
+
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/additional screenings to estimate/i), {
+      target: { value: "20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^estimate$/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/neither records usage nor charges payment/i),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/final invoice depends on actual usage/i)).toBeInTheDocument();
+  });
+
+  it("surfaces a preview failure without hiding the meter's own contractual terms", async () => {
+    previewUsageOverage.mockRejectedValue(new Error("No overage rate is configured."));
+
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/additional screenings to estimate/i), {
+      target: { value: "20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^estimate$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/No overage rate is configured\./)).toBeInTheDocument(),
+    );
+    // The dialog itself, and the meter it is estimating for, remain on screen -- a failed
+    // preview never yanks away the terms the subscriber came here to look at.
+    expect(screen.getByText(/Screenings/)).toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/estimate-usage-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/estimate-usage-dialog.tsx
@@ -1,0 +1,223 @@
+import { Info, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import { Input } from "@/components/ui-kits/input/input";
+import { Label } from "@/components/ui-kits/label/label";
+import { formatMoney } from "../../subscription/utilities/subscription-format";
+import { usePreviewUsageOverage } from "../hooks/use-preview-usage-overage";
+import type { MeterTerms, UsageOveragePreviewResult } from "../models/subscription-simulation.model";
+
+/**
+ * A whole, positive number of additional units -- anything else answers nothing, so the call is
+ * never made for it. Parsed rather than validated with a regex: the input is a number field, and
+ * what actually reaches the server has to survive `Number.isInteger`, not merely look like digits.
+ */
+const parseWholeQuantity = (raw: string): number | null => {
+  if (raw.trim() === "") {
+    return null;
+  }
+
+  const parsed = Number(raw);
+
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+const ChargeLine = ({
+  label,
+  amountMinor,
+  currencyCode,
+  emphasize,
+}: {
+  label: string;
+  amountMinor: number;
+  currencyCode: string;
+  emphasize?: boolean;
+}) => (
+  <div className={`flex items-center justify-between ${emphasize ? "font-medium" : ""}`}>
+    <span className={emphasize ? "" : "text-muted-foreground"}>{label}</span>
+    <span>{formatMoney(amountMinor, currencyCode)}</span>
+  </div>
+);
+
+const PreviewResult = ({ result }: { result: UsageOveragePreviewResult }) => (
+  <div className="space-y-4 rounded-lg border bg-muted/30 p-3 text-sm">
+    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs text-muted-foreground">
+      <span>Current usage</span>
+      <span className="text-right text-foreground">
+        {result.currentUsage.toLocaleString()} {result.unitLabel}
+        {result.currentUsage === 1 ? "" : "s"}
+      </span>
+      <span>Projected usage</span>
+      <span className="text-right text-foreground">
+        {result.projectedUsage.toLocaleString()} {result.unitLabel}
+        {result.projectedUsage === 1 ? "" : "s"}
+      </span>
+    </div>
+
+    {result.additionalTierBreakdown.length > 0 && (
+      <div className="space-y-1 border-t pt-2 text-xs">
+        <p className="font-medium text-muted-foreground">Tier allocation</p>
+        {result.additionalTierBreakdown.map((allocation, index) => (
+          <div key={index} className="flex items-center justify-between">
+            <span className="text-muted-foreground">
+              {allocation.units.toLocaleString()} {result.unitLabel}
+              {allocation.units === 1 ? "" : "s"} @{" "}
+              {formatMoney(allocation.unitAmountMinor, result.currencyCode)}
+            </span>
+            <span>{formatMoney(allocation.amountMinor, result.currencyCode)}</span>
+          </div>
+        ))}
+      </div>
+    )}
+
+    <div className="space-y-1 border-t pt-2">
+      <p className="text-xs font-medium text-muted-foreground">Additional charge</p>
+      <ChargeLine
+        label="Gross"
+        amountMinor={result.additionalCharge.grossMinor}
+        currencyCode={result.currencyCode}
+      />
+      {result.additionalCharge.automaticDiscountMinor > 0 && (
+        <ChargeLine
+          label={`Discount${result.discount.automaticBasisPoints ? ` (${result.discount.automaticBasisPoints / 100}%)` : ""}`}
+          amountMinor={-result.additionalCharge.automaticDiscountMinor}
+          currencyCode={result.currencyCode}
+        />
+      )}
+      {result.tax.rateBasisPoints != null && (
+        <ChargeLine
+          label={`Tax (${result.tax.rateBasisPoints / 100}%, ${result.tax.mode})`}
+          amountMinor={result.additionalCharge.taxMinor}
+          currencyCode={result.currencyCode}
+        />
+      )}
+      <ChargeLine
+        label="Additional charge"
+        amountMinor={result.additionalCharge.totalMinor}
+        currencyCode={result.currencyCode}
+        emphasize
+      />
+    </div>
+
+    <div className="border-t pt-2">
+      <ChargeLine
+        label="Projected period charge"
+        amountMinor={result.projectedPeriodCharge.totalMinor}
+        currencyCode={result.currencyCode}
+        emphasize
+      />
+    </div>
+
+    <div className="flex items-start gap-1.5 rounded-md bg-background p-2 text-xs text-muted-foreground">
+      <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+      <span>
+        {!result.writesUsage && !result.chargesPayment
+          ? "Previewing neither records usage nor charges payment. "
+          : ""}
+        {result.finalChargeDependsOnActualPeriodEndUsage
+          ? "The final invoice depends on actual usage recorded by period end, and may differ from this estimate."
+          : ""}
+      </span>
+    </div>
+  </div>
+);
+
+export const EstimateUsageDialog = ({
+  meter,
+  organizationId,
+  open,
+  onOpenChange,
+}: {
+  meter: MeterTerms;
+  organizationId: string | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { mutateAsync, isPending, data: result, reset } = usePreviewUsageOverage();
+
+  const [quantity, setQuantity] = useState("1");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async () => {
+    const parsedQuantity = parseWholeQuantity(quantity);
+
+    if (parsedQuantity === null) {
+      setFormError("Enter a whole number of additional units greater than zero.");
+      return;
+    }
+
+    setFormError(null);
+
+    try {
+      await mutateAsync({
+        meterKey: meter.meterKey,
+        additionalQuantity: parsedQuantity,
+        organizationId,
+      });
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : "The overage could not be previewed.");
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!isPending) {
+          if (!next) {
+            reset();
+          }
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Estimate additional usage — {meter.displayName}</DialogTitle>
+          <DialogDescription>
+            Sends <code>POST /api/subscription-usage/overage/preview</code> — prices a
+            hypothetical slice of additional usage with this subscription&apos;s own terms.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="estimate-usage-quantity">
+              Additional {meter.unitLabel}s to estimate
+            </Label>
+            <Input
+              id="estimate-usage-quantity"
+              type="number"
+              min={1}
+              step={1}
+              value={quantity}
+              onChange={(event) => setQuantity(event.target.value)}
+            />
+          </div>
+
+          {formError && <p className="text-sm text-destructive">{formError}</p>}
+
+          {result && <PreviewResult result={result} />}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Close
+          </Button>
+          <Button onClick={submit} disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Estimate
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.test.tsx
@@ -13,6 +13,8 @@ const baseSubscription: SimulatedSubscription = {
   unitAmountMinor: 8_900,
   interval: "Month",
   intervalCount: 1,
+  usageInterval: "Month",
+  usageIntervalCount: 1,
   displayPriceNote: null,
   quantities: [],
   currentPeriodStartUtc: "2026-08-01T00:00:00Z",
@@ -58,13 +60,16 @@ const pricedMeter: MeterTerms = {
   },
 };
 
-const renderSection = (meters: MeterTerms[]) => {
+const renderSection = (
+  meters: MeterTerms[],
+  overrides: Partial<SimulatedSubscription> = {},
+) => {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
   return render(
     <QueryClientProvider client={client}>
       <OverageTermsSection
-        subscription={{ ...baseSubscription, meters }}
+        subscription={{ ...baseSubscription, ...overrides, meters }}
         organizationId="org-1"
       />
     </QueryClientProvider>,
@@ -117,5 +122,49 @@ describe("OverageTermsSection", () => {
 
     expect(screen.getByText(/Additional usage is blocked/)).toBeInTheDocument();
     expect(screen.getByText(/First 100 additional screenings/)).toBeInTheDocument();
+  });
+
+  it("describes the allowance from the usage cadence, not the billing cadence", () => {
+    // Yearly-billed, monthly-metered -- the two are independent, and using the billing interval
+    // here would have shown "per year" for an allowance that actually resets every month.
+    renderSection([blockedMeter], {
+      interval: "Year",
+      intervalCount: 1,
+      usageInterval: "Month",
+      usageIntervalCount: 1,
+    });
+
+    expect(screen.getByText(/150 screenings included per month/)).toBeInTheDocument();
+    expect(screen.queryByText(/per year/)).not.toBeInTheDocument();
+  });
+
+  it("shows the terms for a pending subscription, with estimation unavailable rather than absent", () => {
+    renderSection([pricedMeter], { status: "Incomplete" });
+
+    // The terms themselves are still shown -- /current returns them for a pending subscription
+    // too, and hiding the whole section would contradict that.
+    expect(
+      screen.getByText(
+        /First 100 additional screenings: CHF 1\.00 each; thereafter CHF 0\.80 each\./,
+      ),
+    ).toBeInTheDocument();
+    // But estimation calls the preview endpoint, which only resolves a live subscription, so the
+    // action is unavailable rather than offered and then failing.
+    expect(
+      screen.queryByRole("button", { name: /estimate additional usage/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/available once the subscription is active/i)).toBeInTheDocument();
+  });
+
+  it("offers estimation for every status the preview endpoint actually resolves", () => {
+    for (const status of ["Trialing", "Active", "PastDue"] as const) {
+      const { unmount } = renderSection([pricedMeter], { status });
+
+      expect(
+        screen.getByRole("button", { name: /estimate additional usage/i }),
+      ).toBeInTheDocument();
+
+      unmount();
+    }
   });
 });

--- a/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import type { MeterTerms, SimulatedSubscription } from "../models/subscription-simulation.model";
+import { OverageTermsSection } from "./overage-terms-section";
+
+const baseSubscription: SimulatedSubscription = {
+  subscriptionId: "sub-1",
+  status: "Active",
+  planCode: "professional",
+  planName: "Professional",
+  currencyCode: "CHF",
+  unitAmountMinor: 8_900,
+  interval: "Month",
+  intervalCount: 1,
+  displayPriceNote: null,
+  quantities: [],
+  currentPeriodStartUtc: "2026-08-01T00:00:00Z",
+  currentPeriodEndUtc: "2026-09-01T00:00:00Z",
+  nextPaymentAtUtc: "2026-09-01T00:00:00Z",
+  trialEndsAtUtc: null,
+  cancelAtPeriodEnd: false,
+  canceledAtUtc: null,
+  pendingQuantityChange: null,
+  currentTier: null,
+  recurringAmountMinor: 8_900,
+  checkoutUrl: null,
+  meters: [],
+  version: 1,
+};
+
+const blockedMeter: MeterTerms = {
+  meterKey: "screening",
+  displayName: "Screenings",
+  unitLabel: "screening",
+  includedQuantity: 150,
+  resetPolicy: "Periodic",
+  carryForwardCap: null,
+  overageAllowed: false,
+  overagePricing: null,
+};
+
+const unpricedMeter: MeterTerms = {
+  ...blockedMeter,
+  overageAllowed: true,
+  overagePricing: null,
+};
+
+const pricedMeter: MeterTerms = {
+  ...blockedMeter,
+  overageAllowed: true,
+  overagePricing: {
+    currencyCode: "CHF",
+    tiers: [
+      { upToQuantity: 100, unitAmount: "1.00" },
+      { upToQuantity: null, unitAmount: "0.80" },
+    ],
+  },
+};
+
+const renderSection = (meters: MeterTerms[]) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <OverageTermsSection
+        subscription={{ ...baseSubscription, meters }}
+        organizationId="org-1"
+      />
+    </QueryClientProvider>,
+  );
+};
+
+describe("OverageTermsSection", () => {
+  it("renders nothing for a legacy subscription with no meters", () => {
+    const { container } = renderSection([]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("states plainly that additional usage is blocked", () => {
+    renderSection([blockedMeter]);
+
+    expect(screen.getByText(/150 screenings included per month/)).toBeInTheDocument();
+    expect(screen.getByText(/Additional usage is blocked/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /estimate additional usage/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("warns when overage is allowed but nothing prices it, without an estimate action", () => {
+    renderSection([unpricedMeter]);
+
+    expect(
+      screen.getByText(/allowed, but no overage price is configured/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /estimate additional usage/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("formats finite and unbounded graduated tiers into one readable sentence", () => {
+    renderSection([pricedMeter]);
+
+    expect(
+      screen.getByText(
+        /First 100 additional screenings: CHF 1\.00 each; thereafter CHF 0\.80 each\./,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /estimate additional usage/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("maps every meter independently rather than only the first", () => {
+    renderSection([{ ...blockedMeter, meterKey: "storage" }, pricedMeter]);
+
+    expect(screen.getByText(/Additional usage is blocked/)).toBeInTheDocument();
+    expect(screen.getByText(/First 100 additional screenings/)).toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.tsx
@@ -1,0 +1,176 @@
+import { AlertTriangle, Ban, Calculator, Gauge } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui-kits/button/button";
+import { Card } from "@/components/ui-kits/card/card";
+import { formatInterval } from "../../subscription/utilities/subscription-format";
+import type { MeterTerms, SimulatedSubscription } from "../models/subscription-simulation.model";
+import { EstimateUsageDialog } from "./estimate-usage-dialog";
+
+/**
+ * "every month" -> "per month", "every 3 months" -> "per 3 months". Reuses the cadence phrasing
+ * every other price on this page already uses, rather than a second table of interval labels.
+ */
+const perCadence = (interval: string, intervalCount: number): string =>
+  formatInterval(interval, intervalCount).replace(/^every /, "per ");
+
+const describeAllowance = (
+  meter: MeterTerms,
+  interval: string,
+  intervalCount: number,
+): string => {
+  const plural = meter.includedQuantity === 1 ? "" : "s";
+  const included = `${meter.includedQuantity.toLocaleString()} ${meter.unitLabel}${plural} included`;
+
+  if (meter.resetPolicy === "Never") {
+    return `${included} for the life of the subscription.`;
+  }
+
+  if (meter.resetPolicy === "CarryForward") {
+    const cap =
+      meter.carryForwardCap != null
+        ? ` (up to ${meter.carryForwardCap.toLocaleString()} rolling into the next)`
+        : "";
+    return `${included} ${perCadence(interval, intervalCount)}, with unused usage carried forward${cap}.`;
+  }
+
+  return `${included} ${perCadence(interval, intervalCount)}.`;
+};
+
+/**
+ * "First 100 additional screenings: CHF 1.00 each; thereafter CHF 0.80 each." -- one segment per
+ * graduated band, phrased from the bands' own boundaries rather than a fixed template, since a
+ * meter may define anywhere from one flat rate to several.
+ */
+const describeOveragePricing = (meter: MeterTerms): string => {
+  const pricing = meter.overagePricing;
+
+  if (!pricing || pricing.tiers.length === 0) {
+    return "";
+  }
+
+  const unit = meter.unitLabel || "unit";
+  let previousBoundary = 0;
+
+  const segments = pricing.tiers.map((tier, index) => {
+    const amount = `${pricing.currencyCode} ${tier.unitAmount} each`;
+
+    if (tier.upToQuantity == null) {
+      return index === 0 ? amount : `thereafter ${amount}`;
+    }
+
+    const span = tier.upToQuantity - previousBoundary;
+    const label =
+      index === 0
+        ? `First ${span.toLocaleString()} additional ${unit}${span === 1 ? "" : "s"}`
+        : `Next ${span.toLocaleString()} ${unit}${span === 1 ? "" : "s"}`;
+
+    previousBoundary = tier.upToQuantity;
+
+    return `${label}: ${amount}`;
+  });
+
+  return `${segments.join("; ")}.`;
+};
+
+const MeterTermsRow = ({
+  meter,
+  interval,
+  intervalCount,
+  onEstimate,
+}: {
+  meter: MeterTerms;
+  interval: string;
+  intervalCount: number;
+  onEstimate: () => void;
+}) => {
+  const pricingText = describeOveragePricing(meter);
+  const isPriced = meter.overageAllowed && Boolean(pricingText);
+  const isUnpriced = meter.overageAllowed && !pricingText;
+
+  return (
+    <div className="flex flex-col gap-2 border-b py-3 last:border-b-0 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0 space-y-1">
+        <p className="text-sm font-medium">{meter.displayName}</p>
+        <p className="text-xs text-muted-foreground">
+          {describeAllowance(meter, interval, intervalCount)}{" "}
+          {!meter.overageAllowed && (
+            <span className="inline-flex items-center gap-1">
+              <Ban className="h-3 w-3" />
+              Additional usage is blocked.
+            </span>
+          )}
+          {isPriced && pricingText}
+        </p>
+        {isUnpriced && (
+          <p className="flex items-start gap-1.5 text-xs text-warning-800">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            Additional usage is allowed, but no overage price is configured for the subscription
+            currency.
+          </p>
+        )}
+      </div>
+
+      {isPriced && (
+        <Button size="sm" variant="outline" onClick={onEstimate} className="shrink-0">
+          <Calculator className="mr-2 h-3.5 w-3.5" />
+          Estimate additional usage
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export const OverageTermsSection = ({
+  subscription,
+  organizationId,
+}: {
+  subscription: SimulatedSubscription | null | undefined;
+  organizationId: string | undefined;
+}) => {
+  const [estimating, setEstimating] = useState<MeterTerms | null>(null);
+
+  if (!subscription || subscription.meters.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card className="rounded-xl p-0">
+      <div className="border-b p-4 sm:p-5">
+        <h2 className="flex items-center gap-2 font-semibold">
+          <Gauge className="h-4 w-4" />
+          Overage terms
+        </h2>
+        <p className="text-xs text-muted-foreground">
+          What this subscription actually bought for each meter, from{" "}
+          <code className="mx-1 rounded bg-muted px-1">GET /api/subscriptions/current</code>
+          — fixed at signup, unaffected by later edits to the plan catalogue.
+        </p>
+      </div>
+
+      <div className="p-4 sm:p-5">
+        {subscription.meters.map((meter) => (
+          <MeterTermsRow
+            key={meter.meterKey}
+            meter={meter}
+            interval={subscription.interval}
+            intervalCount={subscription.intervalCount}
+            onEstimate={() => setEstimating(meter)}
+          />
+        ))}
+      </div>
+
+      {estimating && (
+        <EstimateUsageDialog
+          meter={estimating}
+          organizationId={organizationId}
+          open={Boolean(estimating)}
+          onOpenChange={(open) => {
+            if (!open) {
+              setEstimating(null);
+            }
+          }}
+        />
+      )}
+    </Card>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/overage-terms-section.tsx
@@ -7,6 +7,14 @@ import type { MeterTerms, SimulatedSubscription } from "../models/subscription-s
 import { EstimateUsageDialog } from "./estimate-usage-dialog";
 
 /**
+ * The statuses whose overage can actually be estimated. Mirrors the server's own
+ * `LiveStatuses`/`GetLiveAsync` -- the overage preview endpoint resolves the subscription with
+ * that same live lookup, so calling it for anything outside this set (Incomplete, Unpaid,
+ * Canceled...) would only ever answer "no active subscription."
+ */
+const PREVIEWABLE_STATUSES = new Set(["Trialing", "Active", "PastDue"]);
+
+/**
  * "every month" -> "per month", "every 3 months" -> "per 3 months". Reuses the cadence phrasing
  * every other price on this page already uses, rather than a second table of interval labels.
  */
@@ -15,8 +23,8 @@ const perCadence = (interval: string, intervalCount: number): string =>
 
 const describeAllowance = (
   meter: MeterTerms,
-  interval: string,
-  intervalCount: number,
+  usageInterval: string,
+  usageIntervalCount: number,
 ): string => {
   const plural = meter.includedQuantity === 1 ? "" : "s";
   const included = `${meter.includedQuantity.toLocaleString()} ${meter.unitLabel}${plural} included`;
@@ -30,10 +38,10 @@ const describeAllowance = (
       meter.carryForwardCap != null
         ? ` (up to ${meter.carryForwardCap.toLocaleString()} rolling into the next)`
         : "";
-    return `${included} ${perCadence(interval, intervalCount)}, with unused usage carried forward${cap}.`;
+    return `${included} ${perCadence(usageInterval, usageIntervalCount)}, with unused usage carried forward${cap}.`;
   }
 
-  return `${included} ${perCadence(interval, intervalCount)}.`;
+  return `${included} ${perCadence(usageInterval, usageIntervalCount)}.`;
 };
 
 /**
@@ -74,13 +82,15 @@ const describeOveragePricing = (meter: MeterTerms): string => {
 
 const MeterTermsRow = ({
   meter,
-  interval,
-  intervalCount,
+  usageInterval,
+  usageIntervalCount,
+  canEstimate,
   onEstimate,
 }: {
   meter: MeterTerms;
-  interval: string;
-  intervalCount: number;
+  usageInterval: string;
+  usageIntervalCount: number;
+  canEstimate: boolean;
   onEstimate: () => void;
 }) => {
   const pricingText = describeOveragePricing(meter);
@@ -92,7 +102,7 @@ const MeterTermsRow = ({
       <div className="min-w-0 space-y-1">
         <p className="text-sm font-medium">{meter.displayName}</p>
         <p className="text-xs text-muted-foreground">
-          {describeAllowance(meter, interval, intervalCount)}{" "}
+          {describeAllowance(meter, usageInterval, usageIntervalCount)}{" "}
           {!meter.overageAllowed && (
             <span className="inline-flex items-center gap-1">
               <Ban className="h-3 w-3" />
@@ -108,9 +118,14 @@ const MeterTermsRow = ({
             currency.
           </p>
         )}
+        {isPriced && !canEstimate && (
+          <p className="text-xs text-muted-foreground">
+            Estimating additional usage becomes available once the subscription is active.
+          </p>
+        )}
       </div>
 
-      {isPriced && (
+      {isPriced && canEstimate && (
         <Button size="sm" variant="outline" onClick={onEstimate} className="shrink-0">
           <Calculator className="mr-2 h-3.5 w-3.5" />
           Estimate additional usage
@@ -133,6 +148,8 @@ export const OverageTermsSection = ({
     return null;
   }
 
+  const canEstimate = PREVIEWABLE_STATUSES.has(subscription.status);
+
   return (
     <Card className="rounded-xl p-0">
       <div className="border-b p-4 sm:p-5">
@@ -152,8 +169,9 @@ export const OverageTermsSection = ({
           <MeterTermsRow
             key={meter.meterKey}
             meter={meter}
-            interval={subscription.interval}
-            intervalCount={subscription.intervalCount}
+            usageInterval={subscription.usageInterval}
+            usageIntervalCount={subscription.usageIntervalCount}
+            canEstimate={canEstimate}
             onEstimate={() => setEstimating(meter)}
           />
         ))}

--- a/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/subscribe-dialog.test.tsx
@@ -82,6 +82,8 @@ const subscription: SimulatedSubscription = {
   unitAmountMinor: 8_900,
   interval: "Month",
   intervalCount: 1,
+  usageInterval: "Month",
+  usageIntervalCount: 1,
   displayPriceNote: null,
   quantities: [{ itemKey: "seat", quantity: 1, unitLabel: "seat" }],
   currentPeriodStartUtc: "2026-08-16T00:00:00Z",

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -44,6 +44,13 @@ export interface SimulatedSubscription {
   unitAmountMinor: number;
   interval: BillingIntervalName;
   intervalCount: number;
+  /**
+   * How often a `"Periodic"` or `"CarryForward"` meter in `meters` resets. Independent of
+   * `interval`/`intervalCount` above -- a plan can bill yearly and meter monthly, so a meter's
+   * allowance must be described from this, never from the fee cadence.
+   */
+  usageInterval: BillingIntervalName;
+  usageIntervalCount: number;
   displayPriceNote: string | null;
   quantities: SubscriptionQuantity[];
   currentPeriodStartUtc: string;

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -77,7 +77,53 @@ export interface SimulatedSubscription {
    * "Add payment method" action, and status alone cannot tell those two apart.
    */
   hasPaymentMethod?: boolean | null;
+  /**
+   * The overage terms this subscription actually bought, one entry per meter its plan snapshot
+   * defines. Read from the subscription's own snapshot, never the mutable plan catalogue -- a
+   * later catalogue edit cannot change what this reports. Empty for a legacy subscription whose
+   * snapshot predates metered usage; never absent.
+   */
+  meters: MeterTerms[];
   version: number;
+}
+
+/** One meter's terms as the subscriber actually bought them. */
+export interface MeterTerms {
+  meterKey: string;
+  displayName: string;
+  unitLabel: string;
+  /** Per period, or for the subscription's lifetime when `resetPolicy` is `"Never"`. */
+  includedQuantity: number;
+  resetPolicy: "Periodic" | "Never" | "CarryForward";
+  /** The most that may roll into one window under `"CarryForward"`. Null otherwise. */
+  carryForwardCap: number | null;
+  /** Whether usage past the included quantity is permitted and billed at all. */
+  overageAllowed: boolean;
+  /**
+   * What overage costs in this subscription's own currency, or null. Null covers two cases a
+   * client must tell apart from `overageAllowed` alone: overage is blocked outright, or overage
+   * is allowed but this plan defines no priceable rate table for the subscription's currency.
+   * Either way, nothing here is a chargeable price -- use the overage preview call for an exact
+   * quote.
+   */
+  overagePricing: OveragePricing | null;
+}
+
+/** A meter's graduated overage rates, already converted to the subscription's currency. */
+export interface OveragePricing {
+  currencyCode: string;
+  tiers: OverageTier[];
+}
+
+/**
+ * One graduated tier band, priced in major units as an invariant decimal string -- e.g.
+ * `"1.00"` CHF, `"100"` JPY, `"0.100"` KWD. Presentation only; not the minor-unit representation
+ * billing actually rates from, and not a number to do arithmetic on.
+ */
+export interface OverageTier {
+  /** Upper bound of the band, counted in overage units. Null is the final, unbounded tier. */
+  upToQuantity: number | null;
+  unitAmount: string;
 }
 
 /**

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.test.tsx
@@ -1,0 +1,172 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { SimulatedSubscription } from "../models/subscription-simulation.model";
+
+const { useCurrentSimulatedSubscription } = vi.hoisted(() => ({
+  useCurrentSimulatedSubscription: vi.fn(),
+}));
+
+vi.mock("../hooks/use-current-simulated-subscription", () => ({
+  useCurrentSimulatedSubscription,
+}));
+
+vi.mock("../../subscription/hooks/use-subscription-plans", () => ({
+  useSubscriptionPlans: () => ({
+    data: [],
+    error: null,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/use-quantity-change", () => ({
+  useCancelPendingQuantityChange: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("../hooks/use-start-payment-method-setup", () => ({
+  useStartPaymentMethodSetup: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("../services/subscription-simulation.service", async () => {
+  const actual = await vi.importActual<
+    typeof import("../services/subscription-simulation.service")
+  >("../services/subscription-simulation.service");
+
+  return {
+    ...actual,
+    subscriptionSimulationService: {
+      getEntitlements: vi.fn().mockResolvedValue({ entitlements: [] }),
+    },
+  };
+});
+
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({
+    data: { organizations: [{ itemId: "org-1", name: "Northwind" }] },
+    isError: false,
+  }),
+}));
+
+vi.mock("@seliseblocks/genesis-os", () => ({
+  useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
+}));
+
+import { SubscriptionSimulationPage } from "./subscription-simulation-page";
+
+const meteredSubscription = (
+  overrides: Partial<SimulatedSubscription> = {},
+): SimulatedSubscription => ({
+  subscriptionId: "sub-1",
+  status: "Active",
+  planCode: "professional",
+  planName: "Professional",
+  currencyCode: "CHF",
+  unitAmountMinor: 8_900,
+  interval: "Month",
+  intervalCount: 1,
+  usageInterval: "Month",
+  usageIntervalCount: 1,
+  displayPriceNote: null,
+  quantities: [],
+  currentPeriodStartUtc: "2026-08-01T00:00:00Z",
+  currentPeriodEndUtc: "2026-09-01T00:00:00Z",
+  nextPaymentAtUtc: "2026-09-01T00:00:00Z",
+  trialEndsAtUtc: null,
+  cancelAtPeriodEnd: false,
+  canceledAtUtc: null,
+  pendingQuantityChange: null,
+  currentTier: null,
+  recurringAmountMinor: 8_900,
+  checkoutUrl: null,
+  hasPaymentMethod: null,
+  meters: [
+    {
+      meterKey: "screening",
+      displayName: "Screenings",
+      unitLabel: "screening",
+      includedQuantity: 150,
+      resetPolicy: "Periodic",
+      carryForwardCap: null,
+      overageAllowed: true,
+      overagePricing: {
+        currencyCode: "CHF",
+        tiers: [{ upToQuantity: null, unitAmount: "1.00" }],
+      },
+    },
+  ],
+  version: 1,
+  ...overrides,
+});
+
+const renderPage = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <SubscriptionSimulationPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe("SubscriptionSimulationPage overage-terms visibility", () => {
+  it("shows the overage terms for a pending Incomplete subscription, without an estimate action", async () => {
+    useCurrentSimulatedSubscription.mockReturnValue({
+      data: meteredSubscription({ status: "Incomplete" }),
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/overage terms/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /estimate additional usage/i }),
+    ).not.toBeInTheDocument();
+    // Incomplete has not paid yet -- the entitlement-gated Usage section stays hidden, unlike
+    // the contractual terms above.
+    expect(screen.queryByText(/^Usage$/)).not.toBeInTheDocument();
+  });
+
+  it("shows both the overage terms and the entitled usage section for an Active subscription", async () => {
+    useCurrentSimulatedSubscription.mockReturnValue({
+      data: meteredSubscription({ status: "Active" }),
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/overage terms/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /estimate additional usage/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the overage terms for a non-entitled Unpaid subscription, without an estimate action", async () => {
+    useCurrentSimulatedSubscription.mockReturnValue({
+      data: meteredSubscription({ status: "Unpaid" }),
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/overage terms/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /estimate additional usage/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Usage$/)).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -315,12 +315,11 @@ export const SubscriptionSimulationPage = () => {
         </div>
       </Card>
 
-      {isEntitled && (
-        <>
-          <OverageTermsSection subscription={currentSubscription} organizationId={organizationScope} />
-          <UsageSection plan={currentPlan} organizationId={organizationScope} />
-        </>
+      {currentSubscription && (
+        <OverageTermsSection subscription={currentSubscription} organizationId={organizationScope} />
       )}
+
+      {isEntitled && <UsageSection plan={currentPlan} organizationId={organizationScope} />}
 
       {currentSubscription && (
         <SimulationHarnessCard

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -32,6 +32,7 @@ import { DataConsoleDialog } from "../components/data-console-dialog";
 import { useCancelPendingQuantityChange } from "../hooks/use-quantity-change";
 import { useStartPaymentMethodSetup } from "../hooks/use-start-payment-method-setup";
 import { CurrentSubscriptionCard } from "../components/current-subscription-card";
+import { OverageTermsSection } from "../components/overage-terms-section";
 import { PaymentOutcomeDialog } from "../components/payment-outcome-dialog";
 import { RunDueJobsDialog } from "../components/run-due-jobs-dialog";
 import { SimulatedPlanCard } from "../components/simulated-plan-card";
@@ -315,7 +316,10 @@ export const SubscriptionSimulationPage = () => {
       </Card>
 
       {isEntitled && (
-        <UsageSection plan={currentPlan} organizationId={organizationScope} />
+        <>
+          <OverageTermsSection subscription={currentSubscription} organizationId={organizationScope} />
+          <UsageSection plan={currentPlan} organizationId={organizationScope} />
+        </>
       )}
 
       {currentSubscription && (

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2776,6 +2776,61 @@ POST /api/subscriptions
             endpoint actually returns; treat it as <code>false</code> only where it is genuinely
             not <code>true</code>.
           </p>
+          <p class="prose">
+            <code>meters</code> names the metered-overage terms this subscription actually bought —
+            one entry per meter, read from the subscription's own plan snapshot at the moment it was
+            sold. It is <strong>not</strong> affected by an edit made afterward to the live plan
+            catalogue, for the same reason renewal pricing is not: this is what was sold, not what is
+            currently on sale. A subscription authored before metered usage existed returns
+            <code>meters: []</code>, never <code>null</code>. This field is returned for every
+            subscription this endpoint answers with, including a pending <code>Incomplete</code> or a
+            recoverable <code>Unpaid</code> one — the contractual terms exist from signup, whether or
+            not the subscription is currently granting anything.
+          </p>
+          <p class="prose">
+            Each meter's own <code>resetPolicy</code> — <code>Periodic</code>, <code>Never</code>, or
+            <code>CarryForward</code> — resets on the plan's <code>usageInterval</code> /
+            <code>usageIntervalCount</code>, <strong>not</strong> on <code>interval</code> /
+            <code>intervalCount</code> above. Those two cadences are independent: a plan may bill
+            yearly and meter monthly, so a client describing when a meter's allowance resets must
+            read <code>usageInterval</code>, never assume the fee cadence also governs usage.
+          </p>
+          <p class="prose">
+            <code>overageAllowed</code> and <code>overagePricing</code> answer two different
+            questions, and a client needs both to render this correctly.
+            <code>overagePricing: null</code> happens for two distinct reasons that read the same on
+            the wire but mean different things on screen:
+          </p>
+          <ul>
+            <li><code>overageAllowed: false</code> — overage is blocked outright; nothing beyond
+              <code>includedQuantity</code> is permitted.</li>
+            <li><code>overageAllowed: true</code> with <code>overagePricing: null</code> — overage is
+              permitted, but this plan defines no rate table for the subscription's own
+              <code>currencyCode</code> (or that table's amounts could not be resolved to a
+              major-unit figure). Show a warning rather than silence: usage beyond the allowance will
+              be recorded and will not be blocked, but nothing here can say what it will cost.</li>
+          </ul>
+          <p class="prose">
+            When present, <code>overagePricing.tiers</code> is priced in this subscription's own
+            currency, in <strong>major units, as an invariant decimal string</strong> —
+            <code>unitAmount</code> is <code>"1.00"</code> for a two-decimal currency like CHF,
+            <code>"100"</code> for a zero-decimal currency like JPY, <code>"0.100"</code> for a
+            three-decimal currency like KWD. This is the one place on this response meant for direct
+            display; every other amount on this endpoint is a minor-unit integer. Do not assume two
+            decimal places, and do not parse it back into minor units in the browser — treat it as
+            text. <code>tiers[].upToQuantity</code> is the graduated band's upper bound, counted in
+            overage units from the first overage unit of the period; <code>null</code> is the final,
+            unbounded tier.
+          </p>
+          <div class="callout">
+            Nothing on <code>meters</code> is a chargeable quote, and it is never rated fresh — it is
+            the plan's terms, not a computed price for a specific quantity. For an exact, rated
+            estimate of a specific additional quantity — current usage, projected usage, tier
+            allocation, discount, tax, and the total charge that quantity would add — call
+            <a href="#api-overage-preview"><code>POST /api/subscription-usage/overage/preview</code></a>.
+            That call remains the only source of a financial estimate; this endpoint only states the
+            terms a preview would be priced against.
+          </div>
           <h4>Query</h4>
           <p>
             <code>organizationId</code> is optional. Ordinary callers always resolve to their own
@@ -2794,6 +2849,8 @@ POST /api/subscriptions
     "unitAmountMinor": 300,
     "interval": "Month",
     "intervalCount": 1,
+    "usageInterval": "Month",
+    "usageIntervalCount": 1,
     "displayPriceNote": null,
     "quantities": [],
     "currentPeriodStartUtc": "2026-08-16T16:29:00Z",
@@ -2809,6 +2866,34 @@ POST /api/subscriptions
     "checkoutUrl": null,
     "pendingCheckout": null,
     "hasPaymentMethod": true,
+    "meters": [
+      {
+        "meterKey": "screening",
+        "displayName": "Screenings",
+        "unitLabel": "screening",
+        "includedQuantity": 150,
+        "resetPolicy": "Periodic",
+        "carryForwardCap": null,
+        "overageAllowed": true,
+        "overagePricing": {
+          "currencyCode": "EUR",
+          "tiers": [
+            { "upToQuantity": 100, "unitAmount": "1.00" },
+            { "upToQuantity": null, "unitAmount": "0.80" }
+          ]
+        }
+      },
+      {
+        "meterKey": "export",
+        "displayName": "Exports",
+        "unitLabel": "export",
+        "includedQuantity": 20,
+        "resetPolicy": "Periodic",
+        "carryForwardCap": null,
+        "overageAllowed": false,
+        "overagePricing": null
+      }
+    ],
     "version": 2
   },
   "error": null,
@@ -3303,7 +3388,7 @@ POST /api/subscriptions
         </div>
       </div>
 
-      <div class="endpoint">
+      <div class="endpoint" id="api-overage-preview">
         <div class="endpoint-head"><span class="method">POST</span><span class="path">/api/subscription-usage/overage/preview</span></div>
         <div class="endpoint-body">
           <p>Estimates what a hypothetical slice of additional metered usage would cost, using the active subscription's own snapshotted terms and the same rating, discount and tax logic period-end usage rating uses to charge the final invoice. Subscription resolution and the platform console's organization override follow the same rule <code>GET /subscription-usage/current</code> already applies.</p>

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -953,6 +953,62 @@ Named failures rather than a misleading zero price: `subscription_not_found`,
 the subscription's currency); `subscription_schedule_unavailable` (503, the usage schedule could
 not place "now" in a period).
 
+### Overage terms on `GET /subscriptions/current`
+
+```json
+{
+  "subscriptionId": "sub-123",
+  "currencyCode": "CHF",
+  "meters": [
+    {
+      "meterKey": "screening",
+      "displayName": "Screenings",
+      "unitLabel": "screening",
+      "includedQuantity": 150,
+      "resetPolicy": "Periodic",
+      "carryForwardCap": null,
+      "overageAllowed": true,
+      "overagePricing": {
+        "currencyCode": "CHF",
+        "tiers": [
+          { "upToQuantity": 100, "unitAmount": "1.00" },
+          { "upToQuantity": null, "unitAmount": "0.80" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+`SubscriptionResponse.Meters` names the terms a subscriber actually bought, one entry per meter
+`SubscriptionDetail.Plan.Meters` defines -- read from the subscription's own plan snapshot, the
+same one everything else in this section reads from, never the mutable catalogue. `Meters` is
+additive to the response and empty (never null) for a legacy subscription whose snapshot predates
+metered usage.
+
+`overagePricing` is `null` for two distinct reasons a client has to tell apart from
+`overageAllowed` alone: overage is blocked outright (`overageAllowed: false`), or overage is
+allowed but this plan defines no rate table for the subscription's own `CurrencyCode` (or a rate
+table's amounts could not be converted -- see below). Either reading leaves `overageAllowed: true`
+with `overagePricing: null`, which is why the field is reported separately rather than folded into
+a single "priced or not" boolean.
+
+**Major units, not minor.** Every other amount on `SubscriptionResponse` is a minor-unit `long`,
+matching the entities and every other financial response in this module. `OverageTierResponse`
+breaks that pattern on purpose: `unitAmount` is an invariant decimal string in major units --
+`"1.00"` (CHF), `"100"` (JPY, no decimal places), `"0.100"` (KWD, three) -- because this is the one
+place on the response meant for direct display rather than further arithmetic, and a minor-unit
+figure would force every caller to duplicate the same currency-exponent lookup
+`MinorUnitMajorAmountFormatter` already does once, from the payment module's own
+`ICurrencyMinorUnitResolver` -- never a hardcoded assumption of two decimal places. If a rate
+table names a currency the resolver can no longer convert, the whole tier list (not just the
+offending tier) is reported as `overagePricing: null` rather than a partially-priced list mixed
+with a fabricated conversion; the meter's other fields, and the rest of the response, are
+unaffected -- the endpoint stays available and simply reports that meter's pricing as unavailable.
+
+The preview endpoint above is unchanged by this: it keeps its exact minor-unit response, and
+remains the only place to get an authoritative, rated quote for a specific quantity.
+
 ## Events
 
 Appended in the same write as the state change that caused them, then published to

--- a/server/Subscription.DomainService/Responses/MeterTermsResponse.cs
+++ b/server/Subscription.DomainService/Responses/MeterTermsResponse.cs
@@ -1,0 +1,66 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// One meter's terms as the subscriber actually bought them.
+/// </summary>
+/// <remarks>
+/// Read from <c>SubscriptionDetail.Plan.Meters</c> -- the subscription's own snapshot, taken at
+/// signup -- never from the mutable plan catalogue. An edit to the catalogue after this
+/// subscription was sold must not change what this reports, for the same reason it must not
+/// change what period-end usage rating eventually charges. See
+/// <c>SubscriptionUsageOveragePreviewService</c>'s remarks for the same principle applied to a
+/// hypothetical charge instead of the terms themselves.
+/// </remarks>
+public sealed class MeterTermsResponse
+{
+    public string MeterKey { get; init; } = string.Empty;
+
+    public string DisplayName { get; init; } = string.Empty;
+
+    public string UnitLabel { get; init; } = string.Empty;
+
+    /// <summary>How much this meter includes per period, or for the subscription's lifetime when
+    /// <see cref="ResetPolicy"/> is <c>"Never"</c>.</summary>
+    public long IncludedQuantity { get; init; }
+
+    /// <summary>"Periodic", "Never", or "CarryForward".</summary>
+    public string ResetPolicy { get; init; } = string.Empty;
+
+    /// <summary>The most that may roll into one window under <c>CarryForward</c>. Null otherwise.</summary>
+    public long? CarryForwardCap { get; init; }
+
+    /// <summary>Whether usage past the included quantity is permitted and billed at all.</summary>
+    public bool OverageAllowed { get; init; }
+
+    /// <summary>
+    /// What overage costs in this subscription's own currency, or null. Null covers two distinct
+    /// cases a client must be able to tell apart from <see cref="OverageAllowed"/> alone:
+    /// overage is blocked outright, or overage is allowed but this plan defines no rate table for
+    /// the subscription's currency (or that table's amounts could not be resolved to a major-unit
+    /// figure -- see <see cref="Utilities.MinorUnitMajorAmountFormatter"/>). Either way, nothing
+    /// here is a chargeable price; use <c>POST /api/subscription-usage/overage/preview</c> for an
+    /// exact quote.
+    /// </summary>
+    public OveragePricingResponse? OveragePricing { get; init; }
+}
+
+/// <summary>A meter's graduated overage rates, already converted to the subscription's currency.</summary>
+public sealed class OveragePricingResponse
+{
+    public string CurrencyCode { get; init; } = string.Empty;
+
+    public List<OverageTierResponse> Tiers { get; init; } = [];
+}
+
+/// <summary>
+/// One graduated tier band, priced in major units -- e.g. <c>"1.00"</c> CHF, <c>"100"</c> JPY,
+/// <c>"0.100"</c> KWD. An invariant decimal string, not a number: presented for display, not for
+/// arithmetic, and not the internal minor-unit representation billing actually rates from.
+/// </summary>
+public sealed class OverageTierResponse
+{
+    /// <summary>Upper bound of the band, counted in overage units. Null is the final, unbounded tier.</summary>
+    public long? UpToQuantity { get; init; }
+
+    public string UnitAmount { get; init; } = string.Empty;
+}

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -192,6 +192,13 @@ public sealed class SubscriptionResponse
     /// </remarks>
     public bool? HasPaymentMethod { get; init; }
 
+    /// <summary>
+    /// The overage terms this subscription actually bought, one entry per meter the plan
+    /// defines. Empty for a legacy subscription whose snapshot predates metered usage -- never
+    /// null, so a client can iterate without an extra guard.
+    /// </summary>
+    public List<MeterTermsResponse> Meters { get; init; } = [];
+
     public int Version { get; init; }
 }
 

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -21,6 +21,18 @@ public sealed class SubscriptionResponse
 
     public int IntervalCount { get; init; }
 
+    /// <summary>
+    /// How often a <c>"Periodic"</c> or <c>"CarryForward"</c> meter in <see cref="Meters"/>
+    /// resets -- from the plan snapshot's own <c>UsageInterval</c>, which the plan is free to set
+    /// independently of <see cref="Interval"/>/<see cref="IntervalCount"/>. A yearly-billed plan
+    /// can still meter monthly, so a client describing a meter's allowance must read this rather
+    /// than assume the fee cadence above also governs usage resets.
+    /// </summary>
+    public string UsageInterval { get; init; } = string.Empty;
+
+    /// <summary>Paired with <see cref="UsageInterval"/> -- see its remarks.</summary>
+    public int UsageIntervalCount { get; init; }
+
     public string? DisplayPriceNote { get; init; }
 
     public List<SubscriptionQuantityResponse> Quantities { get; init; } = [];

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -54,6 +54,8 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             UnitAmountMinor = subscription.Price.UnitAmountMinor,
             Interval = subscription.Price.Interval.ToString(),
             IntervalCount = subscription.Price.IntervalCount,
+            UsageInterval = subscription.Plan.UsageInterval.ToString(),
+            UsageIntervalCount = subscription.Plan.UsageIntervalCount,
             DisplayPriceNote = subscription.Price.DisplayPriceNote,
             Quantities = subscription.QuantityItems
                 .Select(item => new SubscriptionQuantityResponse

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -1,15 +1,29 @@
+using Payment.DomainService.Services;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
 
 public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
 {
     private readonly TimeProvider _time;
+    private readonly ICurrencyMinorUnitResolver _currency;
 
-    public SubscriptionResponseMapper(TimeProvider? time = null) =>
+    /// <summary>
+    /// <paramref name="currency"/> defaults to a resolver that reports every currency
+    /// unresolvable, matching how DI actually wires this in production -- the payment module
+    /// registers the real one as a singleton, so an explicit default here only ever applies to a
+    /// caller (chiefly a test) that has no reason to price a meter's overage in the first place.
+    /// </summary>
+    public SubscriptionResponseMapper(
+        TimeProvider? time = null,
+        ICurrencyMinorUnitResolver? currency = null)
+    {
         _time = time ?? TimeProvider.System;
+        _currency = currency ?? UnresolvedCurrencyMinorUnitResolver.Instance;
+    }
 
     public SubscriptionResponse ToResponse(
         SubscriptionDetail subscription,
@@ -110,7 +124,87 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             CheckoutUrl = checkoutUrl,
             PendingCheckout = pendingCheckout,
             HasPaymentMethod = hasPaymentMethod,
+            Meters = subscription.Plan.Meters
+                .Select(meter => ToMeterTerms(meter, subscription.CurrencyCode))
+                .ToList(),
             Version = subscription.Version
         };
+    }
+
+    private MeterTermsResponse ToMeterTerms(PlanMeter meter, string currencyCode) => new()
+    {
+        MeterKey = meter.MeterKey,
+        DisplayName = meter.DisplayName,
+        UnitLabel = meter.UnitLabel,
+        IncludedQuantity = meter.IncludedQuantity,
+        ResetPolicy = meter.ResetPolicy.ToString(),
+        CarryForwardCap = meter.CarryForwardCap,
+        OverageAllowed = meter.OverageAllowed,
+        OveragePricing = meter.OverageAllowed
+            ? ResolveOveragePricing(meter, currencyCode)
+            : null
+    };
+
+    private OveragePricingResponse? ResolveOveragePricing(PlanMeter meter, string currencyCode)
+    {
+        var table = meter.RateTables.Find(candidate =>
+            string.Equals(candidate.CurrencyCode, currencyCode, StringComparison.OrdinalIgnoreCase));
+
+        // Overage allowed with no rate table for this subscription's currency, and overage
+        // allowed with a rate table this subscription's currency does not match, both read the
+        // same way to a client: allowed, but nothing here prices it.
+        if (table is null)
+        {
+            return null;
+        }
+
+        var tiers = new List<OverageTierResponse>(table.Tiers.Count);
+
+        foreach (var tier in table.Tiers)
+        {
+            if (!MinorUnitMajorAmountFormatter.TryFormat(
+                _currency, tier.UnitAmountMinor, currencyCode, out var amount))
+            {
+                // A rate table naming a currency the payment module can no longer resolve is a
+                // configuration gap, not something to fabricate a conversion for. Report the
+                // whole tier list unavailable rather than a partially-priced one -- a client
+                // cannot use "the first two tiers converted, the third did not" for anything.
+                return null;
+            }
+
+            tiers.Add(new OverageTierResponse
+            {
+                UpToQuantity = tier.UpToQuantity,
+                UnitAmount = amount
+            });
+        }
+
+        return new OveragePricingResponse
+        {
+            CurrencyCode = currencyCode,
+            Tiers = tiers
+        };
+    }
+
+    /// <summary>
+    /// Resolves nothing, honestly, so a mapper built without a real currency resolver never
+    /// fabricates a conversion -- it simply reports every meter's overage as unpriced, which is
+    /// the correct answer for a caller that never wired one in.
+    /// </summary>
+    private sealed class UnresolvedCurrencyMinorUnitResolver : ICurrencyMinorUnitResolver
+    {
+        public static readonly UnresolvedCurrencyMinorUnitResolver Instance = new();
+
+        public bool TryConvert(decimal amount, string currencyCode, out long minorUnits)
+        {
+            minorUnits = 0;
+            return false;
+        }
+
+        public bool TryConvertBack(long minorUnits, string currencyCode, out decimal amount)
+        {
+            amount = 0;
+            return false;
+        }
     }
 }

--- a/server/Subscription.DomainService/Utilities/MinorUnitMajorAmountFormatter.cs
+++ b/server/Subscription.DomainService/Utilities/MinorUnitMajorAmountFormatter.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+using Payment.DomainService.Services;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Minor units as an invariant major-unit decimal string, with no grouping, no currency code, and
+/// no assumption of two decimal places -- e.g. <c>"1.00"</c> (CHF), <c>"100"</c> (JPY),
+/// <c>"0.100"</c> (KWD).
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="Services.FinancialDocumentMoneyFormatter"/>, this returns a raw number --
+/// no currency code prefix, no thousands separator -- the shape wanted for a JSON field a client
+/// reads back as a decimal, not the shape wanted for a line printed on a document. Both derive
+/// the currency's decimal places the same way: from the payment module's own resolver, by
+/// converting one major unit and counting the minor units it becomes, rather than keeping a
+/// second table of currency exponents that could disagree with the one payments actually charges
+/// against.
+/// <para>
+/// Zero is a real price a graduated tier can carry -- a free introductory band -- so, unlike a
+/// charged amount, this does not refuse a non-positive minor-unit figure the way the resolver's
+/// own <c>TryConvertBack</c> does. A failure here means the currency itself could not be
+/// resolved, never that the amount happened to be zero.
+/// </para>
+/// </remarks>
+public static class MinorUnitMajorAmountFormatter
+{
+    /// <summary>
+    /// Converts <paramref name="amountMinor"/> to a major-unit decimal string, or reports it
+    /// could not be done rather than fabricating one.
+    /// </summary>
+    public static bool TryFormat(
+        ICurrencyMinorUnitResolver currency,
+        long amountMinor,
+        string currencyCode,
+        out string amount)
+    {
+        ArgumentNullException.ThrowIfNull(currency);
+
+        amount = string.Empty;
+
+        if (!TryDecimals(currency, currencyCode, out var decimals))
+        {
+            return false;
+        }
+
+        if (amountMinor == 0)
+        {
+            amount = FormatAmount(0m, decimals);
+            return true;
+        }
+
+        // TryConvertBack describes a magnitude, not a direction -- re-signed here the same way
+        // FinancialDocumentMoneyFormatter handles a credit note's negative figures. Guarded
+        // against long.MinValue, whose magnitude does not fit back in a long: a plan-authored
+        // tier amount should never be anywhere near that, but this is the one place a corrupted
+        // document would otherwise throw instead of simply reporting itself unpriceable.
+        long magnitude;
+
+        try
+        {
+            magnitude = Math.Abs(amountMinor);
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+
+        if (!currency.TryConvertBack(magnitude, currencyCode, out var converted))
+        {
+            return false;
+        }
+
+        var formatted = FormatAmount(converted, decimals);
+        amount = amountMinor < 0 ? $"-{formatted}" : formatted;
+
+        return true;
+    }
+
+    private static string FormatAmount(decimal amount, int decimals) =>
+        amount.ToString(
+            "F" + decimals.ToString(CultureInfo.InvariantCulture),
+            CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// How many decimal places this currency has, asked of the resolver rather than assumed --
+    /// see the type remarks for why.
+    /// </summary>
+    private static bool TryDecimals(ICurrencyMinorUnitResolver currency, string currencyCode, out int decimals)
+    {
+        decimals = 0;
+
+        if (!currency.TryConvert(1m, currencyCode, out var minorUnitsInOne) || minorUnitsInOne < 1)
+        {
+            return false;
+        }
+
+        while (minorUnitsInOne >= 10 && decimals < 4)
+        {
+            minorUnitsInOne /= 10;
+            decimals++;
+        }
+
+        return true;
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -71,6 +71,19 @@ public sealed class SubscriptionCheckoutServiceTests
                 return true;
             });
 
+        // CHF-shaped, two decimals -- everything in this file prices in CHF. Also feeds the
+        // response mapper's own major-unit conversion for a meter's overage tiers, since the
+        // mapper is built from this same mock below.
+        _currency
+            .Setup(resolver => resolver.TryConvert(
+                It.IsAny<decimal>(), It.IsAny<string>(), out It.Ref<long>.IsAny))
+            .Returns((decimal amount, string _, out long minor) =>
+            {
+                minor = (long)(amount * 100);
+
+                return true;
+            });
+
         _payments
             .Setup(service => service.MakePaymentAsync(
                 It.IsAny<MakePaymentRequest>(),
@@ -418,6 +431,107 @@ public sealed class SubscriptionCheckoutServiceTests
     }
 
     /// <summary>
+    /// The overage terms on <c>GET current</c> come from the subscription's own plan snapshot,
+    /// never a catalogue lookup -- this service holds no catalogue repository dependency at all,
+    /// so there is nothing here that could read one even by mistake. A plan edit made after this
+    /// subscription was sold cannot reach this response, because nothing about answering this
+    /// call ever looks the plan up again.
+    /// </summary>
+    [Fact]
+    public async Task Current_exposes_the_subscription_s_own_snapshotted_meter_terms()
+    {
+        _subscription.Status = SubscriptionStatus.Active;
+        _subscription.Plan.Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                DisplayName = "Screenings",
+                UnitLabel = "screening",
+                IncludedQuantity = 150,
+                ResetPolicy = MeterResetPolicy.Periodic,
+                OverageAllowed = true,
+                RateTables =
+                [
+                    new MeterRateTable
+                    {
+                        CurrencyCode = "CHF",
+                        Tiers =
+                        [
+                            new MeterTier { UpToQuantity = 100, UnitAmountMinor = 100 },
+                            new MeterTier { UpToQuantity = null, UnitAmountMinor = 80 }
+                        ]
+                    }
+                ]
+            }
+        ];
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_subscription);
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        var meter = result.Value!.Meters.Single();
+        meter.MeterKey.Should().Be("screening");
+        meter.IncludedQuantity.Should().Be(150);
+        meter.ResetPolicy.Should().Be("Periodic");
+        meter.OverageAllowed.Should().BeTrue();
+        meter.OveragePricing.Should().NotBeNull();
+        meter.OveragePricing!.CurrencyCode.Should().Be("CHF");
+        meter.OveragePricing.Tiers.Select(tier => tier.UnitAmount).Should().Equal("1.00", "0.80");
+    }
+
+    [Fact]
+    public async Task Current_reports_an_empty_meter_list_for_a_legacy_subscription()
+    {
+        _subscription.Status = SubscriptionStatus.Active;
+        _subscriptions
+            .Setup(repository => repository.GetLiveAsync(
+                TenantId, OrganizationId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_subscription);
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.Value!.Meters.Should().NotBeNull().And.BeEmpty();
+    }
+
+    /// <summary>
+    /// The one branch of <c>GET current</c> that reports a subscription still short of its first
+    /// payment -- its snapshot exists from the moment it was created, so the same terms are
+    /// already there to show.
+    /// </summary>
+    [Fact]
+    public async Task A_pending_incomplete_subscription_still_exposes_its_snapshotted_meter_terms()
+    {
+        _subscription.Plan.Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                DisplayName = "Screenings",
+                UnitLabel = "screening",
+                IncludedQuantity = 150,
+                OverageAllowed = true,
+                RateTables =
+                [
+                    new MeterRateTable
+                    {
+                        CurrencyCode = "CHF",
+                        Tiers = [new MeterTier { UpToQuantity = null, UnitAmountMinor = 100 }]
+                    }
+                ]
+            }
+        ];
+        ArrangePendingCheckout();
+
+        var result = await Service().GetCurrentAsync(null, "corr-2", CancellationToken.None);
+
+        result.Value!.Status.Should().Be(nameof(SubscriptionStatus.Incomplete));
+        result.Value.Meters.Single().OveragePricing!.Tiers.Single().UnitAmount.Should().Be("1.00");
+    }
+
+    /// <summary>
     /// Whether a card is on file is answered for real, not assumed from the status.
     /// </summary>
     /// <remarks>
@@ -544,7 +658,7 @@ public sealed class SubscriptionCheckoutServiceTests
         _links.Object,
         _contextResolver.Object,
         new SubscriptionOutboxEventFactory(),
-        new SubscriptionResponseMapper(),
+        new SubscriptionResponseMapper(currency: _currency.Object),
         _payments.Object,
         _paymentMethodSetups.Object,
         _paymentRepository.Object,

--- a/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
@@ -1,4 +1,8 @@
 using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Services;
@@ -156,6 +160,214 @@ public sealed class SubscriptionResponseMapperTests
         response.Cancellation.EffectiveAtUtc.Should().Be(subscription.EndedAtUtc.Value,
             "once cancellation has taken effect, EffectiveAtUtc is when it actually did — not " +
             "the period boundary it would otherwise have waited for");
+    }
+
+    [Fact]
+    public void A_priced_meter_returns_the_matching_snapshotted_rate_table()
+    {
+        var subscription = NewSubscription(10);
+        subscription.CurrencyCode = "CHF";
+        subscription.Plan.Meters = [Meter("screening", (100, "1.00"), (null, "0.80"))];
+
+        var response = PricedMapper().ToResponse(subscription);
+
+        var meter = response.Meters.Single();
+        meter.OverageAllowed.Should().BeTrue();
+        meter.OveragePricing.Should().NotBeNull();
+        meter.OveragePricing!.CurrencyCode.Should().Be("CHF");
+        meter.OveragePricing.Tiers.Should().HaveCount(2);
+        meter.OveragePricing.Tiers[0].UpToQuantity.Should().Be(100);
+        meter.OveragePricing.Tiers[0].UnitAmount.Should().Be("1.00");
+        meter.OveragePricing.Tiers[1].UpToQuantity.Should().BeNull();
+        meter.OveragePricing.Tiers[1].UnitAmount.Should().Be("0.80");
+    }
+
+    [Theory]
+    [InlineData("CHF", 2, 100, "1.00")]
+    [InlineData("JPY", 0, 100, "100")]
+    [InlineData("KWD", 3, 100, "0.100")]
+    public void Major_unit_conversion_covers_zero_two_and_three_decimal_currencies(
+        string currencyCode, int decimals, long unitAmountMinor, string expected)
+    {
+        var subscription = NewSubscription(10);
+        subscription.CurrencyCode = currencyCode;
+        subscription.Plan.Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                DisplayName = "Screenings",
+                UnitLabel = "screening",
+                IncludedQuantity = 150,
+                OverageAllowed = true,
+                RateTables =
+                [
+                    new MeterRateTable
+                    {
+                        CurrencyCode = currencyCode,
+                        Tiers = [new MeterTier { UpToQuantity = null, UnitAmountMinor = unitAmountMinor }]
+                    }
+                ]
+            }
+        ];
+
+        var response = PricedMapper(decimalsByCurrency: new() { [currencyCode] = decimals })
+            .ToResponse(subscription);
+
+        response.Meters.Single().OveragePricing!.Tiers.Single().UnitAmount.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Blocked_overage_returns_no_pricing_even_with_a_rate_table_present()
+    {
+        var subscription = NewSubscription(10);
+        subscription.CurrencyCode = "CHF";
+        var meter = Meter("screening", (null, "1.00"));
+        meter.OverageAllowed = false;
+        subscription.Plan.Meters = [meter];
+
+        var response = PricedMapper().ToResponse(subscription);
+
+        var mapped = response.Meters.Single();
+        mapped.OverageAllowed.Should().BeFalse();
+        mapped.OveragePricing.Should().BeNull();
+    }
+
+    [Fact]
+    public void Overage_allowed_with_no_rate_table_is_distinguishable_from_blocked_overage()
+    {
+        var subscription = NewSubscription(10);
+        subscription.CurrencyCode = "CHF";
+        subscription.Plan.Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "screening",
+                DisplayName = "Screenings",
+                UnitLabel = "screening",
+                IncludedQuantity = 150,
+                OverageAllowed = true,
+                RateTables = []
+            }
+        ];
+
+        var response = PricedMapper().ToResponse(subscription);
+
+        var mapped = response.Meters.Single();
+        mapped.OverageAllowed.Should().BeTrue("blocked and unpriced must read differently to a client");
+        mapped.OveragePricing.Should().BeNull();
+    }
+
+    [Fact]
+    public void A_rate_table_for_another_currency_is_never_exposed()
+    {
+        var subscription = NewSubscription(10);
+        subscription.CurrencyCode = "CHF";
+        var meter = Meter("screening", (null, "1.00"));
+        meter.RateTables[0].CurrencyCode = "EUR";
+        subscription.Plan.Meters = [meter];
+
+        var response = PricedMapper().ToResponse(subscription);
+
+        response.Meters.Single().OveragePricing.Should().BeNull(
+            "the subscription is priced in CHF; a EUR-only rate table prices nothing for it");
+    }
+
+    [Fact]
+    public void Multiple_meters_are_mapped_independently()
+    {
+        var subscription = NewSubscription(10);
+        subscription.CurrencyCode = "CHF";
+        var blocked = Meter("blocked-thing", (null, "1.00"));
+        blocked.OverageAllowed = false;
+        subscription.Plan.Meters =
+        [
+            Meter("screening", (100, "1.00"), (null, "0.80")),
+            blocked
+        ];
+
+        var response = PricedMapper().ToResponse(subscription);
+
+        response.Meters.Should().HaveCount(2);
+        response.Meters.Single(meter => meter.MeterKey == "screening")
+            .OveragePricing!.Tiers.Should().HaveCount(2);
+        response.Meters.Single(meter => meter.MeterKey == "blocked-thing")
+            .OveragePricing.Should().BeNull();
+    }
+
+    [Fact]
+    public void A_legacy_subscription_with_no_meters_returns_an_empty_list()
+    {
+        var response = _mapper.ToResponse(NewSubscription(10));
+
+        response.Meters.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void A_mapper_with_no_currency_resolver_wired_leaves_priced_meters_unpriced_rather_than_guessing()
+    {
+        var subscription = NewSubscription(10);
+        subscription.CurrencyCode = "CHF";
+        subscription.Plan.Meters = [Meter("screening", (null, "1.00"))];
+
+        // The default mapper -- exactly the one every other test in this file already uses --
+        // never wires a currency resolver. It must still answer the endpoint, just without a
+        // fabricated price.
+        var response = _mapper.ToResponse(subscription);
+
+        var mapped = response.Meters.Single();
+        mapped.OverageAllowed.Should().BeTrue();
+        mapped.OveragePricing.Should().BeNull();
+    }
+
+    private static PlanMeter Meter(string meterKey, params (long? upTo, string amount)[] tiers) =>
+        new()
+        {
+            MeterKey = meterKey,
+            DisplayName = meterKey,
+            UnitLabel = "unit",
+            IncludedQuantity = 150,
+            ResetPolicy = MeterResetPolicy.Periodic,
+            OverageAllowed = true,
+            RateTables =
+            [
+                new MeterRateTable
+                {
+                    CurrencyCode = "CHF",
+                    Tiers = tiers
+                        .Select(tier => new MeterTier
+                        {
+                            UpToQuantity = tier.upTo,
+                            // Parsed back from the display string at 2 decimals -- only the
+                            // dedicated major-unit conversion test overwrites this with a minor
+                            // amount matching a different currency's precision.
+                            UnitAmountMinor = (long)(decimal.Parse(
+                                tier.amount,
+                                System.Globalization.CultureInfo.InvariantCulture) * 100)
+                        })
+                        .ToList()
+                }
+            ]
+        };
+
+    private static SubscriptionResponseMapper PricedMapper(
+        Dictionary<string, int>? decimalsByCurrency = null)
+    {
+        var options = new Mock<IOptionsMonitor<PaymentOptions>>();
+        options
+            .SetupGet(monitor => monitor.CurrentValue)
+            .Returns(new PaymentOptions
+            {
+                CurrencyMinorUnits = new Dictionary<string, int>(
+                    decimalsByCurrency ?? new Dictionary<string, int> { ["CHF"] = 2 },
+                    StringComparer.OrdinalIgnoreCase)
+            });
+
+        ICurrencyMinorUnitResolver resolver = new CurrencyMinorUnitResolver(options.Object);
+
+        return new SubscriptionResponseMapper(
+            new ControlledTimeProvider(new DateTimeOffset(2026, 8, 16, 12, 0, 0, TimeSpan.Zero)),
+            resolver);
     }
 
     private static SubscriptionQuantityItem Item(long quantity) => new()

--- a/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
@@ -66,6 +66,26 @@ public sealed class SubscriptionResponseMapperTests
     }
 
     [Fact]
+    public void Usage_cadence_is_reported_independently_of_billing_cadence()
+    {
+        // A plan is free to bill yearly and meter monthly -- nothing ties the two together, so
+        // the response must not either. Reading UsageInterval from Price (as Interval is) would
+        // have reported "Year" for a meter that actually resets every month.
+        var subscription = NewSubscription(10);
+        subscription.Price.Interval = BillingInterval.Year;
+        subscription.Price.IntervalCount = 1;
+        subscription.Plan.UsageInterval = BillingInterval.Month;
+        subscription.Plan.UsageIntervalCount = 1;
+
+        var response = _mapper.ToResponse(subscription);
+
+        response.Interval.Should().Be("Year");
+        response.UsageInterval.Should().Be("Month",
+            "the meter resets monthly regardless of how often the fee itself is billed");
+        response.UsageIntervalCount.Should().Be(1);
+    }
+
+    [Fact]
     public void A_subscription_nobody_has_cancelled_carries_no_cancellation()
     {
         var response = _mapper.ToResponse(NewSubscription(10));


### PR DESCRIPTION
## Summary

Extends `GET /api/subscriptions/current` so a subscriber can see the metered-overage terms they actually bought — included allowance, reset policy, whether overage is blocked, and (when priced) the graduated rate tiers in major units — without querying the mutable plan catalogue or guessing from the preview endpoint.

Per spec: terms come from the subscription's own immutable plan snapshot (`SubscriptionDetail.Plan.Meters`), never the catalogue; the existing usage-summary and overage-preview endpoints are untouched.

## API changes

`SubscriptionResponse` gains an additive `meters: MeterTermsResponse[]` field:

```json
{
  "subscriptionId": "sub-123",
  "currencyCode": "CHF",
  "meters": [
    {
      "meterKey": "screening",
      "displayName": "Screenings",
      "unitLabel": "screening",
      "includedQuantity": 150,
      "resetPolicy": "Periodic",
      "carryForwardCap": null,
      "overageAllowed": true,
      "overagePricing": {
        "currencyCode": "CHF",
        "tiers": [
          { "upToQuantity": 100, "unitAmount": "1.00" },
          { "upToQuantity": null, "unitAmount": "0.80" }
        ]
      }
    }
  ]
}
```

- `overagePricing` is `null` for two distinct reasons a client must tell apart from `overageAllowed` alone: overage is blocked outright, or overage is allowed but no rate table matches the subscription's currency (or that table's amounts couldn't be resolved). Either way `overageAllowed` stays truthful and separate.
- `unitAmount` is an **invariant major-unit decimal string** (`"1.00"` CHF, `"100"` JPY, `"0.100"` KWD) — resolved via the payment module's `ICurrencyMinorUnitResolver`, never a hardcoded 2-decimal assumption, and never fabricated when the currency can't be resolved (the whole tier list is reported unavailable instead).
- No catalogue lookup anywhere in this path — `SubscriptionCheckoutService` has no catalogue repository dependency at all, so a later plan edit structurally cannot reach this response.
- Both the live and pending/incomplete/unpaid branches of `GetCurrentAsync` share one mapper call, so a pending subscription reports the same snapshotted terms.
- The overage-preview endpoint (`POST /api/subscription-usage/overage/preview`) is untouched — same request/response contract, exact minor units, still the only place for an authoritative rated quote.

## UI

The subscription-simulation QA console (the only surface driving a real subscription end-to-end today — no production subscriber portal exists yet, see the module README) gets a new **Overage terms** section, reading the new `meters` field:

- `150 screenings included per month. Additional usage is blocked.`
- `150 screenings included per month. First 100 additional screenings: CHF 1.00 each; thereafter CHF 0.80 each.`
- `Additional usage is allowed, but no overage price is configured for the subscription currency.` (warning)

Priced meters get an **Estimate additional usage** action: a whole-number-only quantity field that calls the existing preview endpoint and renders current/projected usage, tier allocation, discount, tax, additional charge, projected period charge, and the response's own non-mutating / estimate-only notices. The existing entitlement-driven Usage section is unchanged.

## Tests

- Server: `SubscriptionResponseMapperTests` — priced/blocked/unpriced/other-currency/multi-meter/legacy/no-resolver-wired cases, plus zero-, two- and three-decimal currency conversion. `SubscriptionCheckoutServiceTests` — `GetCurrentAsync` end to end for a live and a pending subscription.
- Client: `overage-terms-section.test.tsx` and `estimate-usage-dialog.test.tsx` — blocked/unpriced/priced rendering, tier-sentence formatting, whole-number-only preview calls, discount/tax/total display, non-mutating notices, and that a preview failure never hides the meter's own terms.
- Both suites verified by temporarily breaking the core resolution logic (pricing resolver, tier-sentence formatter) and confirming exactly the dependent tests fail while unrelated ones still pass, then restoring the fix.

## Verification

- `dotnet test server/XUnitTest` (excl. Integration): 3288 passed, 4 failed — all four are the pre-existing `SubscriptionSimulation*` permission-guard baseline failures already on `dev`, unrelated to this change.
- `npx vitest run` (client, full suite): 327 files / 2359 tests, all passed.
- `tsc --noEmit` and `eslint` over the touched module: clean.

Four pre-existing `SimulatedSubscription` object literals in other test files gained `meters: []` to satisfy the now-required field — no behavioural change to those tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)