### PR TITLE
Remove Discounts button from Subscription plans page header

### DIFF
--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
@@ -179,11 +179,6 @@ export const SubscriptionPlanListPage = () => {
         description="What your tenant sells — configure once here, then subscribe organizations to it from your own product."
         actions={
           <>
-            <Button variant="outline" asChild>
-              <Link to={withOrganizationScope(`/app/${itemId ?? ""}/subscription/discounts`, organizationScope)}>
-                Discounts
-              </Link>
-            </Button>
             <Button
               variant="outline"
               size="icon"


### PR DESCRIPTION
## Summary
- The Subscription plans page header had a "Discounts" button linking to the discounts page.
- Discounts is now reachable from the left navigation menu, making the header button a duplicate entry point.
- Removed the button; the Refresh and Create plan actions are unchanged.

## Test plan
- [x] `npm run type-check` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)