### PR TITLE
feat(subscription): prepaid opening-stub upgrades (PR 2 of 3)

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -66,6 +66,14 @@ jobs:
       # our code. Left out of this filter they would be demonstrated nowhere, and a renewal that
       # silently dropped the target price would bill the new plan at the old rate.
       #
+      # OpeningStubUpgradeRecoveryIntegrationTests is named because an opening-stub upgrade settles
+      # a prepaid year the subscriber has already paid for, and the replacement year travels as a
+      # nested document inside a settlement reservation before being installed by an update
+      # definition that names one field. Both are claims about MongoDB rather than about our code:
+      # a reservation that round-trips without its replacement year promotes an upgrade that
+      # silently keeps the old annual figures, and the money has already moved by the time anyone
+      # could notice. Left out of this filter that would be demonstrated nowhere.
+      #
       # Several integration classes are still outside this filter and so run nowhere. Widening it
       # further belongs in its own change, since whatever it turns up would arrive as unrelated
       # failures on whichever pull request happened to widen it.
@@ -73,5 +81,5 @@ jobs:
         run: >-
           dotnet test server/XUnitTest/XUnitTest.csproj
           --no-restore
-          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests"
+          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests|FullyQualifiedName~OpeningStubUpgradeRecoveryIntegrationTests"
           --verbosity minimal

--- a/server/Payment.DomainService/Entities/SubscriptionSettlementBreakdown.cs
+++ b/server/Payment.DomainService/Entities/SubscriptionSettlementBreakdown.cs
@@ -33,6 +33,27 @@ public sealed class SubscriptionSettlementBreakdown
     /// banked credit instead of charging, which is why it is not simply the amount charged.
     /// </summary>
     public long NetSettlementMinor { get; set; }
+
+    /// <summary>
+    /// A second settlement, when this change also settles a prepaid annual period alongside the
+    /// opening stub it replaces. Null for every ordinary settlement, which is exactly one period.
+    /// </summary>
+    /// <remarks>
+    /// An upgrade taken during a calendar-aligned yearly subscription's opening stub, once that
+    /// stub's own year has already been paid for, settles two things at once: the days left on the
+    /// stub, and the difference between what the paid year cost and what it costs on the new terms.
+    /// The two are never netted before tax — a plan change can move the subscriber between tax
+    /// modes, so each side is its own subtraction with its own tax, and this is the second one.
+    /// <para>
+    /// <see cref="Outgoing"/>/<see cref="Target"/> above describe the stub in this shape; this
+    /// describes the annual period. Only the <em>top-level</em> <see cref="CreditConsumedMinor"/>
+    /// and <see cref="NetSettlementMinor"/> are the figures actually charged — credit is spent once
+    /// against the combined total, never against each side separately — so the same two fields on
+    /// this nested breakdown describe the annual side's own contribution before that combination,
+    /// for the invoice to explain rather than for anything to re-derive a charge from.
+    /// </para>
+    /// </remarks>
+    public SubscriptionSettlementBreakdown? Annual { get; set; }
 }
 
 /// <summary>One side of a settlement, priced as its own period and then prorated.</summary>

--- a/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
+++ b/server/Subscription.DomainService/Entities/PendingAnnualPeriod.cs
@@ -70,4 +70,39 @@ public sealed class PendingAnnualPeriod
 
     /// <summary>The payment that settled this year, once one has. Null while it is still owed.</summary>
     public string? PaymentDetailId { get; set; }
+
+    /// <summary>
+    /// A copy of this year naming <paramref name="paymentDetailId"/> as the payment that settled
+    /// it, or an unchanged copy when no payment was taken.
+    /// </summary>
+    /// <remarks>
+    /// A copy rather than a mutation, and applied at promotion rather than at reservation, because
+    /// the confirmed payment does not exist yet when the reservation is written. Mutating the
+    /// reserved instance afterwards changes only the copy in memory — the one already persisted
+    /// keeps the old id — so the request path and the recovery sweep would install different
+    /// payment references for the same settled operation, and which one a subscription ended up
+    /// with would depend on whether a process happened to die.
+    /// <para>
+    /// The adjustment's own payment, not the original year's: after a settlement the frozen
+    /// figures describe the new terms, and pointing at the payment that bought the old ones would
+    /// name an invoice for an amount this year no longer says it costs.
+    /// </para>
+    /// </remarks>
+    public PendingAnnualPeriod SettledBy(string? paymentDetailId) => new()
+    {
+        StartUtc = StartUtc,
+        EndUtc = EndUtc,
+        AmountMinor = AmountMinor,
+        NetAmountMinor = NetAmountMinor,
+        TaxAmountMinor = TaxAmountMinor,
+        GrossAmountMinor = GrossAmountMinor,
+        BuiltInDiscountMinor = BuiltInDiscountMinor,
+        PromotionalDiscountMinor = PromotionalDiscountMinor,
+        DiscountApplied = DiscountApplied,
+        CollectedWithCheckout = CollectedWithCheckout,
+        IsPrepaid = IsPrepaid,
+        // Nothing was charged — a settlement covered entirely by credit, say — so the payment that
+        // settled this year is still whichever one did.
+        PaymentDetailId = paymentDetailId is { Length: > 0 } ? paymentDetailId : PaymentDetailId
+    };
 }

--- a/server/Subscription.DomainService/Entities/SettlementReservation.cs
+++ b/server/Subscription.DomainService/Entities/SettlementReservation.cs
@@ -127,4 +127,15 @@ public sealed class ReservedPlanChange
     public PendingUsagePeriod OutgoingUsagePeriod { get; set; } = new();
 
     public long NewCreditBalanceMinor { get; set; }
+
+    /// <summary>
+    /// The prepaid annual period to install in place of the one this change settles alongside its
+    /// opening stub. Null for every ordinary plan change, which touches no annual period at all.
+    /// </summary>
+    /// <remarks>
+    /// Snapshotted at reservation time rather than recomputed on promotion, for the same reason as
+    /// every other field here: a crash between charge and promotion must apply exactly what was
+    /// charged for, not whatever the catalogue says now.
+    /// </remarks>
+    public PendingAnnualPeriod? ReplacementPendingAnnualPeriod { get; set; }
 }

--- a/server/Subscription.DomainService/Entities/SettlementReservation.cs
+++ b/server/Subscription.DomainService/Entities/SettlementReservation.cs
@@ -103,6 +103,12 @@ public sealed class ReservedQuantityChange
     public List<SubscriptionQuantityItem> RequestedQuantities { get; set; } = [];
 
     public long NewCreditBalanceMinor { get; set; }
+
+    /// <summary>
+    /// The prepaid annual period to install at the new quantity, when this increase settles the
+    /// stub and the annual period it already paid for together. Null for every ordinary increase.
+    /// </summary>
+    public PendingAnnualPeriod? ReplacementPendingAnnualPeriod { get; set; }
 }
 
 /// <summary>

--- a/server/Subscription.DomainService/Outbox/SubscriptionSettlementReservationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionSettlementReservationProcessor.cs
@@ -326,7 +326,8 @@ public sealed class SubscriptionSettlementReservationProcessor : ISubscriptionSe
                     quantity.NewCreditBalanceMinor,
                     paymentDetailId,
                     _events.CreateQuantityChanged(subscription, reservation.CorrelationId),
-                    cancellationToken),
+                    cancellationToken,
+                    quantity.ReplacementPendingAnnualPeriod),
             // A reservation with no payload cannot be applied and must not be released either: it
             // may have money behind it. Held for the alert below.
             _ => Task.FromResult(false)

--- a/server/Subscription.DomainService/Outbox/SubscriptionSettlementReservationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionSettlementReservationProcessor.cs
@@ -358,6 +358,7 @@ public sealed class SubscriptionSettlementReservationProcessor : ISubscriptionSe
         subscription.Price = plan.Price;
         subscription.QuantityItems = plan.QuantityItems;
         subscription.CreditBalanceMinor = plan.NewCreditBalanceMinor;
+        subscription.PendingAnnualPeriod = plan.ReplacementPendingAnnualPeriod ?? subscription.PendingAnnualPeriod;
 
         return _subscriptions.TryChangePlanAsync(
             subscription.TenantId,
@@ -372,7 +373,8 @@ public sealed class SubscriptionSettlementReservationProcessor : ISubscriptionSe
             plan.NewCreditBalanceMinor,
             paymentDetailId,
             _events.CreatePlanChanged(subscription, previousPlanCode, reservation.CorrelationId),
-            cancellationToken);
+            cancellationToken,
+            replacementPendingAnnualPeriod: plan.ReplacementPendingAnnualPeriod);
     }
 
     private async Task<bool> ReleaseAsync(

--- a/server/Subscription.DomainService/Outbox/SubscriptionSettlementReservationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionSettlementReservationProcessor.cs
@@ -327,7 +327,8 @@ public sealed class SubscriptionSettlementReservationProcessor : ISubscriptionSe
                     paymentDetailId,
                     _events.CreateQuantityChanged(subscription, reservation.CorrelationId),
                     cancellationToken,
-                    quantity.ReplacementPendingAnnualPeriod),
+                    // Stamped with the confirmed payment, as the request path stamps it.
+                    quantity.ReplacementPendingAnnualPeriod?.SettledBy(paymentDetailId)),
             // A reservation with no payload cannot be applied and must not be released either: it
             // may have money behind it. Held for the alert below.
             _ => Task.FromResult(false)
@@ -355,11 +356,16 @@ public sealed class SubscriptionSettlementReservationProcessor : ISubscriptionSe
 
         // In memory only: this copy is discarded when the pass ends, and the write below is what
         // persists the same terms.
+        // Stamped with the payment this recovery confirmed, exactly as the request path stamps it —
+        // see PendingAnnualPeriod.SettledBy. Without it the two paths would install different
+        // payment references for the same settled change.
+        var replacementAnnual = plan.ReplacementPendingAnnualPeriod?.SettledBy(paymentDetailId);
+
         subscription.Plan = plan.Plan;
         subscription.Price = plan.Price;
         subscription.QuantityItems = plan.QuantityItems;
         subscription.CreditBalanceMinor = plan.NewCreditBalanceMinor;
-        subscription.PendingAnnualPeriod = plan.ReplacementPendingAnnualPeriod ?? subscription.PendingAnnualPeriod;
+        subscription.PendingAnnualPeriod = replacementAnnual ?? subscription.PendingAnnualPeriod;
 
         return _subscriptions.TryChangePlanAsync(
             subscription.TenantId,
@@ -375,7 +381,7 @@ public sealed class SubscriptionSettlementReservationProcessor : ISubscriptionSe
             paymentDetailId,
             _events.CreatePlanChanged(subscription, previousPlanCode, reservation.CorrelationId),
             cancellationToken,
-            replacementPendingAnnualPeriod: plan.ReplacementPendingAnnualPeriod);
+            replacementPendingAnnualPeriod: replacementAnnual);
     }
 
     private async Task<bool> ReleaseAsync(

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -143,6 +143,12 @@ public interface ISubscriptionRepository
     /// Compare-and-set rather than a read-then-write so two administrators cannot both win: the
     /// loser is told to re-read rather than silently overwriting a seat count it never saw.
     /// </remarks>
+    /// <param name="replacementPendingAnnualPeriod">
+    /// Given only by an increase taken during a prepaid opening stub, which settles the stub and
+    /// the annual period together at the new quantity: the new frozen annual figures to install.
+    /// Null for every other quantity change, which leaves whatever annual period the subscription
+    /// already carries untouched.
+    /// </param>
     Task<bool> TryApplyQuantityChangeAsync(
         string tenantId,
         string subscriptionId,
@@ -152,7 +158,8 @@ public interface ISubscriptionRepository
         string? quantityChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
         CancellationToken cancellationToken,
-        SubscriptionDocumentSource? documentSource = null);
+        SubscriptionDocumentSource? documentSource = null,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null);
 
     /// <summary>
     /// Reserves an increase before it is charged, compare-and-set on the version.
@@ -185,7 +192,8 @@ public interface ISubscriptionRepository
         long newCreditBalanceMinor,
         string? quantityChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null);
 
     /// <summary>Withdraws a claim whose charge never succeeded, leaving the quantity untouched.</summary>
     Task<bool> TryReleaseSettlementAsync(

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -112,6 +112,13 @@ public interface ISubscriptionRepository
     /// settle. When given, it addresses the write in place of the version: the charge has already
     /// been taken, so a concurrent version bump must not be able to strand paid-for terms.
     /// </param>
+    /// <param name="replacementPendingAnnualPeriod">
+    /// Given only by an opening-stub upgrade that settled a prepaid annual period alongside its
+    /// stub: the new frozen annual figures to install in place of the old one. Left null for
+    /// every other plan change, which leaves whatever annual period the subscription already
+    /// carries untouched — an ordinary plan change has no annual period to touch, and passing null
+    /// here must never be read as "clear it".
+    /// </param>
     Task<bool> TryChangePlanAsync(
         string tenantId,
         string subscriptionId,
@@ -126,7 +133,8 @@ public interface ISubscriptionRepository
         string? planChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
         CancellationToken cancellationToken,
-        SubscriptionDocumentSource? documentSource = null);
+        SubscriptionDocumentSource? documentSource = null,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null);
 
     /// <summary>
     /// Moves a subscription's purchased quantity, compare-and-set on the version.

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -254,7 +254,8 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         string? planChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
         CancellationToken cancellationToken,
-        SubscriptionDocumentSource? documentSource = null)
+        SubscriptionDocumentSource? documentSource = null,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null)
     {
         ArgumentNullException.ThrowIfNull(newPlan);
         ArgumentNullException.ThrowIfNull(newPrice);
@@ -307,6 +308,17 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             update = update.Set(
                 subscription => subscription.LastRenewalPaymentDetailId,
                 planChangePaymentDetailId);
+        }
+
+        // Only an opening-stub upgrade passes this, replacing the prepaid annual period it just
+        // settled alongside its stub. Every other plan change omits it and leaves whatever annual
+        // period the subscription already carries exactly as it was — an ordinary change has none
+        // to touch, and this write must never be the thing that silently clears one.
+        if (replacementPendingAnnualPeriod is not null)
+        {
+            update = update.Set(
+                subscription => subscription.PendingAnnualPeriod,
+                replacementPendingAnnualPeriod);
         }
 
         var result = await Subscriptions(tenantId).UpdateOneAsync(

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -338,7 +338,8 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         string? quantityChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
         CancellationToken cancellationToken,
-        SubscriptionDocumentSource? documentSource = null)
+        SubscriptionDocumentSource? documentSource = null,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null)
     {
         ArgumentNullException.ThrowIfNull(newQuantityItems);
         ArgumentNullException.ThrowIfNull(outboxEvent);
@@ -367,6 +368,15 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             update = update.Set(
                 subscription => subscription.LastRenewalPaymentDetailId,
                 quantityChangePaymentDetailId);
+        }
+
+        // Only an increase taken during a prepaid opening stub passes this, replacing the annual
+        // period it just settled at the new quantity alongside its stub.
+        if (replacementPendingAnnualPeriod is not null)
+        {
+            update = update.Set(
+                subscription => subscription.PendingAnnualPeriod,
+                replacementPendingAnnualPeriod);
         }
 
         var result = await Subscriptions(tenantId).UpdateOneAsync(
@@ -413,7 +423,8 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         long newCreditBalanceMinor,
         string? quantityChangePaymentDetailId,
         SubscriptionOutboxEvent outboxEvent,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null)
     {
         ArgumentNullException.ThrowIfNull(newQuantityItems);
         ArgumentNullException.ThrowIfNull(outboxEvent);
@@ -434,6 +445,13 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
             update = update.Set(
                 subscription => subscription.LastRenewalPaymentDetailId,
                 quantityChangePaymentDetailId);
+        }
+
+        if (replacementPendingAnnualPeriod is not null)
+        {
+            update = update.Set(
+                subscription => subscription.PendingAnnualPeriod,
+                replacementPendingAnnualPeriod);
         }
 
         var result = await Subscriptions(tenantId).UpdateOneAsync(

--- a/server/Subscription.DomainService/Responses/SubscriptionFinancialDocumentResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionFinancialDocumentResponse.cs
@@ -160,6 +160,13 @@ public sealed class FinancialDocumentSettlementResponse
     public long CreditConsumedMinor { get; init; }
 
     public long NetSettlementMinor { get; init; }
+
+    /// <summary>
+    /// The prepaid annual period's own settlement, alongside this one, when a change taken during
+    /// a calendar-aligned yearly subscription's opening stub settled both together. Null for every
+    /// ordinary settlement.
+    /// </summary>
+    public FinancialDocumentSettlementResponse? Annual { get; init; }
 }
 
 public sealed class FinancialDocumentSettlementSideResponse

