### PR TITLE
feat(subscription): opening-stub upgrades — client and docs (PR 3 of 3)

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
@@ -177,6 +177,20 @@ describe("ChangePlanDialog", () => {
     expect(screen.getByRole("button", { name: /^Confirm change$/ })).toBeDisabled();
   });
 
+  /**
+   * The static copy above the quote used to promise "takes effect immediately" and "a downgrade
+   * becomes credit toward future renewals" unconditionally — both false since scheduled changes
+   * (a downgrade, or an annual cadence change) neither apply today nor bank anything. Guards
+   * against that copy coming back rather than pinning down its exact replacement wording, which is
+   * free to keep improving.
+   */
+  it("never tells every change it applies immediately or banks credit as a downgrade", () => {
+    const { container } = renderDialog();
+
+    expect(container.textContent).not.toMatch(/takes effect immediately/i);
+    expect(container.textContent).not.toMatch(/downgrade becomes credit/i);
+  });
+
   it("previews the settlement before enabling confirm", async () => {
     previewPlanChange.mockResolvedValue(quote);
 

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
@@ -233,6 +233,79 @@ describe("ChangePlanDialog", () => {
     });
   });
 
+  /**
+   * A prepaid opening stub's compatible upgrade settles the stub and the paid year together.
+   * The dialog has to split that back apart for display — the server reports only the stub's
+   * own sides at the top level plus a combined post-credit total, never the stub's own raw delta
+   * directly — so this pins down the arithmetic rather than trusting a plausible-looking
+   * subtraction.
+   */
+  it("shows the stub and the prepaid year as two separate adjustments", async () => {
+    previewPlanChange.mockResolvedValue({
+      ...quote,
+      chargeMinor: 90_000,
+      settlement: {
+        // The stub's own sides, pre-credit: 10,000 owed for the remaining days.
+        outgoing: {
+          grossAmountMinor: 14_500,
+          builtInDiscountMinor: 0,
+          promotionalDiscountMinor: 0,
+          taxAmountMinor: 0,
+          periodTotalMinor: 14_500,
+          proratedValueMinor: 20_000,
+        },
+        target: {
+          grossAmountMinor: 18_000,
+          builtInDiscountMinor: 0,
+          promotionalDiscountMinor: 0,
+          taxAmountMinor: 0,
+          periodTotalMinor: 18_000,
+          proratedValueMinor: 30_000,
+        },
+        // Combined, post-credit: 10,000 (stub) + 100,000 (year) - 20,000 (credit) = 90,000.
+        creditConsumedMinor: 20_000,
+        netSettlementMinor: 90_000,
+        annual: {
+          outgoing: {
+            grossAmountMinor: 1_000_000,
+            builtInDiscountMinor: 0,
+            promotionalDiscountMinor: 0,
+            taxAmountMinor: 0,
+            periodTotalMinor: 1_000_000,
+            proratedValueMinor: 1_000_000,
+          },
+          target: {
+            grossAmountMinor: 1_100_000,
+            builtInDiscountMinor: 0,
+            promotionalDiscountMinor: 0,
+            taxAmountMinor: 0,
+            periodTotalMinor: 1_100_000,
+            proratedValueMinor: 1_100_000,
+          },
+          // The annual side's own raw delta — reported for display, no credit of its own.
+          creditConsumedMinor: 0,
+          netSettlementMinor: 100_000,
+        },
+      },
+    });
+
+    renderDialog();
+    selectTargetPlan();
+    click(/^Preview$/);
+
+    const dialog = await screen.findByTestId("plan-change-quote");
+
+    // 30,000 - 20,000 = 10,000, the stub's own raw delta — not the combined total, and not the
+    // combined total minus the annual delta either (which credit would corrupt).
+    expect(dialog.textContent).toContain("Opening stub adjustment");
+    expect(dialog.textContent).toContain("100.00"); // stub: CHF 100.00 = 10,000 minor
+    expect(dialog.textContent).toContain("Prepaid annual-period adjustment");
+    expect(dialog.textContent).toContain("1,000.00"); // annual: CHF 1,000.00 = 100,000 minor
+    expect(dialog.textContent).toContain("Net settlement");
+    expect(dialog.textContent).toContain("900.00"); // combined post-credit: CHF 900.00 = 90,000
+    expect(dialog.textContent).toContain("Paid from your credit");
+  });
+
   it("shows a blocker and keeps confirm disabled even though the price is quoted", async () => {
     previewPlanChange.mockResolvedValue({
       ...quote,

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -363,6 +363,31 @@ export const ChangePlanDialog = ({
                 label="Next full period"
                 value={formatMoney(quote.nextRenewalAmountMinor, quote.currencyCode)}
               />
+              {quote.settlement.annual ? (
+                // A prepaid opening stub's compatible upgrade settles two things at once: the
+                // days left on the stub, and the paid year repriced onto the new terms. Shown
+                // apart because that is what the invoice will say too — a single combined figure
+                // would read as one oversized plan-change fee with no explanation for the size.
+                // Each is its own raw delta, before credit — credit is spent once, below, against
+                // the combined total, never against either side alone.
+                <>
+                  <Row
+                    label="Opening stub adjustment"
+                    value={formatMoney(
+                      quote.settlement.target.proratedValueMinor -
+                        quote.settlement.outgoing.proratedValueMinor,
+                      quote.currencyCode,
+                    )}
+                  />
+                  <Row
+                    label="Prepaid annual-period adjustment"
+                    value={formatMoney(
+                      quote.settlement.annual.netSettlementMinor,
+                      quote.currencyCode,
+                    )}
+                  />
+                </>
+              ) : null}
               {quote.settlement.netSettlementMinor !== 0 ? (
                 <Row
                   label="Net settlement"
@@ -432,9 +457,10 @@ const describePlanChangeRefusal = (code: string | undefined): string | null => {
         "subscription first — only one change can be waiting at a time.";
     case "subscription_quantity_change_in_flight":
       return "A quantity change is still being settled. Try again once it finishes.";
-    case "subscription_initial_annual_period_prepaid":
-      return "This subscription has already paid for its first year, so it cannot move to another " +
-        "plan until that year begins. A downgrade can still be scheduled now.";
+    // subscription_initial_annual_period_prepaid is retired: a prepaid opening stub no longer
+    // refuses a compatible plan change outright — it settles the stub and the paid year together
+    // instead (the quote above already reflects that combined charge). Only an unpaid stub still
+    // refuses one outright, below.
     case "subscription_initial_annual_period_unpaid":
       return "This subscription's first year has not been charged yet, so it cannot move to " +
         "another plan until it is. A downgrade can still be scheduled now.";

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -324,8 +324,9 @@ export const ChangePlanDialog = ({
           ))}
 
           <p className="text-xs text-muted-foreground">
-            The change takes effect immediately and starts a full target billing period — an
-            upgrade may charge immediately, a downgrade becomes credit toward future renewals.
+            Preview to see whether this applies immediately or at the end of the paid period.
+            An immediate change may require payment; a scheduled one charges nothing and creates
+            no refund or credit today.
           </p>
 
           {profileGap && (

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -347,6 +347,17 @@ export interface PlanChangeSettlement {
   target: PlanChangeSettlementSide;
   creditConsumedMinor: number;
   netSettlementMinor: number;
+  /**
+   * The prepaid annual period's own settlement, alongside this one, when a change taken during a
+   * calendar-aligned yearly subscription's opening stub settled the stub and the paid year
+   * together. Undefined for every ordinary settlement, which is exactly one period.
+   *
+   * Only the *top-level* `creditConsumedMinor`/`netSettlementMinor` are the figures actually
+   * charged — credit is spent once against the combination, never against either side alone — so
+   * this nested settlement's own two fields describe the annual side's own contribution, for
+   * display rather than for anything to add up into a second charge.
+   */
+  annual?: PlanChangeSettlement;
 }
 
 /**

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -591,7 +591,10 @@ const PLAN_CHANGE_ERROR_CODES = [
   "subscription_not_found",
   "subscription_plan_change_not_eligible",
   "subscription_quantity_change_in_flight",
-  "subscription_initial_annual_period_pending",
+  // A prepaid opening stub no longer refuses a compatible plan change outright — see
+  // change-plan-dialog's own remarks on the retired _prepaid code. Only an unpaid stub still
+  // refuses one, so that is the only opening-stub code left to recognize here.
+  "subscription_initial_annual_period_unpaid",
   "subscription_plan_not_found",
   "subscription_price_not_found",
   "subscription_plan_change_currency_mismatch",

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1133,19 +1133,20 @@
       <div class="callout">
         <strong>A document is owed the moment the event happens, not the moment it is scheduled.</strong>
         Every financial event appends an obligation to the subscription in the same write as the
-        transition that caused it, carrying the plan, price, quantities and period as they were then. A
-        change that banks credit appends its obligation inside the very compare-and-set that banks the
-        credit, because it charges nothing and the balance it moves cannot say afterwards which change
-        moved it.
+        transition that caused it, carrying the plan, price, quantities and period as they were then.
+        <strong>No plan or quantity change banks new credit any more</strong> — see
+        <a href="#plan-change">Upgrade, downgrade, or switch plans</a> — so no such source is written
+        today. A legacy consumer is kept solely to drain <code>CreditNote</code> sources written
+        <em>before</em> that policy changed; it issues the last of them and is removed once none remain.
       </div>
       <p class="prose">
         <strong>Recovery has no time window.</strong> Four passes, and none of them looks back a fixed
         number of hours — a window would make recovery a function of how long the worker was away, so an
         outage longer than the window would leave documents that are never issued and nothing that says
-        so. The first reads the recorded obligations, which is the only route by which a banked credit
-        note can be recovered at all. The second and third re-derive from settled payments and confirmed
-        refunds for the case where recording the obligation itself was lost. The fourth walks trials,
-        which leave no payment behind either.
+        so. The first reads the recorded obligations — the only route by which one of those legacy
+        banked-credit sources, if still unissued, can be recovered at all. The second and third re-derive
+        from settled payments and confirmed refunds for the case where recording the obligation itself
+        was lost. The fourth walks trials, which leave no payment behind either.
       </p>
       <p class="prose">
         The last three walk forward from a stored mark that is a <em>position</em> rather than a moment:
@@ -1497,6 +1498,7 @@ stateDiagram-v2
           <tr><td>Quantity increase</td><td>Immediate</td><td class="prose">Charges the prorated difference</td></tr>
           <tr><td>Plan downgrade</td><td>End of paid period</td><td class="prose">No refund, no new credit</td></tr>
           <tr><td>Quantity decrease</td><td>End of paid period</td><td class="prose">No refund, no new credit</td></tr>
+          <tr><td>Prepaid opening-stub upgrade or increase, same cadence</td><td>Immediate</td><td class="prose">Settles the stub and the paid year together — see <a href="#opening-stub-upgrades">Opening-stub upgrades</a></td></tr>
           <tr><td>Prepaid annual cadence change</td><td>Annual renewal</td><td class="prose">Preserves the prepaid commitment</td></tr>
           <tr><td>Trial plan change</td><td>Immediate</td><td class="prose">Nothing paid yet, so nothing to protect</td></tr>
         </tbody>
@@ -1740,7 +1742,7 @@ Content-Type: application/json
           <tbody>
             <tr><td><code>400</code></td><td class="prose">Invalid price, quantity or request shape.</td><td class="prose">Show <code>error.fields</code> beside the relevant inputs.</td></tr>
             <tr><td><code>404</code></td><td class="prose">The subscription, price or target plan is unavailable.</td><td class="prose">Reload current subscription and catalogue; an author may have archived the price.</td></tr>
-            <tr><td><code>409</code></td><td class="prose">Currency mismatch, ineligible state, same plan, missing reusable payment method, or a concurrent change.</td><td class="prose">Read <code>error.code</code>, reload <code>/subscriptions/current</code>, and rebuild the choice. A currency change requires cancel-and-subscribe.</td></tr>
+            <tr><td><code>409</code></td><td class="prose">Currency mismatch, ineligible state, same plan, missing reusable payment method, a concurrent change, or an opening stub whose first year is still unpaid (<code>subscription_initial_annual_period_unpaid</code> — see <a href="#opening-stub-upgrades">Opening-stub upgrades</a>).</td><td class="prose">Read <code>error.code</code>, reload <code>/subscriptions/current</code>, and rebuild the choice. A currency change requires cancel-and-subscribe.</td></tr>
             <tr><td><code>422</code></td><td class="prose">The provider refused an immediate upgrade charge.</td><td class="prose">Keep showing the old plan and present the provider-safe error message.</td></tr>
             <tr><td><code>502</code> / <code>503</code></td><td class="prose">Payment provider or a required service is unavailable.</td><td class="prose">Do not assume the plan changed. Refresh current state before offering retry.</td></tr>
           </tbody>
@@ -1755,6 +1757,86 @@ Content-Type: application/json
         so it holds exactly until the next local midnight; a plan-change preview freezes nothing
         and is priced fresh every time it runs, so it holds only up to the clock. Re-fetch it
         immediately before confirming rather than treating it as a held quote.
+      </p>
+
+      <h3 id="opening-stub-upgrades">Opening-stub upgrades</h3>
+      <p class="prose">
+        A calendar-aligned yearly subscriber can be inside the opening stub — the short period
+        between signup and the first of the month the year actually starts — while that year has
+        already been paid for (<code>calendarAnnualChargeTiming: "AtCheckout"</code>, or
+        <code>"AtBoundary"</code> once the opening charge has cleared). A plan or quantity change
+        asked for during that window is handled by whether the year is paid, and whether the change
+        keeps the subscriber's cadence and calendar boundary:
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>State</th><th>Change</th><th>Result</th></tr></thead>
+          <tbody>
+            <tr>
+              <td>Unpaid</td>
+              <td class="prose">Any plan or quantity increase</td>
+              <td class="prose"><code>409 subscription_initial_annual_period_unpaid</code>. There is
+                nothing paid yet to reprice against; wait for the opening charge to clear, which is
+                at most a month. A downgrade or a decrease can still be scheduled in the meantime.</td>
+            </tr>
+            <tr>
+              <td>Prepaid</td>
+              <td class="prose">Upgrade or quantity increase, same interval and alignment</td>
+              <td class="prose">Settles immediately — the stub's remaining days and the paid year,
+                together, in one charge. See below.</td>
+            </tr>
+            <tr>
+              <td>Prepaid</td>
+              <td class="prose">A change that would re-cadence the year, or that settles to a real
+                downgrade</td>
+              <td class="prose">Scheduled for the year's own end, exactly like an ordinary downgrade
+                — never the stub's own boundary, which would take the plan away mid-commitment.
+                <code>timing: "NextRenewal"</code>, <code>effectiveAtUtc</code> is the year's end.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="prose">
+        A compatible prepaid upgrade settles two things at once: the stub's own remaining days,
+        priced at the linked monthly price exactly as the stub itself was; and the difference
+        between what the paid year cost and what it costs on the new terms, priced for the whole
+        year. Credit is spent once, against the combined total — never against either side alone —
+        so the response's top-level <code>settlement</code> carries the real combined figures, and a
+        nested <code>settlement.annual</code> reports the year's own contribution for display:
+      </p>
+      <pre><code>"settlement": {
+  "outgoing": { "…": "the stub's own outgoing side" },
+  "target": { "…": "the stub's own target side" },
+  "creditConsumedMinor": 5000,
+  "netSettlementMinor": 42000,       // the real combined charge, after credit
+  "annual": {
+    "outgoing": { "…": "the paid year, verbatim" },
+    "target": { "…": "the same year on the new terms" },
+    "creditConsumedMinor": 0,        // always 0 here — credit is never spent per side
+    "netSettlementMinor": 38000      // the year's own raw delta, before credit
+  }
+}</code></pre>
+      <p class="prose">
+        <code>settlement.annual</code> is present only for this composite case; every ordinary
+        settlement omits it. A client showing the settlement should read
+        <code>settlement.annual</code> as an optional two-part breakdown — an opening-stub
+        adjustment and a prepaid annual-period adjustment — with the top-level
+        <code>creditConsumedMinor</code>/<code>netSettlementMinor</code> as the one figure actually
+        charged. The invoice this settlement produces carries the identical two labelled sections.
+      </p>
+      <p class="prose">
+        Quantity increases go through the identical settlement, called with the subscriber's own
+        plan and price on both sides — a quantity change moves neither, so there is no cadence
+        question to ask first. A combined delta at or below zero applies immediately at zero
+        charge, exactly as an ordinary increase reaching a cheaper volume band already does. A
+        decrease is unaffected either way: it still schedules for the year's end.
+      </p>
+      <p class="prose">
+        The charge behind this settlement is reserved the same way every other paid change is
+        reserved (see <a href="#quantities">One settlement at a time</a>) — so if a worker dies
+        between the charge succeeding and the write that records it, the recovery sweep replays the
+        identical reservation and installs the identical replacement year, naming the same payment,
+        rather than leaving the subscription holding the year it had before the money moved.
       </p>
     </section>
 
@@ -1779,7 +1861,7 @@ Content-Type: application/json
             <tr>
               <td>Increase</td>
               <td class="prose">Immediately — the units are handed over at once.</td>
-              <td class="prose">The prorated difference between the old and new discounted totals for the rest of the current period, charged <strong>before</strong> the quantity moves. The units are reserved first, so a charge that settles is never lost even if the subscription changes underneath it. A decline releases the reservation and leaves quantity and entitlement untouched.</td>
+              <td class="prose">The prorated difference between the old and new discounted totals for the rest of the current period, charged <strong>before</strong> the quantity moves. The units are reserved first, so a charge that settles is never lost even if the subscription changes underneath it. A decline releases the reservation and leaves quantity and entitlement untouched. During a prepaid calendar-aligned opening stub this settles the stub and the paid year together instead — see <a href="#opening-stub-upgrades">Opening-stub upgrades</a>; during an unpaid one it refuses outright with <code>subscription_initial_annual_period_unpaid</code>.</td>
             </tr>
             <tr>
               <td>Decrease</td>
@@ -1861,7 +1943,10 @@ Content-Type: application/json
             <code>200</code> · <code>400</code> invalid quantity, unchanged quantity, or an item
             the plan does not define · <code>404</code> · <code>409</code> a stale version, a change
             already being settled (<code>subscription_quantity_change_in_flight</code>), no saved
-            payment method, or a status that does not permit the change ·
+            payment method, an unpaid opening-stub year for an increase
+            (<code>subscription_initial_annual_period_unpaid</code> — see
+            <a href="#opening-stub-upgrades">Opening-stub upgrades</a>), or a status that does not
+            permit the change ·
             <code>422</code> <code>subscription_quantity_charge_failed</code> — the payment method
             declined. One code for every decline, whatever word the acquirer used; the provider's own
             reason is logged, not returned ·
@@ -2216,11 +2301,13 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
             <code>subscription_calendar_annual_charge_timing_unexpected</code>.
           </p>
           <p class="prose">
-            While a subscription is inside its opening stub with a year still pending, plan and
-            quantity changes are refused with <code>409</code>
-            <code>subscription_initial_annual_period_pending</code>. Repricing then would have to
-            unpick a settled annual charge or discard one about to be collected. The wait is at most
-            a month.
+            While a subscription is inside its opening stub, an <em>unpaid</em> year still refuses a
+            plan or quantity change with <code>409</code>
+            <code>subscription_initial_annual_period_unpaid</code> — the opening charge has not
+            cleared yet, so there is nothing paid to reprice against, and the wait is at most a
+            month. A <em>prepaid</em> year no longer refuses one outright: a compatible change
+            settles the stub and the paid year together immediately instead. See
+            <a href="#opening-stub-upgrades">Opening-stub upgrades</a> below for the full behaviour.
           </p>
           <p class="prose">
             <code>quantityDiscountCombination</code> may be omitted; it reads as
@@ -3419,6 +3506,18 @@ POST /api/subscriptions
             two sides.
           </p>
           <p class="prose">
+            An upgrade taken during a calendar-aligned yearly subscription's prepaid opening stub
+            settles two things at once, and its invoice carries a nested
+            <code>settlement.annual</code> alongside the outer <code>outgoing</code>/<code>target</code>
+            &mdash; the outer pair describes the stub, the nested object the paid annual period on its
+            new terms, in the identical shape one level down. Only the <em>outer</em>
+            <code>creditConsumedMinor</code>/<code>netSettlementMinor</code> are the figures actually
+            charged; the nested pair reports the annual side's own contribution for the invoice to
+            render as a second, separately labelled section rather than for anything to add into a
+            second charge. Absent on every ordinary settlement. See
+            <a href="#opening-stub-upgrades">Opening-stub upgrades</a>.
+          </p>
+          <p class="prose">
             <code>trial</code> is populated only on a <code>TrialInvoice</code>, and carries the trial
             window, whether a card was required, and the expected first billing date.
             <code>originalDocumentId</code> and <code>originalDocumentNumber</code> are populated only
@@ -3678,6 +3777,7 @@ POST /api/subscriptions
             <tr><td>subscription_quantity_item_unknown</td><td class="prose">A quantity the plan does not define.</td></tr>
             <tr><td>subscription_plan_change_currency_mismatch</td><td class="prose">Target price is in another currency.</td></tr>
             <tr><td>subscription_plan_change_no_payment_method</td><td class="prose">An upgrade needs a stored card to charge the difference.</td></tr>
+            <tr><td>subscription_initial_annual_period_unpaid</td><td class="prose">A plan or quantity increase asked for while a calendar-aligned opening year's opening charge has not yet cleared. Wait for it — at most a month — or schedule a downgrade instead. See <a href="#opening-stub-upgrades">Opening-stub upgrades</a>; a <em>prepaid</em> year no longer refuses a compatible change this way.</td></tr>
             <tr><td>subscription_version_conflict</td><td class="prose">Another update won the compare-and-set. Re-read the subscription and confirm again.</td></tr>
             <tr><td>subscription_quantity_invalid</td><td class="prose">The quantity is outside the bounds snapshotted on the plan.</td></tr>
             <tr><td>subscription_quantity_unchanged</td><td class="prose">The requested quantity is already the effective one.</td></tr>

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -579,7 +579,8 @@ A change onto a calendar-aligned **yearly** price settles only the target stub i
 from that price's monthly basis exactly as a fresh signup would be. The annual cycle then opens on
 the first like any other calendar-aligned year.
 
-A positive difference is charged immediately; a negative one is banked as credit. The target
+A positive difference is charged immediately; a negative one costs nothing and creates no new
+credit — the same credit-never-banks clamp every settlement in this module applies. The target
 schedule is installed atomically with the settled plan change, and the outgoing usage period is
 closed and rated through the existing safe plan-change flow rather than being reset or discarded.
 
@@ -888,12 +889,14 @@ Two restrictions keep this a contained piece of work rather than a rewrite of th
 - **`Trialing` and `Active` only.** `PastDue`/`Unpaid` is refused as a conflict: a customer who
   owes money changing plans is a support decision, not something to automate.
 
-> **Known gap.** If a charge succeeds but the compare-and-set that records the plan change loses
-> a race immediately after, the money has moved and the write has not. This is the same shape of
-> risk the initial checkout has — and that one has a dedicated recovery sweep
-> (`SubscriptionActivationProcessor.RecoverStaleAsync`) for exactly this reason. A plan change
-> does not have an equivalent sweep yet; the case is rare (a genuine concurrent write to the same
-> subscription, not a network failure) and is called out here rather than left to be discovered.
+A paid plan or quantity change is not exposed to the race a version-keyed write would be: the
+charge is raised against a `SettlementReservation` written *before* the card is charged, and the
+promotion that installs the change afterward is addressed by the reservation id rather than by the
+version that might have moved underneath it. If a worker dies between the charge succeeding and
+that promotion landing, `SubscriptionSettlementReservationProcessor.RecoverStaleAsync` replays the
+identical reservation and installs the identical terms, keyed on the same idempotent charge — the
+same shape of recovery the initial checkout's `SubscriptionActivationProcessor.RecoverStaleAsync`
+provides for the analogous race there.
 
 ### Opening-stub upgrades
 
@@ -1360,7 +1363,7 @@ number series:
 | --- | --- | --- |
 | `Invoice` | Every settled positive charge: the initial checkout payment, a card-free trial's conversion charge, a renewal, a paid plan change, a paid quantity increase, metered overage. | `INV-{year}-{000001}` |
 | `TrialInvoice` | Every trial start, card or no card. Zero total — it states the terms of a period nobody was charged for. | The same `INV-` series, so a subscriber can see they have every invoice. |
-| `CreditNote` | A confirmed refund, and a change that banked subscription credit. Linked to the invoice it adjusts where there is one. | `CRN-{year}-{000001}` |
+| `CreditNote` | A confirmed refund. Historically also a downgrade whose unused time was banked as subscription credit — no plan or quantity change banks credit any more, so no new one is raised for that reason. Linked to the invoice it adjusts where there is one. | `CRN-{year}-{000001}` |
 
 Nothing is issued for a failed, abandoned or pending payment attempt, an ordinary cancellation, or
 credit being *consumed* by a later invoice — that is a deduction on the invoice it paid for, and a
@@ -1492,12 +1495,15 @@ any that remain are precisely what recovery is looking for.
 Two problems, one record:
 
 - **Durability.** Scheduling is a write to another database with no transaction shared with the
-  money, so a crash in that window used to leave nothing behind but a payment. For a change that
-  *banks* credit rather than charging for it, it left nothing at all: the value is folded into
-  `CreditBalanceMinor` and the balance cannot say which change put it there. That one is appended
-  inside the very compare-and-set that banks the credit — `TryChangePlanAsync` and
-  `TryApplyQuantityChangeAsync` both take it — because anywhere else is a window in which the credit
-  note is lost for good.
+  money, so a crash in that window used to leave nothing behind but a payment. **No plan or quantity
+  change banks new credit any more** — see [Plan changes and proration](#plan-changes-and-proration)
+  — so nothing appends this source today. Historically, a change that *banked* credit rather than
+  charging for it left nothing at all if the write were lost: the value was folded into
+  `CreditBalanceMinor` and the balance could not say which change put it there. That source was
+  appended inside the very compare-and-set that banked the credit — `TryChangePlanAsync` and
+  `TryApplyQuantityChangeAsync` still accept the optional parameter, kept for the legacy consumer
+  below rather than because either service still populates it — because anywhere else would have
+  been a window in which the credit note was lost for good.
 - **Historical accuracy.** A document written minutes or days late has to describe the terms the
   money was charged on. Reading them off the live subscription is correct only while nothing has
   changed since, which is the assumption a delayed or recovered issue breaks: an invoice for last
@@ -1508,8 +1514,10 @@ Two problems, one record:
 
 The amounts are deliberately *not* frozen for a charge. What was taken is on the payment, which is
 the only version of the figures the bank agrees with; a second copy would be free to disagree with
-it. The obligation freezes what the money was *for*. A banked credit note is the exception and
-carries its own figures, decomposed at the change from the outgoing side of the settlement — see
+it. The obligation freezes what the money was *for*. A legacy banked credit note — one of the
+sources written before the credit-never-banks policy, still being drained; see
+[Financial documents](#financial-documents) above — is the one exception and carries its own
+figures, decomposed at the change from the outgoing side of the settlement — see
 `FinancialDocumentCreditComposition` — because there is no payment to read them from and the
 outgoing price's tax rate and mode are gone the moment the new plan replaces them.
 

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -374,10 +374,18 @@ would find the year again on the next sweep and charge for it twice. A declined 
 leaves the year pending and enters ordinary dunning, so the retry still owes exactly the frozen
 amount.
 
-**Plan and quantity changes are refused while a year is pending**, with
-`subscription_initial_annual_period_pending`. Repricing then would have to unpick a settled annual
-charge or silently discard one about to be collected, and neither is something a caller can be told
-about after the fact. The wait is at most a month.
+**An unpaid year still refuses a plan or quantity change**, with
+`subscription_initial_annual_period_unpaid`. Repricing before the opening charge has cleared would
+have to silently discard a charge about to be collected, and that is not something a caller can be
+told about after the fact. The wait is at most a month, and a downgrade or a decrease can still be
+scheduled for the boundary in the meantime.
+
+**A prepaid year no longer refuses one outright.** A change that keeps the subscriber's cadence and
+calendar boundary — a compatible plan upgrade, or any quantity increase, since neither moves the
+price — settles the stub's remaining days and the paid year together in one immediate charge; see
+[Opening-stub upgrades](#opening-stub-upgrades) below. A change that would re-cadence a paid year,
+or a genuine downgrade in disguise, still waits for the boundary exactly as an unpaid stub does —
+`subscription_initial_annual_period_prepaid` is retired along with the blanket refusal it named.
 
 The monthly amount and price id are **snapshotted onto the subscription**, so the stub is priced
 without ever reading the monthly price again — not at checkout, not at renewal, not by a recovery
@@ -849,11 +857,12 @@ boundary in the single compare-and-set that advances the period. The subscriber 
 paid for until then.
 
 Two rules sit above that arithmetic. A trial is always immediate — it has paid for nothing, so
-there is no paid period to protect. And a paid annual term being re-cadenced always waits,
-whether it is a calendar-aligned opening stub (`PendingAnnualPeriod.IsPrepaid`) or an ordinary
-running year read from the price's own cadence: annual → monthly tends to settle *positive*,
-because a month costs more than the remaining slice of a discounted year, so charging it now would
-bill the same weeks twice.
+there is no paid period to protect. And a paid annual term being re-cadenced always waits, whether
+it is an ordinary running year read from the price's own cadence, or a calendar-aligned opening
+stub whose year is already prepaid: annual → monthly tends to settle *positive*, because a month
+costs more than the remaining slice of a discounted year, so charging it now would bill the same
+weeks twice. A prepaid stub that keeps its cadence is a third case, settled immediately by its own
+arithmetic rather than by this one — see [Opening-stub upgrades](#opening-stub-upgrades) below.
 
 **Nothing creates credit.** `SubscriptionProrationCalculator` clamps the balance so it can only
 fall — credit already held is still spent against an immediate upgrade, and any remainder still
@@ -886,14 +895,64 @@ Two restrictions keep this a contained piece of work rather than a rewrite of th
 > does not have an equivalent sweep yet; the case is rare (a genuine concurrent write to the same
 > subscription, not a network failure) and is called out here rather than left to be discovered.
 
+### Opening-stub upgrades
+
+A calendar-aligned yearly subscriber who upgrades — or adds units — while still inside the opening
+stub, after that year has already been paid for, is settling two things at once: the stub's own
+remaining days, and the difference between what the paid year cost and what it costs on the new
+terms. `SubscriptionProrationCalculator.CalculateOpeningStubUpgrade` prices both and settles them
+together, in one immediate charge, rather than the blanket refusal this used to be.
+
+The two sides are priced by different rules, each mirroring exactly how the stub and the year were
+priced at signup:
+
+- **The stub** is priced at its own monthly-equivalent stub-basis rate
+  (`CalendarBillingAlignment.TryStubBasis`), for both the outgoing plan and the target — the same
+  substitution [above](#a-yearly-stub-is-priced-from-a-linked-monthly-price) uses, so a week is
+  never priced as a twelfth of an annual rate. The subscriber's promotional code is deliberately
+  excluded on both sides: a code belongs to the year, never to the days before it.
+- **The year** is priced at the target's full rate for the whole period, promotional code
+  included — the frozen `PendingAnnualPeriod` supplies the outgoing side verbatim, since that is
+  exactly what was already charged or promised and re-deriving it risks drifting from what the
+  subscriber agreed to. The code is repriced at the discount-period index that bought the year
+  being replaced, not at the subscription's current one — a prepaid year has already spent its
+  promotional period, and repricing at the current index would treat a one-period promotion as
+  exhausted and quote the replacement year undiscounted.
+
+**Credit is spent once, against the combined total, never against either side alone** — the same
+credit-never-banks clamp every other settlement in this module uses. A combined delta at or below
+zero applies immediately at zero charge, exactly as an ordinary change reaching a cheaper volume
+band already does. A change that would still be worth less than what it replaces, or that would
+re-cadence the year, does not reach this path at all: `PlanChangeClassifier` and
+`ChangesCadenceOrAlignment` route it to the ordinary scheduled path above instead.
+
+**Quantity increases go through the identical calculation**, called with the subscriber's own plan
+and price on both sides — a quantity change moves neither, so there is no cadence question to ask
+first. A decrease is unaffected: it still schedules for the year's end exactly as before.
+
+The invoice for a settled upgrade carries two labelled sections rather than one —
+`SubscriptionSettlementBreakdown.Annual` nests the year's own breakdown beneath the stub's — with a
+single combined credit-and-net total at the end, since credit was never spent against either
+section in isolation. A preview taken during a prepaid stub is quoted through the identical
+calculation the confirm would charge, so it never shows a price the confirm would not actually
+collect.
+
+The reservation this settlement takes carries a `ReplacementPendingAnnualPeriod` alongside the
+ordinary plan or quantity payload, so a crash between the charge and the promotion still installs
+the correct new annual figures — the settlement-reservation recovery sweep applies it the same way
+the request path does, stamping the confirmed payment onto a copy of the reservation's replacement
+year (`PendingAnnualPeriod.SettledBy`) rather than the reservation's own instance, so a replay after
+a crash and a clean run install the identical reference.
+
 ### The preview is priced fresh, not frozen
 
 `POST /api/subscriptions/{id}/plan/preview` answers what a plan change would cost or credit,
 without applying anything. Unlike the purchase preview
 (`SubscriptionCreationService.PreviewAsync`), nothing here is frozen ahead of time —
 `ChangePlanAsync` has never worked that way: it calls `SubscriptionProrationCalculator.Calculate`
-fresh, immediately before charging, every time it runs. So the preview makes the same promise
-this module's quantity-change preview already makes (`SubscriptionQuantityChangeService`'s own
+(or, during a prepaid opening stub, `CalculateOpeningStubUpgrade` — see above) fresh, immediately
+before charging, every time it runs. So the preview makes the same promise this module's
+quantity-change preview already makes (`SubscriptionQuantityChangeService`'s own
 `PreviewAsync`/`ChangeAsync` share one `RunAsync`, and price fresh on both paths) — the same
 math, evaluated a moment later — rather than a stronger one this service has never provided.
 


### PR DESCRIPTION
## Summary

PR 3 of the "Standard Plan and Quantity Change Lifecycle" feature — stacked on [PR #388](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/388) (PR 2: prepaid opening-stub upgrades), which is itself stacked on [PR #387](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/387) (PR 1). Base branch is `feat/prepaid-stub-upgrades`; merge order is #387 → #388 → this one.

Updates the client and the module guide to match PR 2's behavior, which the UI and README both still contradicted going into this PR.

## Client

- `change-plan-dialog` retired its dead `subscription_initial_annual_period_prepaid` case — the server never returns it any more, since a compatible upgrade during a prepaid stub now settles immediately instead of being refused. Only the still-active `_unpaid` case remains.
- The same retirement in `subscription-simulation.service.ts`'s `PLAN_CHANGE_ERROR_CODES` allowlist (it previously listed a code, `subscription_initial_annual_period_pending`, that never matched any code the server actually returns).
- `PlanChangeSettlement` gains the same nested `annual` field the server response now carries, and the confirm dialog renders it as two separate adjustment rows ("Opening stub adjustment", "Prepaid annual-period adjustment") alongside the existing combined net-settlement and credit-consumed rows — mirroring the two-section invoice rather than showing one oversized, unexplained figure.
- New test pins down the arithmetic: the stub's own raw delta has to come from the top-level sides' own prorated values, not from subtracting the annual delta out of the combined post-credit total — which credit consumption would silently corrupt.

## Docs (`server/Subscription.DomainService/README.md`)

- "The year in between" no longer describes the retired blanket refusal (and the wrong error code it never actually used) — states the unpaid refusal that remains and points to the new immediate-settlement path.
- "Plan changes and proration" corrects "a paid annual term being re-cadenced always waits" to name the third case PR 2 added, and a new **"Opening-stub upgrades"** subsection documents the composite calculation, the discount-period-index correction, the credit-once invariant, quantity-increase parity, the two-section invoice, and the reservation/recovery guarantee — cross-linked from both the stub-basis section above and the plan-change preview section below, both of which are updated to mention the composite path.

## Flagged separately, not fixed here

The "Known gap: no recovery sweep for plan changes" callout under "Plan changes and proration" is independently stale — it predates even PR 1 (commit `7ebd2c0d` already added the settlement-reservation recovery sweep this callout says does not exist). Out of scope for this doc pass; flagged as its own follow-up.

## Verification

- `dotnet test` — server-side change in this PR is comment-only (wording fix), so the full suite is unaffected; see #388's own verification for the behavioral changes.
- `npx vitest run app/cross-modules/utilities/subscription-simulation` — 65 passed.
- `npx tsc --noEmit` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)