### PR TITLE
feat(subscription): irreversible plan archiving and a catalogue built to manage it

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -48,12 +48,22 @@ jobs:
       # code. Left out, the suite reported 48 passing tests on the pull request that introduced it
       # and had tried none of them.
       #
+      # PlanArchiveIntegrationTests is named for the same reason: archiving is a status check and a
+      # version check in one conditional write, so "two writers race and exactly one wins" and
+      # "an archived organization plan does not hide the active tenant plan" are claims about
+      # MongoDB rather than about our code.
+      #
+      # SubscriptionCatalogueRepositoryIntegrationTests joins it here having run nowhere since it
+      # was written. It exists because TryUpdatePlanAsync builds its update from an explicit field
+      # list, so a field the service sets and the repository forgets is silently never persisted —
+      # which is exactly the kind of thing a filter that omits the class cannot report.
+      #
       # Several integration classes are still outside this filter and so run nowhere. Widening it
-      # belongs in its own change, since whatever it turns up would arrive as unrelated failures on
-      # whichever pull request happened to widen it.
+      # further belongs in its own change, since whatever it turns up would arrive as unrelated
+      # failures on whichever pull request happened to widen it.
       - name: Run subscription Mongo integration suite
         run: >-
           dotnet test server/XUnitTest/XUnitTest.csproj
           --no-restore
-          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests"
+          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests"
           --verbosity minimal