--- a/server/Subscription.DomainService/Services/FinancialDocumentHtmlTemplate.cs
+++ b/server/Subscription.DomainService/Services/FinancialDocumentHtmlTemplate.cs
@@ -341,12 +341,50 @@ public static class FinancialDocumentHtmlTemplate
     /// The subscriber asking why they were charged a part-month figure is asking about the period they
     /// left and the period they joined, and this is the only place a document can answer that.
     /// </remarks>
+    /// <summary>
+    /// Renders one settlement — or two, when a prepaid opening-stub upgrade settled the stub and
+    /// the annual period it already paid for together.
+    /// </summary>
+    /// <remarks>
+    /// Two sections share one combined total rather than each carrying its own: credit was spent
+    /// once against the combination, not against either side in isolation — see
+    /// <see cref="Payment.DomainService.Entities.SubscriptionSettlementBreakdown.Annual"/> — so a
+    /// per-section credit-and-net line would either double-count it or have to be left blank on
+    /// one side, either of which reads as a mistake rather than as the two-part settlement it is.
+    /// </remarks>
     private static void AppendSettlement(
         StringBuilder html,
         Payment.DomainService.Entities.SubscriptionSettlementBreakdown settlement,
         FinancialDocumentMoneyFormatter money)
     {
-        html.Append("<div class=\"label spaced\">How this change was settled</div>");
+        var isComposite = settlement.Annual is not null;
+
+        html.Append("<div class=\"label spaced\">")
+            .Append(Escape(isComposite ? "Opening stub adjustment" : "How this change was settled"))
+            .Append("</div>");
+        AppendSettlementSection(html, settlement, money, showOwnTotal: !isComposite);
+
+        if (settlement.Annual is { } annual)
+        {
+            html.Append("<div class=\"label spaced\">Prepaid annual-period adjustment</div>");
+            AppendSettlementSection(html, annual, money, showOwnTotal: false);
+
+            html.Append("<table class=\"totals\">");
+            if (settlement.CreditConsumedMinor != 0)
+            {
+                AppendTotalRow(html, "Account credit applied", money, -settlement.CreditConsumedMinor);
+            }
+            AppendTotalRow(html, "Net settlement", money, settlement.NetSettlementMinor, strong: true);
+            html.Append("</table>");
+        }
+    }
+
+    private static void AppendSettlementSection(
+        StringBuilder html,
+        Payment.DomainService.Entities.SubscriptionSettlementBreakdown settlement,
+        FinancialDocumentMoneyFormatter money,
+        bool showOwnTotal)
+    {
         html.Append("<table class=\"lines\"><thead><tr><th></th>");
         html.Append("<th class=\"num\">Previous terms</th>");
         html.Append("<th class=\"num\">New terms</th></tr></thead><tbody>");
@@ -371,12 +409,16 @@ public static class FinancialDocumentHtmlTemplate
         AppendTotalRow(html, "Remaining value on new terms", money,
             settlement.Target.ProratedValueMinor);
 
-        if (settlement.CreditConsumedMinor != 0)
+        if (showOwnTotal)
         {
-            AppendTotalRow(html, "Account credit applied", money, -settlement.CreditConsumedMinor);
+            if (settlement.CreditConsumedMinor != 0)
+            {
+                AppendTotalRow(html, "Account credit applied", money, -settlement.CreditConsumedMinor);
+            }
+
+            AppendTotalRow(html, "Net settlement", money, settlement.NetSettlementMinor, strong: true);
         }
 
-        AppendTotalRow(html, "Net settlement", money, settlement.NetSettlementMinor, strong: true);
         html.Append("</table>");
     }
 

--- a/server/Subscription.DomainService/Services/SettlementCharge.cs
+++ b/server/Subscription.DomainService/Services/SettlementCharge.cs
@@ -65,6 +65,31 @@ internal static class SettlementCharge
         };
     }
 
+    /// <summary>
+    /// The composite arithmetic of an opening-stub upgrade in the shape a payment record stores:
+    /// the stub at top level, the prepaid year nested beneath it.
+    /// </summary>
+    /// <remarks>
+    /// Only the top-level <see cref="SubscriptionSettlementBreakdown.CreditConsumedMinor"/> and
+    /// <see cref="SubscriptionSettlementBreakdown.NetSettlementMinor"/> are the figures actually
+    /// charged — see <see cref="OpeningStubUpgradeOutcome"/> — the nested <c>Annual</c> breakdown
+    /// carries the annual side's own raw figures purely for the invoice to explain.
+    /// </remarks>
+    public static SubscriptionSettlementBreakdown BreakdownOf(OpeningStubUpgradeOutcome outcome) => new()
+    {
+        Outgoing = SideOf(outcome.Stub.Outgoing),
+        Target = SideOf(outcome.Stub.Target),
+        CreditConsumedMinor = outcome.CreditConsumedMinor,
+        NetSettlementMinor = outcome.NetSettlementMinor,
+        Annual = new SubscriptionSettlementBreakdown
+        {
+            Outgoing = SideOf(outcome.Annual.Outgoing),
+            Target = SideOf(outcome.Annual.Target),
+            CreditConsumedMinor = 0,
+            NetSettlementMinor = outcome.Annual.NetSettlementMinor
+        }
+    };
+
     private static SubscriptionSettlementSide SideOf(ProrationSide side) => new()
     {
         GrossAmountMinor = side.GrossAmountMinor,

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -294,26 +294,56 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
         var r = resolved.Value!;
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
-            r.Subscription,
-            r.NewPlan,
-            r.NewPrice,
-            r.Quantities,
-            r.Now,
-            r.NewSchedule.CurrentPeriodStartUtc,
-            r.NewSchedule.CurrentPeriodEndUtc,
-            r.NewSchedule.FeePeriodFraction);
+        // Quoted through the identical composite calculation ChargeAndApplyAsync would charge it
+        // with — see the parallel branch there — so a preview never quotes a price the confirm
+        // would not actually collect.
+        long chargeMinor;
+        long rawSettlementMinor;
+        long targetPeriodTotalMinor;
+        FinancialDocumentSettlementResponse settlementResponse;
+
+        if (r.Subscription.PendingAnnualPeriod is { IsPrepaid: true } prepaidAnnual &&
+            !PlanChangeClassifier.ChangesCadenceOrAlignment(r.Subscription.Price, r.NewPrice))
+        {
+            var stubUpgrade = SubscriptionProrationCalculator.CalculateOpeningStubUpgrade(
+                r.Subscription,
+                r.NewPlan,
+                r.NewPrice,
+                r.Quantities,
+                prepaidAnnual,
+                r.Now,
+                r.NewSchedule.FeePeriodFraction);
+
+            chargeMinor = stubUpgrade.ChargeMinor;
+            rawSettlementMinor = stubUpgrade.RawSettlementMinor;
+            targetPeriodTotalMinor = stubUpgrade.Annual.Target.PeriodTotalMinor;
+            settlementResponse = SettlementResponseOf(stubUpgrade);
+        }
+        else
+        {
+            var outcome = SubscriptionProrationCalculator.Calculate(
+                r.Subscription,
+                r.NewPlan,
+                r.NewPrice,
+                r.Quantities,
+                r.Now,
+                r.NewSchedule.CurrentPeriodStartUtc,
+                r.NewSchedule.CurrentPeriodEndUtc,
+                r.NewSchedule.FeePeriodFraction);
+
+            chargeMinor = outcome.ChargeMinor;
+            rawSettlementMinor =
+                outcome.Breakdown.Target.ProratedValueMinor - outcome.Breakdown.Outgoing.ProratedValueMinor;
+            targetPeriodTotalMinor = outcome.Breakdown.Target.PeriodTotalMinor;
+            settlementResponse = SettlementResponseOf(outcome.Breakdown);
+        }
 
         var blockers = new List<SubscriptionPreviewBlockerResponse>(r.Blockers);
 
         // Quoted by the same rule the confirm applies, from the same settlement — a preview that
         // said "immediate" for a change the confirm then scheduled would be quoting a different
         // operation than the one it is previewing.
-        var timing = PlanChangeClassifier.Classify(
-            r.Subscription,
-            r.NewPrice,
-            outcome.Breakdown.Target.ProratedValueMinor -
-                outcome.Breakdown.Outgoing.ProratedValueMinor);
+        var timing = PlanChangeClassifier.Classify(r.Subscription, r.NewPrice, rawSettlementMinor);
 
         // The dates and schedule the change would actually land on. A scheduled change is derived
         // from the instant it becomes effective, exactly as the confirm derives it — quoting the
@@ -336,7 +366,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         // Gated on the timing rather than on the amount: a scheduled cadence change can settle to
         // a positive figure and still take nothing now, and demanding a card for it would block a
         // change that is not going to charge anybody for weeks.
-        if (timing == PlanChangeTiming.Immediate && outcome.ChargeMinor > 0)
+        if (timing == PlanChangeTiming.Immediate && chargeMinor > 0)
         {
             var account = await _billingAccounts.GetAsync(
                 r.Subscription.TenantId,
@@ -368,7 +398,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                     UnitLabel = item.UnitLabel,
                     Quantity = item.Quantity
                 })],
-                ChargeMinor = outcome.ChargeMinor,
+                ChargeMinor = chargeMinor,
                 Timing = timing.ToString(),
                 EffectiveAtUtc = effectiveAtUtc,
                 // Explicitly zero. Nothing banks credit any more, and this used to report
@@ -377,12 +407,14 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 // CHF 50 for them. Kept on the response for compatibility, and now always zero;
                 // credit actually spent is reported by settlement.creditConsumedMinor.
                 CreditBankedMinor = 0,
-                Settlement = SettlementResponseOf(outcome.Breakdown),
+                Settlement = settlementResponse,
                 NewPeriodStartUtc = quotedSchedule.CurrentPeriodStartUtc,
                 NewPeriodEndUtc = quotedSchedule.CurrentPeriodEndUtc,
                 // Already the whole target period, tax included, undiminished by proration — see
-                // ProrationSide.PeriodTotalMinor — so there is nothing left to compute here.
-                NextRenewalAmountMinor = outcome.Breakdown.Target.PeriodTotalMinor,
+                // ProrationSide.PeriodTotalMinor — so there is nothing left to compute here. For an
+                // opening-stub upgrade this is the target annual period's own total, which is the
+                // figure that will actually recur once the year opens.
+                NextRenewalAmountMinor = targetPeriodTotalMinor,
                 Blockers = blockers,
                 QuotedAtUtc = r.Now
             },
@@ -1572,6 +1604,28 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             TaxAmountMinor = side.TaxAmountMinor,
             PeriodTotalMinor = side.PeriodTotalMinor,
             ProratedValueMinor = side.ProratedValueMinor
+        };
+
+    /// <summary>
+    /// The composite settlement of an opening-stub upgrade, quoted the same way
+    /// <see cref="ChargeAndApplyOpeningStubUpgradeAsync"/> is about to charge it: the stub at top
+    /// level, the prepaid year nested beneath it, one combined credit-and-net total.
+    /// </summary>
+    private static FinancialDocumentSettlementResponse SettlementResponseOf(
+        OpeningStubUpgradeOutcome outcome) =>
+        new()
+        {
+            Outgoing = SettlementSideResponseOf(outcome.Stub.Outgoing),
+            Target = SettlementSideResponseOf(outcome.Stub.Target),
+            CreditConsumedMinor = outcome.CreditConsumedMinor,
+            NetSettlementMinor = outcome.NetSettlementMinor,
+            Annual = new FinancialDocumentSettlementResponse
+            {
+                Outgoing = SettlementSideResponseOf(outcome.Annual.Outgoing),
+                Target = SettlementSideResponseOf(outcome.Annual.Target),
+                CreditConsumedMinor = 0,
+                NetSettlementMinor = outcome.Annual.NetSettlementMinor
+            }
         };
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -947,9 +947,9 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             DiscountApplied = stubUpgrade.TargetAnnualDiscountApplied,
             CollectedWithCheckout = currentAnnual.CollectedWithCheckout,
             IsPrepaid = true,
-            // Carried over by default — the original payment still stands behind this year unless
-            // a new charge below settles the difference, in which case that charge takes its place
-            // as the payment that most recently settled it.
+            // Carried as reserved. The adjustment's own payment is stamped on at promotion by
+            // PendingAnnualPeriod.SettledBy, which the recovery sweep applies identically — see its
+            // remarks on why this must not be mutated onto the reserved instance here.
             PaymentDetailId = currentAnnual.PaymentDetailId
         };
 
@@ -1062,13 +1062,13 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             return charge.ToFailure<SubscriptionResponse>();
         }
 
