### PR TITLE
feat(subscription): clarify the Standard discount duration field, pair its availability dates, and surface Discounts in the sidebar

### DIFF
--- a/client/app/constants/constants.test.ts
+++ b/client/app/constants/constants.test.ts
@@ -62,6 +62,57 @@ describe("navigationMenus", () => {
 
     expect(navigationMenus.some((menu) => hiddenMenuIds.has(menu.id))).toBe(false);
   });
+
+  /**
+   * The Discounts route has been wired in the router for some time, but nothing in the sidebar
+   * pointed at it, so the page was reachable only by typing its URL.
+   */
+  describe("the Subscriptions group", () => {
+    const children = () => {
+      const group = navigationMenus.find((menu) => menu.id === "subscription");
+      if (group?.type !== "menu" || !group.children) {
+        throw new Error("the Subscriptions group is a menu with children");
+      }
+      return group.children;
+    };
+
+    const ids = () => children().map((child) => child.id);
+
+    it("offers Discounts, pointing at the route the router declares", () => {
+      const discounts = children().find((child) => child.id === "subscription-discounts");
+
+      expect(discounts?.type).toBe("menu");
+      expect(discounts?.type === "menu" && discounts.name).toBe("Discounts");
+      expect(discounts?.type === "menu" && discounts.path).toBe("/app/subscription/discounts");
+    });
+
+    it("puts Discounts immediately after Plans", () => {
+      const order = ids();
+
+      expect(order.indexOf("subscription-discounts")).toBe(
+        order.indexOf("subscription-plans") + 1,
+      );
+    });
+
+    it("gives Discounts an icon, like every other entry in the group", () => {
+      const discounts = children().find((child) => child.id === "subscription-discounts");
+
+      expect(discounts?.type === "menu" && discounts.icon).toBeTruthy();
+    });
+
+    /**
+     * The organization scope is carried onto sidebar links by a prefix test on `/app/subscription`
+     * in `withSubscriptionOrganizationScope`. An entry authored under any other prefix would render
+     * a link that silently drops the organization in view, so this holds for the whole group rather
+     * than for Discounts alone.
+     */
+    it("authors every entry under the prefix the organization scope matches", () => {
+      for (const child of children()) {
+        if (child.type !== "menu") continue;
+        expect(child.path.startsWith("/app/subscription")).toBe(true);
+      }
+    });
+  });
 });
 
 describe("BLOCKS_PRODUCTS", () => {

--- a/client/app/constants/navigation-menus.ts
+++ b/client/app/constants/navigation-menus.ts
@@ -1,4 +1,5 @@
 import {
+  BadgePercent,
   Building2,
   CirclePlus,
   CreditCard,
@@ -83,6 +84,13 @@ export const navigationMenus: Menu[] = [
         name: "Plans",
         path: "/app/subscription/plans",
         icon: Layers,
+      },
+      {
+        id: "subscription-discounts",
+        type: "menu",
+        name: "Discounts",
+        path: "/app/subscription/discounts",
+        icon: BadgePercent,
       },
       {
         id: "subscription-invoices",

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
@@ -175,6 +175,22 @@ describe("stepProblems", () => {
     expect(stepProblems(2, draft, plans)).toContain("The discount must expire after it starts.");
   });
 
+  /**
+   * The message names the field by the label the form actually shows. Worth pinning: the two were
+   * out of step once already, leaving an error that named a control nobody could find.
+   */
+  it("step 2 refuses a fractional duration, naming the field as the form labels it", () => {
+    const draft = { ...EMPTY_DRAFT, durationPeriods: "2.5" };
+
+    expect(stepProblems(2, draft, plans)).toContain(
+      "Number of discounted billing periods must be a whole number greater than zero.",
+    );
+  });
+
+  it("step 2 accepts an empty duration, which is what no period limit looks like", () => {
+    expect(stepProblems(2, { ...EMPTY_DRAFT, durationPeriods: "" }, plans)).toHaveLength(0);
+  });
+
   it("step 3 refuses a campaign with no price named", () => {
     const draft = withCampaignKind(EMPTY_DRAFT, "FirstAnnualPeriod");
 

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
@@ -210,7 +210,9 @@ export const stepProblems = (
     if (draft.campaignKind === "Standard" && draft.durationPeriods.trim() !== "") {
       const duration = Number(draft.durationPeriods);
       if (!Number.isInteger(duration) || duration <= 0) {
-        problems.push("Duration in billing periods must be a whole number greater than zero.");
+        problems.push(
+          "Number of discounted billing periods must be a whole number greater than zero.",
+        );
       }
     }
 

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EMPTY_DRAFT, type CampaignDraft } from "./campaign-draft";
+import { StepBenefit } from "./step-benefit";
+
+const DURATION_LABEL = /Number of discounted billing periods \(optional\)/;
+
+const renderStep = (overrides: Partial<CampaignDraft> = {}) => {
+  const onChange = vi.fn();
+  render(<StepBenefit draft={{ ...EMPTY_DRAFT, ...overrides }} onChange={onChange} />);
+  return { onChange };
+};
+
+const durationInput = () => screen.getByLabelText(DURATION_LABEL);
+const startInput = () => screen.getByLabelText(/Starts at \(optional\)/);
+const expiryInput = () => screen.getByLabelText(/Expires at \(optional\)/);
+
+describe("StepBenefit duration field", () => {
+  it("names the field by what it counts, not by a bare 'duration'", () => {
+    renderStep();
+
+    expect(durationInput()).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Duration in billing periods/)).not.toBeInTheDocument();
+  });
+
+  /**
+   * The example is the whole point of the rename: "3" has to mean three charges, not three of
+   * something the reader has to guess at. Tied to the input with aria-describedby so it is read
+   * out rather than merely printed underneath.
+   */
+  it("explains what a number in it does, and announces that explanation", () => {
+    renderStep();
+
+    const help = screen.getByText(
+      /Example: 3 applies the discount to the next three charges\. Leave empty for no period limit\./,
+    );
+
+    expect(help).toBeInTheDocument();
+    expect(durationInput()).toHaveAttribute("aria-describedby", help.id);
+    expect(help.id).toBe("campaign-duration-help");
+  });
+
+  it("still reports what was typed as durationPeriods", () => {
+    const { onChange } = renderStep();
+
+    fireEvent.change(durationInput(), { target: { value: "3" } });
+
+    expect(onChange).toHaveBeenCalledWith({ durationPeriods: "3" });
+  });
+
+  it("shows the value it was given and stays a whole-number control", () => {
+    renderStep({ durationPeriods: "6" });
+
+    expect(durationInput()).toHaveValue(6);
+    expect(durationInput()).toHaveAttribute("type", "number");
+    expect(durationInput()).toHaveAttribute("min", "1");
+  });
+});
+
+describe("StepBenefit availability dates", () => {
+  /**
+   * The layout claim, asserted on the rendered tree rather than by reading the JSX: the two dates
+   * share one container, that container is the two-column responsive grid, and the duration field
+   * is outside it. A future edit that puts duration back into the grid fails here.
+   */
+  it("puts both dates in one responsive two-column row that excludes the duration field", () => {
+    renderStep();
+
+    const row = startInput().closest("div.grid");
+
+    expect(row).not.toBeNull();
+    expect(row).toBe(expiryInput().closest("div.grid"));
+    expect(row!.className).toContain("sm:grid-cols-2");
+    expect(row!.contains(durationInput())).toBe(false);
+  });
+
+  /** Below sm there is one column, so the pair stacks — a datetime-local control needs the width. */
+  it("declares no column count of its own, so the pair stacks on narrow screens", () => {
+    renderStep();
+
+    const row = startInput().closest("div.grid")!;
+
+    expect(row.className).not.toMatch(/(^|\s)grid-cols-/);
+  });
+
+  it("keeps both labels, both help texts, and both reported values", () => {
+    const { onChange } = renderStep({
+      startsAtUtc: "2026-10-01T09:30",
+      expiresAtUtc: "2026-10-31T18:00",
+    });
+
+    expect(startInput()).toHaveValue("2026-10-01T09:30");
+    expect(expiryInput()).toHaveValue("2026-10-31T18:00");
+    expect(
+      screen.getByText(/Leave empty to make the code available immediately\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/The code is unavailable at and after this instant\./)).toBeInTheDocument();
+
+    fireEvent.change(startInput(), { target: { value: "2026-11-01T00:00" } });
+    expect(onChange).toHaveBeenCalledWith({ startsAtUtc: "2026-11-01T00:00" });
+
+    fireEvent.change(expiryInput(), { target: { value: "2026-11-30T23:59" } });
+    expect(onChange).toHaveBeenCalledWith({ expiresAtUtc: "2026-11-30T23:59" });
+  });
+});
+
+/**
+ * The relayout lives inside the existing Standard-only branch. Campaign kinds set their own
+ * duration and validity server-side and must not gain these controls.
+ */
+describe("StepBenefit on campaign kinds", () => {
+  it.each(["FirstAnnualPeriod", "FreeOpeningCalendarPeriod"] as const)(
+    "offers neither a duration nor availability dates for %s",
+    (campaignKind) => {
+      renderStep({ campaignKind });
+
+      expect(screen.queryByLabelText(DURATION_LABEL)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/Starts at \(optional\)/)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/Expires at \(optional\)/)).not.toBeInTheDocument();
+    },
+  );
+});

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/step-benefit.tsx
@@ -155,36 +155,49 @@ export const StepBenefit = ({
       </div>
 
       {!isCampaign ? (
-        <div className="grid gap-5 sm:grid-cols-2">
+        <div className="space-y-5">
+          {/* On its own row. Sharing one with a date was what made this field read as part of the
+              availability window, when it counts charges rather than bounding a period of time. */}
           <div className="space-y-1.5">
-            <Label htmlFor="campaign-duration">Duration in billing periods (optional)</Label>
+            <Label htmlFor="campaign-duration">
+              Number of discounted billing periods (optional)
+            </Label>
             <Input
               id="campaign-duration"
               type="number"
               min={1}
               value={draft.durationPeriods}
               onChange={(event) => onChange({ durationPeriods: event.target.value })}
+              aria-describedby="campaign-duration-help"
             />
+            <p id="campaign-duration-help" className="text-xs text-muted-foreground">
+              Example: 3 applies the discount to the next three charges. Leave empty for no period
+              limit.
+            </p>
           </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="campaign-start">Starts at (optional)</Label>
-            <Input
-              id="campaign-start"
-              type="datetime-local"
-              value={draft.startsAtUtc}
-              onChange={(event) => onChange({ startsAtUtc: event.target.value })}
-            />
-            <p className="text-xs text-muted-foreground">Leave empty to make the code available immediately.</p>
-          </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="campaign-expiry">Expires at (optional)</Label>
-            <Input
-              id="campaign-expiry"
-              type="datetime-local"
-              value={draft.expiresAtUtc}
-              onChange={(event) => onChange({ expiresAtUtc: event.target.value })}
-            />
-            <p className="text-xs text-muted-foreground">The code is unavailable at and after this instant.</p>
+          {/* The two availability dates are one decision, so they sit as one pair. They stack
+              below sm, where a datetime-local control has no room to share a row. */}
+          <div className="grid gap-5 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="campaign-start">Starts at (optional)</Label>
+              <Input
+                id="campaign-start"
+                type="datetime-local"
+                value={draft.startsAtUtc}
+                onChange={(event) => onChange({ startsAtUtc: event.target.value })}
+              />
+              <p className="text-xs text-muted-foreground">Leave empty to make the code available immediately.</p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="campaign-expiry">Expires at (optional)</Label>
+              <Input
+                id="campaign-expiry"
+                type="datetime-local"
+                value={draft.expiresAtUtc}
+                onChange={(event) => onChange({ expiresAtUtc: event.target.value })}
+              />
+              <p className="text-xs text-muted-foreground">The code is unavailable at and after this instant.</p>
+            </div>
           </div>
         </div>
       ) : null}

--- a/client/app/cross-modules/utilities/subscription/utilities/subscription-navigation.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/subscription-navigation.test.ts
@@ -16,6 +16,7 @@ const menus = (): Menu[] => [
     path: "/app/subscription/plans",
     children: [
       { id: "plans", type: "menu", name: "Plans", path: "/app/subscription/plans" },
+      { id: "discounts", type: "menu", name: "Discounts", path: "/app/subscription/discounts" },
       { id: "invoices", type: "menu", name: "Invoices", path: "/app/subscription/invoices" },
       {
         id: "billing-profile",
@@ -101,6 +102,62 @@ describe("subscription menu scope", () => {
     expect(child(result, "invoices").path).toBe(
       "/app/subscription/invoices?organizationId=org%201%26admin%3Dtrue",
     );
+  });
+
+  /**
+   * Discounts is scoped by the same rule as every other subscription entry, without being named in
+   * it. Asserted anyway: the rule is a prefix test on the authored path, and an entry added under a
+   * path that does not start with `/app/subscription` would silently lose the scope.
+   */
+  it("carries the organization onto the Discounts link", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org-1",
+      "/app/project-1/subscription/plans",
+    );
+
+    expect(child(result, "discounts").path).toBe(
+      "/app/subscription/discounts?organizationId=org-1",
+    );
+  });
+
+  /**
+   * The highlighting case. The sidebar marks an entry active with
+   * `pathname.startsWith(menu.path)`, so the moment a query string is appended to the entry the
+   * reader is inside, the prefix stops matching and Discounts goes dark while the Discounts page is
+   * on screen. The guarantee this module provides is the clean path; the two assertions below are
+   * that guarantee and the prefix property that depends on it.
+   */
+  it("leaves the Discounts link clean while the Discounts page is open, so it stays highlighted", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org-1",
+      "/app/project-1/subscription/discounts",
+    );
+    const discounts = child(result, "discounts");
+
+    expect(discounts.path).toBe("/app/subscription/discounts");
+    expect(discounts.path).not.toContain("?");
+
+    // Why the clean path matters, as a property of the prefix test rather than of this module: the
+    // shell inserts the project segment into both sides before comparing, so model that here.
+    const rendered = discounts.path.replace("/app/", "/app/project-1/");
+    expect("/app/project-1/subscription/discounts".startsWith(rendered)).toBe(true);
+    expect(
+      "/app/project-1/subscription/discounts".startsWith(`${rendered}?organizationId=org-1`),
+    ).toBe(false);
+  });
+
+  /** The converse: being on Discounts must not strip the scope from the links leaving it. */
+  it("still scopes Plans and Invoices while the Discounts page is open", () => {
+    const result = withSubscriptionOrganizationScope(
+      menus(),
+      "org-1",
+      "/app/project-1/subscription/discounts",
+    );
+
+    expect(child(result, "plans").path).toBe("/app/subscription/plans?organizationId=org-1");
+    expect(child(result, "invoices").path).toBe("/app/subscription/invoices?organizationId=org-1");
   });
 
   it("keeps separators as they are", () => {


### PR DESCRIPTION
# 1 · Standard discount duration and date layout

## Why

On the campaign builder's **Benefit** step, the Standard-discount branch put three fields in one
`grid gap-5 sm:grid-cols-2`. With three children in two columns that produced:

```
[ Duration in billing periods ] [ Starts at ]
[ Expires at                  ]
```

So the duration sat beside a date and the second date wrapped onto a row of its own. The grouping
read as though all three described one availability window — but the duration counts *charges*,
while the two dates bound a period of *time*. "Duration in billing periods" did nothing to separate
the two ideas.

## What changed

```
[ Number of discounted billing periods (optional)              ]
  Example: 3 applies the discount to the next three charges.
  Leave empty for no period limit.

[ Starts at (optional)        ] [ Expires at (optional)        ]
```

- Renamed the label to **Number of discounted billing periods (optional)**.
- Added the example help text, tied to the input with `aria-describedby` so a screen reader
  announces it rather than it only being printed underneath. This matches how the amount field
  already wires its validation message.
- Duration takes a full-width row of its own; the outer container became `space-y-5`.
- **Starts at** and **Expires at** now share their own `grid gap-5 sm:grid-cols-2` — one pair,
  because they are one decision.
- Still stacks below the `sm` breakpoint. That pair row declares no unconditional `grid-cols-`, so
  on narrow screens it is a single column, which a `datetime-local` control needs.

### One change beyond the brief

`stepProblems` in `campaign-draft.ts` reported *"Duration in billing periods must be a whole number
greater than zero."* Renaming only the label would have left an error naming a control the form no
longer shows, so the message was renamed to match. Easy to drop if you'd rather it stay.

## What did not change

Presentation and wording only.

- Every submitted value: `durationPeriods`, `startsAtUtc`, `expiresAtUtc` are read and reported
  exactly as before, verified by assertions on the `onChange` payloads.
- Discount duration semantics, `toCreateDiscountRequest` / `toUpdateDiscountRequest`, the request
  DTOs, validation *rules* (only one message's wording), and the server contract.
- The relayout stays inside the pre-existing `!isCampaign` branch. Campaign kinds set their own
  duration and validity server-side and gain no controls here — asserted for both
  `FirstAnnualPeriod` and `FreeOpeningCalendarPeriod`.
- The review step's `Duration: 3 billing periods` row. It reads correctly standing alone and does
  not name a form control, so it was left as is.

## Tests

New `step-benefit.test.tsx` (9 tests) plus 2 cases in `campaign-draft.test.ts`.

The layout claim is asserted on the **rendered tree**, not by reading the JSX: both date inputs'
`closest("div.grid")` resolve to the same node, that node carries `sm:grid-cols-2`, and it does
**not** contain the duration input. Putting the duration back into the grid fails it.

**These tests were checked against the old code.** Reverting `step-benefit.tsx` and
`campaign-draft.ts` and re-running produces **6 failures**, including the structural one. The three
that still pass are the deliberate regression guards — labels, help texts, submitted values, and the
campaign-kind exclusions — which are supposed to hold both before and after.

## Verification

| | |
|---|---|
| `campaign-builder/` tests | 42 passed / 42 |
| Reverted-source control run | 6 failed, as designed |
| `tsc --noEmit` | clean |
| `tsc -b && vite build` | exit 0 |
| Full client suite | see below |

Lint on the changed directory reports 2 `react/no-unescaped-entities` errors, both pre-existing and
in lines this PR does not touch (`step-benefit.tsx:134`, `step-eligibility.tsx:226`). Nothing new.

`prettier --check` fails on **all 10** files in that directory on `dev`, so formatting is not
enforced there and `--write` was deliberately not run — it would have buried this change in an
unrelated reformat.

## Manual check worth doing on the preview

Resize across the `sm` breakpoint on the Benefit step of a **Standard** discount and confirm the two
dates stack rather than crowd. The responsive behaviour is asserted by class, not by an actual
viewport, so it is verified structurally rather than visually.

---

# 2 · Discounts in the left navigation

## Why

`router.tsx` has declared the route for some time:

```ts
{ path: "subscription/discounts", element: <SubscriptionDiscountsRoute /> }
```

Nothing in the sidebar pointed at it. The page worked, and was reachable only by typing or
bookmarking its URL.

## What changed

`navigation-menus.ts` — **Discounts** added to the Subscriptions group immediately after **Plans**,
`path: "/app/subscription/discounts"`, icon `BadgePercent` (confirmed present in the installed
`lucide-react`).

## The two behaviours that had to be verified

Both already work, by design rather than by luck. Asserted rather than assumed:

**`organizationId` is carried into the link.** `withSubscriptionOrganizationScope` matches
`menu.path.startsWith("/app/subscription")` — a prefix rule, not a list of entry ids — so a new
entry under that prefix is scoped without being named in it. The test covers the **whole group**,
not just Discounts: an entry authored under any other prefix would silently render a link that
drops the organization in view, and that is the failure mode worth a permanent test.

**It stays highlighted on the Discounts route.** The same function deliberately leaves the entry the
page is *already inside* unscoped, because the sidebar marks an entry active with
`pathname.startsWith(menu.path)` and a query string appended there matches nothing — Discounts would
go dark while the Discounts page is on screen. The parent **Subscriptions** group lights up too,
since `DesktopMenuItem` tests its children's paths as well as its own.

### One honest limit on how that second one is tested

The `/app/` → `/app/{itemId}/` rewrite happens inside `DashboardRoute` in
`@seliseblocks/genesis-os`, a dependency — not this repo. So the test asserts what this module
actually controls (the current entry's path stays query-free) plus the prefix property that depends
on it, with the rewrite modelled explicitly and labelled as a model. It does not claim to test the
shell.

## Tests

`subscription-navigation.test.ts` — `discounts` added to the fixture, plus 3 cases: scoped from
elsewhere; left clean on its own route with the prefix property shown both ways; and the converse,
that being on Discounts does not strip the scope from Plans and Invoices.

`constants.test.ts` — a `the Subscriptions group` block: Discounts exists with the router's path,
sits **immediately after** Plans (asserted by index, so a later insertion between them fails),
carries an icon, and every entry in the group is authored under the scoping prefix.

**Checked against the old code:** reverting `navigation-menus.ts` fails **3** of the new tests.

## Verification

| | |
|---|---|
| All affected test files | 67 passed / 67 |
| Reverted-`navigation-menus.ts` control run | 3 failed, as designed |
| `tsc --noEmit` | clean |
| ESLint on the 3 changed files | clean, no warnings |

## Note on the first commit's local suite run

My earlier local full-suite run reported 3 failures in `create-payment-provider-page.test.tsx` and
`oidc-card.test.tsx`. That was an artefact of my own environment, not the code: the worktree shares
`node_modules` through a Windows junction, vitest's `forks` pool cannot spawn workers through it, and
my `--pool=threads` override shares one process so module state leaks between test files. Both files
pass in isolation at `origin/dev`, and CI's `validate-client` — the real config — reported
**2412/2412 passing** on the first commit.