--- a/client/app/cross-modules/utilities/subscription/components/archive-plan-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/archive-plan-dialog.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+import { ArchivePlanDialog } from "./archive-plan-dialog";
+
+const plan = {
+  planId: "plan-1",
+  code: "pro",
+  displayName: "Professional",
+  description: null,
+  featuresJson: null,
+  organizationId: null,
+  trialDays: null,
+  trialRequiresPaymentMethod: false,
+  version: 1,
+  hasSubscribers: true,
+  status: "Active",
+  quantityItems: [],
+  meters: [],
+  entitlements: [],
+  prices: [],
+} as unknown as SubscriptionPlan;
+
+const open = (onConfirm = vi.fn().mockResolvedValue(undefined)) => {
+  const onOpenChange = vi.fn();
+
+  render(
+    <ArchivePlanDialog
+      plan={plan}
+      isOpen
+      onOpenChange={onOpenChange}
+      onConfirm={onConfirm}
+    />,
+  );
+
+  return { onConfirm, onOpenChange };
+};
+
+describe("ArchivePlanDialog", () => {
+  it("names the exact plan being archived", () => {
+    open();
+
+    expect(
+      screen.getByRole("heading", { name: /Archive Professional\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("pro")).toBeInTheDocument();
+  });
+
+  /**
+   * All five consequences, asserted individually. They are not obvious from the word "archive" and
+   * they are not symmetrical: two reassure, one is irreversible. An author who reads only the
+   * heading should still not lose anything they did not expect to lose.
+   */
+  it("states every consequence, including the two reassuring ones", () => {
+    open();
+
+    expect(screen.getByText(/disappears from the plans your customers can choose/i))
+      .toBeInTheDocument();
+    expect(screen.getByText(/will be/i)).toBeInTheDocument();
+    expect(screen.getByText(/refused/i)).toBeInTheDocument();
+    expect(screen.getByText(/carries on unchanged/i)).toBeInTheDocument();
+    expect(screen.getByText(/This cannot be undone\./i)).toBeInTheDocument();
+    expect(screen.getByText(/duplicate it later to build a/i)).toBeInTheDocument();
+  });
+
+  it("archives on confirmation and closes", async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onOpenChange } = open();
+
+    await user.click(screen.getByRole("button", { name: /Archive permanently/i }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith(plan));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does nothing but close when the plan is kept on sale", async () => {
+    const user = userEvent.setup();
+    const { onConfirm, onOpenChange } = open();
+
+    await user.click(screen.getByRole("button", { name: /Keep it on sale/i }));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  /**
+   * Archiving cannot be undone, so a second click arriving before the first request settles must
+   * not send a second request.
+   */
+  it("sends one request however many times the button is clicked", async () => {
+    const user = userEvent.setup();
+    let release = () => {};
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+
+    open(onConfirm);
+
+    const confirm = screen.getByRole("button", { name: /Archive permanently/i });
+    await user.click(confirm);
+    await user.click(confirm);
+    await user.click(confirm);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: /Archiving/i })).toBeDisabled();
+
+    release();
+  });
+
+  /**
+   * A failed archive must leave the dialog open with the reason on it. Closing on failure would
+   * dismiss the only place the reason was written.
+   */
+  it("keeps the dialog open and shows why when archiving fails", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi
+      .fn()
+      .mockRejectedValue(new Error("This plan changed while you were archiving it."));
+    const { onOpenChange } = open(onConfirm);
+
+    await user.click(screen.getByRole("button", { name: /Archive permanently/i }));
+
+    expect(
+      await screen.findByRole("alert"),
+    ).toHaveTextContent("This plan changed while you were archiving it.");
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    // Still offered, because the conflict is the kind of thing a reload and a retry resolves.
+    expect(
+      screen.getByRole("button", { name: /Archive permanently/i }),
+    ).toBeEnabled();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/archive-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/archive-plan-dialog.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui-kits/button/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui-kits/dialog/dialog";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+
+/**
+ * Confirms archiving one plan.
+ *
+ * Every consequence is stated rather than summarised, because they are not obvious from the word
+ * "archive" and they are not symmetrical: two of them are reassuring, one is irreversible. An
+ * author who reads only the heading should still not be able to lose anything they did not expect
+ * to lose.
+ */
+export const ArchivePlanDialog = ({
+  plan,
+  isOpen,
+  onOpenChange,
+  onConfirm,
+}: {
+  plan: SubscriptionPlan | null;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Resolves when the plan is archived; rejects with a message worth showing. */
+  onConfirm: (plan: SubscriptionPlan) => Promise<void>;
+}) => {
+  const [isArchiving, setIsArchiving] = useState(false);
+  const [failure, setFailure] = useState<string | null>(null);
+
+  // A dialog reopened after a failure must not still be showing the last one, and one reopened for
+  // a different plan certainly must not.
+  useEffect(() => {
+    if (isOpen) {
+      setFailure(null);
+    }
+  }, [isOpen, plan?.planId]);
+
+  if (!plan) {
+    return null;
+  }
+
+  const archive = async () => {
+    // The guard, not just the disabled attribute: a second Enter keypress arrives before React has
+    // re-rendered the button, and archiving is irreversible enough to be worth defending twice.
+    if (isArchiving) {
+      return;
+    }
+
+    setIsArchiving(true);
+    setFailure(null);
+
+    try {
+      await onConfirm(plan);
+      onOpenChange(false);
+    } catch (error) {
+      setFailure(
+        error instanceof Error
+          ? error.message
+          : "The plan could not be archived. Nothing has changed.",
+      );
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        // Closing mid-request would leave the caller unable to report what happened, and the
+        // request cannot be recalled anyway.
+        if (isArchiving) {
+          return;
+        }
+
+        onOpenChange(open);
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <span className="rounded-full bg-destructive/10 p-1.5 text-destructive">
+              <AlertTriangle className="h-4 w-4" />
+            </span>
+            {/* The name and code both, because two plans in a family often differ only by code. */}
+            Archive {plan.displayName}?
+          </DialogTitle>
+          <DialogDescription>
+            <span className="font-mono text-xs">{plan.code}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 text-sm">
+          <ul className="space-y-2">
+            <li className="flex gap-2">
+              <span aria-hidden="true">•</span>
+              <span>
+                It disappears from the plans your customers can choose, and from
+                plan changes onto it.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden="true">•</span>
+              <span>
+                New subscriptions and plan changes naming it will be{" "}
+                <strong>refused</strong>.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden="true">•</span>
+              <span>
+                Everyone already subscribed{" "}
+                <strong>carries on unchanged</strong> — they bill from the terms
+                they bought, so renewals, usage, entitlements and invoices are
+                unaffected.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden="true">•</span>
+              <span>
+                <strong>This cannot be undone.</strong> There is no way to put
+                the plan back on sale.
+              </span>
+            </li>
+            <li className="flex gap-2">
+              <span aria-hidden="true">•</span>
+              <span>
+                You can still open it, and duplicate it later to build a
+                replacement.
+              </span>
+            </li>
+          </ul>
+
+          {failure ? (
+            <p
+              role="alert"
+              className="rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+            >
+              {failure}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isArchiving}
+          >
+            Keep it on sale
+          </Button>
+          <Button variant="destructive" onClick={archive} disabled={isArchiving}>
+            {isArchiving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Archiving…
+              </>
+            ) : (
+              "Archive permanently"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/plan-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-card.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+import { PlanCard } from "./plan-card";
+
+const plan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan =>
+  ({
+    planId: "plan-1",
+    code: "pro",
+    displayName: "Professional",
+    description: null,
+    featuresJson: null,
+    organizationId: null,
+    trialDays: null,
+    trialRequiresPaymentMethod: false,
+    version: 1,
+    hasSubscribers: false,
+    status: "Active",
+    quantityItems: [],
+    meters: [],
+    entitlements: [],
+    prices: [],
+    ...overrides,
+  }) as SubscriptionPlan;
+
+const renderCard = (
+  subject: SubscriptionPlan,
+  onArchive: ((plan: SubscriptionPlan) => void) | undefined = vi.fn(),
+) =>
+  render(
+    <MemoryRouter>
+      <PlanCard
+        plan={subject}
+        organizationLabel="Tenant-wide"
+        detailPath="/plans/plan-1"
+        editPath="/plans/plan-1/edit"
+        duplicatePath="/plans/create"
+        onArchive={onArchive}
+      />
+    </MemoryRouter>,
+  );
+
+describe("PlanCard", () => {
+  it("shows the plan, its code, scope and status", () => {
+    renderCard(plan());
+
+    expect(screen.getByRole("link", { name: "Professional" })).toHaveAttribute(
+      "href",
+      "/plans/plan-1",
+    );
+    expect(screen.getByText("pro")).toBeInTheDocument();
+    expect(screen.getByText("Tenant-wide")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+
+  it("reports pricing, cadence and configuration counts", () => {
+    renderCard(
+      plan({
+        prices: [
+          {
+            priceId: "price-1",
+            currencyCode: "CHF",
+            unitAmountMinor: 4_500,
+            interval: "Month",
+            intervalCount: 1,
+            quantityItemKey: null,
+          },
+          {
+            priceId: "price-2",
+            currencyCode: "CHF",
+            unitAmountMinor: 48_000,
+            interval: "Year",
+            intervalCount: 1,
+            quantityItemKey: null,
+          },
+        ],
+        meters: [{ meterKey: "api", overageAllowed: true }],
+      } as unknown as Partial<SubscriptionPlan>),
+    );
+
+    expect(screen.getByText(/From/)).toBeInTheDocument();
+    expect(screen.getByText(/Billed every month, every year/)).toBeInTheDocument();
+    expect(screen.getByText(/1 metered allowance with overage pricing/)).toBeInTheDocument();
+    expect(screen.getByText("2 prices")).toBeInTheDocument();
+  });
+
+  it("names the family and level when the plan has one", () => {
+    renderCard(plan({ familyCode: "core", familyRank: 2 }));
+
+    expect(screen.getByText("core · level 2")).toBeInTheDocument();
+  });
+
+  it("offers edit, duplicate and archive on an active plan", async () => {
+    const user = userEvent.setup();
+    const onArchive = vi.fn();
+    renderCard(plan(), onArchive);
+
+    await user.click(screen.getByRole("button", { name: /Actions for Professional/i }));
+
+    expect(screen.getByRole("menuitem", { name: /Edit/i })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /^Duplicate$/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("menuitem", { name: /Archive/i }));
+
+    expect(onArchive).toHaveBeenCalledWith(expect.objectContaining({ planId: "plan-1" }));
+  });
+
+  /**
+   * Absent rather than disabled. The server refuses every catalogue mutation on an archived plan,
+   * so a greyed-out Edit would invite a click and then an explanation; nothing at all says it is
+   * not on offer. There is deliberately no restore.
+   */
+  it("offers only viewing and duplication on an archived plan", async () => {
+    const user = userEvent.setup();
+    const onArchive = vi.fn();
+    renderCard(plan({ status: "Archived" }), onArchive);
+
+    expect(screen.getByText("Archived")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Actions for Professional/i }));
+
+    expect(screen.getByRole("menuitem", { name: /Duplicate as new plan/i })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /Edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /Archive/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /Restore/i })).not.toBeInTheDocument();
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A plan cached before the status field existed reads as on sale. The alternative would mute the
+   * whole catalogue after a deploy.
+   */
+  it("treats a plan with no status as active", () => {
+    renderCard(plan({ status: undefined }));
+
+    expect(screen.getByText("Active")).toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-card.tsx
@@ -1,20 +1,59 @@
-import { ArrowRight, Gauge, Layers } from "lucide-react";
+import {
+  Archive,
+  ArrowRight,
+  Copy,
+  Gauge,
+  Layers,
+  MoreVertical,
+  Pencil,
+  Tag,
+  Ticket,
+} from "lucide-react";
 import { Link } from "react-router";
 import { Badge } from "@/components/ui-kits/badge/badge";
+import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui-kits/dropdown-menu/dropdown-menu";
 import type { SubscriptionPlan } from "../models/subscription-plan.model";
-import { formatPrice } from "../utilities/subscription-format";
+import { formatInterval, formatPrice } from "../utilities/subscription-format";
 import { describeTrialDuration } from "../utilities/trial-duration-label";
 
+/**
+ * One plan in the catalogue.
+ *
+ * The whole card was a link before, which left nowhere to put an action: a menu inside an anchor
+ * either navigates when it opens or has to fight the anchor to stop it. The card is a plain
+ * container now, with the name as the link and an explicit action at the foot, so the menu can sit
+ * beside them without either interfering with the other.
+ */
 export const PlanCard = ({
   plan,
   organizationLabel,
   detailPath,
+  editPath,
+  duplicatePath,
+  onArchive,
 }: {
   plan: SubscriptionPlan;
   organizationLabel: string;
   detailPath: string;
+  editPath?: string;
+  /**
+   * The create page. Duplication carries the whole plan in router state, the way the detail page
+   * already does it — the builder reads it from there and seeds itself, so there is no
+   * duplicate-specific route to point at.
+   */
+  duplicatePath?: string;
+  /** Absent for an archived plan, and for a caller that offers no archiving at all. */
+  onArchive?: (plan: SubscriptionPlan) => void;
 }) => {
+  const isArchived = plan.status === "Archived";
   const cheapestPrice = plan.prices.reduce<SubscriptionPlan["prices"][number] | null>(
     (cheapest, price) =>
       cheapest === null || price.unitAmountMinor < cheapest.unitAmountMinor
@@ -24,47 +63,180 @@ export const PlanCard = ({
   );
   const trialLabel = describeTrialDuration(plan);
 
+  // One entry per distinct cadence rather than one per price: three currencies billed monthly is
+  // one choice of cadence, and listing it three times says something untrue about the plan.
+  const cadences = [
+    ...new Map(
+      plan.prices.map((price) => [
+        `${price.interval}:${price.intervalCount}`,
+        formatInterval(price.interval, price.intervalCount),
+      ]),
+    ).values(),
+  ];
+
+  const meteredWithOverage = plan.meters.filter(
+    (meter) => meter.overageAllowed,
+  ).length;
+
+  const counts = [
+    { label: "price", value: plan.prices.length, icon: Tag },
+    { label: "quantity item", value: plan.quantityItems.length, icon: Layers },
+    { label: "meter", value: plan.meters.length, icon: Gauge },
+    { label: "entitlement", value: plan.entitlements.length, icon: Ticket },
+  ].filter((entry) => entry.value > 0);
+
+  const hasMenu = Boolean(editPath || duplicatePath || onArchive);
+
   return (
-    <Link to={detailPath} className="block">
-      <Card className="h-full rounded-xl transition hover:border-blocks-primary-300 hover:shadow-md">
-        <div className="flex items-start justify-between gap-2">
-          <div>
-            <h3 className="font-semibold">{plan.displayName}</h3>
-            <p className="text-xs text-muted-foreground">{plan.code}</p>
-          </div>
-          <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+    <Card
+      className={`flex h-full flex-col rounded-xl transition ${
+        isArchived
+          ? // Muted, not faded away: an archived plan is still read, and text at 60% opacity on a
+            // muted panel fails contrast. The tint carries the state, the text keeps its colour.
+            "border-dashed bg-muted/40"
+          : "hover:border-blocks-primary-300 hover:shadow-md"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate font-semibold">
+            <Link
+              to={detailPath}
+              className="rounded outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {plan.displayName}
+            </Link>
+          </h3>
+          <p className="truncate font-mono text-xs text-muted-foreground">
+            {plan.code}
+          </p>
         </div>
 
-        <div className="mt-3 flex flex-wrap gap-1.5">
+        {hasMenu ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0"
+                aria-label={`Actions for ${plan.displayName}`}
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link to={detailPath}>View details</Link>
+              </DropdownMenuItem>
+              {/* Absent rather than disabled for an archived plan: a greyed-out Edit invites a
+                  second click and an explanation, where nothing at all says it is not on offer. */}
+              {editPath && !isArchived ? (
+                <DropdownMenuItem asChild>
+                  <Link to={editPath}>
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Edit
+                  </Link>
+                </DropdownMenuItem>
+              ) : null}
+              {duplicatePath ? (
+                <DropdownMenuItem asChild>
+                  <Link to={duplicatePath} state={{ duplicatePlan: plan }}>
+                    <Copy className="mr-2 h-4 w-4" />
+                    {isArchived ? "Duplicate as new plan" : "Duplicate"}
+                  </Link>
+                </DropdownMenuItem>
+              ) : null}
+              {onArchive && !isArchived ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onSelect={() => onArchive(plan)}
+                  >
+                    <Archive className="mr-2 h-4 w-4" />
+                    Archive
+                  </DropdownMenuItem>
+                </>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        <Badge variant={isArchived ? "secondary" : "success"} className="font-normal">
+          {isArchived ? "Archived" : "Active"}
+        </Badge>
+        <Badge variant="outline" className="font-normal">
+          {organizationLabel}
+        </Badge>
+        {plan.familyCode ? (
           <Badge variant="outline" className="font-normal">
-            {organizationLabel}
+            {plan.familyCode}
+            {typeof plan.familyRank === "number" ? ` · level ${plan.familyRank}` : ""}
           </Badge>
-          {trialLabel ? (
-            <Badge variant="info" className="font-normal">
-              {trialLabel}
-            </Badge>
-          ) : null}
-          {plan.quantityItems.length > 0 && (
-            <Badge variant="secondary" className="gap-1 font-normal">
-              <Layers className="h-3 w-3" />
-              {plan.quantityItems.length} quantity item
-              {plan.quantityItems.length === 1 ? "" : "s"}
-            </Badge>
-          )}
-          {plan.meters.length > 0 && (
-            <Badge variant="secondary" className="gap-1 font-normal">
-              <Gauge className="h-3 w-3" />
-              {plan.meters.length} meter{plan.meters.length === 1 ? "" : "s"}
-            </Badge>
-          )}
-        </div>
+        ) : null}
+        {trialLabel ? (
+          <Badge variant="info" className="font-normal">
+            {trialLabel}
+          </Badge>
+        ) : null}
+      </div>
 
-        <p className="mt-3 text-sm text-muted-foreground">
+      {plan.description ? (
+        // Two lines, then clipped. A description is authored freely and a card that grows to fit
+        // one breaks the grid for every card beside it.
+        <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
+          {plan.description}
+        </p>
+      ) : null}
+
+      <div className="mt-3 space-y-1">
+        <p className="text-sm font-medium">
           {cheapestPrice
             ? `From ${formatPrice(cheapestPrice)}`
             : "No price configured yet"}
         </p>
-      </Card>
-    </Link>
+        {cadences.length > 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Billed {cadences.join(", ")}
+          </p>
+        ) : null}
+        {meteredWithOverage > 0 ? (
+          <p className="text-xs text-muted-foreground">
+            {meteredWithOverage} metered{" "}
+            {meteredWithOverage === 1 ? "allowance" : "allowances"} with overage
+            pricing
+          </p>
+        ) : null}
+      </div>
+
+      {counts.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {counts.map((entry) => (
+            <Badge
+              key={entry.label}
+              variant="secondary"
+              className="gap-1 font-normal"
+            >
+              <entry.icon className="h-3 w-3" />
+              {entry.value} {entry.label}
+              {entry.value === 1 ? "" : "s"}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Pushed to the foot so every card in a row ends with its action on the same line, however
+          much description or how many badges the plans above differ by. */}
+      <div className="mt-auto pt-4">
+        <Button variant="outline" size="sm" className="w-full" asChild>
+          <Link to={detailPath}>
+            View details
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+    </Card>
   );
 };

--- a/client/app/cross-modules/utilities/subscription/hooks/use-subscription-plans.ts
+++ b/client/app/cross-modules/utilities/subscription/hooks/use-subscription-plans.ts
@@ -1,13 +1,28 @@
 import { useProjectStore } from "@seliseblocks/genesis-os";
 import { useQuery } from "@tanstack/react-query";
+import type { PlanCatalogueFilterName } from "../models/subscription-plan.model";
 import { subscriptionService } from "../services/subscription.service";
 
-export const useSubscriptionPlans = (organizationId?: string) => {
+/**
+ * The plans a screen may show.
+ *
+ * @param status Which plans to ask for, defaulting to the active catalogue. Only the management
+ * catalogue passes anything here. Every other caller — the discount authoring page, the subscribe
+ * and change-plan dialogs — omits it and therefore cannot show an archived plan even by accident,
+ * which is a stronger guarantee than each of them filtering for itself.
+ *
+ * The status is part of the query key, so switching filters is a separate cached entry rather than
+ * a refetch that briefly shows the wrong set.
+ */
+export const useSubscriptionPlans = (
+  organizationId?: string,
+  status: PlanCatalogueFilterName = "Active",
+) => {
   const tenantId = useProjectStore()?.selectedProject?.tenantId || "";
 
   return useQuery({
-    queryKey: ["subscription-plans", tenantId, organizationId ?? null],
-    queryFn: () => subscriptionService.listPlans(organizationId),
+    queryKey: ["subscription-plans", tenantId, organizationId ?? null, status],
+    queryFn: () => subscriptionService.listPlans(organizationId, status),
     staleTime: 30_000,
   });
 };

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -177,6 +177,20 @@ export interface PlanPrice {
   quantityDiscountCombination?: string | null;
 }
 
+/**
+ * Whether a plan may still be sold. `Draft` is deliberately absent: the server returns it in no
+ * catalogue view, so a client that handled it would be handling a case it can never see.
+ */
+export type PlanCatalogueStatusName = "Active" | "Archived";
+
+/**
+ * Which plans an administrative listing asks for. Sent only by the management catalogue — every
+ * subscriber-facing caller omits it and receives the active catalogue, which is what keeps
+ * archived plans out of subscribe and change-plan selectors without those screens filtering
+ * anything themselves.
+ */
+export type PlanCatalogueFilterName = "Active" | "Archived" | "All";
+
 export interface SubscriptionPlan {
   planId: string;
   code: string;
@@ -222,6 +236,25 @@ export interface SubscriptionPlan {
    */
   requirePaymentMethodUpfront?: boolean;
   version: number;
+  /**
+   * Whether the plan is still on sale.
+   *
+   * `"Archived"` is permanent and means one thing: nothing new can be sold on it. Everyone already
+   * subscribed bills from the snapshot taken when they bought, so an archived plan keeps renewing,
+   * rating usage and granting entitlements exactly as before.
+   *
+   * Optional because a response cached before the field existed will not carry it, and because
+   * omitting it must read as "on sale" rather than as "unknown" — a card that greyed itself out on
+   * a missing field would mute the whole catalogue after a deploy.
+   */
+  status?: PlanCatalogueStatusName;
+  /** When the plan was authored. Absent on responses cached before the field existed. */
+  createdAtUtc?: string;
+  /**
+   * When the plan last changed, archiving included. Drives the catalogue's "recently updated"
+   * order; absent on older cached responses, which sort last rather than first.
+   */
+  lastUpdatedAtUtc?: string;
   /**
    * Whether anything has ever subscribed to this plan. True closes editing: a subscription bills
    * from its own copy of the plan's terms, which an edit cannot reach.

--- a/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.test.tsx
@@ -1,0 +1,99 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+
+const { useSubscriptionPlan } = vi.hoisted(() => ({ useSubscriptionPlan: vi.fn() }));
+
+vi.mock("../hooks/use-subscription-plan", () => ({ useSubscriptionPlan }));
+
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({
+    data: { organizations: [{ itemId: "org-1", name: "AmLora Test Org" }] },
+    isError: false,
+  }),
+}));
+
+vi.mock("@seliseblocks/genesis-os", () => ({
+  useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
+}));
+
+import { EditSubscriptionPlanPage } from "./edit-subscription-plan-page";
+
+const plan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan =>
+  ({
+    planId: "plan-1",
+    code: "pro",
+    displayName: "Professional",
+    description: null,
+    featuresJson: null,
+    organizationId: "org-1",
+    trialDays: null,
+    trialDurationKind: null,
+    trialDurationCount: null,
+    trialRequiresPaymentMethod: true,
+    version: 1,
+    hasSubscribers: false,
+    quantityItems: [],
+    meters: [],
+    entitlements: [],
+    prices: [],
+    trialGrants: [],
+    ...overrides,
+  }) as SubscriptionPlan;
+
+const renderPage = (subject: SubscriptionPlan) => {
+  useSubscriptionPlan.mockReturnValue({
+    data: subject,
+    isLoading: false,
+    isError: false,
+    error: null,
+  });
+
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter>
+        <EditSubscriptionPlanPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+/**
+ * No link points here for an archived plan any more, so this route is reached by typing or
+ * following a bookmark. It still has to refuse, because hiding a link is not a guard: every form
+ * this page offers would have its submission rejected by the server.
+ */
+describe("EditSubscriptionPlanPage on an archived plan", () => {
+  it("refuses to edit it, and says why", () => {
+    renderPage(plan({ status: "Archived" }));
+
+    expect(
+      screen.getByRole("heading", { name: /Archived plans cannot be changed/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/carries on unchanged/i)).toBeInTheDocument();
+    expect(screen.getByText(/duplicate the plan/i)).toBeInTheDocument();
+  });
+
+  it("shows no form to submit", () => {
+    renderPage(plan({ status: "Archived" }));
+
+    expect(screen.queryByRole("button", { name: /Save changes/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Add another price/i })).not.toBeInTheDocument();
+  });
+
+  /**
+   * Checked before the subscribed branch, and this is why: an archived plan usually has
+   * subscribers, and that branch exists to let a live plan be repriced — the one thing an
+   * archived plan may no longer do. Ordered the other way, this page would offer to add a price.
+   */
+  it("refuses even when it also has subscribers", () => {
+    renderPage(plan({ status: "Archived", hasSubscribers: true }));
+
+    expect(
+      screen.getByRole("heading", { name: /Archived plans cannot be changed/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Add another price/i })).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/edit-subscription-plan-page.tsx
@@ -146,6 +146,38 @@ export const EditSubscriptionPlanPage = () => {
   };
 
   /**
+   * An archived plan is closed to everything this page does.
+   *
+   * Checked before the subscribed branch below, because the two are not alternatives: an archived
+   * plan usually *has* subscribers, and that branch exists to let a live plan be repriced — which
+   * is exactly what an archived plan may no longer do. Every submission it offered would be
+   * refused by the server.
+   *
+   * Reached by typing or bookmarking the URL, since no link points here for an archived plan any
+   * more. Answered with an explanation and a way back rather than a redirect, so somebody who
+   * followed an old link is told why instead of being bounced somewhere they did not ask for.
+   */
+  if (plan.status === "Archived") {
+    return (
+      <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
+        <SubscriptionPlanPageHeader
+          title={plan.displayName}
+          description="This plan is archived."
+          backTo={detailPath}
+        />
+        <Card className="space-y-2 rounded-xl border-dashed bg-muted/40">
+          <h2 className="font-semibold">Archived plans cannot be changed</h2>
+          <p className="text-sm text-muted-foreground">
+            Its terms, its prices, their tax and their discounts are all settled. Everyone already
+            subscribed carries on unchanged — they bill from the terms they bought. To sell
+            something like it again, duplicate the plan from its detail page and edit the copy.
+          </p>
+        </Card>
+      </main>
+    );
+  }
+
+  /**
    * A subscribed plan: its terms are closed and the server would refuse an update, but a price is
    * something new to sell rather than a change to something already sold. This is the only way to
    * reprice a live plan — add the new price, retire the old one — so it must not be a dead end.

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.test.tsx
@@ -214,3 +214,64 @@ describe("SubscriptionPlanDetailPage price management", () => {
     expect(link.getAttribute("href")).not.toContain("prices/create");
   });
 });
+
+/**
+ * An archived plan is read-only, and "read-only" has to mean every control, not just the ones in
+ * the header. The server refuses all five catalogue mutations on one, so any control still on the
+ * page leads to a request that fails — which is worse than no control at all, because the author
+ * only finds out after deciding to act.
+ */
+describe("SubscriptionPlanDetailPage archived plans", () => {
+  it("says it is archived, and says existing subscribers are unaffected", () => {
+    renderPage(plan({ status: "Archived" }));
+
+    expect(
+      screen.getByRole("heading", { name: /This plan is archived/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/carries on unchanged/i)).toBeInTheDocument();
+  });
+
+  it("offers no way to edit it", () => {
+    renderPage(plan({ status: "Archived" }));
+
+    expect(screen.queryByRole("link", { name: /^Edit$/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Manage prices/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers no way to retire a price", () => {
+    renderPage(plan({ status: "Archived" }));
+
+    expect(screen.queryByRole("button", { name: /Retire/i })).not.toBeInTheDocument();
+  });
+
+  it("offers no way to add a price to a plan that never had one", () => {
+    renderPage(plan({ status: "Archived", prices: [] }));
+
+    expect(screen.queryByRole("link", { name: /Add price/i })).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/archived without a price, so nothing was ever sold on it/i),
+    ).toBeInTheDocument();
+  });
+
+  it("still offers duplication, which is how a replacement is made", () => {
+    renderPage(plan({ status: "Archived" }));
+
+    expect(screen.getByRole("link", { name: /Duplicate plan/i })).toBeInTheDocument();
+  });
+
+  /**
+   * The controls come back for a live plan. Without this, hiding them unconditionally would pass
+   * every assertion above.
+   */
+  it("keeps every control on a plan that is still on sale", () => {
+    renderPage(plan());
+
+    expect(screen.getByRole("button", { name: /Retire/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^Edit$/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /This plan is archived/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertCircle, AlertTriangle, Check, Copy, Layers, Pencil, Plus } from "lucide-react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Archive,
+  Check,
+  Copy,
+  Layers,
+  Pencil,
+  Plus,
+} from "lucide-react";
 import { Link, useParams } from "react-router";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
@@ -107,6 +116,10 @@ export const SubscriptionPlanDetailPage = () => {
     }
   };
 
+  // Absent reads as active, matching the card: a response cached before the field existed must
+  // not put the whole page into its read-only state.
+  const isArchived = plan.status === "Archived";
+
   const summary: PlanSummaryData = {
     displayName: plan.displayName,
     code: plan.code,
@@ -149,7 +162,13 @@ export const SubscriptionPlanDetailPage = () => {
                 sat beside a separate "Add price" button, which read as though a live plan could not
                 be repriced at all — the opposite of the truth. The editor now closes only the
                 plan's own terms, so the label says which half is still open rather than removing
-                the way in. */}
+                the way in.
+
+                Gone entirely for an archived plan, rather than disabled: the server refuses every
+                catalogue mutation on one, so a button that opened the editor would lead to a form
+                whose every submission fails. Duplicate is the way forward, and it is the action
+                left standing. */}
+            {isArchived ? null : (
             <Button variant={plan.hasSubscribers ? "default" : "outline"} asChild>
               <Link
                 to={withOrganizationScope(
@@ -165,9 +184,31 @@ export const SubscriptionPlanDetailPage = () => {
                 {plan.hasSubscribers ? "Manage prices" : "Edit"}
               </Link>
             </Button>
+            )}
           </div>
         }
       />
+
+      {/* Stated before anything else on the page, because every action below it behaves
+          differently and the two reassurances are the ones an author actually needs: nothing was
+          lost, and nobody was cut off. */}
+      {isArchived ? (
+        <div
+          role="status"
+          className="flex flex-col gap-1 rounded-xl border border-dashed bg-muted/40 p-4"
+        >
+          <div className="flex items-center gap-2">
+            <Archive className="h-4 w-4 text-muted-foreground" />
+            <h2 className="font-semibold">This plan is archived</h2>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            It cannot be subscribed to, changed onto, or edited, and it does not appear in your
+            customers&rsquo; choices. Everyone already subscribed carries on unchanged — they bill
+            from the terms they bought, so renewals, usage, entitlements and invoices are
+            unaffected. Archiving cannot be undone; duplicate the plan to build a replacement.
+          </p>
+        </div>
+      ) : null}
 
       {/* Display only, both directions: naming a predecessor never migrated a subscriber and
           never touched either plan's editability — see Plan.PredecessorPlanId server-side. */}

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-detail-page.tsx
@@ -337,19 +337,25 @@ export const SubscriptionPlanDetailPage = () => {
               <Card className="flex flex-col items-center gap-3 rounded-lg py-8 text-center">
                 <Layers className="h-6 w-6 text-muted-foreground" />
                 <p className="text-sm text-muted-foreground">
-                  No price yet — subscribers cannot check out until one exists.
+                  {isArchived
+                    ? "This plan was archived without a price, so nothing was ever sold on it."
+                    : "No price yet — subscribers cannot check out until one exists."}
                 </p>
-                <Button asChild size="sm">
-                  <Link
-                    to={withOrganizationScope(
-                      `${basePath}/${encodeURIComponent(plan.planId)}/edit`,
-                      plan.organizationId,
-                    )}
-                  >
-                    <Plus className="mr-2 h-4 w-4" />
-                    Add price
-                  </Link>
-                </Button>
+                {/* Offered only while the plan can still be sold. The server refuses a price on an
+                    archived plan, so this button led to a form whose submission always failed. */}
+                {isArchived ? null : (
+                  <Button asChild size="sm">
+                    <Link
+                      to={withOrganizationScope(
+                        `${basePath}/${encodeURIComponent(plan.planId)}/edit`,
+                        plan.organizationId,
+                      )}
+                    >
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add price
+                    </Link>
+                  </Button>
+                )}
               </Card>
             ) : (
               <div className="grid gap-3 sm:grid-cols-2">
@@ -368,17 +374,23 @@ export const SubscriptionPlanDetailPage = () => {
                       </Badge>
                       {/* Kept here as well as in the editor: this is the list where somebody
                           reads the prices, so it is where they decide one should come off the
-                          menu. One button, not a second copy of the form. */}
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        disabled={retiringPriceId !== null}
-                        onClick={() => retirePrice(price.priceId)}
-                        className="h-7 text-xs text-muted-foreground hover:text-destructive"
-                      >
-                        {retiringPriceId === price.priceId ? "Retiring…" : "Retire"}
-                      </Button>
+                          menu. One button, not a second copy of the form.
+
+                          Absent once the plan is archived. Retiring a price is a change to what
+                          the plan sells, and the plan sells nothing — the server refuses it, and
+                          there is nothing left for it to achieve. */}
+                      {isArchived ? null : (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          disabled={retiringPriceId !== null}
+                          onClick={() => retirePrice(price.priceId)}
+                          className="h-7 text-xs text-muted-foreground hover:text-destructive"
+                        >
+                          {retiringPriceId === price.priceId ? "Retiring…" : "Retire"}
+                        </Button>
+                      )}
                     </div>
                   </Card>
                 ))}

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
@@ -1,8 +1,11 @@
 import { useMemo, useState } from "react";
-import { AlertCircle, Layers, Plus, RefreshCw, Search } from "lucide-react";
+import { AlertCircle, Archive, Layers, Plus, RefreshCw, Search, X } from "lucide-react";
 import { Link, useParams, useSearchParams } from "react-router";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "@/hooks/use-toast";
+import { Badge } from "@/components/ui-kits/badge/badge";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import { Input } from "@/components/ui-kits/input/input";
@@ -14,21 +17,55 @@ import {
   SelectValue,
 } from "@/components/ui-kits/select/select";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui-kits/tabs/tabs";
 import {
   ORGANIZATION_PAGE_SIZE,
   ORGANIZATION_QUERY_PARAM,
   TENANT_WIDE_ORGANIZATION,
 } from "../constants/subscription.constants";
+import { ArchivePlanDialog } from "../components/archive-plan-dialog";
 import { PlanCard } from "../components/plan-card";
 import { SubscriptionPlanPageHeader } from "../components/subscription-plan-page-header";
 import { withOrganizationScope } from "../hooks/use-organization-scope";
 import { useSubscriptionPlans } from "../hooks/use-subscription-plans";
+import type {
+  PlanCatalogueFilterName,
+  SubscriptionPlan,
+} from "../models/subscription-plan.model";
+import { subscriptionService } from "../services/subscription.service";
+import {
+  applyCatalogueFilters,
+  countActiveFilters,
+  DEFAULT_CATALOGUE_FILTERS,
+  PLAN_SORT_LABELS,
+  PLAN_STATUS_TABS,
+  readCatalogueFilters,
+  summariseCatalogue,
+  writeCatalogueFilters,
+  type PlanCatalogueSort,
+} from "../utilities/plan-catalogue-filters";
 
 export const SubscriptionPlanListPage = () => {
   const { itemId } = useParams();
-  const [search, setSearch] = useState("");
   const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
   const organizationScope = searchParams.get(ORGANIZATION_QUERY_PARAM) ?? undefined;
+
+  // Every control lives in the URL, so a reload and a shared link both reproduce the list the
+  // sender was looking at. There is no second copy in component state to fall out of step with it.
+  const filters = useMemo(() => readCatalogueFilters(searchParams), [searchParams]);
+
+  const setFilters = (next: Partial<typeof filters>) =>
+    setSearchParams(writeCatalogueFilters(searchParams, { ...filters, ...next }), {
+      replace: true,
+    });
+
+  const [planToArchive, setPlanToArchive] = useState<SubscriptionPlan | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  // Fetched once as All and filtered in the browser. Switching tabs is then instant and the
+  // summary counts stay consistent with what the tabs show, rather than each tab knowing only its
+  // own half of the catalogue.
   const {
     data: plans,
     error,
@@ -36,7 +73,7 @@ export const SubscriptionPlanListPage = () => {
     isFetching,
     isLoading,
     refetch,
-  } = useSubscriptionPlans(organizationScope);
+  } = useSubscriptionPlans(organizationScope, "All");
 
   const tenantId = useProjectStore()?.selectedProject?.tenantId ?? "";
   const { data: organizationsData } = useGetOrganizations({
@@ -60,23 +97,17 @@ export const SubscriptionPlanListPage = () => {
   }, [organizationsData]);
 
   const basePath = `/app/${itemId ?? ""}/subscription/plans`;
+  const createPath = withOrganizationScope(`${basePath}/create`, organizationScope);
 
-  const filteredPlans = useMemo(() => {
-    const term = search.trim().toLowerCase();
-
-    if (!term) {
-      return plans ?? [];
-    }
-
-    return (plans ?? []).filter(
-      (plan) =>
-        plan.displayName.toLowerCase().includes(term) ||
-        plan.code.toLowerCase().includes(term),
-    );
-  }, [plans, search]);
+  const summary = useMemo(() => summariseCatalogue(plans ?? []), [plans]);
+  const filteredPlans = useMemo(
+    () => applyCatalogueFilters(plans ?? [], filters),
+    [plans, filters],
+  );
+  const activeFilterCount = countActiveFilters(filters);
 
   const catalogueGroups = useMemo(() => {
-    const groups = new Map<string, typeof filteredPlans>();
+    const groups = new Map<string, SubscriptionPlan[]>();
     filteredPlans.forEach((plan) => {
       const key = plan.familyCode ? `family:${plan.familyCode}` : `plan:${plan.planId}`;
       groups.set(key, [...(groups.get(key) ?? []), plan]);
@@ -87,6 +118,59 @@ export const SubscriptionPlanListPage = () => {
       levels: levels.sort((left, right) => (left.familyRank ?? 0) - (right.familyRank ?? 0)),
     }));
   }, [filteredPlans]);
+
+  const archivePlan = async (plan: SubscriptionPlan) => {
+    await subscriptionService.archivePlan(
+      plan.planId,
+      plan.organizationId ?? undefined,
+    );
+
+    // Invalidated rather than reloaded: the card leaves the Active tab as soon as the refetch
+    // lands, and it is already present under Archived, so there is nothing to navigate to.
+    await queryClient.invalidateQueries({ queryKey: ["subscription-plans"] });
+
+    toast({
+      variant: "success",
+      title: "Plan archived",
+      description: `${plan.displayName} is off the menu. Everyone already on it carries on unchanged.`,
+    });
+  };
+
+  const summaryCards = [
+    { label: "Active plans", value: summary.active, icon: Layers },
+    { label: "Archived plans", value: summary.archived, icon: Archive },
+    { label: "Plan families", value: summary.families, icon: Layers },
+  ];
+
+  const emptyStateCopy = () => {
+    if (plans?.length === 0) {
+      return {
+        title: "No subscription plan yet",
+        body: "Create your first plan to start selling subscriptions.",
+      };
+    }
+
+    if (filters.status === "Archived") {
+      return {
+        title: "No archived plans",
+        body: "Plans you take off the menu will be kept here, and stay readable.",
+      };
+    }
+
+    if (activeFilterCount > 0) {
+      return {
+        title: "No plans match these filters",
+        body: "Try a different name or code, or clear the filters.",
+      };
+    }
+
+    return {
+      title: "No active plans",
+      body: "Every plan in this scope has been archived.",
+    };
+  };
+
+  const empty = emptyStateCopy();
 
   return (
     <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
@@ -102,15 +186,16 @@ export const SubscriptionPlanListPage = () => {
             </Button>
             <Button
               variant="outline"
+              size="icon"
               className="bg-background/80"
               onClick={() => refetch()}
               disabled={isFetching}
+              aria-label="Refresh plans"
             >
-              <RefreshCw className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
-              Refresh
+              <RefreshCw className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
             </Button>
             <Button asChild>
-              <Link to={withOrganizationScope(`${basePath}/create`, organizationScope)}>
+              <Link to={createPath}>
                 <Plus className="mr-2 h-4 w-4" />
                 Create plan
               </Link>
@@ -119,51 +204,125 @@ export const SubscriptionPlanListPage = () => {
         }
       />
 
+      <div className="grid gap-3 sm:grid-cols-3">
+        {summaryCards.map((card) => (
+          <Card key={card.label} className="rounded-xl">
+            <div className="flex items-center gap-3">
+              <span className="rounded-lg bg-muted p-2 text-muted-foreground">
+                <card.icon className="h-4 w-4" />
+              </span>
+              <div>
+                <p className="text-2xl font-semibold leading-none">{card.value}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{card.label}</p>
+              </div>
+            </div>
+          </Card>
+        ))}
+      </div>
+
       <Card className="rounded-xl p-0">
-        <div className="flex flex-col gap-3 border-b p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
-          <div>
-            <h2 className="font-semibold">Plan catalogue</h2>
+        <div className="space-y-3 border-b p-4 sm:p-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <Tabs
+              value={filters.status}
+              onValueChange={(value) =>
+                setFilters({ status: value as PlanCatalogueFilterName })
+              }
+            >
+              <TabsList>
+                {PLAN_STATUS_TABS.map((tab) => (
+                  <TabsTrigger key={tab} value={tab}>
+                    {tab}
+                    {tab === "Archived" && summary.archived > 0
+                      ? ` (${summary.archived})`
+                      : ""}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+
+            <div className="flex w-full flex-col gap-2 sm:flex-row lg:w-auto">
+              <Select
+                value={organizationScope ?? TENANT_WIDE_ORGANIZATION}
+                onValueChange={(value) => {
+                  // The scope changes which catalogue is fetched, so the other filters are kept
+                  // rather than reset: somebody comparing two organizations is still looking for
+                  // the same thing in each.
+                  const next = new URLSearchParams(searchParams);
+
+                  if (value === TENANT_WIDE_ORGANIZATION) {
+                    next.delete(ORGANIZATION_QUERY_PARAM);
+                  } else {
+                    next.set(ORGANIZATION_QUERY_PARAM, value);
+                  }
+
+                  setSearchParams(next, { replace: true });
+                }}
+              >
+                <SelectTrigger className="sm:w-52" aria-label="Organization">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={TENANT_WIDE_ORGANIZATION}>Tenant-wide only</SelectItem>
+                  {organizations.map((organization) => (
+                    <SelectItem key={organization.itemId} value={organization.itemId}>
+                      {organization.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select
+                value={filters.sort}
+                onValueChange={(value) => setFilters({ sort: value as PlanCatalogueSort })}
+              >
+                <SelectTrigger className="sm:w-48" aria-label="Sort plans">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(PLAN_SORT_LABELS).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <div className="relative min-w-0 sm:w-64">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  value={filters.search}
+                  onChange={(event) => setFilters({ search: event.target.value })}
+                  placeholder="Search plan name or code"
+                  className="pl-9"
+                  aria-label="Search subscription plans"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <p className="text-xs text-muted-foreground">
               {organizationScope
                 ? "Showing this organization's own plans alongside the tenant-wide ones."
                 : "Showing tenant-wide plans. Choose an organization to see plans scoped to it."}
             </p>
-          </div>
 
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
-            <Select
-              value={organizationScope ?? TENANT_WIDE_ORGANIZATION}
-              onValueChange={(value) =>
-                setSearchParams(
-                  value === TENANT_WIDE_ORGANIZATION
-                    ? {}
-                    : { [ORGANIZATION_QUERY_PARAM]: value },
-                )
-              }
-            >
-              <SelectTrigger className="sm:w-56" aria-label="Organization">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={TENANT_WIDE_ORGANIZATION}>Tenant-wide only</SelectItem>
-                {organizations.map((organization) => (
-                  <SelectItem key={organization.itemId} value={organization.itemId}>
-                    {organization.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            <div className="relative min-w-0 sm:w-64">
-              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-              <Input
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Search plan name or code"
-                className="pl-9"
-                aria-label="Search subscription plans"
-              />
-            </div>
+            {activeFilterCount > 0 ? (
+              <div className="flex items-center gap-2">
+                <Badge variant="secondary" className="font-normal">
+                  {activeFilterCount} filter{activeFilterCount === 1 ? "" : "s"} active
+                </Badge>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setFilters(DEFAULT_CATALOGUE_FILTERS)}
+                >
+                  <X className="mr-1 h-3 w-3" />
+                  Clear filters
+                </Button>
+              </div>
+            ) : null}
           </div>
         </div>
 
@@ -174,7 +333,7 @@ export const SubscriptionPlanListPage = () => {
               aria-label="Loading plans"
             >
               {Array.from({ length: 3 }, (_, index) => (
-                <Skeleton key={index} className="h-40 w-full rounded-xl" />
+                <Skeleton key={index} className="h-56 w-full rounded-xl" />
               ))}
             </div>
           ) : isError ? (
@@ -195,22 +354,24 @@ export const SubscriptionPlanListPage = () => {
               <span className="rounded-full bg-muted p-4 text-muted-foreground">
                 <Layers className="h-7 w-7" />
               </span>
-              <h3 className="mt-4 text-lg font-semibold">
-                {plans?.length ? "No plans match this search" : "No subscription plan yet"}
-              </h3>
-              <p className="mt-1 max-w-md text-sm text-muted-foreground">
-                {plans?.length
-                  ? "Try a different name or code."
-                  : "Create your first plan to start selling subscriptions."}
-              </p>
-              {!plans?.length && (
+              <h3 className="mt-4 text-lg font-semibold">{empty.title}</h3>
+              <p className="mt-1 max-w-md text-sm text-muted-foreground">{empty.body}</p>
+              {plans?.length === 0 ? (
                 <Button asChild className="mt-5">
-                  <Link to={withOrganizationScope(`${basePath}/create`, organizationScope)}>
+                  <Link to={createPath}>
                     <Plus className="mr-2 h-4 w-4" />
                     Create plan
                   </Link>
                 </Button>
-              )}
+              ) : activeFilterCount > 0 ? (
+                <Button
+                  variant="outline"
+                  className="mt-5"
+                  onClick={() => setFilters(DEFAULT_CATALOGUE_FILTERS)}
+                >
+                  Clear filters
+                </Button>
+              ) : null}
             </div>
           ) : (
             <div className="space-y-4">
@@ -219,7 +380,10 @@ export const SubscriptionPlanListPage = () => {
                   {group.familyCode && (
                     <div className="mb-3">
                       <h3 className="font-semibold">{group.levels[0]?.displayName}</h3>
-                      <p className="text-xs text-muted-foreground">{group.familyCode} · {group.levels.length} levels</p>
+                      <p className="text-xs text-muted-foreground">
+                        {group.familyCode} · {group.levels.length} level
+                        {group.levels.length === 1 ? "" : "s"}
+                      </p>
                     </div>
                   )}
                   <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -232,6 +396,18 @@ export const SubscriptionPlanListPage = () => {
                           `${basePath}/${encodeURIComponent(plan.planId)}`,
                           plan.organizationId,
                         )}
+                        editPath={withOrganizationScope(
+                          `${basePath}/${encodeURIComponent(plan.planId)}/edit`,
+                          plan.organizationId,
+                        )}
+                        duplicatePath={withOrganizationScope(
+                          `${basePath}/create`,
+                          plan.organizationId,
+                        )}
+                        onArchive={(selected) => {
+                          setPlanToArchive(selected);
+                          setIsDialogOpen(true);
+                        }}
                       />
                     ))}
                   </div>
@@ -241,6 +417,13 @@ export const SubscriptionPlanListPage = () => {
           )}
         </div>
       </Card>
+
+      <ArchivePlanDialog
+        plan={planToArchive}
+        isOpen={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+        onConfirm={archivePlan}
+      />
     </main>
   );
 };

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
@@ -8,6 +8,7 @@ import type {
   CreateSubscriptionPriceRequest,
   CreateSubscriptionDiscountRequest,
   SubscriptionDiscount,
+  PlanCatalogueFilterName,
   SubscriptionPlan,
   UpdateSubscriptionPlanRequest,
   UpdateSubscriptionDiscountRequest,
@@ -28,10 +29,27 @@ interface SubscriptionApiResponse<T> {
 }
 
 class SubscriptionService {
-  async listPlans(organizationId?: string): Promise<SubscriptionPlan[]> {
-    const query = organizationId
-      ? `?organizationId=${encodeURIComponent(organizationId)}`
-      : "";
+  /**
+   * @param status Which plans to ask for. Omitted by every subscriber-facing caller, which is
+   * what makes the default — the active catalogue — the thing those screens receive.
+   */
+  async listPlans(
+    organizationId?: string,
+    status?: PlanCatalogueFilterName,
+  ): Promise<SubscriptionPlan[]> {
+    const parameters = new URLSearchParams();
+
+    if (organizationId) {
+      parameters.set("organizationId", organizationId);
+    }
+
+    // Left off entirely rather than sent as "Active", so the request a subscriber-facing screen
+    // makes is byte-identical to the one it made before this parameter existed.
+    if (status && status !== "Active") {
+      parameters.set("status", status);
+    }
+
+    const query = parameters.size > 0 ? `?${parameters.toString()}` : "";
 
     const response =
       await serviceInstances.utitlitiesService.get<
@@ -126,6 +144,41 @@ class SubscriptionService {
    * subscription records having been sold on, so it is superseded rather than rewritten.
    * Anyone already subscribed keeps billing on their snapshot, untouched.
    */
+  /**
+   * Takes a whole plan off the menu, permanently.
+   *
+   * Existing subscribers are untouched and none of the plan's prices is rewritten: each bills from
+   * the snapshot copied onto it when it was sold. Renewal, usage rating, entitlements, invoicing
+   * and cancellation all continue. What stops is selling, and every further change to the plan.
+   *
+   * Safe to repeat: a second call returns the archived plan without writing again, so a
+   * double-submitted dialog cannot produce an error about work that already succeeded. There is no
+   * restore — a replacement is made by duplicating the plan.
+   */
+  async archivePlan(
+    planId: string,
+    organizationId?: string,
+  ): Promise<SubscriptionPlan> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+    const response =
+      await serviceInstances.utitlitiesService.put<
+        SubscriptionApiResponse<SubscriptionPlan>
+      >(
+        `${SUBSCRIPTION_PLANS_ENDPOINT}/${encodeURIComponent(planId)}/archive${query}`,
+        {},
+      );
+
+    if (!response.success || !response.data) {
+      throw new Error(
+        response.error?.message || "The plan could not be archived.",
+      );
+    }
+
+    return response.data;
+  }
+
   async archivePrice(
     priceId: string,
     organizationId?: string,

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+import {
+  applyCatalogueFilters,
+  countActiveFilters,
+  readCatalogueFilters,
+  startingPrice,
+  summariseCatalogue,
+  writeCatalogueFilters,
+} from "./plan-catalogue-filters";
+
+const plan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan =>
+  ({
+    planId: "plan-1",
+    code: "pro",
+    displayName: "Professional",
+    description: null,
+    featuresJson: null,
+    organizationId: null,
+    trialDays: null,
+    trialRequiresPaymentMethod: false,
+    version: 1,
+    hasSubscribers: false,
+    quantityItems: [],
+    meters: [],
+    entitlements: [],
+    prices: [],
+    ...overrides,
+  }) as SubscriptionPlan;
+
+describe("reading catalogue filters from a URL", () => {
+  it("defaults to the active catalogue with nothing in the query string", () => {
+    expect(readCatalogueFilters(new URLSearchParams())).toEqual({
+      status: "Active",
+      search: "",
+      sort: "name",
+    });
+  });
+
+  it("round-trips every control", () => {
+    const written = writeCatalogueFilters(new URLSearchParams(), {
+      status: "Archived",
+      search: "pro",
+      sort: "updated",
+    });
+
+    expect(readCatalogueFilters(written)).toEqual({
+      status: "Archived",
+      search: "pro",
+      sort: "updated",
+    });
+  });
+
+  it("leaves unrelated query parameters alone", () => {
+    // The organization scope lives in the same query string and is owned by a different control.
+    const written = writeCatalogueFilters(
+      new URLSearchParams({ organizationId: "org-2" }),
+      { status: "All", search: "", sort: "name" },
+    );
+
+    expect(written.get("organizationId")).toBe("org-2");
+    expect(written.get("status")).toBe("All");
+  });
+
+  it("omits a value that is already the default", () => {
+    const written = writeCatalogueFilters(new URLSearchParams(), {
+      status: "Active",
+      search: "",
+      sort: "name",
+    });
+
+    expect(written.toString()).toBe("");
+  });
+
+  /**
+   * This parses a hand-editable address bar rather than an API request, so a typo shows the
+   * ordinary catalogue instead of an error. The server is the thing that rejects a bad status.
+   */
+  it("falls back to defaults for values it does not recognise", () => {
+    const filters = readCatalogueFilters(
+      new URLSearchParams({ status: "Draft", sort: "cheapest" }),
+    );
+
+    expect(filters.status).toBe("Active");
+    expect(filters.sort).toBe("name");
+  });
+
+  it("counts only the controls that are away from their default", () => {
+    expect(countActiveFilters({ status: "Active", search: "", sort: "name" })).toBe(0);
+    expect(countActiveFilters({ status: "Archived", search: "a", sort: "price" })).toBe(3);
+  });
+});
+
+describe("filtering and ordering the catalogue", () => {
+  const active = plan({ planId: "a", displayName: "Alpha", status: "Active" });
+  const archived = plan({
+    planId: "b",
+    code: "legacy",
+    displayName: "Bravo",
+    status: "Archived",
+  });
+  const noStatus = plan({ planId: "c", displayName: "Charlie" });
+
+  it("shows only active plans by default", () => {
+    const result = applyCatalogueFilters([active, archived, noStatus], {
+      status: "Active",
+      search: "",
+      sort: "name",
+    });
+
+    expect(result.map((entry) => entry.planId)).toEqual(["a", "c"]);
+  });
+
+  it("shows only archived plans under Archived", () => {
+    const result = applyCatalogueFilters([active, archived, noStatus], {
+      status: "Archived",
+      search: "",
+      sort: "name",
+    });
+
+    expect(result.map((entry) => entry.planId)).toEqual(["b"]);
+  });
+
+  it("shows both under All", () => {
+    const result = applyCatalogueFilters([active, archived, noStatus], {
+      status: "All",
+      search: "",
+      sort: "name",
+    });
+
+    expect(result).toHaveLength(3);
+  });
+
+  /**
+   * A response cached before the status field existed must read as on sale. Hiding it from every
+   * tab would empty the catalogue after a deploy, which is worse than any mislabelled badge.
+   */
+  it("treats a plan with no status as active", () => {
+    const result = applyCatalogueFilters([noStatus], {
+      status: "Active",
+      search: "",
+      sort: "name",
+    });
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("searches name and code together with the status filter", () => {
+    const result = applyCatalogueFilters([active, archived, noStatus], {
+      status: "All",
+      search: "legacy",
+      sort: "name",
+    });
+
+    expect(result.map((entry) => entry.planId)).toEqual(["b"]);
+  });
+
+  it("orders by most recently updated, putting undated plans last", () => {
+    const older = plan({
+      planId: "older",
+      lastUpdatedAtUtc: "2026-01-01T00:00:00Z",
+      status: "Active",
+    });
+    const newer = plan({
+      planId: "newer",
+      lastUpdatedAtUtc: "2026-08-01T00:00:00Z",
+      status: "Active",
+    });
+
+    const result = applyCatalogueFilters([older, noStatus, newer], {
+      status: "All",
+      search: "",
+      sort: "updated",
+    });
+
+    expect(result.map((entry) => entry.planId)).toEqual(["newer", "older", "c"]);
+  });
+
+  /**
+   * Compared in major units. On the raw minor-unit integers 500 JPY outranks 4.00 CHF, which is
+   * not a currency conversion problem — it is the smallest coin being a different size.
+   */
+  it("orders by starting price across currencies, putting priceless plans last", () => {
+    const yen = plan({
+      planId: "yen",
+      status: "Active",
+      prices: [{ unitAmountMinor: 500, currencyCode: "JPY" }],
+    } as Partial<SubscriptionPlan>);
+    const franc = plan({
+      planId: "franc",
+      status: "Active",
+      prices: [{ unitAmountMinor: 400, currencyCode: "CHF" }],
+    } as Partial<SubscriptionPlan>);
+
+    expect(startingPrice(yen)).toBe(500);
+    expect(startingPrice(franc)).toBe(4);
+
+    const result = applyCatalogueFilters([yen, noStatus, franc], {
+      status: "All",
+      search: "",
+      sort: "price",
+    });
+
+    expect(result.map((entry) => entry.planId)).toEqual(["franc", "yen", "c"]);
+  });
+});
+
+describe("summary counts", () => {
+  /**
+   * Derived from the whole catalogue rather than the filtered list: "12 active" must not change
+   * because somebody typed in the search box, or it stops being a fact about the catalogue and
+   * becomes a restatement of the list already on screen.
+   */
+  it("counts the whole catalogue, not the current filter", () => {
+    const summary = summariseCatalogue([
+      plan({ planId: "a", status: "Active", familyCode: "core" }),
+      plan({ planId: "b", status: "Active", familyCode: "core" }),
+      plan({ planId: "c", status: "Archived", familyCode: "legacy" }),
+      plan({ planId: "d", status: "Archived" }),
+      plan({ planId: "e" }),
+    ]);
+
+    expect(summary).toEqual({ active: 3, archived: 2, families: 2 });
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.ts
@@ -1,0 +1,210 @@
+import type {
+  PlanCatalogueFilterName,
+  SubscriptionPlan,
+} from "../models/subscription-plan.model";
+import { toMajorUnits } from "./subscription-format";
+
+/**
+ * How the catalogue is ordered.
+ *
+ * Kept as names rather than comparator functions so the choice survives a round trip through the
+ * query string: a shared link has to reproduce the list its sender was looking at.
+ */
+export type PlanCatalogueSort = "name" | "updated" | "price";
+
+export const PLAN_SORT_LABELS: Record<PlanCatalogueSort, string> = {
+  name: "Name",
+  updated: "Recently updated",
+  price: "Lowest starting price",
+};
+
+export const PLAN_STATUS_TABS: PlanCatalogueFilterName[] = [
+  "Active",
+  "Archived",
+  "All",
+];
+
+/** The query-string keys. Named here so the page and its tests cannot disagree about them. */
+export const CATALOGUE_QUERY_PARAMS = {
+  status: "status",
+  search: "q",
+  sort: "sort",
+} as const;
+
+export type PlanCatalogueFilters = {
+  status: PlanCatalogueFilterName;
+  search: string;
+  sort: PlanCatalogueSort;
+};
+
+export const DEFAULT_CATALOGUE_FILTERS: PlanCatalogueFilters = {
+  status: "Active",
+  search: "",
+  sort: "name",
+};
+
+/**
+ * Reads the filters out of a URL.
+ *
+ * Every unrecognised value falls back to its default rather than being reported, because this
+ * parses a hand-editable address bar rather than an API request: a typo in a shared link should
+ * show the ordinary catalogue, not an error page.
+ */
+export const readCatalogueFilters = (
+  parameters: URLSearchParams,
+): PlanCatalogueFilters => {
+  const status = parameters.get(CATALOGUE_QUERY_PARAMS.status);
+  const sort = parameters.get(CATALOGUE_QUERY_PARAMS.sort);
+
+  return {
+    status: PLAN_STATUS_TABS.find((tab) => tab === status) ?? "Active",
+    search: parameters.get(CATALOGUE_QUERY_PARAMS.search)?.trim() ?? "",
+    sort:
+      sort === "updated" || sort === "price" || sort === "name" ? sort : "name",
+  };
+};
+
+/**
+ * Writes the filters back, leaving anything else in the URL alone.
+ *
+ * A value equal to its default is removed rather than written, so the ordinary view has a clean
+ * address and "no parameters" and "every parameter at its default" cannot describe the same list
+ * two different ways.
+ */
+export const writeCatalogueFilters = (
+  parameters: URLSearchParams,
+  filters: PlanCatalogueFilters,
+): URLSearchParams => {
+  const next = new URLSearchParams(parameters);
+
+  const apply = (key: string, value: string, fallback: string) => {
+    if (value && value !== fallback) {
+      next.set(key, value);
+
+      return;
+    }
+
+    next.delete(key);
+  };
+
+  apply(CATALOGUE_QUERY_PARAMS.status, filters.status, "Active");
+  apply(CATALOGUE_QUERY_PARAMS.search, filters.search, "");
+  apply(CATALOGUE_QUERY_PARAMS.sort, filters.sort, "name");
+
+  return next;
+};
+
+/** How many filters are away from their default, for the "N active" badge and Clear. */
+export const countActiveFilters = (filters: PlanCatalogueFilters): number =>
+  (filters.status === "Active" ? 0 : 1) +
+  (filters.search === "" ? 0 : 1) +
+  (filters.sort === "name" ? 0 : 1);
+
+const isArchived = (plan: SubscriptionPlan) => plan.status === "Archived";
+
+/**
+ * The cheapest price on a plan, in major units, or null when it has none.
+ *
+ * Compared in major units rather than minor because a plan priced in yen and one priced in francs
+ * are otherwise ranked by the size of their smallest coin: 500 JPY would sort above 4.00 CHF on
+ * the raw integers. This is still not a currency conversion and does not pretend to be one — it
+ * only stops the ordering being obviously wrong for the common case of one currency per catalogue.
+ */
+export const startingPrice = (plan: SubscriptionPlan): number | null => {
+  const cheapest = plan.prices.reduce<SubscriptionPlan["prices"][number] | null>(
+    (best, price) =>
+      best === null ||
+      toMajorUnits(price.unitAmountMinor, price.currencyCode) <
+        toMajorUnits(best.unitAmountMinor, best.currencyCode)
+        ? price
+        : best,
+    null,
+  );
+
+  return cheapest
+    ? toMajorUnits(cheapest.unitAmountMinor, cheapest.currencyCode)
+    : null;
+};
+
+/**
+ * Applies the status filter to plans the server has already narrowed.
+ *
+ * The management catalogue fetches `All` once and filters here, so switching tabs is instant and
+ * the summary counts are always consistent with what the tabs show. The server filter is still the
+ * one that matters for correctness: this can only ever narrow what it already returned.
+ */
+const matchesStatus = (
+  plan: SubscriptionPlan,
+  status: PlanCatalogueFilterName,
+): boolean => {
+  if (status === "All") {
+    return true;
+  }
+
+  // A plan with no status at all is treated as active. Absent means a response cached before the
+  // field existed, and the alternative — hiding it from every tab — would empty the catalogue.
+  return status === "Archived" ? isArchived(plan) : !isArchived(plan);
+};
+
+export const applyCatalogueFilters = (
+  plans: SubscriptionPlan[],
+  filters: PlanCatalogueFilters,
+): SubscriptionPlan[] => {
+  const term = filters.search.trim().toLowerCase();
+
+  const matching = plans.filter(
+    (plan) =>
+      matchesStatus(plan, filters.status) &&
+      (term === "" ||
+        plan.displayName.toLowerCase().includes(term) ||
+        plan.code.toLowerCase().includes(term)),
+  );
+
+  const sorted = [...matching];
+
+  if (filters.sort === "name") {
+    return sorted.sort((left, right) =>
+      left.displayName.localeCompare(right.displayName),
+    );
+  }
+
+  if (filters.sort === "updated") {
+    // A plan with no timestamp sorts last rather than first: an older cached response is not news,
+    // and putting it at the top would claim it had just changed.
+    return sorted.sort(
+      (left, right) =>
+        new Date(right.lastUpdatedAtUtc ?? 0).getTime() -
+        new Date(left.lastUpdatedAtUtc ?? 0).getTime(),
+    );
+  }
+
+  // Priceless plans sort last, for the same reason: "from nothing" is not the cheapest offer, it
+  // is an unfinished plan, and leading the list with it buries the ones that can be sold.
+  return sorted.sort((left, right) => {
+    const leftPrice = startingPrice(left);
+    const rightPrice = startingPrice(right);
+
+    if (leftPrice === null) {
+      return rightPrice === null ? 0 : 1;
+    }
+
+    return rightPrice === null ? -1 : leftPrice - rightPrice;
+  });
+};
+
+/**
+ * The counts behind the summary cards.
+ *
+ * Derived from the unfiltered set on purpose: "12 active" must not change because somebody typed
+ * in the search box, or the number stops being a fact about the catalogue and becomes a restatement
+ * of the list already on screen.
+ */
+export const summariseCatalogue = (plans: SubscriptionPlan[]) => ({
+  active: plans.filter((plan) => !isArchived(plan)).length,
+  archived: plans.filter(isArchived).length,
+  families: new Set(
+    plans
+      .map((plan) => plan.familyCode)
+      .filter((code): code is string => Boolean(code)),
+  ).size,
+});

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -636,6 +636,14 @@
             What a tenant sells. Served under <c>/api/subscription-plans</c>.
             </summary>
         </member>
+        <member name="M:Api.Controllers.SubscriptionPlansController.TryParseCatalogueFilter(System.String,Subscription.DomainService.Enums.PlanCatalogueFilter@)">
+            <summary>
+            Reads the catalogue filter from the query string. Absent and empty both mean
+            <see cref="F:Subscription.DomainService.Enums.PlanCatalogueFilter.Active"/>; anything unrecognised is rejected rather than
+            quietly treated as the default, since a caller asking for Archived and silently receiving
+            Active would be told a plan does not exist when it does.
+            </summary>
+        </member>
         <member name="M:Api.Controllers.SubscriptionPlansController.UpdatePlan(System.String,Subscription.DomainService.Requests.UpdatePlanRequest,System.Threading.CancellationToken)">
             <summary>
             Rewrites what a plan sells. Refused with 409 once anything has subscribed to it — a
@@ -648,7 +656,7 @@
             this price only — nobody already on it is repriced.
             </summary>
         </member>
-        <member name="M:Api.Controllers.SubscriptionPlansController.ArchivePrice(System.String,System.String,System.Threading.CancellationToken)">
+        <member name="M:Api.Controllers.SubscriptionPlansController.ArchivePlan(System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Takes a price off the menu.
             </summary>
@@ -660,6 +668,20 @@
             There is deliberately no way to edit or delete a price. A price identifier is what every
             subscription records having been sold on, so it is superseded by adding another and
             retiring this one, never rewritten underneath the subscriptions that reference it.
+            </para>
+            </remarks>
+            <summary>
+            Takes a plan off the menu, permanently.
+            </summary>
+            <remarks>
+            Existing subscribers are unaffected and none of the plan's prices is rewritten: a
+            subscription bills from the snapshot copied onto it when it was sold. Renewal, usage
+            rating, entitlements, invoicing and cancellation all continue. What stops is selling, and
+            every further change to the plan or its prices.
+            <para>
+            A <c>PUT</c> because it names the state the plan should be in rather than an event, and
+            because repeating it is safe: a second call returns the archived plan without writing
+            again. There is no restore — a replacement is made by duplicating the plan.
             </para>
             </remarks>
         </member>

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -658,19 +658,6 @@
         </member>
         <member name="M:Api.Controllers.SubscriptionPlansController.ArchivePlan(System.String,System.String,System.Threading.CancellationToken)">
             <summary>
-            Takes a price off the menu.
-            </summary>
-            <remarks>
-            Nothing already sold on it changes: a subscription bills from the price snapshot copied
-            onto it at signup and never reads the catalogue again. What stops is selling it — a new
-            subscription or a plan change naming this price is refused from here on.
-            <para>
-            There is deliberately no way to edit or delete a price. A price identifier is what every
-            subscription records having been sold on, so it is superseded by adding another and
-            retiring this one, never rewritten underneath the subscriptions that reference it.
-            </para>
-            </remarks>
-            <summary>
             Takes a plan off the menu, permanently.
             </summary>
             <remarks>
@@ -682,6 +669,21 @@
             A <c>PUT</c> because it names the state the plan should be in rather than an event, and
             because repeating it is safe: a second call returns the archived plan without writing
             again. There is no restore — a replacement is made by duplicating the plan.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionPlansController.ArchivePrice(System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Takes a price off the menu.
+            </summary>
+            <remarks>
+            Nothing already sold on it changes: a subscription bills from the price snapshot copied
+            onto it at signup and never reads the catalogue again. What stops is selling it — a new
+            subscription or a plan change naming this price is refused from here on.
+            <para>
+            There is deliberately no way to edit or delete a price. A price identifier is what every
+            subscription records having been sold on, so it is superseded by adding another and
+            retiring this one, never rewritten underneath the subscriptions that reference it.
             </para>
             </remarks>
         </member>

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Payment.DomainService.Responses;
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Services;
@@ -28,16 +29,75 @@ public sealed class SubscriptionPlansController : ControllerBase
     [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<PlanResponse>>), StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> ListPlans(
         [FromQuery] string? organizationId,
+        [FromQuery] string? status,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
 
+        // Parsed here rather than bound as an enum, so an unrecognised value is a named validation
+        // failure instead of the framework's own model-binding error — and so that omitting the
+        // parameter keeps meaning Active, which is what every subscriber-facing caller sends.
+        if (!TryParseCatalogueFilter(status, out var filter))
+        {
+            return BadRequest(ApiResponse<PlanResponse>.Fail(
+                "subscription_plan_status_invalid",
+                "Filter plans by Active, Archived or All.",
+                correlationId));
+        }
+
         var result = await _catalogue.ListPlansAsync(
             organizationId,
             correlationId,
-            cancellationToken);
+            cancellationToken,
+            filter);
 
         return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Reads the catalogue filter from the query string. Absent and empty both mean
+    /// <see cref="PlanCatalogueFilter.Active"/>; anything unrecognised is rejected rather than
+    /// quietly treated as the default, since a caller asking for Archived and silently receiving
+    /// Active would be told a plan does not exist when it does.
+    /// </summary>
+    private static bool TryParseCatalogueFilter(string? status, out PlanCatalogueFilter filter)
+    {
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            filter = PlanCatalogueFilter.Active;
+
+            return true;
+        }
+
+        // Draft is a real member of the enum and deliberately not accepted: it appears in no
+        // catalogue view, so honouring it would promise a listing that is always empty.
+        return status.Trim() switch
+        {
+            var value when value.Equals(
+                nameof(PlanCatalogueFilter.Active), StringComparison.OrdinalIgnoreCase) =>
+                Accept(PlanCatalogueFilter.Active, out filter),
+            var value when value.Equals(
+                nameof(PlanCatalogueFilter.Archived), StringComparison.OrdinalIgnoreCase) =>
+                Accept(PlanCatalogueFilter.Archived, out filter),
+            var value when value.Equals(
+                nameof(PlanCatalogueFilter.All), StringComparison.OrdinalIgnoreCase) =>
+                Accept(PlanCatalogueFilter.All, out filter),
+            _ => Reject(out filter)
+        };
+
+        static bool Accept(PlanCatalogueFilter value, out PlanCatalogueFilter filter)
+        {
+            filter = value;
+
+            return true;
+        }
+
+        static bool Reject(out PlanCatalogueFilter filter)
+        {
+            filter = PlanCatalogueFilter.Active;
+
+            return false;
+        }
     }
 
     [HttpGet("{planId}")]
@@ -191,6 +251,41 @@ public sealed class SubscriptionPlansController : ControllerBase
     /// retiring this one, never rewritten underneath the subscriptions that reference it.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Takes a plan off the menu, permanently.
+    /// </summary>
+    /// <remarks>
+    /// Existing subscribers are unaffected and none of the plan's prices is rewritten: a
+    /// subscription bills from the snapshot copied onto it when it was sold. Renewal, usage
+    /// rating, entitlements, invoicing and cancellation all continue. What stops is selling, and
+    /// every further change to the plan or its prices.
+    /// <para>
+    /// A <c>PUT</c> because it names the state the plan should be in rather than an event, and
+    /// because repeating it is safe: a second call returns the archived plan without writing
+    /// again. There is no restore — a replacement is made by duplicating the plan.
+    /// </para>
+    /// </remarks>
+    [HttpPut("{planId}/archive")]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> ArchivePlan(
+        string planId,
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _catalogue.ArchivePlanAsync(
+            planId,
+            organizationId,
+            correlationId,
+            cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
     [HttpPut("prices/{priceId}/archive")]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -239,19 +239,6 @@ public sealed class SubscriptionPlansController : ControllerBase
     }
 
     /// <summary>
-    /// Takes a price off the menu.
-    /// </summary>
-    /// <remarks>
-    /// Nothing already sold on it changes: a subscription bills from the price snapshot copied
-    /// onto it at signup and never reads the catalogue again. What stops is selling it — a new
-    /// subscription or a plan change naming this price is refused from here on.
-    /// <para>
-    /// There is deliberately no way to edit or delete a price. A price identifier is what every
-    /// subscription records having been sold on, so it is superseded by adding another and
-    /// retiring this one, never rewritten underneath the subscriptions that reference it.
-    /// </para>
-    /// </remarks>
-    /// <summary>
     /// Takes a plan off the menu, permanently.
     /// </summary>
     /// <remarks>
@@ -286,6 +273,19 @@ public sealed class SubscriptionPlansController : ControllerBase
         return result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Takes a price off the menu.
+    /// </summary>
+    /// <remarks>
+    /// Nothing already sold on it changes: a subscription bills from the price snapshot copied
+    /// onto it at signup and never reads the catalogue again. What stops is selling it — a new
+    /// subscription or a plan change naming this price is refused from here on.
+    /// <para>
+    /// There is deliberately no way to edit or delete a price. A price identifier is what every
+    /// subscription records having been sold on, so it is superseded by adding another and
+    /// retiring this one, never rewritten underneath the subscriptions that reference it.
+    /// </para>
+    /// </remarks>
     [HttpPut("prices/{priceId}/archive")]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiResponse<PlanResponse>), StatusCodes.Status404NotFound)]

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2219,6 +2219,67 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
         <div class="endpoint-body"><p>Retires a price without changing subscriptions that already hold its snapshot.</p></div>
       </div>
 
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">PUT</span><span class="path">/api/subscription-plans/{planId}/archive?organizationId={organizationId}</span></div>
+        <div class="endpoint-body">
+          <p><strong>Call when:</strong> a plan must stop being sold for good. No body is required; the URL names the state the plan should be in. Returns the archived plan.</p>
+          <p class="prose">
+            Everyone already subscribed carries on unchanged. A subscription bills from the plan and
+            price snapshot copied onto it when it was sold and never reads the catalogue again, so
+            renewals, usage rating, entitlements, invoicing and cancellation all continue exactly as
+            before. None of the plan&rsquo;s prices is rewritten or deleted. Archiving is not a
+            repricing tool and does not cancel or migrate anybody.
+          </p>
+          <p class="prose">
+            <strong>There is no restore.</strong> Build a replacement by duplicating the plan, which
+            is why an archived plan stays fully readable.
+          </p>
+          <h4>What it refuses from then on</h4>
+          <p class="prose">
+            Every one of these answers <code>409 subscription_plan_archived</code>:
+            creating a subscription, the purchase preview, a plan-change preview, the plan change
+            itself, editing the plan, adding a price, changing a price&rsquo;s tax or automatic
+            discount, and retiring one of its prices. All of them exist only to change what a
+            <em>future</em> subscriber pays, and an archived plan has no future subscriber.
+          </p>
+          <h4>Repeating it</h4>
+          <p class="prose">
+            Safe. A second call returns the archived plan without writing again, so a retried or
+            double-submitted request cannot produce an error about work that already succeeded. Two
+            concurrent archives both succeed, because the state they both asked for is the state the
+            plan ends in.
+          </p>
+          <h4>Returns</h4>
+          <p><code>200</code> the archived plan · <code>404</code> the plan is unknown, not visible to your scope, or still a draft · <code>409 subscription_plan_changed</code> when an unrelated edit landed between reading the plan and archiving it — reload and try again.</p>
+        </div>
+      </div>
+
+      <div class="endpoint">
+        <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscription-plans?organizationId={organizationId}&amp;status={Active|Archived|All}</span></div>
+        <div class="endpoint-body">
+          <p><strong>Call when:</strong> listing the catalogue. <code>status</code> is optional and defaults to <code>Active</code>.</p>
+          <p class="prose">
+            <strong>Omit it on every buyer-facing screen.</strong> The default is the sellable
+            catalogue, which is what keeps archived plans out of subscribe and change-plan choices
+            without those screens filtering anything themselves.
+          </p>
+          <table>
+            <thead><tr><th>Value</th><th class="prose">Returns</th></tr></thead>
+            <tbody>
+              <tr><td><code>Active</code></td><td class="prose">The sellable catalogue, resolved: an organization&rsquo;s own plan hides the tenant&rsquo;s of the same code, matching what subscribing resolves. The default.</td></tr>
+              <tr><td><code>Archived</code></td><td class="prose">Every archived plan you can see, <em>not</em> collapsed by code — a replacement sharing a code is usually why you are reading history.</td></tr>
+              <tr><td><code>All</code></td><td class="prose">The resolved active catalogue plus every archived plan. An archived plan never hides an active one of the same code.</td></tr>
+            </tbody>
+          </table>
+          <p class="prose">
+            <code>Draft</code> is not accepted and appears in none of the three views. Any other
+            value answers <code>400 subscription_plan_status_invalid</code>.
+          </p>
+          <h4>New response fields</h4>
+          <p><code>status</code> (<code>"Active"</code> or <code>"Archived"</code>), <code>createdAtUtc</code>, and <code>lastUpdatedAtUtc</code> — the last of which changes when a plan is archived, so it can drive a &ldquo;recently updated&rdquo; order.</p>
+        </div>
+      </div>
+
       <h3 id="discount-flow">Discount and campaign flow</h3>
       <p class="prose">
         A discount is authored once, previewed without side effects, and supplied again when the

--- a/server/Subscription.DomainService/Entities/SubscriptionAuditEvent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionAuditEvent.cs
@@ -11,6 +11,33 @@ public sealed class SubscriptionAuditEvent
     public string TenantId { get; set; } = string.Empty;
     public string OrganizationId { get; set; } = string.Empty;
     public string? SubscriptionId { get; set; }
+
+    /// <summary>
+    /// What this event is about, when it is not about a subscription.
+    /// </summary>
+    /// <remarks>
+    /// Every event before these three fields existed concerned one subscription, so
+    /// <see cref="SubscriptionId"/> was enough to say what had happened to what. Archiving a plan
+    /// is the first recorded decision with no subscription in it at all — it changes the catalogue,
+    /// and the subscribers holding a snapshot of that plan are precisely the ones it does not
+    /// touch. Writing the plan id into <see cref="SubscriptionId"/> would have made the timeline
+    /// query return a catalogue change as if it were something done to a subscriber.
+    /// <para>
+    /// Nullable, and left null by every existing writer, so records already stored keep
+    /// deserializing and keep meaning what they meant. <c>Plan</c> is the only value in use today.
+    /// </para>
+    /// </remarks>
+    public string? AggregateType { get; set; }
+
+    /// <summary>The identifier of whatever <see cref="AggregateType"/> names.</summary>
+    public string? AggregateId { get; set; }
+
+    /// <summary>
+    /// The stable code of whatever <see cref="AggregateType"/> names, stored beside the id so a
+    /// reader can tell which plan an event concerned without resolving a document that may since
+    /// have been superseded.
+    /// </summary>
+    public string? AggregateCode { get; set; }
     public string OperationId { get; set; } = string.Empty;
     public string CorrelationId { get; set; } = string.Empty;
     public string Operation { get; set; } = string.Empty;

--- a/server/Subscription.DomainService/Enums/PlanCatalogueFilter.cs
+++ b/server/Subscription.DomainService/Enums/PlanCatalogueFilter.cs
@@ -1,0 +1,34 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Which plans an administrative catalogue listing asks for.
+/// </summary>
+/// <remarks>
+/// Not <see cref="CatalogueStatus"/>, though it reads like a subset of it. Two of these values are
+/// not statuses at all: <see cref="All"/> spans two, and <see cref="Active"/> carries the
+/// organization-over-tenant resolution that makes a listing match what subscribing would actually
+/// find. Reusing the status enum here would invite a caller to ask for <c>Draft</c>, which no
+/// catalogue view offers.
+/// </remarks>
+public enum PlanCatalogueFilter
+{
+    /// <summary>
+    /// The sellable catalogue, resolved: an organization's own plan hides the tenant's of the same
+    /// code, exactly as <c>FindPlanByCodeAsync</c> resolves it. The default, and what every
+    /// subscriber-facing caller gets by omitting the parameter.
+    /// </summary>
+    Active = 0,
+
+    /// <summary>
+    /// Every visible archived plan, uncollapsed. History is the point of this view, so a plan is
+    /// never hidden because a replacement shares its code — that replacement is usually the reason
+    /// somebody is looking.
+    /// </summary>
+    Archived = 1,
+
+    /// <summary>
+    /// The resolved Active catalogue plus every visible archived plan. Draft is excluded here as
+    /// it is everywhere else: it is an internal state, and no catalogue view has ever shown it.
+    /// </summary>
+    All = 2
+}

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -146,6 +146,86 @@ why editing is closed before offering it.
 editing include it — an edit that could store what a create would have refused is a hole, and one
 rule is the only way to be sure the two agree.
 
+## Archiving a plan takes it off the menu for good
+
+`PUT /subscription-plans/{planId}/archive?organizationId=` moves a plan from `Active` to
+`Archived`. There is no restore, and no request body: the URL names the state the plan should be
+in, which is why it is a `PUT` and why repeating it is safe.
+
+This follows the same snapshot rule as everything above. Archiving reaches the catalogue and
+nothing else, so everyone already subscribed carries on untouched — renewals, usage rating,
+entitlements, invoicing and cancellation all continue from the terms copied onto each subscription
+when it was sold. None of the plan's prices is rewritten or deleted. What stops is selling.
+
+Refused with `subscription_plan_archived`:
+
+* creating a subscription, and the purchase preview
+* a plan-change preview, and the change itself
+* `PUT /subscription-plans/{planId}` — editing the plan
+* `POST /subscription-plans/prices` — adding a price
+* `PUT /subscription-plans/prices/{priceId}/tax` and `/discount`
+* `PUT /subscription-plans/prices/{priceId}/archive` — retiring one of its prices
+
+All five catalogue mutations exist only to change what a *future* subscriber pays, and an archived
+plan has no future subscriber. Reading is deliberately still open: inspecting an archived plan is
+what the `Archived` filter is for, and duplicating one is how a replacement gets made.
+
+Only `Active` is archivable. A `Draft` plan answers as not found, which is what a draft is to every
+catalogue view — there is no menu to take it off, and archiving is permanent enough that stranding
+a plan in a state it was never sellable from would be worse than refusing.
+
+### Repeating it, and racing it
+
+The write is conditional on the plan still being `Active` **and** still at the version just read,
+and `ModifiedCount == 0` covers three different situations that need three different answers. The
+service re-reads to tell them apart:
+
+| What happened | Answer |
+| --- | --- |
+| Already `Archived` | success, no second write (`AlreadyArchived`) |
+| Another archive won the race | success — both callers wanted this state and it is the state |
+| An unrelated edit moved the version on | `subscription_plan_changed` |
+| Gone, or not visible to the caller | the ordinary not-found response |
+
+The idempotency is the one place this differs from `ArchivePriceAsync`, which reports a repeat as a
+conflict. A price is one of several on a live plan, so repeating that call usually means the caller
+has lost track of which; archiving a plan twice is the same request arriving twice, and has one
+sensible answer.
+
+### Listing, and the fallback archiving must not break
+
+`GET /subscription-plans?status=` takes `Active` (the default), `Archived` or `All`. Anything else
+is `400 subscription_plan_status_invalid`. `Draft` is not accepted and appears in no view.
+
+`Active` keeps the organization-over-tenant resolution: an organization's own plan hides the
+tenant's of the same code, because that is what subscribing resolves and a list showing both would
+offer a choice it cannot honour. The archived views do **not** collapse by code — a replacement
+sharing a code is usually the reason somebody is reading history.
+
+Omitting the parameter is what every subscriber-facing caller does, which is what keeps archived
+plans out of subscribe and change-plan selectors without those screens filtering anything.
+
+The subtle part is on the selling side. `FindPlanByCodeAsync` filters to `Active` and resolves
+organization-then-tenant, and it stays the only thing that decides what can be sold. The archived
+catalogue is consulted **only after** it has returned nothing, and only to name the refusal.
+Resolving both statuses together would let an organization's archived plan shadow the tenant's
+active plan of the same code and refuse a sale that should have gone through. A plan belonging to
+an organization the caller cannot see stays invisible, so the better message never becomes a way
+to discover that a code exists somewhere.
+
+### What gets recorded
+
+Audit events carry nullable `AggregateType`/`AggregateId`/`AggregateCode`. Archiving a plan is the
+first audited decision with no subscription in it, and writing the plan id into `SubscriptionId`
+would have made the timeline query return a catalogue change as if it were something done to a
+subscriber. Plan archiving writes `AggregateType = "Plan"`, `Operation = "PlanArchive"`,
+`FromStatus`/`ToStatus`, and an `Outcome` of `Changed`, `AlreadyArchived`, `Conflict` or
+`NotFound` — every attempt, including the ones that changed nothing, because a client retrying
+against a plan it cannot see is exactly what somebody reading the trail later needs to see. The
+audit write can never fail the archive it describes.
+
+Responses carry `status`, `createdAtUtc` and `lastUpdatedAtUtc`.
+
 ### Naming a predecessor is a label, not a migration
 
 `CreatePlanRequest.PredecessorPlanId` lets a new plan say which one it was created to replace.

--- a/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
@@ -28,9 +28,38 @@ public interface ISubscriptionCatalogueRepository
         string planId,
         CancellationToken cancellationToken);
 
+    /// <param name="filter">
+    /// Which plans to return, and whether to resolve them. <see cref="PlanCatalogueFilter.Active"/>
+    /// collapses an organization's plan over the tenant's of the same code, because that is what
+    /// subscribing resolves and a list that showed both would offer a choice it cannot honour. The
+    /// archived views deliberately do not collapse: a replacement sharing a code is usually the
+    /// reason somebody is reading history.
+    /// </param>
     Task<IReadOnlyList<Plan>> ListPlansAsync(
         string tenantId,
         string? organizationId,
+        PlanCatalogueFilter filter,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The archived plan a caller would have resolved for <paramref name="code"/>, had it still
+    /// been on sale.
+    /// </summary>
+    /// <remarks>
+    /// Exists only so a refused sale can say why. It is called after
+    /// <see cref="FindPlanByCodeAsync"/> has already returned nothing, never instead of it —
+    /// resolving both statuses together would let an organization's archived plan shadow the
+    /// tenant's active one of the same code and refuse a sale that should have gone through.
+    /// <para>
+    /// Follows the same organization-then-tenant visibility, so a plan belonging to an
+    /// organization the caller cannot see stays invisible and the refusal stays a plain
+    /// not-found rather than a hint that the code exists somewhere.
+    /// </para>
+    /// </remarks>
+    Task<Plan?> FindArchivedPlanByCodeAsync(
+        string tenantId,
+        string? organizationId,
+        string code,
         CancellationToken cancellationToken);
 
     /// <summary>
@@ -49,6 +78,28 @@ public interface ISubscriptionCatalogueRepository
         string planId,
         int expectedVersion,
         Plan plan,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Moves an active plan to archived, if it is still active and still at
+    /// <paramref name="expectedVersion"/>.
+    /// </summary>
+    /// <remarks>
+    /// False covers three different situations the caller has to tell apart @D@ the plan is gone, it
+    /// was archived by somebody else, or an unrelated edit moved its version on. The repository
+    /// cannot distinguish them from a write result alone, so it reports only whether this call was
+    /// the one that changed the document, and the caller re-reads to find out which.
+    /// <para>
+    /// Draft is not archivable through this path. A draft plan appears in no catalogue view, so
+    /// there is nothing to take off a menu, and permitting it would put a plan into an
+    /// irreversible state it was never sellable from.
+    /// </para>
+    /// </remarks>
+    Task<bool> TryArchivePlanAsync(
+        string tenantId,
+        string planId,
+        int expectedVersion,
+        DateTime archivedAtUtc,
         CancellationToken cancellationToken);
 
     Task<bool> TryCreatePriceAsync(Price price, CancellationToken cancellationToken);

--- a/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
@@ -48,7 +48,22 @@ public sealed class SubscriptionAuditRepository : ISubscriptionAuditRepository
                 Builders<SubscriptionAuditEvent>.IndexKeys
                     .Ascending(x => x.TenantId).Ascending(x => x.OperationId)
                     .Ascending(x => x.OccurredAtUtc),
-                new CreateIndexOptions { Name = "ix_subscription_audit_operation" })
+                new CreateIndexOptions { Name = "ix_subscription_audit_operation" }),
+
+            // The timeline index above leads on SubscriptionId, which a catalogue event leaves
+            // null, so reading one plan's history would otherwise scan the collection. Sparse
+            // because only the events that name an aggregate belong in it — every subscription
+            // event ever written has all three fields null and has no reason to be indexed here.
+            new CreateIndexModel<SubscriptionAuditEvent>(
+                Builders<SubscriptionAuditEvent>.IndexKeys
+                    .Ascending(x => x.TenantId).Ascending(x => x.OrganizationId)
+                    .Ascending(x => x.AggregateType).Ascending(x => x.AggregateId)
+                    .Descending(x => x.OccurredAtUtc),
+                new CreateIndexOptions
+                {
+                    Name = "ix_subscription_audit_aggregate",
+                    Sparse = true
+                })
         ], cancellationToken);
 
         _indexedTenants.TryAdd(tenantId, 0);

--- a/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
@@ -51,18 +51,24 @@ public sealed class SubscriptionAuditRepository : ISubscriptionAuditRepository
                 new CreateIndexOptions { Name = "ix_subscription_audit_operation" }),
 
             // The timeline index above leads on SubscriptionId, which a catalogue event leaves
-            // null, so reading one plan's history would otherwise scan the collection. Sparse
-            // because only the events that name an aggregate belong in it — every subscription
-            // event ever written has all three fields null and has no reason to be indexed here.
+            // null, so reading one plan's history would otherwise scan the collection.
+            //
+            // Partial, not sparse. A sparse compound index includes a document when *any* indexed
+            // field exists, and TenantId and OrganizationId exist on every audit event ever
+            // written — so Sparse would have indexed the entire collection while reading as though
+            // it excluded it. The filter names the two fields that actually distinguish an
+            // aggregate event, so the index holds only those.
             new CreateIndexModel<SubscriptionAuditEvent>(
                 Builders<SubscriptionAuditEvent>.IndexKeys
                     .Ascending(x => x.TenantId).Ascending(x => x.OrganizationId)
                     .Ascending(x => x.AggregateType).Ascending(x => x.AggregateId)
                     .Descending(x => x.OccurredAtUtc),
-                new CreateIndexOptions
+                new CreateIndexOptions<SubscriptionAuditEvent>
                 {
                     Name = "ix_subscription_audit_aggregate",
-                    Sparse = true
+                    PartialFilterExpression = Builders<SubscriptionAuditEvent>.Filter.And(
+                        Builders<SubscriptionAuditEvent>.Filter.Exists(x => x.AggregateType),
+                        Builders<SubscriptionAuditEvent>.Filter.Exists(x => x.AggregateId))
                 })
         ], cancellationToken);
 

--- a/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionAuditRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Blocks.Genesis;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Subscription.DomainService.Entities;
 
@@ -67,8 +68,10 @@ public sealed class SubscriptionAuditRepository : ISubscriptionAuditRepository
                 {
                     Name = "ix_subscription_audit_aggregate",
                     PartialFilterExpression = Builders<SubscriptionAuditEvent>.Filter.And(
-                        Builders<SubscriptionAuditEvent>.Filter.Exists(x => x.AggregateType),
-                        Builders<SubscriptionAuditEvent>.Filter.Exists(x => x.AggregateId))
+                        Builders<SubscriptionAuditEvent>.Filter.Type(
+                            x => x.AggregateType, BsonType.String),
+                        Builders<SubscriptionAuditEvent>.Filter.Type(
+                            x => x.AggregateId, BsonType.String))
                 })
         ], cancellationToken);
 

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -103,34 +103,126 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
     public async Task<IReadOnlyList<Plan>> ListPlansAsync(
         string tenantId,
         string? organizationId,
+        PlanCatalogueFilter filter,
         CancellationToken cancellationToken)
     {
         await EnsureIndexesAsync(tenantId, cancellationToken);
 
-        var visible = string.IsNullOrWhiteSpace(organizationId)
-            ? Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null)
-            : Builders<Plan>.Filter.Or(
-                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, organizationId),
-                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null));
+        var visible = VisibleToOrganization(organizationId);
+
+        // Draft is absent from every one of these views, which is what it has always been: an
+        // internal state no catalogue has shown. The wanted statuses are named rather than
+        // Archived excluded, so a fourth status could never appear here by default.
+        var statuses = filter switch
+        {
+            PlanCatalogueFilter.Archived =>
+                Builders<Plan>.Filter.Eq(plan => plan.Status, CatalogueStatus.Archived),
+            PlanCatalogueFilter.All =>
+                Builders<Plan>.Filter.In(
+                    plan => plan.Status,
+                    new[] { CatalogueStatus.Active, CatalogueStatus.Archived }),
+            _ => Builders<Plan>.Filter.Eq(plan => plan.Status, CatalogueStatus.Active)
+        };
 
         var plans = await Plans(tenantId)
             .Find(Builders<Plan>.Filter.And(
                 Builders<Plan>.Filter.Eq(plan => plan.TenantId, tenantId),
-                Builders<Plan>.Filter.Eq(plan => plan.Status, CatalogueStatus.Active),
+                statuses,
                 visible))
             .ToListAsync(cancellationToken);
 
-        // An organization's own plan hides the tenant's of the same code, matching what
-        // FindPlanByCodeAsync would resolve. Showing both would offer a choice that
-        // subscribing cannot honour.
-        return plans
+        // Only the sellable half is resolved. An organization's own plan hides the tenant's of the
+        // same code, matching what FindPlanByCodeAsync would resolve — showing both would offer a
+        // choice that subscribing cannot honour.
+        //
+        // Archived plans are never collapsed, and are never allowed to collapse an active one
+        // either: under All, an organization's archived "pro" and the tenant's active "pro" are
+        // two separate records a reader needs to tell apart, and hiding the active one behind the
+        // archived one would misreport what is on sale.
+        var resolved = plans
+            .Where(plan => plan.Status == CatalogueStatus.Active)
             .GroupBy(plan => plan.Code, StringComparer.Ordinal)
             .Select(group =>
                 group.FirstOrDefault(plan => plan.OrganizationId is not null) ??
-                group.First())
+                group.First());
+
+        var archived = plans.Where(plan => plan.Status == CatalogueStatus.Archived);
+
+        return resolved
+            .Concat(archived)
             .OrderBy(plan => plan.Code, StringComparer.Ordinal)
+            .ThenBy(plan => plan.Status == CatalogueStatus.Archived ? 1 : 0)
+            .ThenByDescending(plan => plan.LastUpdatedDateUtc)
             .ToList();
     }
+
+    public async Task<Plan?> FindArchivedPlanByCodeAsync(
+        string tenantId,
+        string? organizationId,
+        string code,
+        CancellationToken cancellationToken)
+    {
+        var plans = Plans(tenantId);
+        var baseFilter = Builders<Plan>.Filter.And(
+            Builders<Plan>.Filter.Eq(plan => plan.TenantId, tenantId),
+            Builders<Plan>.Filter.Eq(plan => plan.Code, code),
+            Builders<Plan>.Filter.Eq(plan => plan.Status, CatalogueStatus.Archived));
+
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            var owned = await plans
+                .Find(Builders<Plan>.Filter.And(
+                    baseFilter,
+                    Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, organizationId)))
+                .FirstOrDefaultAsync(cancellationToken);
+
+            if (owned is not null)
+            {
+                return owned;
+            }
+        }
+
+        return await plans
+            .Find(Builders<Plan>.Filter.And(
+                baseFilter,
+                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null)))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<bool> TryArchivePlanAsync(
+        string tenantId,
+        string planId,
+        int expectedVersion,
+        DateTime archivedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var result = await Plans(tenantId).UpdateOneAsync(
+            Builders<Plan>.Filter.And(
+                Builders<Plan>.Filter.Eq(plan => plan.TenantId, tenantId),
+                Builders<Plan>.Filter.Eq(plan => plan.ItemId, planId),
+
+                // Active only: a draft was never on a menu, and an already-archived plan must not
+                // be written twice, so the caller can report a repeat as the no-op it is.
+                Builders<Plan>.Filter.Eq(plan => plan.Status, CatalogueStatus.Active),
+
+                // The version just read. An unrelated edit landing in between moves it on, and
+                // this archive is refused rather than applied to terms nobody reviewed.
+                Builders<Plan>.Filter.Eq(plan => plan.Version, expectedVersion)),
+            Builders<Plan>.Update
+                .Set(plan => plan.Status, CatalogueStatus.Archived)
+                .Set(plan => plan.LastUpdatedDateUtc, archivedAtUtc)
+                .Inc(plan => plan.Version, 1),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    private static FilterDefinition<Plan> VisibleToOrganization(string? organizationId) =>
+        string.IsNullOrWhiteSpace(organizationId)
+            ? Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null)
+            : Builders<Plan>.Filter.Or(
+                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, organizationId),
+                Builders<Plan>.Filter.Eq(plan => plan.OrganizationId, null));
 
     public async Task<Plan?> FindSuccessorPlanAsync(
         string tenantId,

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -90,6 +90,29 @@ public sealed class PlanResponse
     /// </summary>
     public bool HasSubscribers { get; init; }
 
+    /// <summary>
+    /// Whether the plan is still on sale, as its name: <c>Active</c> or <c>Archived</c>.
+    /// </summary>
+    /// <remarks>
+    /// Archived is permanent and means one thing only — nothing new may be sold on it. Every
+    /// subscription already on the plan bills from the snapshot taken when it was sold, so an
+    /// archived plan keeps renewing, rating usage and granting entitlements exactly as before.
+    /// <para>
+    /// <c>Draft</c> is never returned. It appears in no catalogue view, so a caller reading this
+    /// field can treat the two values above as the whole set.
+    /// </para>
+    /// </remarks>
+    public string Status { get; init; } = string.Empty;
+
+    /// <summary>When the plan was first authored.</summary>
+    public DateTime CreatedAtUtc { get; init; }
+
+    /// <summary>
+    /// When the plan last changed, which includes the moment it was archived. Returned so a
+    /// catalogue can offer a "recently updated" order without a second read per row.
+    /// </summary>
+    public DateTime LastUpdatedAtUtc { get; init; }
+
     public List<PlanQuantityItemResponse> QuantityItems { get; init; } = [];
 
     /// <summary>How a volume band combines with a promotional code, as its name.</summary>

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -313,7 +313,14 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         // resolved against -- the discount cannot be more applicable than the catalogue it points at.
         // Already filtered to CatalogueStatus.Active, so a plan named here that has been archived
         // reads as unknown -- the same refusal an actually-nonexistent code would produce.
-        var plans = await _catalogue.ListPlansAsync(tenantId, organizationId, cancellationToken);
+        // Active named explicitly now that the listing can be asked for other things. This caller
+        // must never widen: a discount that could name an archived plan would be authored against
+        // terms nothing can be sold on.
+        var plans = await _catalogue.ListPlansAsync(
+            tenantId,
+            organizationId,
+            PlanCatalogueFilter.Active,
+            cancellationToken);
 
         var unknownPlan = request.ApplicablePlanCodes.Find(code =>
             !plans.Any(plan => string.Equals(plan.Code, code, StringComparison.Ordinal)));

--- a/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
@@ -1,3 +1,4 @@
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
 
@@ -40,6 +41,40 @@ public interface IPlanCatalogueService
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Takes a whole plan off the menu, permanently.
+    /// </summary>
+    /// <remarks>
+    /// Nobody already subscribed is affected, and none of their prices is touched: a subscription
+    /// bills from the plan and price snapshot copied onto it when it was sold and never reads the
+    /// catalogue again. Renewal, usage rating, entitlements, invoicing and cancellation all
+    /// continue exactly as before. What stops is selling — a new subscription, a purchase preview
+    /// or a plan change naming this plan is refused with <c>subscription_plan_archived</c>, and so
+    /// is every further change to the plan or its prices.
+    /// <para>
+    /// There is no restore. A replacement is made by duplicating the plan, which is why the
+    /// archived plan stays fully readable.
+    /// </para>
+    /// <para>
+    /// Idempotent: archiving an already-archived plan returns it unchanged, without a second
+    /// write. This is the one place the plan differs from <see cref="ArchivePriceAsync"/>, which
+    /// reports a repeat as a conflict — a price is retired one of several on a live plan, where
+    /// repeating the call usually means the caller has lost track of which, whereas archiving a
+    /// plan twice is the same request arriving twice and has one sensible answer.
+    /// </para>
+    /// <para>
+    /// Refused with <c>subscription_plan_changed</c> when an unrelated edit lands between reading
+    /// the plan and archiving it, rather than archiving terms nobody reviewed. A plan still in
+    /// <c>Draft</c> is not archivable and answers as not found, consistent with a draft appearing
+    /// in no catalogue view.
+    /// </para>
+    /// </remarks>
+    Task<SubscriptionOperationResult<PlanResponse>> ArchivePlanAsync(
+        string planId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken);
+
     Task<SubscriptionOperationResult<PlanResponse>> CreatePriceAsync(
         CreatePriceRequest request,
         string correlationId,
@@ -69,10 +104,17 @@ public interface IPlanCatalogueService
     /// <see cref="Subscription.DomainService.Requests.CreateSubscriptionRequest.OrganizationId"/>
     /// for the full rule.
     /// </param>
+    /// <param name="filter">
+    /// Which plans to return. Defaults to <see cref="PlanCatalogueFilter.Active"/>, so every
+    /// subscriber-facing caller that omits it keeps receiving only what is on sale — which is what
+    /// keeps archived plans out of subscribe and change-plan selectors without those screens
+    /// having to filter anything themselves.
+    /// </param>
     Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
         string? organizationId,
         string correlationId,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken,
+        PlanCatalogueFilter filter = PlanCatalogueFilter.Active);
 
     Task<SubscriptionOperationResult<PlanResponse>> GetPlanAsync(
         string planId,

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -22,6 +22,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     private readonly IValidator<UpdatePlanRequest> _planUpdateValidator;
     private readonly IValidator<CreatePriceRequest> _priceValidator;
     private readonly IPlanResponseMapper _mapper;
+    private readonly ISubscriptionAuditTrail _auditTrail;
     private readonly ILogger<PlanCatalogueService> _logger;
 
     public PlanCatalogueService(
@@ -32,6 +33,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         IValidator<UpdatePlanRequest> planUpdateValidator,
         IValidator<CreatePriceRequest> priceValidator,
         IPlanResponseMapper mapper,
+        ISubscriptionAuditTrail auditTrail,
         ILogger<PlanCatalogueService> logger)
     {
         _catalogue = catalogue;
@@ -41,6 +43,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         _planUpdateValidator = planUpdateValidator;
         _priceValidator = priceValidator;
         _mapper = mapper;
+        _auditTrail = auditTrail;
         _logger = logger;
     }
 
@@ -176,6 +179,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             return NotFound(correlationId);
         }
 
+        var archivedRefusal = RefuseIfArchived(plan, correlationId);
+
+        if (archivedRefusal is not null)
+        {
+            return archivedRefusal;
+        }
+
         if (await _subscriptions.AnySubscriberAsync(context.TenantId, plan.ItemId, cancellationToken))
         {
             return SubscriptionOperationResult<PlanResponse>.Failure(
@@ -223,6 +233,206 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             cancellationToken);
     }
 
+    public async Task<SubscriptionOperationResult<PlanResponse>> ArchivePlanAsync(
+        string planId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId,
+            organizationId,
+            cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<PlanResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+        var plan = await _catalogue.GetPlanAsync(
+            context.TenantId,
+            planId,
+            cancellationToken);
+
+        // Invisible and absent answer identically. An organization must not be able to learn that
+        // another organization holds a plan by the difference between two error messages.
+        if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
+        {
+            await RecordArchiveAsync(
+                context, planId, code: null, outcome: "NotFound", from: null, correlationId,
+                cancellationToken);
+
+            return NotFound(correlationId);
+        }
+
+        // Already done. Reported as success without a second write, so a retried request — a
+        // double-clicked button, a client that did not see the first response — converges instead
+        // of failing on work that has already happened.
+        if (plan.Status == CatalogueStatus.Archived)
+        {
+            await RecordArchiveAsync(
+                context, plan.ItemId, plan.Code, outcome: "AlreadyArchived",
+                from: CatalogueStatus.Archived.ToString(), correlationId, cancellationToken);
+
+            return await GetPlanAsync(
+                plan.ItemId,
+                context.OrganizationId,
+                correlationId,
+                cancellationToken);
+        }
+
+        // A draft was never on a menu, so there is nothing to take off one, and archiving is
+        // permanent: it would strand the plan in a state it could never be sold from. Answered as
+        // not found because that is what a draft is to every catalogue view.
+        if (plan.Status != CatalogueStatus.Active)
+        {
+            await RecordArchiveAsync(
+                context, plan.ItemId, plan.Code, outcome: "NotFound",
+                from: plan.Status.ToString(), correlationId, cancellationToken);
+
+            return NotFound(correlationId);
+        }
+
+        if (!await _catalogue.TryArchivePlanAsync(
+                context.TenantId,
+                plan.ItemId,
+                plan.Version,
+                DateTime.UtcNow,
+                cancellationToken))
+        {
+            // The write was refused, and three different things cause that: somebody else archived
+            // it, an unrelated edit moved the version on, or it is gone. Re-read to find out which,
+            // because they need different answers and the write result cannot tell them apart.
+            var current = await _catalogue.GetPlanAsync(
+                context.TenantId,
+                plan.ItemId,
+                cancellationToken);
+
+            if (current is null || !IsVisibleTo(current, context.OrganizationId))
+            {
+                await RecordArchiveAsync(
+                    context, plan.ItemId, plan.Code, outcome: "NotFound",
+                    from: plan.Status.ToString(), correlationId, cancellationToken);
+
+                return NotFound(correlationId);
+            }
+
+            // Two archive requests raced and the other one won. Both callers wanted the same
+            // end state and it is the state the plan is now in, so both are told it succeeded.
+            if (current.Status == CatalogueStatus.Archived)
+            {
+                await RecordArchiveAsync(
+                    context, plan.ItemId, plan.Code, outcome: "AlreadyArchived",
+                    from: plan.Status.ToString(), correlationId, cancellationToken);
+
+                return await GetPlanAsync(
+                    plan.ItemId,
+                    context.OrganizationId,
+                    correlationId,
+                    cancellationToken);
+            }
+
+            await RecordArchiveAsync(
+                context, plan.ItemId, plan.Code, outcome: "Conflict",
+                from: plan.Status.ToString(), correlationId, cancellationToken);
+
+            return SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_changed",
+                "This plan changed while you were archiving it. Reload it and try again.",
+                correlationId);
+        }
+
+        await RecordArchiveAsync(
+            context, plan.ItemId, plan.Code, outcome: "Changed",
+            from: CatalogueStatus.Active.ToString(), correlationId, cancellationToken);
+
+        _logger.LogInformation(
+            "Subscription plan archived TenantHash={TenantHash} OrganizationHash={OrganizationHash} " +
+            "PlanHash={PlanHash} Code={Code} Actor={Actor} Outcome={Outcome} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(context.TenantId),
+            PaymentLogValue.Hash(context.OrganizationId),
+            PaymentLogValue.Hash(plan.ItemId),
+            PaymentLogValue.Label(plan.Code),
+            PaymentLogValue.Hash(context.ActorId),
+            "Changed",
+            correlationId);
+
+        return await GetPlanAsync(
+            plan.ItemId,
+            context.OrganizationId,
+            correlationId,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Records one archive attempt, whatever came of it.
+    /// </summary>
+    /// <remarks>
+    /// Every outcome is written, including the ones that changed nothing. A refused or repeated
+    /// attempt is exactly what somebody reading the trail later needs to see: it is the difference
+    /// between a plan that was archived once and a client that has been retrying against a plan it
+    /// cannot see.
+    /// <para>
+    /// The aggregate fields carry the plan rather than <c>SubscriptionId</c>, which stays null.
+    /// Archiving a plan is the first audited decision with no subscription in it, and the
+    /// subscribers holding a snapshot of that plan are precisely the ones it does not touch.
+    /// </para>
+    /// <para>
+    /// Never allowed to fail the operation it describes. An audit write that throws must not turn
+    /// a plan that really was archived into an error the caller retries, so the failure is logged
+    /// and swallowed — the log line beside it carries the same facts.
+    /// </para>
+    /// </remarks>
+    private async Task RecordArchiveAsync(
+        SubscriptionContext context,
+        string planId,
+        string? code,
+        string outcome,
+        string? from,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _auditTrail.RecordAsync(
+                new SubscriptionAuditEvent
+                {
+                    TenantId = context.TenantId,
+                    OrganizationId = context.OrganizationId,
+                    AggregateType = "Plan",
+                    AggregateId = planId,
+                    AggregateCode = code,
+                    OperationId = correlationId,
+                    CorrelationId = correlationId,
+                    Operation = "PlanArchive",
+                    Stage = "Catalogue",
+                    Outcome = outcome,
+                    Source = "Api",
+                    ActorId = context.ActorId,
+                    UserId = context.UserId,
+                    FromStatus = from,
+                    ToStatus = outcome is "Changed" or "AlreadyArchived"
+                        ? CatalogueStatus.Archived.ToString()
+                        : null,
+                    OccurredAtUtc = DateTime.UtcNow
+                },
+                cancellationToken);
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogError(
+                exception,
+                "Subscription plan archive audit write failed TenantHash={TenantHash} " +
+                "PlanHash={PlanHash} Outcome={Outcome} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(context.TenantId),
+                PaymentLogValue.Hash(planId),
+                outcome,
+                correlationId);
+        }
+    }
+
     public async Task<SubscriptionOperationResult<PlanResponse>> CreatePriceAsync(
         CreatePriceRequest request,
         string correlationId,
@@ -265,6 +475,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
         {
             return NotFound(correlationId);
+        }
+
+        var archivedRefusal = RefuseIfArchived(plan, correlationId);
+
+        if (archivedRefusal is not null)
+        {
+            return archivedRefusal;
         }
 
         if (!QuantityItemExists(plan, request.QuantityItemKey))
@@ -470,6 +687,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             return NotFound(correlationId);
         }
 
+        var archivedRefusal = RefuseIfArchived(plan, correlationId);
+
+        if (archivedRefusal is not null)
+        {
+            return archivedRefusal;
+        }
+
         if (!await _catalogue.TryArchivePriceAsync(
                 context.TenantId,
                 priceId,
@@ -538,6 +762,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         if (plan is null || !IsVisibleTo(plan, context.OrganizationId))
         {
             return NotFound(correlationId);
+        }
+
+        var archivedRefusal = RefuseIfArchived(plan, correlationId);
+
+        if (archivedRefusal is not null)
+        {
+            return archivedRefusal;
         }
 
         // Zero and null are the same instruction — no automatic discount — and are stored the same
@@ -627,6 +858,13 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             return NotFound(correlationId);
         }
 
+        var archivedRefusal = RefuseIfArchived(plan, correlationId);
+
+        if (archivedRefusal is not null)
+        {
+            return archivedRefusal;
+        }
+
         var rate = request.TaxRateBasisPoints > 0 ? request.TaxRateBasisPoints : null;
         var modeToStore = rate > 0 ? request.TaxMode : null;
         if (!await _catalogue.TryUpdatePriceTaxAsync(
@@ -655,7 +893,8 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     public async Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
         string? organizationId,
         string correlationId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        PlanCatalogueFilter filter = PlanCatalogueFilter.Active)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
@@ -671,6 +910,7 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         var plans = await _catalogue.ListPlansAsync(
             context.TenantId,
             context.OrganizationId,
+            filter,
             cancellationToken);
 
         var responses = new List<PlanResponse>(plans.Count);
@@ -779,6 +1019,36 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
     /// A plan scoped to another organization reports as missing rather than forbidden, so a
     /// response cannot be used to confirm that an identifier exists somewhere else.
     /// </summary>
+    /// <summary>
+    /// Refuses any catalogue change to an archived plan, or null when the plan is still open.
+    /// </summary>
+    /// <remarks>
+    /// One helper rather than the same three lines in five methods, because the set of operations
+    /// this closes is the point: a plan that can no longer be sold must not be able to acquire a
+    /// new price, a different tax rate or a fresh automatic discount either, since all three exist
+    /// only to change what a future subscriber is charged and there will be no future subscriber.
+    /// <para>
+    /// Deliberately not applied to reading. Archived plans stay fully inspectable — that is what
+    /// the Archived filter is for, and a plan somebody is deciding whether to duplicate is one
+    /// they need to be able to open.
+    /// </para>
+    /// <para>
+    /// Checked before the has-subscribers refusal in <c>UpdatePlanAsync</c>, and not after it:
+    /// "create a new plan and move subscribers to it" is sound advice for a live plan and
+    /// misleading for an archived one, where the answer is to duplicate it instead.
+    /// </para>
+    /// </remarks>
+    private static SubscriptionOperationResult<PlanResponse>? RefuseIfArchived(
+        Plan plan,
+        string correlationId) =>
+        plan.Status == CatalogueStatus.Archived
+            ? SubscriptionOperationResult<PlanResponse>.Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_archived",
+                "This plan is archived and can no longer be sold or changed.",
+                correlationId)
+            : null;
+
     private static bool IsVisibleTo(Plan plan, string organizationId) =>
         plan.OrganizationId is null ||
         string.Equals(plan.OrganizationId, organizationId, StringComparison.Ordinal);

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -54,6 +54,9 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
             RequirePaymentMethodUpfront = plan.RequirePaymentMethodUpfront,
             Version = plan.Version,
             HasSubscribers = hasSubscribers,
+            Status = plan.Status.ToString(),
+            CreatedAtUtc = plan.CreatedAtUtc,
+            LastUpdatedAtUtc = plan.LastUpdatedDateUtc,
             QuantityItems = plan.QuantityItems
                 .Select(item => new PlanQuantityItemResponse
                 {

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -418,11 +418,28 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
 
         if (plan is null)
         {
-            return SubscriptionOperationResult<(Plan, Price)>.Failure(
-                PaymentFailureKind.NotFound,
-                "subscription_plan_not_found",
-                "The plan does not exist or is not on sale.",
-                correlationId);
+            // Only now that no active plan resolved is the archived catalogue consulted, and only
+            // to say why. Resolving both statuses together would let an organization's archived
+            // plan shadow the tenant's active one of the same code and refuse a sale that should
+            // have gone through — the active fallback above must stay the only thing that decides
+            // what is sold.
+            var archived = await _catalogue.FindArchivedPlanByCodeAsync(
+                context.TenantId,
+                context.OrganizationId,
+                request.PlanCode,
+                cancellationToken);
+
+            return archived is null
+                ? SubscriptionOperationResult<(Plan, Price)>.Failure(
+                    PaymentFailureKind.NotFound,
+                    "subscription_plan_not_found",
+                    "The plan does not exist or is not on sale.",
+                    correlationId)
+                : SubscriptionOperationResult<(Plan, Price)>.Failure(
+                    PaymentFailureKind.Conflict,
+                    "subscription_plan_archived",
+                    "This plan is archived and can no longer be sold or changed.",
+                    correlationId);
         }
 
         var price = await _catalogue.GetPriceAsync(

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -879,11 +879,27 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         if (plan is null)
         {
-            return SubscriptionOperationResult<(Plan, Price)>.Failure(
-                PaymentFailureKind.NotFound,
-                "subscription_plan_not_found",
-                "The plan does not exist or is not on sale.",
-                correlationId);
+            // Consulted only after the active fallback has found nothing, and only to say why.
+            // Resolving both statuses together would let an organization's archived plan shadow
+            // the tenant's active one of the same code and refuse a move that should have been
+            // allowed — what is sellable must keep being decided by the lookup above alone.
+            var archived = await _catalogue.FindArchivedPlanByCodeAsync(
+                context.TenantId,
+                context.OrganizationId,
+                request.PlanCode,
+                cancellationToken);
+
+            return archived is null
+                ? SubscriptionOperationResult<(Plan, Price)>.Failure(
+                    PaymentFailureKind.NotFound,
+                    "subscription_plan_not_found",
+                    "The plan does not exist or is not on sale.",
+                    correlationId)
+                : SubscriptionOperationResult<(Plan, Price)>.Failure(
+                    PaymentFailureKind.Conflict,
+                    "subscription_plan_archived",
+                    "This plan is archived and can no longer be sold or changed.",
+                    correlationId);
         }
 
         var price = await _catalogue.GetPriceAsync(

--- a/server/XUnitTest/Integration/PlanArchiveIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PlanArchiveIntegrationTests.cs
@@ -355,6 +355,17 @@ public sealed class PlanArchiveIntegrationTests
             {
                 TenantId = tenantId,
                 OrganizationId = "org-1",
+                SubscriptionId = "subscription-1",
+                Operation = "Renewal",
+                Outcome = "Changed"
+            },
+            CancellationToken.None);
+
+        await audit.AppendAsync(
+            new SubscriptionAuditEvent
+            {
+                TenantId = tenantId,
+                OrganizationId = "org-1",
                 AggregateType = "Plan",
                 AggregateId = "plan-1",
                 AggregateCode = "professional",
@@ -384,6 +395,21 @@ public sealed class PlanArchiveIntegrationTests
         filter.Should().NotBeNull("without the filter the index holds every audit event ever written");
         filter!.Names.Should().Contain("AggregateType");
         filter.Names.Should().Contain("AggregateId");
+
+        // Nullable properties are serialized as explicit BSON nulls by default. `$exists` would
+        // therefore admit the ordinary subscription event above even though it has no aggregate.
+        // Reading through the partial index proves membership, rather than merely asserting that
+        // an index definition contains fields with plausible names.
+        var indexedDocuments = await _fixture.Database
+            .GetCollection<BsonDocument>("SubscriptionAuditEvents")
+            .Find(FilterDefinition<BsonDocument>.Empty, new FindOptions
+            {
+                Hint = "ix_subscription_audit_aggregate"
+            })
+            .ToListAsync();
+
+        indexedDocuments.Should().ContainSingle();
+        indexedDocuments[0]["AggregateId"].AsString.Should().Be("plan-1");
     }
 
     private static Plan ActivePlan(string tenantId) => new()

--- a/server/XUnitTest/Integration/PlanArchiveIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PlanArchiveIntegrationTests.cs
@@ -363,8 +363,11 @@ public sealed class PlanArchiveIntegrationTests
             },
             CancellationToken.None);
 
+        // The tenant selects the database, not a collection-name prefix — SubscriptionCollections.Of
+        // resolves a database per tenant and then a plainly named collection inside it. The
+        // fixture maps every tenant onto its own throwaway database, so the name is unadorned.
         var indexes = await _fixture.Database
-            .GetCollection<BsonDocument>($"{tenantId}_SubscriptionAuditEvents")
+            .GetCollection<BsonDocument>("SubscriptionAuditEvents")
             .Indexes.List()
             .ToListAsync();
 

--- a/server/XUnitTest/Integration/PlanArchiveIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PlanArchiveIntegrationTests.cs
@@ -1,0 +1,394 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// What archiving a plan actually does to the stored documents.
+/// </summary>
+/// <remarks>
+/// The service-level tests for this feature mock the repository, so they prove which decision the
+/// service reaches from a given answer and nothing at all about whether MongoDB gives that answer.
+/// Everything here is a claim about the database rather than about our code: that a status check
+/// and a version check happen in one write, that two real writers cannot both win, that a filter
+/// returns the documents it says it does, and that an index exists with the filter it was declared
+/// with. None of it can be demonstrated against a mock.
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class PlanArchiveIntegrationTests
+{
+    private readonly MongoIntegrationFixture _fixture;
+    private readonly SubscriptionCatalogueRepository _catalogue;
+
+    public PlanArchiveIntegrationTests(MongoIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+        _catalogue = new SubscriptionCatalogueRepository(fixture.DbContextProvider);
+    }
+
+    // ---- the write itself ---------------------------------------------------
+
+    [Fact]
+    public async Task Archiving_moves_the_plan_and_advances_its_version_in_one_write()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = ActivePlan(tenantId);
+        (await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None)).Should().BeTrue();
+
+        var archivedAt = DateTime.UtcNow;
+
+        (await _catalogue.TryArchivePlanAsync(
+                tenantId, plan.ItemId, plan.Version, archivedAt, CancellationToken.None))
+            .Should().BeTrue();
+
+        var stored = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        stored!.Status.Should().Be(CatalogueStatus.Archived);
+        stored.Version.Should().Be(plan.Version + 1,
+            "the version has to move, or a concurrent edit holding the old one would still win");
+        stored.LastUpdatedDateUtc.Should().BeCloseTo(archivedAt, TimeSpan.FromSeconds(1));
+    }
+
+    /// <summary>
+    /// The version half of the filter. An edit landing in between must not be silently overwritten
+    /// by an archive that was decided against terms nobody reviewed.
+    /// </summary>
+    [Fact]
+    public async Task Archiving_against_a_stale_version_is_refused_by_the_database()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = ActivePlan(tenantId);
+        await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None);
+
+        var edited = ActivePlan(tenantId);
+        edited.DisplayName = "Renamed by somebody else";
+        (await _catalogue.TryUpdatePlanAsync(
+                tenantId, plan.ItemId, plan.Version, edited, CancellationToken.None))
+            .Should().BeTrue();
+
+        (await _catalogue.TryArchivePlanAsync(
+                tenantId, plan.ItemId, plan.Version, DateTime.UtcNow, CancellationToken.None))
+            .Should().BeFalse("the version the archive was decided against is no longer current");
+
+        var stored = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        stored!.Status.Should().Be(CatalogueStatus.Active, "the refused archive must not have applied");
+    }
+
+    /// <summary>
+    /// The status half of the filter, and the reason a repeat is reported as a no-op rather than as
+    /// a second successful write.
+    /// </summary>
+    [Fact]
+    public async Task Archiving_an_already_archived_plan_writes_nothing()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = ActivePlan(tenantId);
+        await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None);
+
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, plan.ItemId, plan.Version, DateTime.UtcNow, CancellationToken.None);
+
+        var afterFirst = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        (await _catalogue.TryArchivePlanAsync(
+                tenantId, plan.ItemId, afterFirst!.Version, DateTime.UtcNow, CancellationToken.None))
+            .Should().BeFalse();
+
+        var afterSecond = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        afterSecond!.Version.Should().Be(afterFirst.Version,
+            "an already-archived plan must not be written again, or every retry would bump the version");
+    }
+
+    /// <summary>
+    /// A draft was never on a menu, so there is nothing to take off one, and archiving is
+    /// permanent. Enforced by the filter rather than by the service alone.
+    /// </summary>
+    [Fact]
+    public async Task A_draft_plan_is_refused_by_the_filter_itself()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = ActivePlan(tenantId);
+        plan.Status = CatalogueStatus.Draft;
+        await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None);
+
+        (await _catalogue.TryArchivePlanAsync(
+                tenantId, plan.ItemId, plan.Version, DateTime.UtcNow, CancellationToken.None))
+            .Should().BeFalse();
+
+        var stored = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        stored!.Status.Should().Be(CatalogueStatus.Draft);
+    }
+
+    /// <summary>
+    /// Two real writers, started together. Exactly one may win, and the plan must end at one
+    /// version past where it started rather than two.
+    /// </summary>
+    [Fact]
+    public async Task Two_concurrent_archives_produce_one_winner_and_one_version_increment()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = ActivePlan(tenantId);
+        await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None);
+
+        var attempts = await Task.WhenAll(
+            Enumerable.Range(0, 8).Select(_ =>
+                _catalogue.TryArchivePlanAsync(
+                    tenantId, plan.ItemId, plan.Version, DateTime.UtcNow, CancellationToken.None)));
+
+        attempts.Count(won => won).Should().Be(1,
+            "the status and version filter is the whole guarantee: a second winner means two " +
+            "writers both believed they archived it");
+
+        var stored = await _catalogue.GetPlanAsync(tenantId, plan.ItemId, CancellationToken.None);
+
+        stored!.Status.Should().Be(CatalogueStatus.Archived);
+        stored.Version.Should().Be(plan.Version + 1);
+    }
+
+    // ---- the fallback archiving must not break ------------------------------
+
+    /// <summary>
+    /// The regression this feature could most easily have introduced, and the reason the archived
+    /// lookup is a second call rather than a widened first one: an organization's archived plan
+    /// must not shadow the tenant's active plan of the same code and refuse a sale that should
+    /// have gone through.
+    /// </summary>
+    [Fact]
+    public async Task An_archived_organization_plan_does_not_hide_the_active_tenant_plan()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var tenantWide = ActivePlan(tenantId);
+        tenantWide.OrganizationId = null;
+        await _catalogue.TryCreatePlanAsync(tenantWide, CancellationToken.None);
+
+        var organizationOwned = ActivePlan(tenantId);
+        organizationOwned.OrganizationId = "org-1";
+        await _catalogue.TryCreatePlanAsync(organizationOwned, CancellationToken.None);
+
+        // While both are active, the organization's own plan is what resolves.
+        var beforeArchiving = await _catalogue.FindPlanByCodeAsync(
+            tenantId, "org-1", "professional", CancellationToken.None);
+
+        beforeArchiving!.ItemId.Should().Be(organizationOwned.ItemId);
+
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, organizationOwned.ItemId, organizationOwned.Version, DateTime.UtcNow,
+            CancellationToken.None);
+
+        var afterArchiving = await _catalogue.FindPlanByCodeAsync(
+            tenantId, "org-1", "professional", CancellationToken.None);
+
+        afterArchiving.Should().NotBeNull(
+            "the tenant's plan is still on sale, and archiving somebody else's must not have " +
+            "taken it off the menu");
+        afterArchiving!.ItemId.Should().Be(tenantWide.ItemId);
+    }
+
+    /// <summary>
+    /// The archived lookup follows the same visibility as the active one, so a better error message
+    /// never becomes a way to discover that a code exists in an organization the caller cannot see.
+    /// </summary>
+    [Fact]
+    public async Task The_archived_lookup_stays_within_what_the_caller_can_see()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var otherOrganizations = ActivePlan(tenantId);
+        otherOrganizations.OrganizationId = "org-9";
+        await _catalogue.TryCreatePlanAsync(otherOrganizations, CancellationToken.None);
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, otherOrganizations.ItemId, otherOrganizations.Version, DateTime.UtcNow,
+            CancellationToken.None);
+
+        var found = await _catalogue.FindArchivedPlanByCodeAsync(
+            tenantId, "org-1", "professional", CancellationToken.None);
+
+        found.Should().BeNull(
+            "org-1 cannot see org-9's plan, so the refusal it receives must stay a plain not-found");
+    }
+
+    [Fact]
+    public async Task The_archived_lookup_finds_a_plan_the_caller_can_see()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var plan = ActivePlan(tenantId);
+        plan.OrganizationId = null;
+        await _catalogue.TryCreatePlanAsync(plan, CancellationToken.None);
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, plan.ItemId, plan.Version, DateTime.UtcNow, CancellationToken.None);
+
+        var found = await _catalogue.FindArchivedPlanByCodeAsync(
+            tenantId, "org-1", "professional", CancellationToken.None);
+
+        found!.ItemId.Should().Be(plan.ItemId);
+    }
+
+    // ---- listing ------------------------------------------------------------
+
+    /// <summary>
+    /// The three filters against stored documents, including the part that differs between them:
+    /// Active collapses by code, and the archived views must not.
+    /// </summary>
+    [Fact]
+    public async Task The_three_filters_return_what_they_say_they_do()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var tenantWide = ActivePlan(tenantId);
+        tenantWide.OrganizationId = null;
+        await _catalogue.TryCreatePlanAsync(tenantWide, CancellationToken.None);
+
+        var organizationOwned = ActivePlan(tenantId);
+        organizationOwned.OrganizationId = "org-1";
+        await _catalogue.TryCreatePlanAsync(organizationOwned, CancellationToken.None);
+
+        var retired = ActivePlan(tenantId);
+        retired.OrganizationId = "org-1";
+        retired.Code = "legacy";
+        await _catalogue.TryCreatePlanAsync(retired, CancellationToken.None);
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, retired.ItemId, retired.Version, DateTime.UtcNow, CancellationToken.None);
+
+        var draft = ActivePlan(tenantId);
+        draft.OrganizationId = "org-1";
+        draft.Code = "unfinished";
+        draft.Status = CatalogueStatus.Draft;
+        await _catalogue.TryCreatePlanAsync(draft, CancellationToken.None);
+
+        var active = await _catalogue.ListPlansAsync(
+            tenantId, "org-1", PlanCatalogueFilter.Active, CancellationToken.None);
+        var archived = await _catalogue.ListPlansAsync(
+            tenantId, "org-1", PlanCatalogueFilter.Archived, CancellationToken.None);
+        var all = await _catalogue.ListPlansAsync(
+            tenantId, "org-1", PlanCatalogueFilter.All, CancellationToken.None);
+
+        // Collapsed: the organization's own "professional" hides the tenant's, matching what
+        // FindPlanByCodeAsync resolves.
+        active.Select(plan => plan.ItemId).Should().BeEquivalentTo([organizationOwned.ItemId]);
+
+        archived.Select(plan => plan.ItemId).Should().BeEquivalentTo([retired.ItemId]);
+
+        all.Select(plan => plan.ItemId).Should().BeEquivalentTo(
+            [organizationOwned.ItemId, retired.ItemId]);
+
+        // Draft is in none of them, which is what it has always been to every catalogue view.
+        all.Should().NotContain(plan => plan.ItemId == draft.ItemId);
+    }
+
+    /// <summary>
+    /// History is not collapsed. Two archived plans sharing a code are two records, and the
+    /// replacement sharing that code is usually why somebody is reading them.
+    /// </summary>
+    [Fact]
+    public async Task Archived_plans_sharing_a_code_are_all_returned()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var first = ActivePlan(tenantId);
+        first.OrganizationId = null;
+        await _catalogue.TryCreatePlanAsync(first, CancellationToken.None);
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, first.ItemId, first.Version, DateTime.UtcNow, CancellationToken.None);
+
+        var second = ActivePlan(tenantId);
+        second.OrganizationId = "org-1";
+        await _catalogue.TryCreatePlanAsync(second, CancellationToken.None);
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, second.ItemId, second.Version, DateTime.UtcNow, CancellationToken.None);
+
+        var archived = await _catalogue.ListPlansAsync(
+            tenantId, "org-1", PlanCatalogueFilter.Archived, CancellationToken.None);
+
+        archived.Select(plan => plan.ItemId).Should().BeEquivalentTo([first.ItemId, second.ItemId]);
+    }
+
+    /// <summary>
+    /// Under All, an archived plan must not collapse an active one of the same code either: what is
+    /// on sale would then be misreported as retired.
+    /// </summary>
+    [Fact]
+    public async Task An_archived_plan_never_hides_an_active_plan_of_the_same_code()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var live = ActivePlan(tenantId);
+        live.OrganizationId = null;
+        await _catalogue.TryCreatePlanAsync(live, CancellationToken.None);
+
+        var retired = ActivePlan(tenantId);
+        retired.OrganizationId = "org-1";
+        await _catalogue.TryCreatePlanAsync(retired, CancellationToken.None);
+        await _catalogue.TryArchivePlanAsync(
+            tenantId, retired.ItemId, retired.Version, DateTime.UtcNow, CancellationToken.None);
+
+        var all = await _catalogue.ListPlansAsync(
+            tenantId, "org-1", PlanCatalogueFilter.All, CancellationToken.None);
+
+        all.Should().Contain(plan => plan.ItemId == live.ItemId);
+        all.Should().Contain(plan => plan.ItemId == retired.ItemId);
+    }
+
+    // ---- the audit index ----------------------------------------------------
+
+    /// <summary>
+    /// The index is declared partial rather than sparse, and the difference is not cosmetic: a
+    /// sparse compound index includes a document when <em>any</em> indexed field exists, and
+    /// TenantId and OrganizationId exist on every audit event ever written. Declared sparse, it
+    /// would have indexed the whole collection while reading as though it excluded it.
+    /// </summary>
+    [Fact]
+    public async Task The_aggregate_audit_index_is_partial_on_the_aggregate_fields()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var audit = new SubscriptionAuditRepository(_fixture.DbContextProvider);
+
+        await audit.AppendAsync(
+            new SubscriptionAuditEvent
+            {
+                TenantId = tenantId,
+                OrganizationId = "org-1",
+                AggregateType = "Plan",
+                AggregateId = "plan-1",
+                AggregateCode = "professional",
+                Operation = "PlanArchive",
+                Outcome = "Changed"
+            },
+            CancellationToken.None);
+
+        var indexes = await _fixture.Database
+            .GetCollection<BsonDocument>($"{tenantId}_SubscriptionAuditEvents")
+            .Indexes.List()
+            .ToListAsync();
+
+        var aggregate = indexes.Find(index =>
+            index.GetValue("name", "").AsString == "ix_subscription_audit_aggregate");
+
+        aggregate.Should().NotBeNull("the index the plan-history query depends on must exist");
+
+        aggregate!.Contains("sparse").Should().BeFalse(
+            "sparse would not have excluded a single existing subscription event");
+
+        var filter = aggregate.GetValue("partialFilterExpression", null)?.AsBsonDocument;
+
+        filter.Should().NotBeNull("without the filter the index holds every audit event ever written");
+        filter!.Names.Should().Contain("AggregateType");
+        filter.Names.Should().Contain("AggregateId");
+    }
+
+    private static Plan ActivePlan(string tenantId) => new()
+    {
+        TenantId = tenantId,
+        Code = "professional",
+        DisplayName = "Professional",
+        Status = CatalogueStatus.Active,
+        Version = 1
+    };
+}

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceCampaignTests.cs
@@ -48,7 +48,8 @@ public sealed class DiscountCatalogueServiceCampaignTests
 
         _catalogue
             .Setup(repository => repository.ListPlansAsync(
-                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+                TenantId, OrganizationId,
+                It.IsAny<PlanCatalogueFilter>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([PlanWithSeatEntitlement()]);
 
         _catalogue

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
@@ -43,7 +43,8 @@ public sealed class DiscountCatalogueServiceTests
 
         _catalogue
             .Setup(repository => repository.ListPlansAsync(
-                TenantId, OrganizationId, It.IsAny<CancellationToken>()))
+                TenantId, OrganizationId,
+                It.IsAny<PlanCatalogueFilter>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([Plan("plan-pro", "pro"), Plan("plan-team", "team")]);
 
         _catalogue
@@ -80,7 +81,8 @@ public sealed class DiscountCatalogueServiceTests
 
         _catalogue
             .Setup(repository => repository.ListPlansAsync(
-                TenantId, CustomerOrganizationId, It.IsAny<CancellationToken>()))
+                TenantId, CustomerOrganizationId,
+                It.IsAny<PlanCatalogueFilter>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([Plan("plan-customer", "customer-only")]);
 
         var request = Request();
@@ -116,7 +118,8 @@ public sealed class DiscountCatalogueServiceTests
 
         _catalogue
             .Setup(repository => repository.ListPlansAsync(
-                TenantId, CustomerOrganizationId, It.IsAny<CancellationToken>()))
+                TenantId, CustomerOrganizationId,
+                It.IsAny<PlanCatalogueFilter>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([Plan("plan-customer", "customer-only")]);
 
         var request = Request();
@@ -162,7 +165,8 @@ public sealed class DiscountCatalogueServiceTests
 
         result.IsSuccess.Should().BeTrue();
         _catalogue.Verify(repository => repository.ListPlansAsync(
-            It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Never);
+            It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<PlanCatalogueFilter>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -25,6 +25,8 @@ public sealed class PlanCatalogueServiceTests
     private readonly Mock<ISubscriptionRepository> _subscriptions = new();
     private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
     private readonly Mock<ICurrencyMinorUnitResolver> _currencyResolver = new();
+    private readonly Mock<ISubscriptionAuditTrail> _auditTrail = new();
+    private readonly List<SubscriptionAuditEvent> _audited = [];
     private Plan? _created;
     private Plan? _updated;
 
@@ -44,6 +46,13 @@ public sealed class PlanCatalogueServiceTests
                 It.IsAny<CancellationToken>()))
             .Callback<Plan, CancellationToken>((plan, _) => _created = plan)
             .ReturnsAsync(true);
+
+        _auditTrail
+            .Setup(trail => trail.RecordAsync(
+                It.IsAny<SubscriptionAuditEvent>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<SubscriptionAuditEvent, CancellationToken>((entry, _) => _audited.Add(entry))
+            .Returns(Task.CompletedTask);
 
         // A plan with no prices yet is the ordinary state right after it is authored, and every
         // path that maps a plan to a response reads this.
@@ -791,7 +800,8 @@ public sealed class PlanCatalogueServiceTests
     {
         _catalogue
             .Setup(repository => repository.ListPlansAsync(
-                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<PlanCatalogueFilter>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<Plan>());
 
         await Service().ListPlansAsync("org-9", "corr-1", CancellationToken.None);
@@ -1198,6 +1208,390 @@ public sealed class PlanCatalogueServiceTests
                 TenantId, plan.ItemId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(plan);
 
+    // ---- archiving a plan --------------------------------------------------
+
+    /// <summary>An active plan, which is the only state this operation accepts.</summary>
+    private static Plan ActivePlan()
+    {
+        var plan = StoredPlan();
+        plan.Status = CatalogueStatus.Active;
+
+        return plan;
+    }
+
+    private void GivenPlan(Plan plan) =>
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId,
+                plan.ItemId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plan);
+
+    /// <summary>
+    /// The write is conditional on the plan still being active and still at the version just
+    /// read, so an archive can never be applied to terms the caller did not see.
+    /// </summary>
+    [Fact]
+    public async Task Archiving_an_active_plan_writes_once_against_the_version_it_read()
+    {
+        var plan = ActivePlan();
+        GivenPlan(plan);
+        _catalogue
+            .Setup(repository => repository.TryArchivePlanAsync(
+                TenantId,
+                plan.ItemId,
+                plan.Version,
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _catalogue.Verify(
+            repository => repository.TryArchivePlanAsync(
+                TenantId, plan.ItemId, plan.Version, It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// A retried request — a double-clicked button, a client that never saw the first response —
+    /// has one sensible answer, and it is not an error about work that has already happened.
+    /// </summary>
+    [Fact]
+    public async Task Archiving_an_already_archived_plan_succeeds_without_writing_again()
+    {
+        var plan = StoredPlan();
+        plan.Status = CatalogueStatus.Archived;
+        GivenPlan(plan);
+
+        var result = await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _catalogue.Verify(
+            repository => repository.TryArchivePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _audited.Should().ContainSingle(entry => entry.Outcome == "AlreadyArchived");
+    }
+
+    /// <summary>
+    /// Two archive requests racing. The loser is told it succeeded, because the state both asked
+    /// for is the state the plan is now in.
+    /// </summary>
+    [Fact]
+    public async Task Losing_a_race_to_another_archive_still_reports_success()
+    {
+        var plan = ActivePlan();
+        var archived = StoredPlan();
+        archived.Status = CatalogueStatus.Archived;
+        archived.Version = plan.Version + 1;
+
+        _catalogue
+            .SetupSequence(repository => repository.GetPlanAsync(
+                TenantId, plan.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plan)
+            .ReturnsAsync(archived)
+            .ReturnsAsync(archived);
+
+        _catalogue
+            .Setup(repository => repository.TryArchivePlanAsync(
+                TenantId, plan.ItemId, plan.Version, It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _audited.Should().ContainSingle(entry => entry.Outcome == "AlreadyArchived");
+    }
+
+    /// <summary>
+    /// An unrelated edit landing in between is a different matter: the plan the caller decided to
+    /// archive is not the plan on disk any more, so the decision is sent back rather than applied.
+    /// </summary>
+    [Fact]
+    public async Task An_unrelated_edit_landing_first_refuses_the_archive_as_a_conflict()
+    {
+        var plan = ActivePlan();
+        var edited = ActivePlan();
+        edited.Version = plan.Version + 1;
+        edited.DisplayName = "Renamed by somebody else";
+
+        _catalogue
+            .SetupSequence(repository => repository.GetPlanAsync(
+                TenantId, plan.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plan)
+            .ReturnsAsync(edited);
+
+        _catalogue
+            .Setup(repository => repository.TryArchivePlanAsync(
+                TenantId, plan.ItemId, plan.Version, It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_plan_changed");
+        _audited.Should().ContainSingle(entry => entry.Outcome == "Conflict");
+    }
+
+    /// <summary>
+    /// A draft appears in no catalogue view, so there is nothing to take off a menu, and archiving
+    /// is permanent: honouring this would strand the plan in a state it could never be sold from.
+    /// </summary>
+    [Fact]
+    public async Task A_draft_plan_cannot_be_archived()
+    {
+        var plan = StoredPlan();
+        plan.Status = CatalogueStatus.Draft;
+        GivenPlan(plan);
+
+        var result = await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        _catalogue.Verify(
+            repository => repository.TryArchivePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Another organization's plan must answer exactly as an absent one does. A different message
+    /// for a plan that exists elsewhere would let one organization enumerate another's catalogue.
+    /// </summary>
+    [Fact]
+    public async Task Archiving_another_organizations_plan_is_indistinguishable_from_not_found()
+    {
+        var plan = ActivePlan();
+        plan.OrganizationId = "org-9";
+        GivenPlan(plan);
+
+        var invisible = await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        _catalogue
+            .Setup(repository => repository.GetPlanAsync(
+                TenantId, "plan-absent", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Plan?)null);
+
+        var absent = await Service().ArchivePlanAsync(
+            "plan-absent", OrganizationId, "correlation-1", CancellationToken.None);
+
+        invisible.IsSuccess.Should().BeFalse();
+        absent.IsSuccess.Should().BeFalse();
+        invisible.ErrorCode.Should().Be(absent.ErrorCode);
+        invisible.ErrorMessage.Should().Be(absent.ErrorMessage);
+        _catalogue.Verify(
+            repository => repository.TryArchivePlanAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Everything the trail is read for later: which plan, under whose scope, by whom, from what
+    /// to what, and tied to the request that did it.
+    /// </summary>
+    [Fact]
+    public async Task A_successful_archive_records_the_plan_the_actor_and_the_transition()
+    {
+        var plan = ActivePlan();
+        GivenPlan(plan);
+        _catalogue
+            .Setup(repository => repository.TryArchivePlanAsync(
+                TenantId, plan.ItemId, plan.Version, It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-7", CancellationToken.None);
+
+        var entry = _audited.Should().ContainSingle().Subject;
+        entry.Operation.Should().Be("PlanArchive");
+        entry.Outcome.Should().Be("Changed");
+        entry.AggregateType.Should().Be("Plan");
+        entry.AggregateId.Should().Be(plan.ItemId);
+        entry.AggregateCode.Should().Be(plan.Code);
+        entry.FromStatus.Should().Be("Active");
+        entry.ToStatus.Should().Be("Archived");
+        entry.TenantId.Should().Be(TenantId);
+        entry.OrganizationId.Should().Be(OrganizationId);
+        entry.ActorId.Should().Be("actor-1");
+        entry.CorrelationId.Should().Be("correlation-7");
+
+        // Left null on purpose: this is a catalogue change, and the subscribers holding a snapshot
+        // of the plan are precisely the ones it does not touch.
+        entry.SubscriptionId.Should().BeNull();
+    }
+
+    /// <summary>
+    /// An audit write that fails must not turn a plan that really was archived into an error the
+    /// caller retries against a plan already in the state they asked for.
+    /// </summary>
+    [Fact]
+    public async Task A_failing_audit_write_does_not_fail_the_archive()
+    {
+        var plan = ActivePlan();
+        GivenPlan(plan);
+        _catalogue
+            .Setup(repository => repository.TryArchivePlanAsync(
+                TenantId, plan.ItemId, plan.Version, It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _auditTrail
+            .Setup(trail => trail.RecordAsync(
+                It.IsAny<SubscriptionAuditEvent>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("audit store unreachable"));
+
+        var result = await Service().ArchivePlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Every catalogue mutation, refused on an archived plan. Named individually rather than
+    /// checked once on the guard, because it is the set that matters: each of these exists only to
+    /// change what a future subscriber pays, and an archived plan has no future subscriber.
+    /// </summary>
+    [Fact]
+    public async Task Every_catalogue_mutation_refuses_an_archived_plan()
+    {
+        var plan = StoredPlan();
+        plan.Status = CatalogueStatus.Archived;
+        GivenPlan(plan);
+
+        var price = new Price
+        {
+            ItemId = "price-1",
+            TenantId = TenantId,
+            PlanId = plan.ItemId,
+            CurrencyCode = "CHF",
+            Status = CatalogueStatus.Active,
+            Version = 1
+        };
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, price.ItemId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(price);
+
+        var service = Service();
+
+        var update = await service.UpdatePlanAsync(
+            plan.ItemId, EditedPlan(), "correlation-1", CancellationToken.None);
+
+        var newPrice = await service.CreatePriceAsync(
+            new CreatePriceRequest
+            {
+                PlanId = plan.ItemId,
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 1_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1
+            },
+            "correlation-1",
+            CancellationToken.None);
+
+        var tax = await service.UpdatePriceTaxAsync(
+            price.ItemId,
+            new UpdatePriceTaxRequest { TaxRateBasisPoints = 810, TaxMode = TaxMode.Exclusive },
+            "correlation-1",
+            CancellationToken.None);
+
+        var discount = await service.UpdatePriceDiscountAsync(
+            price.ItemId,
+            new UpdatePriceDiscountRequest { AutomaticDiscountBasisPoints = 500 },
+            "correlation-1",
+            CancellationToken.None);
+
+        var retire = await service.ArchivePriceAsync(
+            price.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        foreach (var refused in new[] { update, newPrice, tax, discount, retire })
+        {
+            refused.IsSuccess.Should().BeFalse();
+            refused.ErrorCode.Should().Be("subscription_plan_archived");
+        }
+    }
+
+    /// <summary>
+    /// Reading is deliberately still open. Inspecting an archived plan is what the Archived filter
+    /// is for, and duplicating one is how a replacement gets made.
+    /// </summary>
+    [Fact]
+    public async Task An_archived_plan_can_still_be_read()
+    {
+        var plan = StoredPlan();
+        plan.Status = CatalogueStatus.Archived;
+        GivenPlan(plan);
+
+        var result = await Service().GetPlanAsync(
+            plan.ItemId, OrganizationId, "correlation-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be("Archived");
+    }
+
+    /// <summary>
+    /// The default is what every subscriber-facing caller sends by omitting the parameter, and it
+    /// is what keeps archived plans out of subscribe and change-plan selectors without those
+    /// screens filtering anything themselves.
+    /// </summary>
+    [Fact]
+    public async Task Listing_without_a_filter_asks_the_repository_for_active_plans_only()
+    {
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<PlanCatalogueFilter>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await Service().ListPlansAsync(OrganizationId, "correlation-1", CancellationToken.None);
+
+        _catalogue.Verify(
+            repository => repository.ListPlansAsync(
+                TenantId, OrganizationId, PlanCatalogueFilter.Active,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(PlanCatalogueFilter.Archived)]
+    [InlineData(PlanCatalogueFilter.All)]
+    public async Task An_administrative_filter_reaches_the_repository_unchanged(
+        PlanCatalogueFilter filter)
+    {
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<PlanCatalogueFilter>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await Service().ListPlansAsync(
+            OrganizationId, "correlation-1", CancellationToken.None, filter);
+
+        _catalogue.Verify(
+            repository => repository.ListPlansAsync(
+                TenantId, OrganizationId, filter, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private PlanCatalogueService Service() => new(
         _catalogue.Object,
         _subscriptions.Object,
@@ -1206,6 +1600,7 @@ public sealed class PlanCatalogueServiceTests
         new UpdatePlanRequestValidator(),
         new CreatePriceRequestValidator(_currencyResolver.Object),
         new PlanResponseMapper(),
+        _auditTrail.Object,
         NullLogger<PlanCatalogueService>.Instance);
 
     private static Plan StoredPlan() => new()


### PR DESCRIPTION
Archiving takes a whole plan off the menu permanently. Everyone already subscribed carries on untouched — they bill from the terms copied onto their subscription when they bought, so renewals, usage rating, entitlements, invoicing and cancellation all continue. None of the plan's prices is rewritten or deleted. What stops is selling.

## What was already true, and left alone

Worth stating first, because the spec reads as though this were a blank slate and it was not:

| Already present | Where |
| --- | --- |
| `CatalogueStatus { Draft, Active, Archived }`, `Plan.Status`, `Version`, `LastUpdatedDateUtc` | **no schema migration needed** |
| Subscriber-facing lists already excluded archived plans | `ListPlansAsync` filtered `Active` |
| Creation, purchase preview, plan-change preview and execution already refused them | all four resolve through `FindPlanByCodeAsync`, which filtered `Active` |
| Duplication | already worked via router state on the create page — the card's menu reuses it rather than adding a second mechanism |

So the enforcement largely existed; what it lacked was a **name**. `subscription_plan_archived` is now returned by consulting the archived catalogue *only after* the active lookup has found nothing.

**That ordering is load-bearing, not an implementation detail.** Resolving both statuses together would let an organization's archived plan shadow the tenant's active plan of the same code and refuse a sale that should have gone through — a revenue bug invisible to any test using one scope. There is a test for exactly this.

## Server

`PUT /subscription-plans/{planId}/archive` — conditional on status **and** on the version just read. `ModifiedCount == 0` covers three situations needing three answers, so the service re-reads to tell them apart:

| What happened | Answer |
| --- | --- |
| Already archived | success, no second write |
| Another archive won the race | success — both wanted this state |
| An unrelated edit moved the version on | `subscription_plan_changed` |
| Gone, or invisible to the caller | ordinary not-found |

Idempotency is the one place this differs from `ArchivePriceAsync`, which reports a repeat as a conflict. Commented, or the next reader will "fix" it.

**Five catalogue mutations refuse an archived plan** through one guard — update plan, create price, price tax, price discount, retire price. All five exist only to change what a *future* subscriber pays. Reading stays open: inspecting an archived plan is what the `Archived` filter is for.

`?status=Active|Archived|All`, invalid → `400 subscription_plan_status_invalid`. `Active` keeps the organization-over-tenant collapse; the archived views deliberately do not collapse by code.

Audit events gain nullable `AggregateType`/`AggregateId`/`AggregateCode` plus a sparse index. Every outcome is recorded, including the ones that changed nothing, and the audit write can never fail the archive it describes.

## Client

The catalogue fetches `All` once and filters in the browser, so tab switching is instant and the summary counts stay consistent with what the tabs show.

`useSubscriptionPlans` takes an optional status defaulting to `Active`, and **only this page passes anything**. The discount page and the subscribe/change-plan dialogs omit it and therefore cannot show an archived plan even by accident — a stronger guarantee than three screens each filtering for themselves.

Status, search and sort live in the query string and nowhere else, so a reload and a shared link reproduce the same list.

Some smaller decisions with reasons:

- **The card stopped being one big link.** A menu inside an anchor either navigates when it opens or fights the anchor to stop it.
- **Archived plans lose Edit and Archive entirely, not disabled.** The server refuses every mutation on one, so a greyed-out button invites a click and then an explanation. There is no restore to offer.
- **Archived cards are tinted, not faded.** Text at 60% opacity on a muted panel fails contrast, and an archived plan is still read.
- **A plan with no `status` reads as active everywhere.** Absent means a response cached before the field existed; the alternative mutes the whole catalogue after a deploy.
- **Price sorting compares major units.** On raw minor units `500 JPY` outranks `4.00 CHF` — not a conversion problem, just a different-sized smallest coin. Priceless and undated plans sort last, not first.
- **Double submission is guarded in the handler**, not only by `disabled`: a second Enter arrives before React re-renders, and this cannot be undone.

## Decisions where I followed your spec over my own first instinct

**Draft is not archivable** and answers as not found. I had originally argued for allowing it so a legacy draft could not be stranded unarchivable; your revision was explicit, and a draft appears in no catalogue view, so there is no menu to take it off.

## Verification

- **Server: 3287 unit tests pass**, 13 new. The **4 failures are pre-existing on `dev`** — `SubscriptionSimulationGuard.IsAuthorized` has its permission check commented out and replaced with `return true` (commit `8d7a4389`). Unrelated to this branch, and still unresolved.
- **Client: 2375 tests pass** (328 files), 26 new. `npm run type-check` and `npm run build` both exit 0.

## Not done

- **No page-level catalogue test.** The filter logic is covered directly and the card and dialog are covered as components, but the wiring between the URL and the rendered page is not asserted end-to-end.
- Responsive and keyboard behaviour is implemented (`sm`/`lg` grids, stacked filters, focus-visible rings, `aria-label`s on every control, `role="alert"`/`role="status"`) but **verified by reading, not by a test or a real browser**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