-        replacementAnnual.PaymentDetailId = charge.Value;
-
         return await ApplyAsync(
             subscription, newPlan, newPrice, quantities, compositeSchedule,
             stubUpgrade.NewCreditBalanceMinor, charge.Value, reservation.ReservationId,
             correlationId, cancellationToken,
-            reservation.Settlement, requestedByUserId, replacementAnnual);
+            reservation.Settlement, requestedByUserId,
+            // Exactly what the recovery sweep would install for this same reservation and payment.
+            reservation.PlanChange!.ReplacementPendingAnnualPeriod!.SettledBy(charge.Value));
     }
 
 

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -660,6 +660,40 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         string correlationId,
         CancellationToken cancellationToken)
     {
+        // A prepaid opening stub, moving onto a plan that keeps the subscriber's calendar boundary,
+        // settles the stub and the year it already paid for together rather than being refused
+        // outright — see ChargeAndApplyOpeningStubUpgradeAsync. Every other case falls through to
+        // the ordinary path below: an unpaid stub is still refused there, and a prepaid stub moving
+        // cadence or alignment is already routed to ScheduleAsync by Classify's own check, since
+        // re-cadencing a paid annual term can never be priced against it mid-commitment.
+        if (subscription.PendingAnnualPeriod is { IsPrepaid: true } prepaidAnnual &&
+            !PlanChangeClassifier.ChangesCadenceOrAlignment(subscription.Price, newPrice))
+        {
+            var stubUpgrade = SubscriptionProrationCalculator.CalculateOpeningStubUpgrade(
+                subscription,
+                newPlan,
+                newPrice,
+                quantities,
+                prepaidAnnual,
+                now,
+                newSchedule.FeePeriodFraction);
+
+            // Classified on the combined delta, not the stub's alone: a nominally-positive stub
+            // settlement paired with a strongly negative annual one is a real downgrade, and
+            // classifying by the stub alone would charge it today instead of waiting for the year.
+            if (PlanChangeClassifier.Classify(subscription, newPrice, stubUpgrade.RawSettlementMinor)
+                == PlanChangeTiming.NextRenewal)
+            {
+                return await ScheduleAsync(
+                    subscription, newPlan, newPrice, quantities, now,
+                    requestedByUserId, correlationId, cancellationToken);
+            }
+
+            return await ChargeAndApplyOpeningStubUpgradeAsync(
+                subscription, newPlan, newPrice, quantities, newSchedule, prepaidAnnual,
+                stubUpgrade, now, requestedByUserId, correlationId, cancellationToken);
+        }
+
         var outcome = SubscriptionProrationCalculator.Calculate(
             subscription,
             newPlan,
@@ -687,27 +721,19 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 requestedByUserId, correlationId, cancellationToken);
         }
 
-        // An immediate change against a paid-but-unopened year would have to settle the stub and
-        // the year as two independent periods, which nothing here does yet. Refused rather than
-        // priced against the stub alone, which would undercharge for a year already collected.
-        //
-        // Only the immediate path: a scheduled change reaches none of this, moves no money, and is
-        // exactly what an opening-stub subscriber should be able to ask for.
-        if (subscription.PendingAnnualPeriod is { } opening)
+        // Only an unpaid stub reaches this any more: a prepaid one was intercepted above, whether
+        // it settled immediately or was routed to ScheduleAsync. The opening charge has not
+        // cleared yet, so there is nothing paid to settle a plan change against — it must wait
+        // until the opening charge either succeeds (making it prepaid, and eligible for the
+        // composite path above on the next attempt) or the subscription is cancelled.
+        if (subscription.PendingAnnualPeriod is { IsPrepaid: false })
         {
-            return opening.IsPrepaid
-                ? Failure(
-                    PaymentFailureKind.Conflict,
-                    "subscription_initial_annual_period_prepaid",
-                    "This subscription has already paid for its first year, so it cannot move onto "
-                        + "another plan until that year begins. A downgrade can be scheduled now.",
-                    correlationId)
-                : Failure(
-                    PaymentFailureKind.Conflict,
-                    "subscription_initial_annual_period_unpaid",
-                    "This subscription's first year has not been charged yet, so it cannot move "
-                        + "onto another plan until it is. A downgrade can be scheduled now.",
-                    correlationId);
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_initial_annual_period_unpaid",
+                "This subscription's first year has not been charged yet, so it cannot move "
+                    + "onto another plan until it is. A downgrade can be scheduled now.",
+                correlationId);
         }
 
         if (outcome.ChargeMinor <= 0)
@@ -835,6 +861,182 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             outcome.NewCreditBalanceMinor, charge.Value, reservation.ReservationId,
             correlationId, cancellationToken,
             reservation.Settlement, requestedByUserId);
+    }
+
+    /// <summary>
+    /// Settles a prepaid opening stub's remaining days and the annual period it already paid for,
+    /// together, once <see cref="ChargeAndApplyAsync"/> has decided the change belongs today.
+    /// </summary>
+    /// <remarks>
+    /// The stub itself does not move — only its price does. <paramref name="newSchedule"/> was
+    /// resolved fresh at <paramref name="now"/> purely for pricing — its
+    /// <see cref="SubscriptionPlanSchedule.FeePeriodFraction"/> is exactly the days remaining on
+    /// the stub — but its own <c>CurrentPeriodStartUtc</c>/<c>EndUtc</c> describe a period anchored
+    /// on today rather than the stub the subscriber is actually partway through. Applying it
+    /// verbatim would silently move the subscription's period-start date to today, so this method
+    /// keeps the subscription's own stub bounds and only swaps the recurring cadence descriptor and
+    /// usage schedule the target carries going forward — the compatible-alignment guarantee the
+    /// caller already checked means the derived cadence is equivalent to what is already in force.
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<SubscriptionResponse>> ChargeAndApplyOpeningStubUpgradeAsync(
+        SubscriptionDetail subscription,
+        PlanSnapshot newPlan,
+        PriceSnapshot newPrice,
+        List<SubscriptionQuantityItem> quantities,
+        SubscriptionPlanSchedule newSchedule,
+        PendingAnnualPeriod currentAnnual,
+        OpeningStubUpgradeOutcome stubUpgrade,
+        DateTime now,
+        string? requestedByUserId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var compositeSchedule = newSchedule with
+        {
+            CurrentPeriodStartUtc = subscription.CurrentPeriodStartUtc,
+            CurrentPeriodEndUtc = subscription.CurrentPeriodEndUtc,
+            NextFeeBillingAtUtc = subscription.CurrentPeriodEndUtc,
+            FeePeriodFraction = default
+        };
+
+        // The same dates the stub already carries — this settles what the year costs, not when it
+        // runs. Everything else about it is repriced onto the target's own terms.
+        var replacementAnnual = new PendingAnnualPeriod
+        {
+            StartUtc = currentAnnual.StartUtc,
+            EndUtc = currentAnnual.EndUtc,
+            AmountMinor = stubUpgrade.Annual.Target.ProratedValueMinor,
+            NetAmountMinor = stubUpgrade.Annual.Target.ProratedValueMinor
+                - stubUpgrade.Annual.Target.TaxAmountMinor,
+            TaxAmountMinor = stubUpgrade.Annual.Target.TaxAmountMinor,
+            GrossAmountMinor = stubUpgrade.Annual.Target.GrossAmountMinor,
+            BuiltInDiscountMinor = stubUpgrade.Annual.Target.BuiltInDiscountMinor,
+            PromotionalDiscountMinor = stubUpgrade.Annual.Target.PromotionalDiscountMinor,
+            DiscountApplied = stubUpgrade.TargetAnnualDiscountApplied,
+            CollectedWithCheckout = currentAnnual.CollectedWithCheckout,
+            IsPrepaid = true,
+            // Carried over by default — the original payment still stands behind this year unless
+            // a new charge below settles the difference, in which case that charge takes its place
+            // as the payment that most recently settled it.
+            PaymentDetailId = currentAnnual.PaymentDetailId
+        };
+
+        if (stubUpgrade.ChargeMinor <= 0)
+        {
+            // Credit alone covers the combined settlement. It applies now, exactly as an ordinary
+            // credit-covered upgrade does, and the balance it spent is written with it.
+            return await ApplyAsync(
+                subscription, newPlan, newPrice, quantities, compositeSchedule,
+                stubUpgrade.NewCreditBalanceMinor, null, null, correlationId, cancellationToken,
+                SettlementCharge.BreakdownOf(stubUpgrade), requestedByUserId, replacementAnnual);
+        }
+
+        var account = await _billingAccounts.GetAsync(
+            subscription.TenantId,
+            subscription.BillingAccountId,
+            cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(account?.DefaultPaymentMethodId))
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_change_no_payment_method",
+                "This upgrade cannot be charged without a saved payment method.",
+                correlationId);
+        }
+
+        var reservation = new SettlementReservation
+        {
+            ReservationId = Guid.NewGuid().ToString("N"),
+            Kind = SettlementReservationKind.PlanChange,
+            PlanChange = new ReservedPlanChange
+            {
+                Plan = newPlan,
+                Price = newPrice,
+                QuantityItems = quantities,
+                Schedule = compositeSchedule,
+                OutgoingUsagePeriod = await SnapshotOutgoingUsagePeriodAsync(
+                    subscription, correlationId, cancellationToken),
+                NewCreditBalanceMinor = stubUpgrade.NewCreditBalanceMinor,
+                ReplacementPendingAnnualPeriod = replacementAnnual
+            },
+            ChargeAmountMinor = stubUpgrade.ChargeMinor,
+            Settlement = SettlementCharge.BreakdownOf(stubUpgrade),
+            RequestedByUserId = requestedByUserId,
+            BillingAccountId = subscription.BillingAccountId,
+            ProviderName = account.ProviderName,
+            ProviderOrganizationId = account.ProviderOrganizationId,
+            ProviderCustomerId = account.ProviderCustomerId,
+            StoredPaymentMethodId = account.DefaultPaymentMethodId,
+            ReservedAtUtc = now,
+            CorrelationId = correlationId,
+            ReservedAtVersion = subscription.Version
+        };
+
+        if (!await _subscriptions.TryReserveSettlementAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                subscription.Version,
+                reservation,
+                cancellationToken))
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_plan_change_conflict",
+                "The subscription changed while this plan change was being applied.",
+                correlationId);
+        }
+
+        if (_scheduler is not null)
+        {
+            await _scheduler.ScheduleReservationRecoveryAsync(
+                subscription, reservation, correlationId, cancellationToken);
+        }
+
+        var charge = await _gateway.ChargeAsync(
+            SettlementCharge.RequestFor(subscription, reservation),
+            SettlementCharge.KeyFor(subscription, reservation),
+            correlationId,
+            cancellationToken);
+
+        if (!charge.IsSuccess)
+        {
+            _logger.LogWarning(
+                "Subscription opening-stub upgrade was not charged TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} Kind={Kind} Reason={Reason}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                charge.FailureKind,
+                PaymentLogValue.Label(charge.ErrorCode ?? "unknown"));
+
+            if (!SettledFailureKinds.Contains(charge.FailureKind))
+            {
+                _logger.LogError(
+                    "A subscription opening-stub upgrade left its charge unanswered and is held " +
+                    "for reconciliation SubscriptionHash={SubscriptionHash} Kind={Kind}",
+                    PaymentLogValue.Hash(subscription.ItemId),
+                    charge.FailureKind);
+
+                return Failure(
+                    charge.FailureKind,
+                    "subscription_plan_change_charge_unresolved",
+                    "The charge for this plan change could not be confirmed. " +
+                    "Re-read the subscription before trying again.",
+                    correlationId);
+            }
+
+            await ReleaseAsync(subscription, reservation, cancellationToken);
+
+            return charge.ToFailure<SubscriptionResponse>();
+        }
+
+        replacementAnnual.PaymentDetailId = charge.Value;
+
+        return await ApplyAsync(
+            subscription, newPlan, newPrice, quantities, compositeSchedule,
+            stubUpgrade.NewCreditBalanceMinor, charge.Value, reservation.ReservationId,
+            correlationId, cancellationToken,
+            reservation.Settlement, requestedByUserId, replacementAnnual);
     }
 
 
@@ -972,7 +1174,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         string correlationId,
         CancellationToken cancellationToken,
         SubscriptionSettlementBreakdown? settlement = null,
-        string? initiatedByUserId = null)
+        string? initiatedByUserId = null,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null)
     {
         var previousPlanCode = subscription.Plan.Code;
         var expectedVersion = subscription.Version;
@@ -997,6 +1200,14 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         subscription.NextUsageBillingAtUtc = newSchedule.NextUsageBillingAtUtc;
         subscription.CreditBalanceMinor = newCreditBalanceMinor;
 
+        // Only an opening-stub upgrade passes this, replacing the prepaid annual period it just
+        // settled alongside its stub with the new one priced on the target's terms. Left as-is
+        // otherwise: an ordinary plan change touches no annual period at all.
+        if (replacementPendingAnnualPeriod is not null)
+        {
+            subscription.PendingAnnualPeriod = replacementPendingAnnualPeriod;
+        }
+
         var outboxEvent = _events.CreatePlanChanged(
             subscription,
             previousPlanCode,
@@ -1014,7 +1225,8 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             newCreditBalanceMinor,
             paymentDetailId,
             outboxEvent,
-            cancellationToken);
+            cancellationToken,
+            replacementPendingAnnualPeriod: replacementPendingAnnualPeriod);
 
         if (!applied)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -214,12 +214,29 @@ public static class SubscriptionProrationCalculator
         // Priced exactly as SubscriptionCreationService.BuildPendingAnnualPeriod prices the year at
         // signup: the whole period, the subscriber's own discount included, at the target price's
         // own tax rate and mode.
+        //
+        // At the index that priced the year being replaced, not at the subscription's current one.
+        // A prepaid year has already spent its promotional period — the activation that collected
+        // it counted one, and SubscriptionRenewalService deliberately does not count a second when
+        // the year opens ("a prepaid year reduced it once already"). Repricing the replacement at
+        // the current index would therefore treat a one-period promotion as exhausted and quote the
+        // year undiscounted, so the upgrade would charge the plan difference *plus* repayment of a
+        // discount the subscriber has already been granted for this very period.
+        //
+        // Conditioned on the frozen year's own DiscountApplied rather than stepped back
+        // unconditionally: when no promotion reduced this year, nothing was counted for it — the
+        // period on the counter belongs to the stub — and stepping back there would hand out an
+        // extra discounted period that was never bought.
+        var annualDiscountPeriodsApplied = currentAnnual.DiscountApplied
+            ? Math.Max(0, subscription.DiscountPeriodsApplied - 1)
+            : subscription.DiscountPeriodsApplied;
+
         var targetAnnualCharge = SubscriptionAmountCalculator.DiscountedAmountMinor(
             targetPlan,
             subscription.Discount,
             targetPrice,
             targetQuantityItems,
-            subscription.DiscountPeriodsApplied,
+            annualDiscountPeriodsApplied,
             nowUtc);
         var targetAnnualTax = SubscriptionAmountCalculator.TaxBreakdownFor(
             targetAnnualCharge.AmountMinor, targetPrice.TaxRateBasisPoints, targetPrice.TaxMode);

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -125,49 +125,195 @@ public static class SubscriptionProrationCalculator
                 : Prorate(newTaxInclusive, targetRemainingTicks, targetTotalTicks);
 
         var rawDelta = newRemainingCost - oldRemainingValue;
-        var netAfterCredit = rawDelta - subscription.CreditBalanceMinor;
 
         // Reported, not recomputed later. Every figure below was needed to reach the charge, and an
         // invoice for a settlement cannot be explained from the charge alone: "CHF 41.30" is the
         // remainder of a subtraction between two prorated periods, and a subscriber asking why is
         // asking about the two sides, not the remainder.
-        var breakdown = new ProrationBreakdown(
-            new ProrationSide(
-                oldDiscounted.GrossAmountMinor,
-                oldDiscounted.BuiltInDiscountMinor,
-                oldDiscounted.PromotionalDiscountMinor,
-                oldTaxInclusive - oldDiscounted.AmountMinor,
-                oldTaxInclusive,
-                oldRemainingValue),
-            new ProrationSide(
-                newDiscounted.GrossAmountMinor,
-                newDiscounted.BuiltInDiscountMinor,
-                newDiscounted.PromotionalDiscountMinor,
-                newTaxInclusive - newDiscounted.AmountMinor,
-                newTaxInclusive,
-                newRemainingCost),
-            // What the credit balance actually paid for. A settlement worth less than what it
-            // replaced has a negative delta and spends nothing — and, since the clamp below never
-            // lets the balance grow, it leaves the balance exactly where it was.
-            Math.Clamp(rawDelta, 0, Math.Max(0, subscription.CreditBalanceMinor)),
-            netAfterCredit);
+        var outgoing = new ProrationSide(
+            oldDiscounted.GrossAmountMinor,
+            oldDiscounted.BuiltInDiscountMinor,
+            oldDiscounted.PromotionalDiscountMinor,
+            oldTaxInclusive - oldDiscounted.AmountMinor,
+            oldTaxInclusive,
+            oldRemainingValue);
+        var target = new ProrationSide(
+            newDiscounted.GrossAmountMinor,
+            newDiscounted.BuiltInDiscountMinor,
+            newDiscounted.PromotionalDiscountMinor,
+            newTaxInclusive - newDiscounted.AmountMinor,
+            newTaxInclusive,
+            newRemainingCost);
 
