### PR TITLE
Allow Standard discounts to configure precedence

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.test.tsx
@@ -76,8 +76,11 @@ describe("CampaignBuilder", () => {
     fireEvent.change(screen.getByLabelText(/Display name/), { target: { value: "Launch offer" } });
     click(/^Next$/);
 
-    // Benefit: the default 10% carries through untouched.
+    // Benefit: Standard discounts expose the same explicit precedence choices as campaigns.
     await screen.findByText(/What redeeming this discount takes off/);
+    expect(screen.getByLabelText("Discount precedence")).toHaveTextContent("Best discount wins");
+    fireEvent.click(screen.getByLabelText("Discount precedence"));
+    fireEvent.click(screen.getByRole("option", { name: "Replace the price's own discount" }));
     fireEvent.change(screen.getByLabelText(/Starts at \(optional\)/), {
       target: { value: "2026-10-01T09:30" },
     });
@@ -96,6 +99,7 @@ describe("CampaignBuilder", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
     const [draft] = onSubmit.mock.calls[0]!;
     expect(draft.campaignKind).toBe("Standard");
+    expect(draft.campaignPrecedence).toBe("ReplaceBuiltIn");
     expect(draft.code).toBe("launch-25");
     expect(draft.startsAtUtc).toBe("2026-10-01T09:30");
     expect(draft.expiresAtUtc).toBe("2026-10-31T18:00");

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
@@ -247,16 +247,25 @@ describe("canSubmit", () => {
 });
 
 describe("toCreateDiscountRequest", () => {
-  it("omits every campaign field for a Standard discount", () => {
+  it("sends an explicitly selected precedence for a Standard discount", () => {
     const draft: CampaignDraft = { ...EMPTY_DRAFT, code: "launch-25", displayName: "Launch" };
 
     const request = toCreateDiscountRequest(draft, "org-1");
 
     expect(request.campaignKind).toBeUndefined();
-    expect(request.campaignPrecedence).toBeUndefined();
+    expect(request.campaignPrecedence).toBe("BestDiscount");
     expect(request.validFromDate).toBeUndefined();
     expect(request.oneUsePerOrganization).toBeUndefined();
     expect(request.entitlementOverrideKey).toBeUndefined();
+  });
+
+  it("preserves the plan-policy behavior of a legacy Standard discount until an admin chooses", () => {
+    const request = toCreateDiscountRequest(
+      { ...EMPTY_DRAFT, code: "legacy", displayName: "Legacy", campaignPrecedence: "" },
+      undefined,
+    );
+
+    expect(request.campaignPrecedence).toBeUndefined();
   });
 
   it("never sends a duration for a campaign, even if one was left over from Standard", () => {

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
@@ -27,7 +27,7 @@ export interface CampaignDraft {
   percent: string;
   amount: string;
   currencyCode: string;
-  campaignPrecedence: CampaignPrecedence;
+  campaignPrecedence: CampaignPrecedence | "";
   /** Standard only — a campaign's own duration is forced server-side and never authored here. */
   durationPeriods: string;
   startsAtUtc: string;
@@ -85,7 +85,8 @@ export const discountToDraft = (discount: SubscriptionDiscount): CampaignDraft =
     ? ""
     : String(toMajorUnits(discount.amountMinor, discount.currencyCode ?? "USD")),
   currencyCode: discount.currencyCode ?? "USD",
-  campaignPrecedence: discount.campaignPrecedence,
+  campaignPrecedence:
+    discount.campaignPrecedenceConfigured === false ? "" : discount.campaignPrecedence,
   durationPeriods: discount.durationPeriods == null ? "" : String(discount.durationPeriods),
   startsAtUtc: toLocalDateTimeInput(discount.startsAtUtc),
   expiresAtUtc: toLocalDateTimeInput(discount.expiresAtUtc),
@@ -308,7 +309,7 @@ export const toCreateDiscountRequest = (
     applicablePlanCodes: draft.planCodes,
     applicablePriceIds: draft.priceIds,
     campaignKind: isCampaign ? draft.campaignKind : undefined,
-    campaignPrecedence: isCampaign ? draft.campaignPrecedence : undefined,
+    campaignPrecedence: draft.campaignPrecedence || undefined,
     validFromDate: isCampaign ? draft.validFromDate : undefined,
     validThroughDate: isCampaign && draft.validThroughDate ? draft.validThroughDate : undefined,
     timeZoneId: isCampaign ? draft.timeZoneId : undefined,

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
@@ -130,29 +130,31 @@ export const StepBenefit = ({
         </div>
       )}
 
-      {isCampaign ? (
-        <div className="space-y-2">
-          <Label>How it meets the price's own discount</Label>
-          <Select
-            value={draft.campaignPrecedence}
-            onValueChange={(value) => onChange({ campaignPrecedence: value as CampaignPrecedence })}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {PRECEDENCE_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <p className="text-xs text-muted-foreground">
-            {PRECEDENCE_OPTIONS.find((option) => option.value === draft.campaignPrecedence)?.description}
-          </p>
-        </div>
-      ) : (
+      <div className="space-y-2">
+        <Label>How it meets the price's own discount</Label>
+        <Select
+          value={draft.campaignPrecedence}
+          onValueChange={(value) => onChange({ campaignPrecedence: value as CampaignPrecedence })}
+        >
+          <SelectTrigger aria-label="Discount precedence">
+            <SelectValue placeholder="Use the plan's discount policy" />
+          </SelectTrigger>
+          <SelectContent>
+            {PRECEDENCE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          {draft.campaignPrecedence
+            ? PRECEDENCE_OPTIONS.find((option) => option.value === draft.campaignPrecedence)?.description
+            : "This existing Standard discount keeps using each plan's discount-combination policy until you choose an option."}
+        </p>
+      </div>
+
+      {!isCampaign ? (
         <div className="grid gap-5 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label htmlFor="campaign-duration">Duration in billing periods (optional)</Label>
@@ -185,7 +187,7 @@ export const StepBenefit = ({
             <p className="text-xs text-muted-foreground">The code is unavailable at and after this instant.</p>
           </div>
         </div>
-      )}
+      ) : null}
 
       {isCampaign && !isFreeMonth && (
         <p className="text-xs text-muted-foreground">

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-review.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-review.tsx
@@ -55,16 +55,14 @@ export const StepReview = ({
               : `${formatMoney(toMinorUnits(Number(draft.amount || 0), draft.currencyCode), draft.currencyCode)} off`
           }
         />
-        {isCampaign && (
-          <Row
-            label="Meets the price's own discount"
-            value={
-              { BestDiscount: "Best discount wins", ReplaceBuiltIn: "Replaces it", Stack: "Stacks on top" }[
+        <Row
+          label="Meets the price's own discount"
+          value={draft.campaignPrecedence
+            ? { BestDiscount: "Best discount wins", ReplaceBuiltIn: "Replaces it", Stack: "Stacks on top" }[
                 draft.campaignPrecedence
               ]
-            }
-          />
-        )}
+            : "Uses the plan's discount policy (legacy behavior)"}
+        />
         {!isCampaign && draft.durationPeriods && (
           <Row label="Duration" value={`${draft.durationPeriods} billing periods`} />
         )}

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -445,7 +445,7 @@ export interface UpdateSubscriptionPriceTaxRequest {
  */
 export type CampaignKind = "Standard" | "FirstAnnualPeriod" | "FreeOpeningCalendarPeriod";
 
-/** How a campaign's reduction interacts with a price's own automatic and volume discounts. */
+/** How a Standard code or campaign reduction interacts with automatic and volume discounts. */
 export type CampaignPrecedence = "BestDiscount" | "ReplaceBuiltIn" | "Stack";
 
 /**
@@ -475,6 +475,8 @@ export interface SubscriptionDiscount {
   version: number;
   campaignKind: CampaignKind;
   campaignPrecedence: CampaignPrecedence;
+  /** False only for a legacy Standard discount that still follows the plan's combination policy. */
+  campaignPrecedenceConfigured?: boolean;
   /** The local dates a campaign authored them in, present only for a non-Standard campaign. */
   validFromDate: string | null;
   validThroughDate: string | null;

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2319,9 +2319,17 @@ GET /api/subscription-discounts?organizationId=org-1</code></pre>
         <tbody>
           <tr><td><code>kind</code></td><td><code>0</code> Percent<br><code>1</code> FixedAmount</td><td>Exactly one of <code>percentBasisPoints</code> or <code>amountMinor</code> is supplied. A fixed amount also requires <code>currencyCode</code>.</td></tr>
           <tr><td><code>campaignKind</code></td><td><code>Standard</code><br><code>FirstAnnualPeriod</code><br><code>FreeOpeningCalendarPeriod</code></td><td>Standard is an ordinary reusable code. Campaign kinds add a redemption window and special billing-period behavior.</td></tr>
-          <tr><td><code>campaignPrecedence</code></td><td><code>BestDiscount</code><br><code>ReplaceBuiltIn</code><br><code>Stack</code></td><td>Chooses the larger reduction; suppresses built-in discounts; or adds rates (capped at 100%). AMLora yearly campaigns use <code>ReplaceBuiltIn</code>.</td></tr>
+          <tr><td><code>campaignPrecedence</code></td><td><code>BestDiscount</code><br><code>ReplaceBuiltIn</code><br><code>Stack</code></td><td>Available for Standard codes and campaign offers. Chooses the larger reduction; suppresses built-in discounts; or stacks the code on the already-discounted subtotal. AMLora yearly campaigns use <code>ReplaceBuiltIn</code>.</td></tr>
         </tbody>
       </table>
+      <p class="prose">
+        Standard discounts created before configurable precedence keep following the plan's
+        <code>quantityDiscountCombinationPolicy</code>. Their response reports
+        <code>campaignPrecedenceConfigured: false</code>. Supplying
+        <code>campaignPrecedence</code> on create or update makes the selected rule explicit and the
+        response reports <code>true</code>. Omitting it through the API preserves the legacy behavior;
+        it never silently reprices an existing code.
+      </p>
       <p class="prose">
         Money in the API is minor units: CHF 290.00 is <code>29000</code>. Percentage rates are basis
         points: 8% is <code>800</code>, 10% is <code>1000</code>, and 20% is <code>2000</code>. The
@@ -2378,6 +2386,7 @@ GET /api/subscription-discounts?organizationId=org-1</code></pre>
     "version": 1,
     "campaignKind": "FirstAnnualPeriod",
     "campaignPrecedence": "ReplaceBuiltIn",
+    "campaignPrecedenceConfigured": true,
     "validFromDate": "2026-10-01",
     "validThroughDate": "2026-10-31",
     "timeZoneId": "Europe/Zurich",

--- a/server/Subscription.DomainService/Entities/Discount.cs
+++ b/server/Subscription.DomainService/Entities/Discount.cs
@@ -39,9 +39,8 @@ public sealed class Discount
     public long Version { get; set; }
 
     /// <summary>
-    /// Campaign behaviour layered on top of the ordinary percentage or fixed reduction above.
-    /// Always present, never null -- gated the same way <see cref="Price.BillingAlignment"/> gates
-    /// on its own zero value rather than on a nullable wrapper. A discount created before campaigns
+    /// Campaign and discount-composition behaviour layered on top of the ordinary percentage or
+    /// fixed reduction above. Always present, never null. A discount created before campaigns
     /// existed, or one a caller creates without naming a kind, deserializes with
     /// <see cref="CampaignTerms.Kind"/> at its zero value, <see cref="CampaignKind.Standard"/>,
     /// which every campaign-specific code path treats identically to "no campaign at all".
@@ -57,16 +56,25 @@ public sealed class Discount
 /// </summary>
 /// <remarks>
 /// One embedded document rather than a dozen fields flattened onto <see cref="Discount"/>, so
-/// every campaign-specific code path has a single thing to gate on --
-/// <c>discount.Campaign.Kind != CampaignKind.Standard</c> -- instead of remembering to check each
-/// field individually. An accidental campaign behaviour on an ordinary discount would otherwise be
-/// one missed <c>if</c> away.
+/// campaign-specific code paths have one embedded source of truth. Standard discounts use only the
+/// precedence fields; campaign windows, redemption rules and entitlement overrides remain gated on
+/// <c>discount.Campaign.Kind != CampaignKind.Standard</c>.
 /// </remarks>
 [BsonIgnoreExtraElements]
 public sealed class CampaignTerms
 {
     public CampaignKind Kind { get; set; } = CampaignKind.Standard;
     public CampaignPrecedence Precedence { get; set; } = CampaignPrecedence.BestDiscount;
+
+    /// <summary>
+    /// Whether a Standard discount explicitly chose how it meets built-in discounts.
+    /// </summary>
+    /// <remarks>
+    /// False is the backward-compatible value for every Standard discount stored before this
+    /// capability existed: it continues through the plan's QuantityDiscountCombinationPolicy.
+    /// Campaign kinds always use <see cref="Precedence"/> and do not depend on this marker.
+    /// </remarks>
+    public bool PrecedenceConfigured { get; set; }
 
     /// <summary>
     /// The campaign's own validity window, as the admin who authored it typed it -- calendar

--- a/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/CreateDiscountRequest.cs
@@ -19,7 +19,7 @@ public sealed class CreateDiscountRequest : ICampaignDiscountRequest
     public List<string> ApplicablePriceIds { get; set; } = [];
 
     public CampaignKind CampaignKind { get; set; } = CampaignKind.Standard;
-    public CampaignPrecedence CampaignPrecedence { get; set; } = CampaignPrecedence.BestDiscount;
+    public CampaignPrecedence? CampaignPrecedence { get; set; }
     public DateOnly? ValidFromDate { get; set; }
     public DateOnly? ValidThroughDate { get; set; }
 

--- a/server/Subscription.DomainService/Requests/ICampaignDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/ICampaignDiscountRequest.cs
@@ -22,7 +22,7 @@ public interface ICampaignDiscountRequest
     List<string> ApplicablePriceIds { get; }
 
     CampaignKind CampaignKind { get; }
-    CampaignPrecedence CampaignPrecedence { get; }
+    CampaignPrecedence? CampaignPrecedence { get; }
     DateOnly? ValidFromDate { get; }
     DateOnly? ValidThroughDate { get; }
     string? TimeZoneId { get; }

--- a/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
+++ b/server/Subscription.DomainService/Requests/UpdateDiscountRequest.cs
@@ -34,7 +34,7 @@ public sealed class UpdateDiscountRequest : ICampaignDiscountRequest
     public List<string> ApplicablePriceIds { get; set; } = [];
 
     public CampaignKind CampaignKind { get; set; } = CampaignKind.Standard;
-    public CampaignPrecedence CampaignPrecedence { get; set; } = CampaignPrecedence.BestDiscount;
+    public CampaignPrecedence? CampaignPrecedence { get; set; }
     public DateOnly? ValidFromDate { get; set; }
     public DateOnly? ValidThroughDate { get; set; }
     public string? TimeZoneId { get; set; }

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -22,6 +22,7 @@ public sealed class DiscountResponse
 
     public string CampaignKind { get; init; } = string.Empty;
     public string CampaignPrecedence { get; init; } = string.Empty;
+    public bool CampaignPrecedenceConfigured { get; init; }
     public DateOnly? ValidFromDate { get; init; }
     public DateOnly? ValidThroughDate { get; init; }
     public string? TimeZoneId { get; init; }

--- a/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/DiscountCatalogueService.cs
@@ -235,7 +235,11 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
 
         if (request.CampaignKind == CampaignKind.Standard)
         {
-            return new CampaignTerms();
+            return new CampaignTerms
+            {
+                Precedence = request.CampaignPrecedence ?? CampaignPrecedence.BestDiscount,
+                PrecedenceConfigured = request.CampaignPrecedence.HasValue
+            };
         }
 
         if (!BillingLocalTime.TryFindTimeZone(request.TimeZoneId, out var timeZone))
@@ -259,7 +263,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         return new CampaignTerms
         {
             Kind = request.CampaignKind,
-            Precedence = request.CampaignPrecedence,
+            Precedence = request.CampaignPrecedence ?? CampaignPrecedence.BestDiscount,
+            PrecedenceConfigured = true,
             ValidFromDate = from,
             ValidThroughDate = through,
             TimeZoneId = request.TimeZoneId,
@@ -543,6 +548,8 @@ public sealed class DiscountCatalogueService : IDiscountCatalogueService
         Version = item.Version,
         CampaignKind = item.Campaign.Kind.ToString(),
         CampaignPrecedence = item.Campaign.Precedence.ToString(),
+        CampaignPrecedenceConfigured =
+            item.Campaign.Kind != CampaignKind.Standard || item.Campaign.PrecedenceConfigured,
         ValidFromDate = item.Campaign.ValidFromDate,
         ValidThroughDate = item.Campaign.ValidThroughDate,
         TimeZoneId = item.Campaign.TimeZoneId,

--- a/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionAmountCalculator.cs
@@ -239,9 +239,10 @@ public static class SubscriptionAmountCalculator
         // QuantityOnly ("built-in discounts only, no code ever counts") would silently discard
         // every campaign ever run against it, which is not a plan author's decision to make about
         // a campaign they may not even know exists.
-        if (discount?.Campaign.Kind is { } campaignKind && campaignKind != CampaignKind.Standard)
+        if (discount?.Campaign is { } campaign &&
+            (campaign.Kind != CampaignKind.Standard || campaign.PrecedenceConfigured))
         {
-            switch (discount.Campaign.Precedence)
+            switch (campaign.Precedence)
             {
                 case CampaignPrecedence.ReplaceBuiltIn:
                 {

--- a/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/DiscountCatalogueServiceTests.cs
@@ -65,6 +65,32 @@ public sealed class DiscountCatalogueServiceTests
     }
 
     [Fact]
+    public async Task A_standard_discount_persists_an_explicit_precedence()
+    {
+        var request = Request();
+        request.CampaignPrecedence = CampaignPrecedence.ReplaceBuiltIn;
+
+        var result = await Service().CreateAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Campaign.Kind.Should().Be(CampaignKind.Standard);
+        _created.Campaign.Precedence.Should().Be(CampaignPrecedence.ReplaceBuiltIn);
+        _created.Campaign.PrecedenceConfigured.Should().BeTrue();
+        result.Value!.CampaignPrecedenceConfigured.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_omitted_standard_precedence_preserves_the_legacy_plan_policy()
+    {
+        var result = await Service().CreateAsync(Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _created!.Campaign.PrecedenceConfigured.Should().BeFalse();
+        result.Value!.CampaignPrecedence.Should().Be("BestDiscount");
+        result.Value.CampaignPrecedenceConfigured.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task Authoring_for_another_organization_validates_against_that_organizations_catalogue()
     {
         // The console authoring a customer's discount. Resolved against the organization named in the

--- a/server/XUnitTest/Subscription/SubscriptionAmountCalculatorCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionAmountCalculatorCampaignTests.cs
@@ -113,22 +113,62 @@ public sealed class SubscriptionAmountCalculatorCampaignTests
     }
 
     [Fact]
-    public void A_standard_discount_is_unaffected_by_any_of_this()
+    public void A_legacy_standard_discount_keeps_the_plans_existing_policy()
     {
-        // No Campaign at all -- the ordinary coupon path, exactly as SubscriptionAmountCalculatorTests
-        // already pins it, confirmed here specifically against a subscription that also carries an
-        // automatic discount, which is the shape every new branch above gates on.
         var subscription = new SubscriptionDetail
         {
-            Price = new PriceSnapshot { UnitAmountMinor = 10_000, AutomaticDiscountBasisPoints = 1_000 },
-            Plan = new PlanSnapshot(),
-            Discount = new DiscountTerms { Kind = DiscountKind.Percent, PercentBasisPoints = 2_000 }
+            Price = new PriceSnapshot { UnitAmountMinor = 10_000, AutomaticDiscountBasisPoints = 2_000 },
+            Plan = new PlanSnapshot
+            {
+                QuantityDiscountCombinationPolicy = QuantityDiscountCombinationPolicy.Stack
+            },
+            Discount = new DiscountTerms
+            {
+                Kind = DiscountKind.Percent,
+                PercentBasisPoints = 1_000,
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.Standard,
+                    Precedence = CampaignPrecedence.ReplaceBuiltIn,
+                    PrecedenceConfigured = false
+                }
+            }
         };
 
         var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
 
-        // Existing default-case behaviour: the larger of the two wins, ties to the promotion.
-        charge.AmountMinor.Should().Be(8_000);
+        charge.AmountMinor.Should().Be(7_200,
+            "the stored precedence was previously ignored, so an old record must still Stack through the plan");
+    }
+
+    [Fact]
+    public void A_standard_discount_with_explicit_precedence_overrides_the_plan_policy()
+    {
+        var subscription = new SubscriptionDetail
+        {
+            Price = new PriceSnapshot { UnitAmountMinor = 10_000, AutomaticDiscountBasisPoints = 2_000 },
+            Plan = new PlanSnapshot
+            {
+                QuantityDiscountCombinationPolicy = QuantityDiscountCombinationPolicy.Stack
+            },
+            Discount = new DiscountTerms
+            {
+                Kind = DiscountKind.Percent,
+                PercentBasisPoints = 1_000,
+                Campaign = new CampaignTerms
+                {
+                    Kind = CampaignKind.Standard,
+                    Precedence = CampaignPrecedence.ReplaceBuiltIn,
+                    PrecedenceConfigured = true
+                }
+            }
+        };
+
+        var charge = SubscriptionAmountCalculator.PeriodAmountMinor(subscription, Now);
+
+        charge.AmountMinor.Should().Be(9_000,
+            "the explicitly configured Standard code replaces the larger built-in discount");
+        charge.BuiltInDiscountMinor.Should().Be(0);
     }
 
     private static SubscriptionDetail NewSubscription(


### PR DESCRIPTION
## Summary
- show the discount-precedence selector for Standard discount codes
- persist and apply BestDiscount, ReplaceBuiltIn, or Stack on Standard discounts
- preserve the existing plan-policy behavior for legacy Standard records until an administrator explicitly chooses a rule
- expose campaignPrecedenceConfigured so edit UI and API clients can distinguish explicit configuration from legacy fallback
- document the request, response, and backward-compatibility behavior

## Verification
- targeted server tests: 21 passed
- full non-integration server suite: 3304 passed, 4 pre-existing SubscriptionSimulation permission-guard failures, 1 skipped
- campaign-builder client tests: 31 passed
- client type-check: passed
- changed-file ESLint: passed
- client production build: passed