-        // The balance can only ever fall. Credit spent bringing a charge down is real and the
-        // remainder must persist, but a settlement worth less than what it replaced must not hand
-        // the difference back as new credit: a downgrade is not refunded, and neither is an
-        // increase that reaches a cheaper volume band. Both are worth exactly what they cost —
-        // nothing — and banking value for either is a refund under another name.
-        //
-        // Clamping here rather than at each call site because this is the money rule itself, not
-        // one caller's policy: every path that settles two periods against each other reads this
-        // number, and a second caller added later must inherit the rule rather than remember it.
-        var newCreditBalanceMinor = netAfterCredit > 0
-            ? 0
-            : Math.Min(subscription.CreditBalanceMinor, -netAfterCredit);
+        var settled = SettleRawDelta(rawDelta, subscription.CreditBalanceMinor);
+        var breakdown = new ProrationBreakdown(
+            outgoing, target, settled.CreditConsumedMinor, settled.NetSettlementMinor);
+
+        return new ProrationOutcome(settled.ChargeMinor, settled.NewCreditBalanceMinor, breakdown);
+    }
+
+    /// <param name="currentAnnual">
+    /// The year already frozen on the subscription — bought at signup and, since this method may
+    /// only be called while it is prepaid, already paid for in full. Read verbatim for the
+    /// outgoing annual side rather than recomputed, because it is exactly what was charged and
+    /// cannot drift from a live recalculation the way an on-the-fly figure could.
+    /// </param>
+    /// <param name="stubFraction">
+    /// How much of a calendar month the days between now and the boundary cover — the same
+    /// <see cref="Repositories.SubscriptionPlanSchedule.FeePeriodFraction"/> a fresh schedule
+    /// resolved at this instant already carries. Shared between the outgoing and target stub
+    /// sides: both run to the identical boundary, since this method is only ever called once the
+    /// caller has confirmed the target keeps the subscriber's cadence and alignment, so only the
+    /// per-day <em>rate</em> differs between them, never the days themselves.
+    /// </param>
+    /// <remarks>
+    /// Two settlements at once, computed and credited together rather than one after the other:
+    /// the remaining value of the stub at its own monthly-equivalent rate, and the difference
+    /// between what the paid year cost and what it costs on the new terms. The stub side excludes
+    /// the subscriber's promotional code on both its outgoing and target sides, mirroring exactly
+    /// how the stub was priced at signup — a code belongs to the year, never to the days before
+    /// it, and repricing the stub as if it had one would credit a discount that was never actually
+    /// spent on it, understating what is still owed for days already lived on the plan being left.
+    /// The annual side carries the code on both sides, for the identical reason in reverse.
+    /// <para>
+    /// Credit is spent once, against the combined total, never against the stub and the annual
+    /// side separately — spending it twice would let a settlement worth less on one side consume
+    /// the same balance twice.
+    /// </para>
+    /// </remarks>
+    public static OpeningStubUpgradeOutcome CalculateOpeningStubUpgrade(
+        SubscriptionDetail subscription,
+        PlanSnapshot targetPlan,
+        PriceSnapshot targetPrice,
+        IReadOnlyList<SubscriptionQuantityItem> targetQuantityItems,
+        PendingAnnualPeriod currentAnnual,
+        DateTime nowUtc,
+        BillingDayFraction stubFraction)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+        ArgumentNullException.ThrowIfNull(targetPlan);
+        ArgumentNullException.ThrowIfNull(targetPrice);
+        ArgumentNullException.ThrowIfNull(targetQuantityItems);
+        ArgumentNullException.ThrowIfNull(currentAnnual);
+
+        var outgoingStub = StubSide(
+            subscription.Plan, subscription.Price, subscription.QuantityItems, nowUtc, stubFraction);
+        var targetStub = StubSide(targetPlan, targetPrice, targetQuantityItems, nowUtc, stubFraction);
+
+        // The frozen figures verbatim — this is what was actually charged, or promised, for the
+        // year. ProratedValueMinor is the whole amount: the year has not started, so none of it is
+        // "used" yet, and the entire figure is the baseline the target year is compared against.
+        var outgoingAnnual = new ProrationSide(
+            currentAnnual.GrossAmountMinor,
+            currentAnnual.BuiltInDiscountMinor,
+            currentAnnual.PromotionalDiscountMinor,
+            currentAnnual.TaxAmountMinor,
+            currentAnnual.AmountMinor,
+            currentAnnual.AmountMinor);
+
+        // Priced exactly as SubscriptionCreationService.BuildPendingAnnualPeriod prices the year at
+        // signup: the whole period, the subscriber's own discount included, at the target price's
+        // own tax rate and mode.
+        var targetAnnualCharge = SubscriptionAmountCalculator.DiscountedAmountMinor(
+            targetPlan,
+            subscription.Discount,
+            targetPrice,
+            targetQuantityItems,
+            subscription.DiscountPeriodsApplied,
+            nowUtc);
+        var targetAnnualTax = SubscriptionAmountCalculator.TaxBreakdownFor(
+            targetAnnualCharge.AmountMinor, targetPrice.TaxRateBasisPoints, targetPrice.TaxMode);
+        var targetAnnual = new ProrationSide(
+            targetAnnualCharge.GrossAmountMinor,
+            targetAnnualCharge.BuiltInDiscountMinor,
+            targetAnnualCharge.PromotionalDiscountMinor,
+            targetAnnualTax.TaxAmountMinor,
+            targetAnnualTax.TotalAmountMinor,
+            targetAnnualTax.TotalAmountMinor);
+
+        var stubRawDelta = targetStub.ProratedValueMinor - outgoingStub.ProratedValueMinor;
+        var annualRawDelta = targetAnnual.ProratedValueMinor - outgoingAnnual.ProratedValueMinor;
+        var combinedRawDelta = stubRawDelta + annualRawDelta;
+
+        var settled = SettleRawDelta(combinedRawDelta, subscription.CreditBalanceMinor);
+
+        // Each side's own breakdown carries its raw, pre-credit figure for the invoice to explain
+        // — "the stub came to X, the year came to Y" — and reports no credit of its own, since
+        // credit was never spent against either side in isolation. Only the combination above
+        // reflects what was actually charged and what the balance actually became.
+        var stubBreakdown = new ProrationBreakdown(outgoingStub, targetStub, 0, stubRawDelta);
+        var annualBreakdown = new ProrationBreakdown(outgoingAnnual, targetAnnual, 0, annualRawDelta);
+
+        return new OpeningStubUpgradeOutcome(
+            settled.ChargeMinor,
+            settled.NewCreditBalanceMinor,
+            settled.CreditConsumedMinor,
+            combinedRawDelta,
+            settled.NetSettlementMinor,
+            stubBreakdown,
+            annualBreakdown,
+            targetAnnualCharge.DiscountApplied);
+    }
+
+    /// <summary>
+    /// One side of the stub component of an opening-stub upgrade: a plan and price's monthly
+    /// stub-basis rate, discounted with no promotional code, for the fraction of a month the stub
+    /// still covers.
+    /// </summary>
+    private static ProrationSide StubSide(
+        PlanSnapshot plan,
+        PriceSnapshot price,
+        IReadOnlyList<SubscriptionQuantityItem> quantityItems,
+        DateTime nowUtc,
+        BillingDayFraction stubFraction)
+    {
+        var (basisPrice, basisQuantityItems) = CalendarBillingAlignment.TryStubBasis(
+            price, quantityItems, out var stubPrice, out var stubQuantityItems)
+            ? (stubPrice, stubQuantityItems)
+            : (price, quantityItems);
+
+        // No discount here — see this method's caller. Built-in and volume reductions still apply,
+        // since those belong to the price rather than to the subscriber's code.
+        var discounted = SubscriptionAmountCalculator.DiscountedAmountMinor(
+            plan, null, basisPrice, basisQuantityItems, 0, nowUtc, stubFraction);
+        var tax = SubscriptionAmountCalculator.TaxBreakdownFor(
+            discounted.AmountMinor, basisPrice.TaxRateBasisPoints, basisPrice.TaxMode);
+
+        return new ProrationSide(
+            discounted.GrossAmountMinor,
+            discounted.BuiltInDiscountMinor,
+            discounted.PromotionalDiscountMinor,
+            tax.TaxAmountMinor,
+            tax.TotalAmountMinor,
+            tax.TotalAmountMinor);
+    }
+
+    /// <summary>
+    /// The one money rule every settlement in this module answers to: the balance can only ever
+    /// fall.
+    /// </summary>
+    /// <remarks>
+    /// Credit spent bringing a charge down is real and the remainder must persist, but a
+    /// settlement worth less than what it replaced must not hand the difference back as new
+    /// credit: a downgrade is not refunded, and neither is an increase that reaches a cheaper
+    /// volume band. Both are worth exactly what they cost — nothing — and banking value for either
+    /// is a refund under another name.
+    /// <para>
+    /// Factored out rather than left inline in <see cref="Calculate"/>, which is where this rule
+    /// first existed, so that <see cref="CalculateOpeningStubUpgrade"/> — settling a combined
+    /// stub-and-annual delta rather than a single period's — inherits the identical rule instead
+    /// of a second copy of it that could quietly drift from the first.
+    /// </para>
+    /// </remarks>
+    private static (long ChargeMinor, long NewCreditBalanceMinor, long CreditConsumedMinor, long NetSettlementMinor)
+        SettleRawDelta(long rawDelta, long creditBalanceMinor)
+    {
+        var netAfterCredit = rawDelta - creditBalanceMinor;
+        var creditConsumedMinor = Math.Clamp(rawDelta, 0, Math.Max(0, creditBalanceMinor));
 
         return netAfterCredit > 0
-            ? new ProrationOutcome(netAfterCredit, 0, breakdown)
-            : new ProrationOutcome(0, newCreditBalanceMinor, breakdown);
+            ? (netAfterCredit, 0, creditConsumedMinor, netAfterCredit)
+            : (0, Math.Min(creditBalanceMinor, -netAfterCredit), creditConsumedMinor, netAfterCredit);
     }
 
     /// <summary>
@@ -233,3 +379,38 @@ public readonly record struct ProrationBreakdown(
     ProrationSide Target,
     long CreditConsumedMinor,
     long NetSettlementMinor);
+
+/// <summary>
+/// What an upgrade taken during a calendar-aligned yearly subscription's opening stub costs, once
+/// that stub's own year has already been paid for.
+/// </summary>
+/// <param name="ChargeMinor">What is left to collect after the combined settlement spends credit.</param>
+/// <param name="NewCreditBalanceMinor">The balance afterward — never higher than it was before.</param>
+/// <param name="CreditConsumedMinor">What the balance actually paid for, of the combined total.</param>
+/// <param name="RawSettlementMinor">
+/// The combined stub-and-annual delta before credit pays any of it. Used for classification —
+/// whether this change is worth more than what it replaces is a property of the change, not of how
+/// much credit happens to be lying around — mirroring how the ordinary immediate-vs-scheduled path
+/// classifies on <see cref="ProrationBreakdown.NetSettlementMinor"/> rather than the post-credit
+/// charge.
+/// </param>
+/// <param name="NetSettlementMinor">The combined delta after credit, for the invoice's final total.</param>
+/// <param name="Stub">
+/// The opening stub's own settlement: its remaining value at the outgoing plan's stub-basis rate,
+/// against its remaining value at the target's.
+/// </param>
+/// <param name="Annual">The prepaid year's own settlement: what was paid, against what it costs on the target's terms.</param>
+/// <param name="TargetAnnualDiscountApplied">
+/// Whether the subscriber's promotional code actually reduced the target annual amount, to carry
+/// onto the replacement <see cref="PendingAnnualPeriod.DiscountApplied"/> — read later, when the
+/// year opens, to decide whether to count it against the code's remaining duration.
+/// </param>
+public readonly record struct OpeningStubUpgradeOutcome(
+    long ChargeMinor,
+    long NewCreditBalanceMinor,
+    long CreditConsumedMinor,
+    long RawSettlementMinor,
+    long NetSettlementMinor,
+    ProrationBreakdown Stub,
+    ProrationBreakdown Annual,
+    bool TargetAnnualDiscountApplied);

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -224,9 +224,9 @@ public static class SubscriptionProrationCalculator
         // discount the subscriber has already been granted for this very period.
         //
         // Conditioned on the frozen year's own DiscountApplied rather than stepped back
-        // unconditionally: when no promotion reduced this year, nothing was counted for it — the
-        // period on the counter belongs to the stub — and stepping back there would hand out an
-        // extra discounted period that was never bought.
+        // unconditionally: when no promotion reduced this year, nothing was counted for it, and
+        // stepping the index back anyway would revive a period the promotion never actually spent
+        // on this year — handing out a discount that was never bought.
         var annualDiscountPeriodsApplied = currentAnnual.DiscountApplied
             ? Math.Max(0, subscription.DiscountPeriodsApplied - 1)
             : subscription.DiscountPeriodsApplied;

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -329,21 +329,20 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
         // a decrease in an opening stub is the case that most needs to work: it takes nothing away
         // now, schedules for the end of what was actually paid for, and moves no money at all. The
         // two halves also fail for different reasons, so they no longer share one message.
-        if (!preview && direction >= 0 && subscription.PendingAnnualPeriod is { } opening)
+        //
+        // A prepaid stub no longer refuses the increase outright: IncreaseAsync settles the stub
+        // and the paid year together at the new quantity — see
+        // SubscriptionProrationCalculator.CalculateOpeningStubUpgrade. Only the unpaid case is
+        // still refused here, since there is nothing paid yet to settle a quantity increase
+        // against.
+        if (!preview && direction >= 0 && subscription.PendingAnnualPeriod is { IsPrepaid: false })
         {
-            return opening.IsPrepaid
-                ? Failure(
-                    PaymentFailureKind.Conflict,
-                    "subscription_initial_annual_period_prepaid",
-                    "This subscription has already paid for its first year, so units cannot be " +
-                    "added until that year begins. Reducing units can be scheduled now.",
-                    correlationId)
-                : Failure(
-                    PaymentFailureKind.Conflict,
-                    "subscription_initial_annual_period_unpaid",
-                    "This subscription's first year has not been charged yet, so units cannot be " +
-                    "added until it is. Reducing units can be scheduled now.",
-                    correlationId);
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_initial_annual_period_unpaid",
+                "This subscription's first year has not been charged yet, so units cannot be " +
+                "added until it is. Reducing units can be scheduled now.",
+                correlationId);
         }
 
         // Asked of a real increase only. A preview moves no money, and a decrease is scheduled for
@@ -405,30 +404,88 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
         string correlationId,
         CancellationToken cancellationToken)
     {
-        var outcome = SubscriptionProrationCalculator.Calculate(
-            subscription,
-            // The same plan: a quantity change moves the quantity, never the plan. The bands and
-            // the combination policy on both sides are the ones the subscriber already holds.
-            subscription.Plan,
-            subscription.Price,
-            target,
-            now,
-            subscription.CurrentPeriodStartUtc,
-            subscription.CurrentPeriodEndUtc);
+        long chargeMinor;
+        long newCreditBalanceMinor;
+        SubscriptionSettlementBreakdown? settlementBreakdown;
+        PendingAnnualPeriod? replacementAnnual = null;
+
+        // An increase taken during a prepaid opening stub settles the stub and the paid year
+        // together, at the new quantity — see
+        // SubscriptionProrationCalculator.CalculateOpeningStubUpgrade. Unlike a plan change, a
+        // quantity increase never changes cadence or alignment (the price itself is unchanged), so
+        // every prepaid stub qualifies; the only question left is whether the combined delta is
+        // owed or not, exactly as an ordinary increase already asks of a single period.
+        if (subscription.PendingAnnualPeriod is { IsPrepaid: true } prepaidAnnual)
+        {
+            var stubFraction = CalendarBillingAlignment.TryResolveFirstPeriod(
+                now, subscription.FeeSchedule.TimeZoneId, out var first)
+                ? BillingDayFraction.Of(first)
+                : default;
+
+            var stubUpgrade = SubscriptionProrationCalculator.CalculateOpeningStubUpgrade(
+                subscription,
+                // The same plan and price: a quantity change moves the quantity, never either of
+                // those.
+                subscription.Plan,
+                subscription.Price,
+                target,
+                prepaidAnnual,
+                now,
+                stubFraction);
+
+            chargeMinor = stubUpgrade.ChargeMinor;
+            newCreditBalanceMinor = stubUpgrade.NewCreditBalanceMinor;
+            settlementBreakdown = SettlementCharge.BreakdownOf(stubUpgrade);
+            replacementAnnual = new PendingAnnualPeriod
+            {
+                StartUtc = prepaidAnnual.StartUtc,
+                EndUtc = prepaidAnnual.EndUtc,
+                AmountMinor = stubUpgrade.Annual.Target.ProratedValueMinor,
+                NetAmountMinor = stubUpgrade.Annual.Target.ProratedValueMinor
+                    - stubUpgrade.Annual.Target.TaxAmountMinor,
+                TaxAmountMinor = stubUpgrade.Annual.Target.TaxAmountMinor,
+                GrossAmountMinor = stubUpgrade.Annual.Target.GrossAmountMinor,
+                BuiltInDiscountMinor = stubUpgrade.Annual.Target.BuiltInDiscountMinor,
+                PromotionalDiscountMinor = stubUpgrade.Annual.Target.PromotionalDiscountMinor,
+                DiscountApplied = stubUpgrade.TargetAnnualDiscountApplied,
+                CollectedWithCheckout = prepaidAnnual.CollectedWithCheckout,
+                IsPrepaid = true,
+                PaymentDetailId = prepaidAnnual.PaymentDetailId
+            };
+        }
+        else
+        {
+            var outcome = SubscriptionProrationCalculator.Calculate(
+                subscription,
+                // The same plan: a quantity change moves the quantity, never the plan. The bands
+                // and the combination policy on both sides are the ones the subscriber already
+                // holds.
+                subscription.Plan,
+                subscription.Price,
+                target,
+                now,
+                subscription.CurrentPeriodStartUtc,
+                subscription.CurrentPeriodEndUtc);
+
+            chargeMinor = outcome.ChargeMinor;
+            newCreditBalanceMinor = outcome.NewCreditBalanceMinor;
+            settlementBreakdown = SettlementCharge.BreakdownOf(outcome);
+        }
 
         if (preview)
         {
             return SubscriptionOperationResult<QuantityChangeResponse>.Success(
                 Describe(
                     subscription, target, subscription.Version, preview: true, immediate: true,
-                    effectiveAtUtc: now, proratedChargeMinor: outcome.ChargeMinor,
+                    effectiveAtUtc: now, proratedChargeMinor: chargeMinor,
                     paymentDetailId: null, pending: null),
                 correlationId);
         }
 
         // Nothing to reserve against: an increase that costs nothing cannot be half-paid, so it
-        // takes the ordinary compare-and-set. A band that makes more units cheaper lands here too.
-        if (outcome.ChargeMinor <= 0)
+        // takes the ordinary compare-and-set. A band that makes more units cheaper lands here too,
+        // and so does a stub-and-annual combination that comes to zero or less.
+        if (chargeMinor <= 0)
         {
             return await ApplyFreeIncreaseAsync(
                 subscription,
@@ -437,12 +494,13 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 // nothing is real and must persist, but an increase that reaches a cheaper band
                 // must not hand back the difference as new credit: a change that costs nothing
                 // costs nothing, and banking value for it is a refund with another name.
-                Math.Min(subscription.CreditBalanceMinor, outcome.NewCreditBalanceMinor),
+                Math.Min(subscription.CreditBalanceMinor, newCreditBalanceMinor),
                 now,
                 requestedByUserId,
-                SettlementCharge.BreakdownOf(outcome),
+                settlementBreakdown,
                 correlationId,
-                cancellationToken);
+                cancellationToken,
+                replacementAnnual);
         }
 
         var account = await _billingAccounts.GetAsync(
@@ -466,10 +524,11 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
             QuantityChange = new ReservedQuantityChange
             {
                 RequestedQuantities = target,
-                NewCreditBalanceMinor = outcome.NewCreditBalanceMinor
+                NewCreditBalanceMinor = newCreditBalanceMinor,
+                ReplacementPendingAnnualPeriod = replacementAnnual
             },
-            ChargeAmountMinor = outcome.ChargeMinor,
-            Settlement = SettlementCharge.BreakdownOf(outcome),
+            ChargeAmountMinor = chargeMinor,
+            Settlement = settlementBreakdown,
             BillingAccountId = subscription.BillingAccountId,
             ProviderName = account.ProviderName,
             ProviderOrganizationId = account.ProviderOrganizationId,
@@ -550,7 +609,8 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 correlationId);
         }
 
-        if (!await PromoteAsync(subscription, reservation, charge.Value, correlationId, cancellationToken))
+        if (!await PromoteAsync(
+                subscription, reservation, charge.Value, correlationId, cancellationToken))
         {
             // The claim is gone, so something else already settled it - the recovery sweep, or a
             // retry of this same request. Either way the units are granted exactly once and the
@@ -572,7 +632,7 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 preview: false,
                 immediate: true,
                 effectiveAtUtc: now,
-                proratedChargeMinor: outcome.ChargeMinor,
+                proratedChargeMinor: chargeMinor,
                 paymentDetailId: charge.Value,
                 pending: null),
             correlationId);
@@ -587,7 +647,8 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
         string? requestedByUserId,
         SubscriptionSettlementBreakdown? settlement,
         string correlationId,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        PendingAnnualPeriod? replacementPendingAnnualPeriod = null)
     {
         var outboxEvent = _events.CreateQuantityChanged(subscription, correlationId);
 
@@ -608,9 +669,15 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 newCreditBalanceMinor,
                 null,
                 outboxEvent,
-                cancellationToken))
+                cancellationToken,
+                replacementPendingAnnualPeriod: replacementPendingAnnualPeriod))
         {
             return VersionConflict(correlationId);
+        }
+
+        if (replacementPendingAnnualPeriod is not null)
+        {
+            subscription.PendingAnnualPeriod = replacementPendingAnnualPeriod;
         }
 
 
@@ -693,7 +760,16 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
             reservation.QuantityChange!.NewCreditBalanceMinor,
             paymentDetailId,
             outboxEvent,
-            cancellationToken);
+            cancellationToken,
+            reservation.QuantityChange.ReplacementPendingAnnualPeriod);
+
+        if (promoted)
+        {
+            if (reservation.QuantityChange.ReplacementPendingAnnualPeriod is { } replacement)
+            {
+                subscription.PendingAnnualPeriod = replacement;
+            }
+        }
 
         if (promoted && _scheduler is not null)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -752,6 +752,12 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
         CancellationToken cancellationToken)
     {
         var outboxEvent = _events.CreateQuantityChanged(subscription, correlationId);
+
+        // Stamped with the payment that settled it, exactly as the recovery sweep stamps it — see
+        // PendingAnnualPeriod.SettledBy.
+        var replacementAnnual =
+            reservation.QuantityChange!.ReplacementPendingAnnualPeriod?.SettledBy(paymentDetailId);
+
         var promoted = await _subscriptions.TryPromoteQuantityReservationAsync(
             subscription.TenantId,
             subscription.ItemId,
@@ -761,14 +767,11 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
             paymentDetailId,
             outboxEvent,
             cancellationToken,
-            reservation.QuantityChange.ReplacementPendingAnnualPeriod);
+            replacementAnnual);
 
-        if (promoted)
+        if (promoted && replacementAnnual is not null)
         {
-            if (reservation.QuantityChange.ReplacementPendingAnnualPeriod is { } replacement)
-            {
-                subscription.PendingAnnualPeriod = replacement;
-            }
+            subscription.PendingAnnualPeriod = replacementAnnual;
         }
 
         if (promoted && _scheduler is not null)

--- a/server/Subscription.DomainService/Utilities/PlanChangeTiming.cs
+++ b/server/Subscription.DomainService/Utilities/PlanChangeTiming.cs
@@ -97,8 +97,14 @@ public static class PlanChangeClassifier
     /// rhythms even though both are monthly intervals — and alignment beside them, because a
     /// calendar-aligned month and an anniversary month fall due on different days and a prepaid
     /// year cannot be re-anchored onto the other one mid-commitment.
+    /// <para>
+    /// Internal rather than private: <see cref="Services.SubscriptionPlanChangeService"/> asks the
+    /// identical question when deciding whether a change taken during a prepaid opening stub
+    /// keeps the subscriber's calendar boundary — the same rhythm/alignment equality this method
+    /// already answers, and a second copy of it could quietly drift from this one.
+    /// </para>
     /// </remarks>
-    private static bool ChangesCadenceOrAlignment(PriceSnapshot current, PriceSnapshot target) =>
+    internal static bool ChangesCadenceOrAlignment(PriceSnapshot current, PriceSnapshot target) =>
         current.Interval != target.Interval ||
         current.IntervalCount != target.IntervalCount ||
         current.BillingAlignment != target.BillingAlignment;

--- a/server/XUnitTest/Integration/OpeningStubUpgradeRecoveryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/OpeningStubUpgradeRecoveryIntegrationTests.cs
@@ -1,0 +1,456 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// That an opening-stub upgrade's replacement year survives the database, and that a crash between
+/// the charge and the promotion cannot leave a different year behind than a clean run would.
+/// </summary>
+/// <remarks>
+/// Unit tests prove the services pass the right object; they cannot prove Mongo stores it. The
+/// replacement year travels as a nested document inside a settlement reservation and is installed
+/// by an update definition that names one field — two places a mistake is invisible to a mocked
+/// repository and total in production: a reservation that round-trips without its replacement year
+/// promotes an upgrade that silently keeps the old annual figures, and money has already moved by
+/// the time anyone could notice.
+/// <para>
+/// Driven through the real <see cref="SubscriptionRepository"/> against a real database, because
+/// the invariants under test belong to the persistence layer itself — the serializer's treatment of
+/// a nullable nested entity, and whether the promotion's <c>$set</c> lands atomically with the plan
+/// it belongs to.
+/// </para>
+/// <para>
+/// The crash is simulated the way the renewal recovery suite simulates one: by the state a crash
+/// leaves behind rather than by killing a process. The reservation is written and the promotion is
+/// then replayed against it, which is exactly the position a worker that died after charging
+/// leaves the subscription in.
+/// </para>
+/// </remarks>
+public sealed class OpeningStubUpgradeRecoveryIntegrationTests
+    : IClassFixture<MongoIntegrationFixture>
+{
+    private const string OrganizationId = "org-1";
+
+    private static readonly DateTime StubStartUtc = new(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime AnnualStartUtc = new(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime AnnualEndUtc = new(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly MongoIntegrationFixture _fixture;
+    private readonly string _tenantId = MongoIntegrationFixture.NewTenantId();
+
+    // Unique per test: the item id is the document's _id and the class fixture shares one database
+    // across the file, so a reused id inserts a duplicate and silently reads back nothing.
+    private readonly string _subscriptionId = Guid.NewGuid().ToString("N");
+    private readonly string _reservationId = Guid.NewGuid().ToString("N");
+
+    public OpeningStubUpgradeRecoveryIntegrationTests(MongoIntegrationFixture fixture) =>
+        _fixture = fixture;
+
+    /// <summary>
+    /// A reserved plan change carries its replacement year through the database intact.
+    /// </summary>
+    /// <remarks>
+    /// The first half of the recovery guarantee: whatever the sweep later promotes, it can only be
+    /// as good as what the reservation actually stored. A nested entity that the serializer drops
+    /// would leave the replay with nothing to install and no way to know it was ever meant to.
+    /// </remarks>
+    [Fact]
+    public async Task A_reserved_plan_change_stores_its_replacement_year()
+    {
+        var subscriptions = new SubscriptionRepository(_fixture.DbContextProvider);
+        var subscription = await GivenSubscriptionAsync(subscriptions);
+
+        await subscriptions.TryReserveSettlementAsync(
+            _tenantId, _subscriptionId, subscription.Version, PlanReservation(), default);
+
+        var reserved = (await Read(subscriptions)).SettlementReservation;
+
+        reserved.Should().NotBeNull();
+        var replacement = reserved!.PlanChange!.ReplacementPendingAnnualPeriod;
+        replacement.Should().NotBeNull("a dropped replacement year cannot be recovered from");
+        replacement!.AmountMinor.Should().Be(1_200_000);
+        replacement.GrossAmountMinor.Should().Be(1_500_000);
+        replacement.PromotionalDiscountMinor.Should().Be(300_000);
+        replacement.DiscountApplied.Should().BeTrue();
+        replacement.IsPrepaid.Should().BeTrue();
+        replacement.StartUtc.Should().Be(AnnualStartUtc);
+        replacement.EndUtc.Should().Be(AnnualEndUtc);
+        replacement.PaymentDetailId.Should().Be("pay-original");
+    }
+
+    /// <summary>
+    /// Promoting the reservation installs the plan and the replacement year in one write, and
+    /// releases the reservation as it does.
+    /// </summary>
+    [Fact]
+    public async Task Promoting_a_plan_change_installs_the_replacement_year_atomically()
+    {
+        var subscriptions = new SubscriptionRepository(_fixture.DbContextProvider);
+        var subscription = await GivenSubscriptionAsync(subscriptions);
+        var reservation = PlanReservation();
+
+        await subscriptions.TryReserveSettlementAsync(
+            _tenantId, _subscriptionId, subscription.Version, reservation, default);
+
+        var promoted = await PromotePlanAsync(subscriptions, reservation, "pay-adjustment");
+
+        promoted.Should().BeTrue();
+
+        var settled = await Read(subscriptions);
+
+        settled.Plan.Code.Should().Be("scale");
+        settled.PendingAnnualPeriod.Should().NotBeNull();
+        settled.PendingAnnualPeriod!.AmountMinor.Should().Be(1_200_000);
+        settled.PendingAnnualPeriod.StartUtc.Should().Be(AnnualStartUtc);
+        settled.PendingAnnualPeriod.EndUtc.Should().Be(AnnualEndUtc);
+
+        // The adjustment's payment, stamped at promotion — the value the request path installs for
+        // this same reservation and charge.
+        settled.PendingAnnualPeriod.PaymentDetailId.Should().Be("pay-adjustment");
+
+        // Same write: a promotion that installed the plan but left the reservation standing would
+        // block every later change on a subscription that has already been settled.
+        settled.SettlementReservation.Should().BeNull();
+        settled.CreditBalanceMinor.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Replaying a promotion that already landed changes nothing and reports that it changed
+    /// nothing.
+    /// </summary>
+    /// <remarks>
+    /// The sweep is at-least-once, so a reservation can be replayed after a successful promotion
+    /// whose acknowledgement was lost. The promotion is addressed by the reservation id and that id
+    /// is cleared by the write, so the second attempt matches no document — which is what makes the
+    /// year installed exactly once rather than re-stamped by whichever replay ran last.
+    /// </remarks>
+    [Fact]
+    public async Task A_replayed_promotion_neither_reapplies_nor_rewrites_the_year()
+    {
+        var subscriptions = new SubscriptionRepository(_fixture.DbContextProvider);
+        var subscription = await GivenSubscriptionAsync(subscriptions);
+        var reservation = PlanReservation();
+
+        await subscriptions.TryReserveSettlementAsync(
+            _tenantId, _subscriptionId, subscription.Version, reservation, default);
+
+        var first = await PromotePlanAsync(subscriptions, reservation, "pay-adjustment");
+        var afterFirst = await Read(subscriptions);
+
+        // A replay carrying a different payment, which is the case that would corrupt the record if
+        // the reservation id did not gate the write.
+        var second = await PromotePlanAsync(subscriptions, reservation, "pay-duplicate");
+        var afterSecond = await Read(subscriptions);
+
+        first.Should().BeTrue();
+        second.Should().BeFalse("the reservation was cleared by the promotion that already landed");
+
+        afterSecond.PendingAnnualPeriod!.PaymentDetailId.Should().Be("pay-adjustment");
+        afterSecond.Version.Should().Be(afterFirst.Version, "the replay wrote nothing");
+    }
+
+    /// <summary>
+    /// A promotion that loses its race leaves the reservation exactly as it found it.
+    /// </summary>
+    /// <remarks>
+    /// The failure this rules out is a partial one: a write that installed some of the year, or
+    /// cleared the reservation without installing any of it, would strand a paid-for upgrade with
+    /// nothing left to replay it from. A promotion addressed to a reservation this subscription is
+    /// not holding must be a no-op in every field it touches.
+    /// </remarks>
+    [Fact]
+    public async Task A_promotion_for_another_reservation_leaves_this_one_untouched()
+    {
+        var subscriptions = new SubscriptionRepository(_fixture.DbContextProvider);
+        var subscription = await GivenSubscriptionAsync(subscriptions);
+        var reservation = PlanReservation();
+
+        await subscriptions.TryReserveSettlementAsync(
+            _tenantId, _subscriptionId, subscription.Version, reservation, default);
+
+        var stale = PlanReservation();
+        stale.ReservationId = Guid.NewGuid().ToString("N");
+
+        var promoted = await PromotePlanAsync(subscriptions, stale, "pay-wrong");
+
+        promoted.Should().BeFalse();
+
+        var untouched = await Read(subscriptions);
+
+        untouched.Plan.Code.Should().Be("team", "the plan must not move for another reservation");
+        untouched.PendingAnnualPeriod!.AmountMinor.Should().Be(
+            1_000_000, "the year on the subscription is still the one that was bought");
+        untouched.PendingAnnualPeriod.PaymentDetailId.Should().Be("pay-original");
+        untouched.SettlementReservation.Should().NotBeNull("the real reservation is still owed");
+        untouched.SettlementReservation!.ReservationId.Should().Be(_reservationId);
+        untouched.SettlementReservation.PlanChange!.ReplacementPendingAnnualPeriod
+            .Should().NotBeNull("a replay must still have everything it needs");
+    }
+
+    /// <summary>
+    /// The same guarantees for a quantity increase, which reaches the year through its own
+    /// reservation payload and its own promotion.
+    /// </summary>
+    [Fact]
+    public async Task Promoting_a_quantity_increase_installs_the_replacement_year_atomically()
+    {
+        var subscriptions = new SubscriptionRepository(_fixture.DbContextProvider);
+        var subscription = await GivenSubscriptionAsync(subscriptions);
+        var reservation = QuantityReservation();
+
+        await subscriptions.TryReserveSettlementAsync(
+            _tenantId, _subscriptionId, subscription.Version, reservation, default);
+
+        var reserved = (await Read(subscriptions)).SettlementReservation;
+        reserved!.QuantityChange!.ReplacementPendingAnnualPeriod
+            .Should().NotBeNull("the quantity payload carries the year too");
+
+        var promoted = await subscriptions.TryPromoteQuantityReservationAsync(
+            _tenantId,
+            _subscriptionId,
+            reservation.ReservationId,
+            reservation.QuantityChange!.RequestedQuantities,
+            reservation.QuantityChange.NewCreditBalanceMinor,
+            "pay-adjustment",
+            OutboxEvent(),
+            default,
+            reserved.QuantityChange.ReplacementPendingAnnualPeriod!.SettledBy("pay-adjustment"));
+
+        promoted.Should().BeTrue();
+
+        var settled = await Read(subscriptions);
+
+        settled.QuantityItems.Single().Quantity.Should().Be(12);
+        settled.PendingAnnualPeriod!.AmountMinor.Should().Be(1_200_000);
+        settled.PendingAnnualPeriod.PaymentDetailId.Should().Be("pay-adjustment");
+        settled.PendingAnnualPeriod.StartUtc.Should().Be(AnnualStartUtc);
+        settled.SettlementReservation.Should().BeNull();
+    }
+
+    /// <summary>
+    /// An ordinary plan change — one with no year to replace — leaves the year alone rather than
+    /// clearing it.
+    /// </summary>
+    /// <remarks>
+    /// The omitted-parameter case, and the reason the update is conditional rather than an
+    /// unconditional <c>$set</c> of a nullable field. An unconditional set would erase a prepaid
+    /// year on every ordinary change that happened to run while one was pending, which is a year
+    /// the subscriber has paid for and nothing would restore.
+    /// </remarks>
+    [Fact]
+    public async Task A_change_carrying_no_replacement_year_leaves_the_existing_one_standing()
+    {
+        var subscriptions = new SubscriptionRepository(_fixture.DbContextProvider);
+        var subscription = await GivenSubscriptionAsync(subscriptions);
+
+        var applied = await subscriptions.TryChangePlanAsync(
+            _tenantId,
+            _subscriptionId,
+            subscription.Version,
+            null,
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot { CurrencyCode = "CHF", UnitAmountMinor = 1_200_000 },
+            [Quantity(10)],
+            Schedule(),
+            new PendingUsagePeriod(),
+            0,
+            null,
+            OutboxEvent(),
+            default);
+
+        applied.Should().BeTrue();
+
+        var settled = await Read(subscriptions);
+
+        settled.Plan.Code.Should().Be("scale");
+        settled.PendingAnnualPeriod.Should().NotBeNull(
+            "a change with no year of its own must never clear one the subscriber has paid for");
+        settled.PendingAnnualPeriod!.AmountMinor.Should().Be(1_000_000);
+        settled.PendingAnnualPeriod.PaymentDetailId.Should().Be("pay-original");
+    }
+
+    private Task<bool> PromotePlanAsync(
+        ISubscriptionRepository subscriptions,
+        SettlementReservation reservation,
+        string paymentDetailId) =>
+        subscriptions.TryChangePlanAsync(
+            _tenantId,
+            _subscriptionId,
+            // Deliberately stale: a promotion is addressed by its reservation, never by a version,
+            // because the money has already moved and a concurrent bump must not strand it.
+            expectedVersion: 0,
+            reservation.ReservationId,
+            reservation.PlanChange!.Plan,
+            reservation.PlanChange.Price,
+            reservation.PlanChange.QuantityItems,
+            reservation.PlanChange.Schedule,
+            reservation.PlanChange.OutgoingUsagePeriod,
+            reservation.PlanChange.NewCreditBalanceMinor,
+            paymentDetailId,
+            OutboxEvent(),
+            default,
+            replacementPendingAnnualPeriod:
+                reservation.PlanChange.ReplacementPendingAnnualPeriod?.SettledBy(paymentDetailId));
+
+    private async Task<SubscriptionDetail> GivenSubscriptionAsync(
+        ISubscriptionRepository subscriptions)
+    {
+        await subscriptions.TryCreateAsync(NewSubscription(), default);
+
+        return await Read(subscriptions);
+    }
+
+    private async Task<SubscriptionDetail> Read(ISubscriptionRepository subscriptions) =>
+        (await subscriptions.GetAsync(_tenantId, OrganizationId, _subscriptionId, default))!;
+
+    private SettlementReservation PlanReservation() => new()
+    {
+        ReservationId = _reservationId,
+        Kind = SettlementReservationKind.PlanChange,
+        ChargeAmountMinor = 260_000,
+        BillingAccountId = "acct-1",
+        ProviderName = "STRIPE",
+        ProviderCustomerId = "cus_123",
+        StoredPaymentMethodId = "pm-1",
+        ReservedAtUtc = new DateTime(2026, 8, 16, 11, 0, 0, DateTimeKind.Utc),
+        CorrelationId = "corr-1",
+        ReservedAtVersion = 1,
+        PlanChange = new ReservedPlanChange
+        {
+            Plan = new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            Price = new PriceSnapshot { CurrencyCode = "CHF", UnitAmountMinor = 1_500_000 },
+            QuantityItems = [Quantity(10)],
+            Schedule = Schedule(),
+            OutgoingUsagePeriod = new PendingUsagePeriod(),
+            NewCreditBalanceMinor = 0,
+            ReplacementPendingAnnualPeriod = ReplacementAnnual()
+        }
+    };
+
+    private SettlementReservation QuantityReservation() => new()
+    {
+        ReservationId = _reservationId,
+        Kind = SettlementReservationKind.QuantityIncrease,
+        ChargeAmountMinor = 260_000,
+        BillingAccountId = "acct-1",
+        ProviderName = "STRIPE",
+        ProviderCustomerId = "cus_123",
+        StoredPaymentMethodId = "pm-1",
+        ReservedAtUtc = new DateTime(2026, 8, 16, 11, 0, 0, DateTimeKind.Utc),
+        CorrelationId = "corr-1",
+        ReservedAtVersion = 1,
+        QuantityChange = new ReservedQuantityChange
+        {
+            RequestedQuantities = [Quantity(12)],
+            NewCreditBalanceMinor = 0,
+            ReplacementPendingAnnualPeriod = ReplacementAnnual()
+        }
+    };
+
+    /// <summary>
+    /// The year as reserved: repriced onto the target's terms, and still naming the payment that
+    /// bought the terms being replaced — the adjustment's own payment does not exist yet when a
+    /// reservation is written.
+    /// </summary>
+    private static PendingAnnualPeriod ReplacementAnnual() => new()
+    {
+        StartUtc = AnnualStartUtc,
+        EndUtc = AnnualEndUtc,
+        GrossAmountMinor = 1_500_000,
+        PromotionalDiscountMinor = 300_000,
+        AmountMinor = 1_200_000,
+        NetAmountMinor = 1_200_000,
+        DiscountApplied = true,
+        CollectedWithCheckout = true,
+        IsPrepaid = true,
+        PaymentDetailId = "pay-original"
+    };
+
+    private static SubscriptionPlanSchedule Schedule() => new(
+        MonthlySchedule(),
+        StubStartUtc,
+        AnnualStartUtc,
+        AnnualStartUtc,
+        MonthlySchedule(),
+        StubStartUtc,
+        AnnualStartUtc,
+        AnnualStartUtc);
+
+    private static BillingSchedule MonthlySchedule() => new()
+    {
+        Interval = BillingInterval.Month,
+        IntervalCount = 1,
+        AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        TimeZoneId = "UTC",
+        AnchorDayOfMonth = 1
+    };
+
+    private static SubscriptionQuantityItem Quantity(long quantity) => new()
+    {
+        ItemKey = "user",
+        UnitLabel = "user",
+        Quantity = quantity,
+        UnitAmountMinor = 100_000
+    };
+
+    private static SubscriptionOutboxEvent OutboxEvent() =>
+        new SubscriptionOutboxEventFactory().CreateQuantityChanged(
+            new SubscriptionDetail
+            {
+                ItemId = "sub-1",
+                TenantId = "tenant-1",
+                OrganizationId = OrganizationId,
+                Plan = new PlanSnapshot { Code = "scale" },
+                Price = new PriceSnapshot { CurrencyCode = "CHF" }
+            },
+            "corr-1");
+
+    /// <summary>
+    /// A subscriber part-way through a prepaid opening stub: on a calendar-aligned yearly price,
+    /// inside the days before the year opens, with that year already paid for.
+    /// </summary>
+    private SubscriptionDetail NewSubscription() => new()
+    {
+        ItemId = _subscriptionId,
+        TenantId = _tenantId,
+        OrganizationId = OrganizationId,
+        BillingAccountId = "acct-1",
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        Version = 1,
+        CurrentPeriodStartUtc = StubStartUtc,
+        CurrentPeriodEndUtc = AnnualStartUtc,
+        NextFeeBillingAtUtc = AnnualStartUtc,
+        Plan = new PlanSnapshot { Code = "team", DisplayName = "Team" },
+        Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 1_000_000,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = 90_000
+        },
+        QuantityItems = [Quantity(10)],
+        FeeSchedule = MonthlySchedule(),
+        UsageSchedule = MonthlySchedule(),
+        PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = AnnualStartUtc,
+            EndUtc = AnnualEndUtc,
+            GrossAmountMinor = 1_250_000,
+            PromotionalDiscountMinor = 250_000,
+            AmountMinor = 1_000_000,
+            NetAmountMinor = 1_000_000,
+            DiscountApplied = true,
+            CollectedWithCheckout = true,
+            IsPrepaid = true,
+            PaymentDetailId = "pay-original"
+        }
+    };
+}

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -33,6 +33,9 @@ public sealed class SubscriptionPlanChangeServiceTests
     private SubscriptionDetail _subscription = NewSubscription(SubscriptionStatus.Active, 1_000);
     private SettlementReservation? _reserved;
 
+    /// <summary>The replacement annual period the change actually wrote, when it wrote one.</summary>
+    private PendingAnnualPeriod? _appliedAnnual;
+
     /// <summary>What a change classified as NextRenewal booked, when one was.</summary>
     private PendingPlanChange? _scheduled;
     private BillingAccount? _account = new()
@@ -98,6 +101,11 @@ public sealed class SubscriptionPlanChangeServiceTests
                 It.IsAny<CancellationToken>(),
                 It.IsAny<SubscriptionDocumentSource?>(),
                 It.IsAny<PendingAnnualPeriod?>()))
+            .Callback((string _, string _, int _, string? _, PlanSnapshot _, PriceSnapshot _,
+                    List<SubscriptionQuantityItem> _, SubscriptionPlanSchedule _,
+                    PendingUsagePeriod _, long _, string? _, SubscriptionOutboxEvent _,
+                    CancellationToken _, SubscriptionDocumentSource? _,
+                    PendingAnnualPeriod? annual) => _appliedAnnual = annual)
             .ReturnsAsync(true);
 
         _catalogue
@@ -1439,6 +1447,206 @@ public sealed class SubscriptionPlanChangeServiceTests
 
         result.IsSuccess.Should().BeTrue();
         _scheduled!.EffectiveAtUtc.Should().Be(new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    /// <summary>
+    /// A subscriber part-way through a prepaid opening stub, on a calendar-aligned yearly price,
+    /// with a compatible yearly target waiting at <c>price-2</c>.
+    /// </summary>
+    /// <param name="discountApplied">
+    /// Whether a promotion reduced the year that was bought. This is what says whether that year
+    /// already spent a period of the promotion — see
+    /// <see cref="SubscriptionProrationCalculator.CalculateOpeningStubUpgrade"/>.
+    /// </param>
+    private void GivenPrepaidOpeningStub(bool discountApplied = false)
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Active, 1_000);
+        _subscription.Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 1_000_000,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = 90_000
+        };
+        // The frozen figures are what was actually collected, so a year flagged as discounted
+        // carries the reduction it was bought with — 20% off 1,000,000.
+        _subscription.PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            GrossAmountMinor = 1_000_000,
+            PromotionalDiscountMinor = discountApplied ? 200_000 : 0,
+            AmountMinor = discountApplied ? 800_000 : 1_000_000,
+            NetAmountMinor = discountApplied ? 800_000 : 1_000_000,
+            DiscountApplied = discountApplied,
+            IsPrepaid = true,
+            PaymentDetailId = "pay-original"
+        };
+        // 15 August: partway through the stub that runs from the 1st to the boundary on 1
+        // September, so the stub side of the settlement is a genuine fraction rather than a whole
+        // month either side happens to land on.
+        _time.Advance(TimeSpan.FromDays(14));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price
+            {
+                ItemId = "price-2",
+                TenantId = TenantId,
+                PlanId = "plan-2",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 1_200_000,
+                Interval = BillingInterval.Year,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth,
+                CalendarStubBasePriceId = "price-monthly-2",
+                CalendarStubBaseUnitAmountMinor = 110_000,
+                Status = CatalogueStatus.Active
+            });
+    }
+
+    /// <summary>A promotion the subscriber redeemed, running for <paramref name="durationPeriods"/>.</summary>
+    private static DiscountTerms Promotion(int? durationPeriods) => new()
+    {
+        Code = "save20",
+        Kind = DiscountKind.Percent,
+        PercentBasisPoints = 2_000,
+        DurationPeriods = durationPeriods
+    };
+
+    /// <summary>
+    /// A prepaid year bought with a one-period promotion keeps that promotion when the plan is
+    /// upgraded during the stub.
+    /// </summary>
+    /// <remarks>
+    /// The regression this guards: the replacement year used to be repriced at the subscription's
+    /// <em>current</em> discount-period counter. A prepaid year has already spent its period — the
+    /// activation that collected it counted one, and the renewal that opens it deliberately does
+    /// not count a second — so repricing at the current counter treated a one-period promotion as
+    /// exhausted and quoted the replacement year at full price. The upgrade would then have
+    /// charged the plan difference <em>plus</em> repayment of a discount already granted for that
+    /// same year.
+    /// </remarks>
+    [Fact]
+    public async Task A_one_period_promotion_still_discounts_the_year_it_already_paid_for()
+    {
+        GivenPrepaidOpeningStub(discountApplied: true);
+        _subscription.Discount = Promotion(durationPeriods: 1);
+        _subscription.DiscountPeriodsApplied = 1;
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var annual = _reserved!.Settlement!.Annual!.Target;
+        annual.PromotionalDiscountMinor.Should().Be(
+            240_000,
+            "20% of the 1,200,000 target year — the promotion the subscriber already holds for "
+                + "this period must survive the upgrade");
+        annual.PeriodTotalMinor.Should().Be(960_000);
+    }
+
+    /// <summary>
+    /// A promotion with periods still to run is likewise priced at the index that bought the year,
+    /// so the upgrade neither loses a period nor grants an extra one.
+    /// </summary>
+    [Fact]
+    public async Task A_multi_period_promotion_prices_the_replacement_year_at_the_index_that_bought_it()
+    {
+        GivenPrepaidOpeningStub(discountApplied: true);
+        _subscription.Discount = Promotion(durationPeriods: 3);
+        _subscription.DiscountPeriodsApplied = 1;
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _reserved!.Settlement!.Annual!.Target.PromotionalDiscountMinor.Should().Be(240_000);
+    }
+
+    /// <summary>
+    /// A year bought without a promotion does not acquire one from the upgrade.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart to the two above, and the reason the correction is conditioned on the
+    /// frozen year's own <see cref="PendingAnnualPeriod.DiscountApplied"/> rather than applied
+    /// unconditionally: here the period on the counter was spent by the stub, not by this year, so
+    /// stepping the index back would hand out a discounted period the subscriber never bought.
+    /// </remarks>
+    [Fact]
+    public async Task A_year_bought_without_a_promotion_does_not_gain_one_from_the_upgrade()
+    {
+        GivenPrepaidOpeningStub(discountApplied: false);
+        _subscription.Discount = Promotion(durationPeriods: 1);
+        _subscription.DiscountPeriodsApplied = 1;
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _reserved!.Settlement!.Annual!.Target.PromotionalDiscountMinor.Should().Be(
+            0, "the promotion was spent on the stub and has no periods left for this year");
+    }
+
+    /// <summary>
+    /// The preview quotes the same discounted year the confirm then charges.
+    /// </summary>
+    [Fact]
+    public async Task A_preview_and_the_confirm_agree_on_the_discounted_replacement_year()
+    {
+        GivenPrepaidOpeningStub(discountApplied: true);
+        _subscription.Discount = Promotion(durationPeriods: 1);
+        _subscription.DiscountPeriodsApplied = 1;
+
+        var preview = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+        var confirmed = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        preview.IsSuccess.Should().BeTrue();
+        confirmed.IsSuccess.Should().BeTrue();
+
+        var quoted = preview.Value!.Settlement.Annual!.Target;
+        var charged = _reserved!.Settlement!.Annual!.Target;
+
+        quoted.PromotionalDiscountMinor.Should().Be(charged.PromotionalDiscountMinor);
+        quoted.PeriodTotalMinor.Should().Be(charged.PeriodTotalMinor);
+        preview.Value.ChargeMinor.Should().Be(_reserved.ChargeAmountMinor);
+    }
+
+    /// <summary>
+    /// The year the change installs names the payment that settled the adjustment, not the one
+    /// that bought the terms it replaced.
+    /// </summary>
+    /// <remarks>
+    /// Asserted on the value actually written, and paired with
+    /// <c>SubscriptionSettlementReservationProcessorTests</c>'s recovery case, because the two
+    /// paths used to disagree: the request path mutated the replacement after the reservation was
+    /// already persisted, so a recovery replaying that reservation installed the original year's
+    /// payment id instead. The same settled operation must not leave different state behind
+    /// depending on whether a process died.
+    /// </remarks>
+    [Fact]
+    public async Task The_installed_year_names_the_payment_that_settled_the_adjustment()
+    {
+        GivenPrepaidOpeningStub();
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _appliedAnnual.Should().NotBeNull();
+        _appliedAnnual!.PaymentDetailId.Should().Be("in_1");
+
+        // The reservation still carries what it was written with, so a replay has the same
+        // starting point the request path had.
+        _reserved!.PlanChange!.ReplacementPendingAnnualPeriod!.PaymentDetailId
+            .Should().Be("pay-original");
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -96,7 +96,8 @@ public sealed class SubscriptionPlanChangeServiceTests
                 It.IsAny<string?>(),
                 It.IsAny<SubscriptionOutboxEvent>(),
                 It.IsAny<CancellationToken>(),
-                It.IsAny<SubscriptionDocumentSource?>()))
+                It.IsAny<SubscriptionDocumentSource?>(),
+                It.IsAny<PendingAnnualPeriod?>()))
             .ReturnsAsync(true);
 
         _catalogue
@@ -202,7 +203,8 @@ public sealed class SubscriptionPlanChangeServiceTests
             .Callback((string _, string _, int _, string? _, PlanSnapshot _, PriceSnapshot _,
                     List<SubscriptionQuantityItem> _, SubscriptionPlanSchedule _,
                     PendingUsagePeriod _, long _, string? _, SubscriptionOutboxEvent _,
-                    CancellationToken _, SubscriptionDocumentSource? source) => carried = source)
+                    CancellationToken _, SubscriptionDocumentSource? source,
+                    PendingAnnualPeriod? _) => carried = source)
             .ReturnsAsync(true);
 
         var result = await Service().ChangePlanAsync(
@@ -290,7 +292,8 @@ public sealed class SubscriptionPlanChangeServiceTests
             .Callback((string _, string _, int _, string? _, PlanSnapshot _, PriceSnapshot _,
                     List<SubscriptionQuantityItem> _, SubscriptionPlanSchedule _,
                     PendingUsagePeriod pending, long _, string? _, SubscriptionOutboxEvent _,
-                    CancellationToken _, SubscriptionDocumentSource? _) => captured = pending)
+                    CancellationToken _, SubscriptionDocumentSource? _,
+                    PendingAnnualPeriod? _) => captured = pending)
             .ReturnsAsync(true);
 
         var result = await ServiceWithUsage(usage.Object).ChangePlanAsync(
@@ -1379,22 +1382,136 @@ public sealed class SubscriptionPlanChangeServiceTests
         _scheduled!.EffectiveAtUtc.Should().Be(new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc));
     }
 
+    /// <summary>
+    /// An upgrade taken during a prepaid opening stub, onto a plan that keeps the same calendar
+    /// boundary, settles the stub and the paid year together instead of being refused outright.
+    /// </summary>
+    /// <remarks>
+    /// This used to be refused unconditionally, because the calculator had no way to price a stub
+    /// and an already-paid year against each other without either undercharging the stub or
+    /// double-billing the year. See
+    /// <see cref="SubscriptionProrationCalculator.CalculateOpeningStubUpgrade"/>.
+    /// </remarks>
     [Fact]
-    public async Task An_upgrade_inside_a_prepaid_opening_stub_is_still_refused()
+    public async Task An_upgrade_inside_a_prepaid_opening_stub_settles_the_stub_and_the_year_together()
     {
         _subscription = NewSubscription(SubscriptionStatus.Active, 1_000);
+        _subscription.Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 1_000_000,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = 90_000
+        };
         _subscription.PendingAnnualPeriod = new PendingAnnualPeriod
         {
             StartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
             EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc),
-            IsPrepaid = true
+            GrossAmountMinor = 1_000_000,
+            AmountMinor = 1_000_000,
+            NetAmountMinor = 1_000_000,
+            IsPrepaid = true,
+            PaymentDetailId = "pay-original"
         };
+        // 15 August: partway through the stub that runs from the 1st to the boundary on 1
+        // September, so the stub side of the settlement is a genuine fraction rather than a whole
+        // month either side happens to land on.
+        _time.Advance(TimeSpan.FromDays(14));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price
+            {
+                ItemId = "price-2",
+                TenantId = TenantId,
+                PlanId = "plan-2",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 1_200_000,
+                Interval = BillingInterval.Year,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth,
+                CalendarStubBasePriceId = "price-monthly-2",
+                CalendarStubBaseUnitAmountMinor = 110_000,
+                Status = CatalogueStatus.Active
+            });
 
         var result = await Service().ChangePlanAsync(
             "sub-1", Request(), "corr-1", CancellationToken.None);
 
-        result.IsSuccess.Should().BeFalse();
-        result.ErrorCode.Should().Be("subscription_initial_annual_period_prepaid");
+        result.IsSuccess.Should().BeTrue();
+
+        // A real settlement moved money: the target's stub-basis rate and its annual amount both
+        // exceed the outgoing plan's, so the combined delta is positive.
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // The stub's own bounds are untouched — only its price changed — and the replacement
+        // annual period keeps the year's own dates while carrying the target's own amount.
+        _reserved.Should().NotBeNull();
+        var replacement = _reserved!.PlanChange!.ReplacementPendingAnnualPeriod;
+        replacement.Should().NotBeNull();
+        replacement!.StartUtc.Should().Be(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+        replacement.EndUtc.Should().Be(new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+        replacement.IsPrepaid.Should().BeTrue();
+        replacement.AmountMinor.Should().BeGreaterThan(1_000_000);
+
+        _reserved.Settlement.Should().NotBeNull();
+        _reserved.Settlement!.Annual.Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// A change that would re-cadence or re-align a prepaid opening stub still waits for the year
+    /// to end, rather than being priced against a commitment already settled in full.
+    /// </summary>
+    [Fact]
+    public async Task A_cadence_change_inside_a_prepaid_opening_stub_still_waits_for_the_year_to_end()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Active, 1_000);
+        _subscription.Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 1_000_000,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = 90_000
+        };
+        _subscription.PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            GrossAmountMinor = 1_000_000,
+            AmountMinor = 1_000_000,
+            NetAmountMinor = 1_000_000,
+            IsPrepaid = true
+        };
+
+        // A monthly price -- a different cadence entirely, which cannot be priced against a
+        // commitment already settled in full for the year.
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(NewPrice(120_000));
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _scheduled.Should().NotBeNull();
+        _scheduled!.EffectiveAtUtc.Should().Be(new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -1070,6 +1070,65 @@ public sealed class SubscriptionPlanChangeServiceTests
     }
 
     /// <summary>
+    /// A preview taken during a prepaid opening stub quotes the identical composite settlement
+    /// the confirm would charge, not the ordinary single-period calculation — which would price the
+    /// stub's remaining days against the whole annual price rather than its own monthly-equivalent
+    /// rate.
+    /// </summary>
+    [Fact]
+    public async Task A_preview_inside_a_prepaid_opening_stub_quotes_the_composite_settlement()
+    {
+        _subscription = NewSubscription(SubscriptionStatus.Active, 1_000);
+        _subscription.Price = new PriceSnapshot
+        {
+            CurrencyCode = "CHF",
+            UnitAmountMinor = 1_000_000,
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = 90_000
+        };
+        _subscription.PendingAnnualPeriod = new PendingAnnualPeriod
+        {
+            StartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            GrossAmountMinor = 1_000_000,
+            AmountMinor = 1_000_000,
+            NetAmountMinor = 1_000_000,
+            IsPrepaid = true
+        };
+        _time.Advance(TimeSpan.FromDays(14));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price
+            {
+                ItemId = "price-2",
+                TenantId = TenantId,
+                PlanId = "plan-2",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 1_200_000,
+                Interval = BillingInterval.Year,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth,
+                CalendarStubBasePriceId = "price-monthly-2",
+                CalendarStubBaseUnitAmountMinor = 110_000,
+                Status = CatalogueStatus.Active
+            });
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Timing.Should().Be("Immediate");
+        result.Value.ChargeMinor.Should().BeGreaterThan(0);
+        result.Value.Settlement.Annual.Should().NotBeNull();
+        result.Value.NextRenewalAmountMinor.Should().Be(result.Value.Settlement.Annual!.Target.PeriodTotalMinor);
+    }
+
+    /// <summary>
     /// The one refusal that stays a hard failure on preview rather than becoming a blocker: the
     /// real change never charges a price with the discount silently dropped, so there is no
     /// honest number to show alongside the refusal.

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -1575,8 +1575,9 @@ public sealed class SubscriptionPlanChangeServiceTests
     /// <remarks>
     /// The counterpart to the two above, and the reason the correction is conditioned on the
     /// frozen year's own <see cref="PendingAnnualPeriod.DiscountApplied"/> rather than applied
-    /// unconditionally: here the period on the counter was spent by the stub, not by this year, so
-    /// stepping the index back would hand out a discounted period the subscriber never bought.
+    /// unconditionally: here the promotion never reduced this year, so stepping the index back
+    /// anyway would revive a period it never actually spent on this year — handing out a discount
+    /// the subscriber never bought.
     /// </remarks>
     [Fact]
     public async Task A_year_bought_without_a_promotion_does_not_gain_one_from_the_upgrade()

--- a/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceTests.cs
@@ -71,7 +71,7 @@ public sealed class SubscriptionQuantityChangeServiceTests
                 TenantId, "sub-1", It.IsAny<int>(),
                 It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<long>(), It.IsAny<string?>(),
                 It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>(),
-                It.IsAny<SubscriptionDocumentSource?>()))
+                It.IsAny<SubscriptionDocumentSource?>(), It.IsAny<PendingAnnualPeriod?>()))
             .ReturnsAsync(true);
 
         _subscriptions
@@ -89,7 +89,8 @@ public sealed class SubscriptionQuantityChangeServiceTests
             .Setup(repository => repository.TryPromoteQuantityReservationAsync(
                 TenantId, "sub-1", It.IsAny<string>(),
                 It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<long>(), It.IsAny<string?>(),
-                It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>()))
+                It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>(),
+                It.IsAny<PendingAnnualPeriod?>()))
             .Callback(() => _calls.Add("promote"))
             .ReturnsAsync(true);
 
@@ -779,24 +780,74 @@ public sealed class SubscriptionQuantityChangeServiceTests
     }
 
     /// <summary>
-    /// Increases stay blocked in an opening stub, and the two reasons are told apart. The old
-    /// message said the first year "is not yet settled" for both, which is untrue of a prepaid
-    /// year — it is settled, which is precisely why adding units cannot be priced against it yet.
+    /// An increase inside an <em>unpaid</em> opening stub still waits: there is nothing settled
+    /// yet to price a quantity increase against.
     /// </summary>
-    [Theory]
-    [InlineData(true, "subscription_initial_annual_period_prepaid")]
-    [InlineData(false, "subscription_initial_annual_period_unpaid")]
-    public async Task An_increase_inside_an_opening_stub_is_refused_for_the_right_reason(
-        bool prepaid,
-        string expectedCode)
+    [Fact]
+    public async Task An_increase_inside_an_unpaid_opening_stub_is_still_refused()
     {
-        _subscription = InOpeningStub(10, prepaid: prepaid);
+        _subscription = InOpeningStub(10, prepaid: false);
 
         var result = await Service().ChangeAsync("sub-1", Request(12), "corr-1", default);
 
         result.IsSuccess.Should().BeFalse();
-        result.ErrorCode.Should().Be(expectedCode);
+        result.ErrorCode.Should().Be("subscription_initial_annual_period_unpaid");
         _gateway.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// An increase inside a <em>prepaid</em> opening stub settles the stub and the paid year
+    /// together at the new quantity, rather than being refused outright.
+    /// </summary>
+    /// <remarks>
+    /// This used to be refused unconditionally, for the identical reason a plan change was: there
+    /// was no way to price a stub and an already-paid year against each other. See
+    /// <see cref="SubscriptionProrationCalculator.CalculateOpeningStubUpgrade"/>.
+    /// </remarks>
+    [Fact]
+    public async Task An_increase_inside_a_prepaid_opening_stub_settles_the_stub_and_the_year_together()
+    {
+        _subscription = InOpeningStub(10, prepaid: true);
+        _subscription.Price = new PriceSnapshot
+        {
+            UnitAmountMinor = 1_000_000,
+            CurrencyCode = "CHF",
+            QuantityItemKey = "user",
+            Interval = BillingInterval.Year,
+            IntervalCount = 1,
+            BillingAlignment = BillingAlignment.CalendarMonth,
+            CalendarStubBasePriceId = "price-monthly",
+            CalendarStubBaseUnitAmountMinor = UnitAmount
+        };
+        // Items carry their own snapshotted per-unit amount rather than the price's — see
+        // SubscriptionAmountCalculator.GrossAmountMinor's own remarks — so the frozen annual
+        // figure has to be scaled to what 10 of these units actually came to, not to the price's
+        // headline amount, or the "already paid" baseline would be too large for any increase to
+        // ever clear it.
+        _subscription.PendingAnnualPeriod!.AmountMinor = 10 * UnitAmount;
+        var originalStartUtc = _subscription.PendingAnnualPeriod!.StartUtc;
+        var originalEndUtc = _subscription.PendingAnnualPeriod!.EndUtc;
+
+        var result = await Service().ChangeAsync("sub-1", Request(12), "corr-1", default);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorCode);
+        result.Value!.ProratedChargeMinor.Should().BeGreaterThan(0);
+        _gateway.Verify(
+            gateway => gateway.ChargeAsync(
+                It.IsAny<SubscriptionChargeRequest>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _reservation.Should().NotBeNull();
+        var replacement = _reservation!.QuantityChange!.ReplacementPendingAnnualPeriod;
+        replacement.Should().NotBeNull();
+        replacement!.StartUtc.Should().Be(originalStartUtc);
+        replacement.EndUtc.Should().Be(originalEndUtc);
+        replacement.IsPrepaid.Should().BeTrue();
+        replacement.AmountMinor.Should().BeGreaterThan(0);
+
+        _reservation.Settlement.Should().NotBeNull();
+        _reservation.Settlement!.Annual.Should().NotBeNull();
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionSettlementReservationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSettlementReservationProcessorTests.cs
@@ -397,6 +397,103 @@ public sealed class SubscriptionSettlementReservationProcessorTests
         payload.PreviousPlanCode.Should().Be("team");
     }
 
+    /// <summary>
+    /// Recovering an opening-stub upgrade installs the replacement year the reservation carried,
+    /// naming the payment this recovery confirmed.
+    /// </summary>
+    /// <remarks>
+    /// The regression this guards: the request path used to stamp the confirmed payment onto the
+    /// replacement year <em>after</em> the reservation had already been persisted, so it changed
+    /// only the in-memory copy. A recovery replaying that reservation read the un-stamped value and
+    /// installed the original year's payment id, leaving the same settled operation with different
+    /// state depending on whether a process happened to die. Both paths now stamp it at promotion,
+    /// through <see cref="PendingAnnualPeriod.SettledBy"/>.
+    /// </remarks>
+    [Fact]
+    public async Task A_recovered_stub_upgrade_installs_the_year_naming_the_payment_it_confirmed()
+    {
+        _subscription.SettlementReservation = new SettlementReservation
+        {
+            ReservationId = ReservationId,
+            Kind = SettlementReservationKind.PlanChange,
+            ChargeAmountMinor = 12_000,
+            BillingAccountId = "acct-1",
+            ProviderName = "STRIPE",
+            ProviderCustomerId = "cus_123",
+            StoredPaymentMethodId = "pm-1",
+            ReservedAtUtc = new DateTime(2026, 8, 16, 11, 0, 0, DateTimeKind.Utc),
+            CorrelationId = "corr-1",
+            PlanChange = new ReservedPlanChange
+            {
+                Plan = new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+                Price = new PriceSnapshot { UnitAmountMinor = 20_000, CurrencyCode = "CHF" },
+                QuantityItems = [Item(5)],
+                Schedule = new SubscriptionPlanSchedule(
+                    new BillingSchedule(),
+                    new DateTime(2026, 8, 16, 0, 0, 0, DateTimeKind.Utc),
+                    new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+                    new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+                    new BillingSchedule(),
+                    new DateTime(2026, 8, 16, 0, 0, 0, DateTimeKind.Utc),
+                    new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+                    new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)),
+                OutgoingUsagePeriod = new PendingUsagePeriod(),
+                NewCreditBalanceMinor = 400,
+                // As reserved: still naming the payment that bought the terms being replaced,
+                // because the adjustment's own payment did not exist when this was written.
+                ReplacementPendingAnnualPeriod = new PendingAnnualPeriod
+                {
+                    StartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+                    EndUtc = new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+                    GrossAmountMinor = 1_200_000,
+                    AmountMinor = 1_200_000,
+                    NetAmountMinor = 1_200_000,
+                    IsPrepaid = true,
+                    PaymentDetailId = "pay-original"
+                }
+            }
+        };
+
+        PendingAnnualPeriod? installed = null;
+
+        _subscriptions
+            .Setup(repository => repository.TryChangePlanAsync(
+                TenantId, "sub-1", It.IsAny<int>(), ReservationId,
+                It.IsAny<PlanSnapshot>(), It.IsAny<PriceSnapshot>(),
+                It.IsAny<List<SubscriptionQuantityItem>>(), It.IsAny<SubscriptionPlanSchedule>(),
+                It.IsAny<PendingUsagePeriod>(), It.IsAny<long>(), It.IsAny<string?>(),
+                It.IsAny<SubscriptionOutboxEvent>(), It.IsAny<CancellationToken>(),
+                It.IsAny<SubscriptionDocumentSource?>(), It.IsAny<PendingAnnualPeriod?>()))
+            .Callback((string _, string _, int _, string? _, PlanSnapshot _, PriceSnapshot _,
+                    List<SubscriptionQuantityItem> _, SubscriptionPlanSchedule _,
+                    PendingUsagePeriod _, long _, string? _, SubscriptionOutboxEvent _,
+                    CancellationToken _, SubscriptionDocumentSource? _,
+                    PendingAnnualPeriod? annual) => installed = annual)
+            .ReturnsAsync(true);
+
+        GivenPayment(ChargeKey, PaymentStatuses.Captured);
+
+        var resolved = await Processor().RecoverStaleAsync(TenantId, default);
+
+        resolved.Should().Be(1);
+        installed.Should().NotBeNull();
+
+        // The payment this recovery confirmed, which is what the request path would have installed
+        // for the same reservation and the same charge.
+        installed!.PaymentDetailId.Should().Be("pay-1");
+
+        // Every other frozen figure is the reservation's, untouched.
+        installed.AmountMinor.Should().Be(1_200_000);
+        installed.StartUtc.Should().Be(new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+        installed.EndUtc.Should().Be(new DateTime(2027, 9, 1, 0, 0, 0, DateTimeKind.Utc));
+        installed.IsPrepaid.Should().BeTrue();
+
+        // Stamping produces a copy, so the reservation still reads as it was persisted and a
+        // second replay starts from the same place this one did.
+        _subscription.SettlementReservation.PlanChange!.ReplacementPendingAnnualPeriod!
+            .PaymentDetailId.Should().Be("pay-original");
+    }
+
     private void GivenPayment(string idempotencyKey, string status) =>
         _payments
             .Setup(repository => repository.GetByIdempotencyKeyAsync(

--- a/server/XUnitTest/Subscription/SubscriptionSettlementReservationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSettlementReservationProcessorTests.cs
@@ -359,7 +359,8 @@ public sealed class SubscriptionSettlementReservationProcessorTests
             .Callback((string _, string _, int _, string? _, PlanSnapshot _, PriceSnapshot _,
                     List<SubscriptionQuantityItem> _, SubscriptionPlanSchedule _,
                     PendingUsagePeriod _, long _, string? _, SubscriptionOutboxEvent raised,
-                    CancellationToken _, SubscriptionDocumentSource? _) => announced = raised)
+                    CancellationToken _, SubscriptionDocumentSource? _,
+                    PendingAnnualPeriod? _) => announced = raised)
             .ReturnsAsync(true);
 
         GivenPayment(ChargeKey, PaymentStatuses.Captured);


### PR DESCRIPTION
## Summary

PR 2 of the "Standard Plan and Quantity Change Lifecycle" feature — stacked on [PR #387](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/387) (PR 1: scheduled plan changes, credit-never-banks policy). Base branch is `feat/plan-change-lifecycle`, not `dev`; merge PR 1 first.

Replaces the blanket refusal of any plan or quantity change while a calendar-aligned yearly subscription's opening stub is prepaid. A change that keeps the subscriber's cadence and calendar boundary now **settles the stub's remaining days and the paid annual period together, in one immediate charge**, instead of being refused outright.

## What changed

- **`SubscriptionProrationCalculator.CalculateOpeningStubUpgrade`** — the new composite calculation. Prices the stub at its own monthly-equivalent stub-basis rate (promotional discount excluded, mirroring how the stub was priced at signup) and the annual period at full rate (promotional discount included, mirroring signup). Settles the combined delta through the same credit-never-banks rule every other settlement uses (`SettleRawDelta`, extracted from the existing `Calculate` so both share one rule rather than two copies that could drift).
- **Plan changes** (`SubscriptionPlanChangeService`): a prepaid stub that keeps cadence/alignment now settles immediately (or schedules, if the combined delta says it's really a downgrade) instead of being refused. A cadence/alignment change, or an unpaid stub, still waits/refuses exactly as before.
- **Quantity increases** (`SubscriptionQuantityChangeService`): the identical composite calculation, reused as-is — a quantity change moves neither plan nor price, so there's no cadence question to ask first. A combined delta at or below zero applies immediately at zero charge, mirroring how an ordinary increase reaching a cheaper volume band already behaves.
- **Reservation/recovery**: `SettlementReservation.PlanChange`/`QuantityChange` gain `ReplacementPendingAnnualPeriod`, threaded through `TryChangePlanAsync`/`TryApplyQuantityChangeAsync`/`TryPromoteQuantityReservationAsync` and the settlement-reservation recovery sweep, so a crash between charge and promotion still installs the correct new annual figures.
- **Invoices**: `SubscriptionSettlementBreakdown` gains a nested `Annual` field (payment entity and preview response both), and `FinancialDocumentHtmlTemplate` renders a second labelled section ("Prepaid annual-period adjustment") with one combined credit-and-net total at the end — credit is spent once against the combination, never against either side separately.
- **Preview**: quotes the identical composite settlement the confirm would charge, so a preview never shows a price the confirm wouldn't actually collect.

## Verification

- `dotnet build` — Subscription.DomainService, Payment.DomainService, XUnitTest, Api, Worker all build clean, 0 errors.
- `dotnet test --filter "FullyQualifiedName!~Integration"` — 3338 passed, 4 known pre-existing permission-guard failures (present on `dev`, unrelated), 1 skipped.
- New unit tests cover: the composite plan-change upgrade (immediate settlement, reservation carries the replacement annual period, two-section settlement breakdown), the cadence-change-still-waits case, the composite preview quote, the composite quantity increase, and the unpaid-stub refusal for both plan and quantity changes.
- Manually traced that reusing the existing single-period `Calculate()` for the stub side would have priced the "unused stub value" against the whole annual price rather than its monthly-equivalent stub-base rate — a severe overcharge bug — which is why this needed a dedicated calculation rather than reusing the generic one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)