### PR TITLE
feat(subscription): publish a current-usage read model beside the counters

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -81,5 +81,5 @@ jobs:
         run: >-
           dotnet test server/XUnitTest/XUnitTest.csproj
           --no-restore
-          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests|FullyQualifiedName~OpeningStubUpgradeRecoveryIntegrationTests"
+          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests|FullyQualifiedName~OpeningStubUpgradeRecoveryIntegrationTests|FullyQualifiedName~SubscriptionUsageCurrentIntegrationTests"
           --verbosity minimal

--- a/server/Api/Api.csproj
+++ b/server/Api/Api.csproj
@@ -13,6 +13,13 @@
 	
 	
   <ItemGroup>
+    <!-- The usage-read and projection-publish instruments are recorded in this process, so this is
+         where they have to be exported from. Versions come from Directory.Packages.props, the same
+         ones the Worker already uses. -->
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Remove="appsettings.Development.json" />
   </ItemGroup>
   <ItemGroup>

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -975,6 +975,45 @@
             must not exceed its allowance should set <c>enforce</c> and act on <c>allowed</c>.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionUsageController.GetCurrent(System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Current usage for every meter on the organization's live subscription.
+            </summary>
+            <remarks>
+            <c>readMode</c> chooses where the figures come from and nothing else. It is a performance
+            choice, never an authorisation one: neither mode may be used to decide whether usage is
+            allowed. Only <c>POST /api/subscription-usage</c> with <c>enforce</c> can claim capacity,
+            because only the counter's atomic increment settles two callers wanting the same last unit.
+            <list type="bullet">
+            <item><c>authoritative</c> (the default, and what this endpoint has always done) reads the
+            counters.</item>
+            <item><c>projection</c> reads the published read model in one indexed query, falling back to
+            the counters if nothing has been published for the subscription yet.</item>
+            </list>
+            Both modes return the identical <c>UsageResponse[]</c> body. How the read was served is
+            reported in <c>X-Usage-Read-*</c> response headers rather than in the body, so opting into a
+            mode cannot change the shape a consumer parses.
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionUsageController.TryParseReadMode(System.String,Subscription.DomainService.Enums.UsageReadMode@)">
+            <summary>
+            Accepts the mode by name, case-insensitively, and refuses anything else.
+            </summary>
+            <remarks>
+            Refused rather than silently defaulted. A caller that misspells <c>projection</c> and is
+            quietly served the authoritative path would measure the wrong thing and conclude the
+            projection had no benefit.
+            </remarks>
+        </member>
+        <member name="M:Api.Controllers.SubscriptionUsageController.Describe(Subscription.DomainService.Responses.UsageReadDiagnostics)">
+            <summary>
+            Puts the read diagnostics on the response headers.
+            </summary>
+            <remarks>
+            Headers rather than the body, so both modes keep the identical array contract and no existing
+            consumer of this endpoint sees a changed shape.
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.SubscriptionUsageController.PreviewOverage(Subscription.DomainService.Requests.PreviewUsageOverageRequest,System.Threading.CancellationToken)">
             <summary>
             Estimates the cost of additional metered usage, using the active subscription's own

--- a/server/Api/Controllers/SubscriptionUsageController.cs
+++ b/server/Api/Controllers/SubscriptionUsageController.cs
@@ -154,6 +154,10 @@ public sealed class SubscriptionUsageController : ControllerBase
         headers["X-Usage-Read-Documents"] =
             diagnostics.DocumentCount.ToString(CultureInfo.InvariantCulture);
         headers["X-Usage-Read-Stale"] = diagnostics.Stale ? "true" : "false";
+        // Named rather than implied by Source differing from Mode: "nothing published" and "only
+        // some windows published" both fall back to the counters, and they mean different things to
+        // whoever is watching.
+        headers["X-Usage-Read-Fallback"] = diagnostics.Fallback.ToString();
 
         if (diagnostics.NewestProjectionAgeSeconds is { } age)
         {

--- a/server/Api/Controllers/SubscriptionUsageController.cs
+++ b/server/Api/Controllers/SubscriptionUsageController.cs
@@ -1,8 +1,10 @@
+using System.Globalization;
 using Api.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Payment.DomainService.Responses;
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Services;
@@ -52,22 +54,112 @@ public sealed class SubscriptionUsageController : ControllerBase
         return result.ToActionResult(correlationId);
     }
 
+    /// <summary>
+    /// Current usage for every meter on the organization's live subscription.
+    /// </summary>
+    /// <remarks>
+    /// <c>readMode</c> chooses where the figures come from and nothing else. It is a performance
+    /// choice, never an authorisation one: neither mode may be used to decide whether usage is
+    /// allowed. Only <c>POST /api/subscription-usage</c> with <c>enforce</c> can claim capacity,
+    /// because only the counter's atomic increment settles two callers wanting the same last unit.
+    /// <list type="bullet">
+    /// <item><c>authoritative</c> (the default, and what this endpoint has always done) reads the
+    /// counters.</item>
+    /// <item><c>projection</c> reads the published read model in one indexed query, falling back to
+    /// the counters if nothing has been published for the subscription yet.</item>
+    /// </list>
+    /// Both modes return the identical <c>UsageResponse[]</c> body. How the read was served is
+    /// reported in <c>X-Usage-Read-*</c> response headers rather than in the body, so opting into a
+    /// mode cannot change the shape a consumer parses.
+    /// </remarks>
     [HttpGet("current")]
     [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<UsageResponse>>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<UsageResponse>>), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiResponse<IReadOnlyList<UsageResponse>>), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetCurrent(
         [FromQuery] string? organizationId,
+        [FromQuery] string? readMode,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
 
-        var result = await _usage.GetCurrentUsageAsync(
+        if (!TryParseReadMode(readMode, out var mode))
+        {
+            return BadRequest(ApiResponse<IReadOnlyList<UsageResponse>>.Fail(
+                "subscription_usage_read_mode_invalid",
+                "readMode must be omitted, 'authoritative' or 'projection'.",
+                correlationId));
+        }
+
+        var result = await _usage.ReadCurrentAsync(
             organizationId,
+            mode,
             correlationId,
             cancellationToken);
 
-        return result.ToActionResult(correlationId);
+        if (!result.IsSuccess)
+        {
+            return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
+                    result.FailureKind,
+                    result.ErrorCode!,
+                    result.ErrorMessage!,
+                    correlationId)
+                .ToActionResult(correlationId);
+        }
+
+        Describe(result.Value!.Diagnostics);
+
+        return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Success(
+                result.Value!.Items,
+                correlationId)
+            .ToActionResult(correlationId);
+    }
+
+    /// <summary>
+    /// Accepts the mode by name, case-insensitively, and refuses anything else.
+    /// </summary>
+    /// <remarks>
+    /// Refused rather than silently defaulted. A caller that misspells <c>projection</c> and is
+    /// quietly served the authoritative path would measure the wrong thing and conclude the
+    /// projection had no benefit.
+    /// </remarks>
+    private static bool TryParseReadMode(string? value, out UsageReadMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            mode = UsageReadMode.Authoritative;
+            return true;
+        }
+
+        return Enum.TryParse(value, ignoreCase: true, out mode) &&
+               Enum.IsDefined(mode);
+    }
+
+    /// <summary>
+    /// Puts the read diagnostics on the response headers.
+    /// </summary>
+    /// <remarks>
+    /// Headers rather than the body, so both modes keep the identical array contract and no existing
+    /// consumer of this endpoint sees a changed shape.
+    /// </remarks>
+    private void Describe(UsageReadDiagnostics diagnostics)
+    {
+        var headers = Response.Headers;
+
+        headers["X-Usage-Read-Mode"] = diagnostics.RequestedMode.ToString();
+        headers["X-Usage-Read-Source"] = diagnostics.ActualMode.ToString();
+        headers["X-Usage-Read-Duration-Ms"] =
+            diagnostics.DurationMs.ToString("F1", CultureInfo.InvariantCulture);
+        headers["X-Usage-Read-Documents"] =
+            diagnostics.DocumentCount.ToString(CultureInfo.InvariantCulture);
+        headers["X-Usage-Read-Stale"] = diagnostics.Stale ? "true" : "false";
+
+        if (diagnostics.NewestProjectionAgeSeconds is { } age)
+        {
+            headers["X-Usage-Projection-Age-Seconds"] =
+                age.ToString("F1", CultureInfo.InvariantCulture);
+        }
     }
 
     /// <summary>

--- a/server/Api/Program.cs
+++ b/server/Api/Program.cs
@@ -13,6 +13,8 @@ using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
 using SeliseBlocks.ConfigurationDriver;
 using Scalar.AspNetCore;
+using OpenTelemetry.Metrics;
+using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 using Utility.DomainService.MagicLink.Utilities;
 using Utility.DomainService.Messaging;
@@ -111,6 +113,24 @@ services.AddSingleton<IVault>(_ => paymentVault);
 services.RegisterPaymentDomainServices(builder.Configuration);
 services.RegisterSubscriptionDomainServices(builder.Configuration, builder.Environment);
 services.RegisterUtilityServices();
+
+// Metrics for the current-usage projection.
+//
+// This process is where they happen: a read of GET /subscription-usage/current and the synchronous
+// publish inside POST /subscription-usage both run here, so the read-duration histogram that makes
+// authoritative and projection modes comparable is recorded here and nowhere else. The Worker
+// registers the same meter for the sweep and backfill instruments it records.
+//
+// Creating instruments does not export them - an exporter observes only the meters it subscribes to,
+// which is why this registration exists rather than the meter being picked up automatically.
+//
+// The OTLP exporter reads its endpoint from the standard OTEL_EXPORTER_OTLP_* environment, the same
+// way the Worker's does. An Api deployment without that configured will log export failures rather
+// than silently drop them.
+services.AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddMeter(UsageProjectionMetrics.MeterName)
+        .AddOtlpExporter());
 
 var app = builder.Build();
 

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageCurrent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageCurrent.cs
@@ -96,7 +96,25 @@ public sealed class SubscriptionUsageCurrent
     /// upsert reject a slow request carrying an older figure instead of letting it overwrite a newer
     /// one. Without it, two concurrent recordings would race to be last rather than to be highest.
     /// </remarks>
-    public long SourceVersion { get; set; }
+    public long CounterVersion { get; set; }
+
+    /// <summary>
+    /// <c>SubscriptionDetail.Version</c> at the moment this was published.
+    /// </summary>
+    /// <remarks>
+    /// The second half of the ordering, and it is load-bearing rather than informational.
+    /// <see cref="CounterVersion"/> moves only when usage is recorded, so a change that alters what
+    /// this document <em>says</em> without altering the balance — a new plan, a changed quantity, a
+    /// cancellation, a status transition — leaves the counter version exactly where it was. Ordering
+    /// on the counter version alone, a republish carrying the new allowance would compare equal and
+    /// be refused as stale, and the projection would keep advertising the old terms indefinitely.
+    /// <para>
+    /// Monotonic for the same reason the counter version is: every mutating write in
+    /// <c>SubscriptionRepository</c> does <c>.Inc(subscription => subscription.Version, 1)</c>, so it
+    /// only ever rises for a given subscription.
+    /// </para>
+    /// </remarks>
+    public long SubscriptionVersion { get; set; }
 
     /// <summary>
     /// The shape of this document, so a consumer reading it directly can refuse an unfamiliar one

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageCurrent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageCurrent.cs
@@ -1,0 +1,122 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The published state of one subscription, meter and usage period, shaped for reading.
+/// </summary>
+/// <remarks>
+/// A projection of <see cref="SubscriptionUsageCounter"/>, published synchronously by the call that
+/// moved the counter. It exists so a consumer can answer "how much is left?" with one indexed read
+/// instead of resolving a subscription, walking its meters and point-reading a counter per meter.
+/// <para>
+/// <b>It is not an authority and must never be used as one.</b> Only
+/// <c>POST /api/subscription-usage</c> with <c>enforce</c> can claim capacity, because only the
+/// counter's atomic increment settles a race — two callers reading this document at the same instant
+/// will both be told the same remaining figure, and they cannot both have it. Everything here is for
+/// display and for cheap pre-checks that save a doomed request.
+/// </para>
+/// <para>
+/// Derived, never computed. <see cref="Used"/>, <see cref="Remaining"/> and <see cref="Overage"/> are
+/// copied from the counter result the authoritative write returned. Nothing increments this document:
+/// an independent counter would be a second set of billing arithmetic, and the two would disagree
+/// exactly when it mattered.
+/// </para>
+/// <para>
+/// The identifier is composed the same way the counter's is, so a projection addresses its own source
+/// without a lookup, crossing a period boundary simply addresses a different document, and the unique
+/// index on subscription/meter/period is a restatement of the key rather than a second constraint
+/// that could disagree with it.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionUsageCurrent
+{
+    /// <summary><c>{subscriptionId}:{meterKey}:{periodKey}</c> — the counter's own id.</summary>
+    [BsonId]
+    public string ItemId { get; set; } = string.Empty;
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The subscription's status when this was published, so a reader can tell a live allowance from
+    /// one frozen by cancellation without joining to the subscription.
+    /// </summary>
+    public SubscriptionStatus SubscriptionStatus { get; set; }
+
+    public string PlanId { get; set; } = string.Empty;
+
+    public string PlanCode { get; set; } = string.Empty;
+
+    public string MeterKey { get; set; } = string.Empty;
+
+    public string UnitLabel { get; set; } = string.Empty;
+
+    public string PeriodKey { get; set; } = string.Empty;
+
+    public DateTime PeriodStartUtc { get; set; }
+
+    /// <summary>
+    /// <c>DateTime.MaxValue</c> for a never-reset capacity meter, whose window is the subscription's
+    /// whole life. A boundary query for "the current period" therefore selects it correctly without
+    /// naming it as a special case.
+    /// </summary>
+    public DateTime PeriodEndUtc { get; set; }
+
+    /// <summary>The allowance in force for this window, after any carry-forward.</summary>
+    public long Included { get; set; }
+
+    public long Used { get; set; }
+
+    /// <summary>Never below zero. Copied from the authoritative result, not recomputed here.</summary>
+    public long Remaining { get; set; }
+
+    /// <summary>How far past the allowance this window has gone. Never below zero.</summary>
+    public long Overage { get; set; }
+
+    /// <summary>
+    /// Whether the meter's terms permit going past <see cref="Included"/>. A reader with
+    /// <see cref="Remaining"/> of zero needs this to know whether the next unit is refused or
+    /// chargeable.
+    /// </summary>
+    public bool OverageAllowed { get; set; }
+
+    /// <summary>
+    /// The counter's <c>AppliedRecordCount</c> at the moment this was published.
+    /// </summary>
+    /// <remarks>
+    /// The monotonic version this document is ordered by. It only ever rises on a given counter —
+    /// <c>ApplyDeltaAsync</c> increments it by one per ledger entry and <c>TryRepairCounterAsync</c>
+    /// only writes a value strictly greater than the one stored — which is what lets a conditional
+    /// upsert reject a slow request carrying an older figure instead of letting it overwrite a newer
+    /// one. Without it, two concurrent recordings would race to be last rather than to be highest.
+    /// </remarks>
+    public long SourceVersion { get; set; }
+
+    /// <summary>
+    /// The shape of this document, so a consumer reading it directly can refuse an unfamiliar one
+    /// rather than silently misread a field that changed meaning.
+    /// </summary>
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+    public DateTime UpdatedAtUtc { get; set; }
+
+    /// <summary>
+    /// When this derived document may be discarded, following the counter's own retention. The ledger
+    /// behind it is kept regardless.
+    /// </summary>
+    public DateTime ExpiresAtUtc { get; set; }
+
+    public const int CurrentSchemaVersion = 1;
+
+    public static string CreateId(
+        string subscriptionId,
+        string meterKey,
+        string periodKey) =>
+        SubscriptionUsageCounter.CreateId(subscriptionId, meterKey, periodKey);
+}

--- a/server/Subscription.DomainService/Enums/SubscriptionWorkType.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionWorkType.cs
@@ -51,5 +51,20 @@ public enum SubscriptionWorkType
 
     /// <summary>Turn a scheduled period-end cancellation into an ended subscription once its
     /// current period has actually run out.</summary>
-    CancellationEffective = 9
+    CancellationEffective = 9,
+
+    /// <summary>
+    /// Republish a subscription's current-usage projection from its authoritative counters.
+    /// </summary>
+    /// <remarks>
+    /// Scheduled when a synchronous publish could not be completed after the usage it describes had
+    /// already committed, and by the repair sweep for projections nobody announced. Safe to repeat and
+    /// safe to run late: it reads the counters and republishes, and the version condition on the
+    /// projection means a repair carrying an older figure than a recording that has since landed
+    /// changes nothing.
+    /// <para>
+    /// Bookkeeping, not money. Priority sits below every work type that can charge a customer.
+    /// </para>
+    /// </remarks>
+    UsageProjectionRefresh = 10
 }

--- a/server/Subscription.DomainService/Enums/UsageReadMode.cs
+++ b/server/Subscription.DomainService/Enums/UsageReadMode.cs
@@ -1,0 +1,33 @@
+namespace Subscription.DomainService.Enums;
+
+/// <summary>
+/// Where a current-usage read gets its figures.
+/// </summary>
+/// <remarks>
+/// A diagnostic and performance choice, not a correctness one: neither mode may be used to authorise
+/// usage. Only <c>POST /api/subscription-usage</c> with <c>enforce</c> can claim capacity, because
+/// only the counter's atomic increment settles a race between two callers wanting the same last unit.
+/// </remarks>
+public enum UsageReadMode
+{
+    /// <summary>
+    /// The authoritative counters. The default, and unchanged from before this projection existed.
+    /// </summary>
+    /// <remarks>
+    /// Default so that no existing caller's behaviour depends on a read model having been published.
+    /// A projection that is briefly behind is acceptable for a dashboard; changing what the existing
+    /// endpoint returns without being asked is not.
+    /// </remarks>
+    Authoritative = 0,
+
+    /// <summary>
+    /// The published projection, in one indexed query.
+    /// </summary>
+    /// <remarks>
+    /// Falls back to the authoritative counters when the projection has nothing for this
+    /// subscription, so a caller that opts in cannot be handed an empty allowance for a subscription
+    /// that simply has not been published yet. The fallback is reported in the diagnostics rather
+    /// than hidden.
+    /// </remarks>
+    Projection = 1
+}

--- a/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionUsageRatingProcessor.cs
@@ -6,7 +6,19 @@ namespace Subscription.DomainService.Outbox;
 public interface ISubscriptionUsageRatingProcessor
 {
     /// <returns>How many usage periods were closed out, across every subscription swept.</returns>
-    Task<int> CloseDuePeriodsAsync(string tenantId, CancellationToken cancellationToken);
+    /// <summary>
+    /// Closes every usage window that has ended, and reports which subscriptions actually rolled.
+    /// </summary>
+    /// <remarks>
+    /// Returns the ids rather than a bare count because a point-of-change producer has to act on the
+    /// subscriptions whose clocks <em>committed</em> a move, not on a second guess at which ones they
+    /// were. Re-running the due query to find out is not equivalent: it has its own batch size, its
+    /// own <c>now</c>, and by then the clocks have advanced — so it can name subscriptions that were
+    /// not closed and miss ones that were.
+    /// </remarks>
+    Task<UsagePeriodClosureOutcome> CloseDuePeriodsAsync(
+        string tenantId,
+        CancellationToken cancellationToken);
 
     /// <returns>How many invoices were attempted, whether they charged, retried or were abandoned.</returns>
     Task<int> ChargeDueInvoicesAsync(string tenantId, CancellationToken cancellationToken);
@@ -29,4 +41,17 @@ public interface ISubscriptionUsageRatingProcessor
 
     /// <summary>Attempts exactly one invoice's charge, regardless of whether its own retry schedule is due.</summary>
     Task ChargeInvoiceAsync(SubscriptionUsageInvoice invoice, CancellationToken cancellationToken);
+}
+
+/// <summary>What one pass of usage-period closure committed.</summary>
+/// <param name="PeriodsClosed">How many windows were closed, across every subscription.</param>
+/// <param name="RolledSubscriptionIds">
+/// The subscriptions that actually closed at least one window, and whose next window is therefore now
+/// current. The authoritative answer to "who just rolled over".
+/// </param>
+public sealed record UsagePeriodClosureOutcome(
+    int PeriodsClosed,
+    IReadOnlyList<string> RolledSubscriptionIds)
+{
+    public static readonly UsagePeriodClosureOutcome Nothing = new(0, []);
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -7,6 +7,7 @@ using Payment.DomainService.Utilities;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
 using Subscription.DomainService.Utilities;
 using Subscription.DomainService.Services;
 
@@ -50,6 +51,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
     private readonly ISubscriptionAuditTrail? _audit;
     private readonly ICampaignRedemptionRepository? _redemptions;
     private readonly ISubscriptionRenewalService? _renewals;
+    private readonly IUsageProjectionReconciler? _usageProjections;
 
     public SubscriptionActivationProcessor(
         ISubscriptionPaymentLinkRepository links,
@@ -64,7 +66,10 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         ISubscriptionAuditTrail? audit = null,
         ISubscriptionFinancialDocumentAnnouncer? documents = null,
         ICampaignRedemptionRepository? redemptions = null,
-        ISubscriptionRenewalService? renewals = null)
+        ISubscriptionRenewalService? renewals = null,
+        // Optional, like every collaborator threaded through this class: it publishes a read
+        // model, and a caller or test unaware that model exists must keep working unchanged.
+        IUsageProjectionReconciler? usageProjections = null)
     {
         _links = links;
         _subscriptions = subscriptions;
@@ -79,6 +84,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         _documents = documents;
         _redemptions = redemptions;
         _renewals = renewals;
+        _usageProjections = usageProjections;
     }
 
     /// <summary>
@@ -411,6 +417,28 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                 discount.DiscountId!,
                 subscription.ItemId,
                 _time.GetUtcNow().UtcDateTime,
+                cancellationToken);
+        }
+
+        if (_usageProjections is not null)
+        {
+            // After the transition commits, for the same reason the redemption above is: this
+            // publishes what the subscription now is, and publishing it against a transition that
+            // then failed to apply would advertise meters and allowances for a subscription nobody
+            // activated.
+            //
+            // Re-reads the subscription rather than projecting the copy in hand, which is still the
+            // pre-transition document: its status says Incomplete, and a projection carrying that
+            // would tell a reader the allowance is not yet granted at the exact moment it was.
+            //
+            // This is what lets a consumer discover a subscription's meters and allowances before
+            // any usage exists — the difference, to a reader that cannot see the plan, between "no
+            // usage yet" and "no such meter". It creates zero-usage documents and never overwrites a
+            // balance, so it is safe if usage somehow arrived first.
+            await _usageProjections.RefreshSubscriptionAsync(
+                link.TenantId,
+                link.SubscriptionId,
+                link.CorrelationId,
                 cancellationToken);
         }
 

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -97,7 +97,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
     /// <summary>Announces the overage invoice. Optional, like the scheduler beside it.</summary>
     private readonly ISubscriptionFinancialDocumentAnnouncer? _documents;
 
-    public async Task<int> CloseDuePeriodsAsync(
+    public async Task<UsagePeriodClosureOutcome> CloseDuePeriodsAsync(
         string tenantId,
         CancellationToken cancellationToken)
     {
@@ -112,6 +112,11 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
 
         var closed = 0;
 
+        // The subscriptions whose clock actually advanced, collected as it happens. This is the
+        // authoritative record of who rolled: asking the due query again afterwards would answer with
+        // a different batch, a different instant, and clocks that have already moved.
+        var rolled = new List<string>();
+
         foreach (var subscription in due)
         {
             using var logScope = _logger.BeginScope(new Dictionary<string, object?>
@@ -124,11 +129,20 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             var subscriptionPeriodsClosed = await CloseSubscriptionAsync(
                 subscription, now, cancellationToken);
             closed += subscriptionPeriodsClosed;
+
+            if (subscriptionPeriodsClosed > 0)
+            {
+                rolled.Add(subscription.ItemId);
+            }
+
             await AuditAsync(subscription, "PeriodsClosed",
                 subscriptionPeriodsClosed > 0 ? "Succeeded" : "NoOp", cancellationToken);
         }
 
-        return closed;
+        // A subscription that was due but closed nothing is deliberately absent: its window did not
+        // move, so nothing about its current projection changed either. That covers the one deferred
+        // by an outstanding usage claim, which rating skips and will pick up on a later pass.
+        return new UsagePeriodClosureOutcome(closed, rolled);
     }
 
     public Task<int> CloseSubscriptionPeriodsAsync(

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1011,6 +1011,111 @@ Counters expire (`Subscription:CounterRetentionDays`, default 400). **The ledger
 > shared billing store, retained for years and exported for invoicing; anything naming a person
 > belongs in the calling product's own records with an opaque reference here.
 
+## The current-usage projection
+
+`SubscriptionUsageCurrent`, one document per subscription, meter and usage period, in the **tenant's
+own database** — not `BlocksRootDb`. Its `_id` is the counter's own composed id,
+`{subscriptionId}:{meterKey}:{periodKey}`, so a projection addresses its source without a lookup.
+
+It exists so "how much is left?" is one indexed read. The authoritative answer needs a subscription
+resolved, its meters walked and a counter read per meter; a consumer that only wants to draw a usage
+bar or skip a request that is going to be refused should not pay for that.
+
+### It is not an authority, and it cannot become one
+
+Only `POST /api/subscription-usage` with `enforce` can claim capacity, because only the counter's
+atomic increment settles two callers wanting the same last unit. Two callers reading this collection
+at the same instant will both be told the same figure remains, and they cannot both have it. That is
+not a defect to be fixed here — it is why the counter exists.
+
+Everything in the document is **derived**. `used`, `remaining` and `overage` are copied from the
+counter result the authoritative write produced. Nothing increments this document. A projection with
+its own arithmetic would be a second set of billing rules, and the two would disagree exactly when it
+mattered.
+
+### Published synchronously, ordered by version
+
+The authoritative sequence is unchanged: append the ledger entry, update the counter atomically,
+apply any reversal, and **then** publish. Publishing last is what guarantees a reader never sees the
+momentary exceeded balance that an enforced refusal passes through on its way to being undone — a
+refusal publishes the post-reversal figure, which is the same one the caller is told.
+
+Writes are conditional on `sourceVersion`, which is the counter's `AppliedRecordCount`. That value
+only ever rises: `ApplyDeltaAsync` increments it by one per ledger entry, and `TryRepairCounterAsync`
+writes only a value strictly greater than the one stored. So the **highest version wins, not the last
+writer** — a request delayed between updating its counter and publishing cannot overwrite a newer
+balance with an older one.
+
+### The gap that cannot be closed, and what closes it anyway
+
+There is no transaction across the counter write and the projection write. A process that dies
+between them leaves the projection behind with nothing to announce it. Four things cover that:
+
+| Path | Covers |
+| --- | --- |
+| Synchronous publish, retried briefly for transient Mongo errors | the ordinary case |
+| `UsageProjectionRefresh` queue item, scheduled when a publish fails after the usage committed | a failure the request itself saw |
+| Version-comparison sweep in `SubscriptionRepairAnnouncer` | a miss nothing announced |
+| Projection read falls back to the counters when nothing is published | a subscription never published at all |
+
+A failed publish **does not fail the request.** The response is the authoritative `200` with
+`projection: "Pending"` on it, and a repair scheduled. Returning an error would let a read model veto
+a committed billing write, and the usage is recorded either way — a caller that retried under a new
+idempotency key because it read a `503` as "not recorded" would double-count.
+
+Zero-usage documents are created on activation and when a period rolls over, so a consumer can
+discover a subscription's meters and allowances before any usage exists — the difference, to a reader
+that cannot see the plan, between "no usage yet" and "no such meter". Seeding is insert-only and
+never overwrites a balance.
+
+### Reading it
+
+`GET /api/subscription-usage/current` takes an optional `readMode`:
+
+| `readMode` | Reads |
+| --- | --- |
+| omitted or `authoritative` | the counters. **The default**, so no existing caller's behaviour changes |
+| `projection` | this collection, in one query, falling back to the counters if nothing is published |
+
+Anything else is `400 subscription_usage_read_mode_invalid` — refused rather than quietly defaulted,
+because a caller that misspells `projection` and is served the counters would measure the wrong thing
+and conclude the projection had no benefit.
+
+Both modes return the identical `UsageResponse[]` body. How the read was served is reported in
+headers, so opting into a mode never changes the shape a consumer parses:
+`X-Usage-Read-Mode`, `X-Usage-Read-Source`, `X-Usage-Read-Duration-Ms`, `X-Usage-Read-Documents`,
+`X-Usage-Read-Stale`, `X-Usage-Projection-Age-Seconds`.
+
+The authoritative mode was also fixed while this was built: it read one counter per meter, and now
+reads them in one batch. That batch is keyed by **composed id, not period key** — a `Never`-reset
+capacity meter lives under `LIFETIME` while its periodic neighbours use the billing schedule's key,
+so the meters of one subscription do not share a period, and a batch filtered by any single period
+would have returned nothing for the others and reported them as unused.
+
+### Reading it directly, from outside this service
+
+Intended, and the reason it is a separate collection: a consumer can be granted read access to
+exactly this and nothing else. Granting a reader `SubscriptionUsageCounters` would hand it the
+enforcement authority for metered billing.
+
+**The grant itself is not created by this repository.** A read-only Mongo role scoped to
+`SubscriptionUsageCurrent` in the resolved tenant database has to be provisioned where database users
+are managed. Nothing here can do it, and nothing here should be read as having done it.
+
+A direct query must include the organization and the period boundaries. Both are indexed
+(`ix_usage_current_org_subscription_status_period`); an unscoped query is a collection scan and a
+cross-organization read of billing state.
+
+Staleness is exposed rather than hidden: `sourceVersion` and `updatedAtUtc` are on every document. A
+projection is stale when its version is behind its counter, or when its age exceeds
+`Subscription:UsageProjectionStalenessSeconds` (default 900). Age alone cannot tell a quiet meter
+from a missed publish, which is why the read reports it and only the sweep — which reads both sides —
+acts on it.
+
+Retention follows the counter's: the same `Subscription:CounterRetentionDays`, so a projection never
+outlives what it projects. A lifetime window is kept as long as the subscription, because its
+allowance has no later window to move to.
+
 ## Usage rating
 
 `PlanMeter.RateTables` existed from the first commit but priced nothing until now — usage was

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1055,14 +1055,32 @@ counter version alone, a republish carrying the new allowance compares equal and
 — and the projection would advertise the old terms **indefinitely**, until somebody happened to
 record usage against that meter. It is a tie-break rather than an alternative:
 
-```text
-incoming.counterVersion  >  stored.counterVersion
-  OR (incoming.counterVersion == stored.counterVersion
-      AND incoming.subscriptionVersion > stored.subscriptionVersion)
-```
+Crucially, **each version governs its own fields and neither replaces the whole document.** The
+write is an aggregation pipeline:
 
-A newer counter version always wins, because a newer balance is newer information about the same
-subscription even if it was read at an older subscription version.
+| Field group | Moves when |
+| --- | --- |
+| `used`, `expiresAtUtc` | `counterVersion` is newer |
+| `subscriptionStatus`, `planId`, `planCode`, `unitLabel`, `included`, `overageAllowed` | `subscriptionVersion` is newer |
+| `counterVersion`, `subscriptionVersion` | each becomes the **maximum** of stored and incoming |
+| `remaining`, `overage` | recomputed from whichever `used` and `included` won |
+
+A single conditional replacement of the whole document cannot honour both, and got it wrong in both
+directions. A cancellation publishing `(counter 10, subscription 6, Cancelled)` followed by a usage
+request already in flight publishing `(counter 11, subscription 5, Active)` restored `Active` and
+drove the stored subscription version **backwards** from 6 to 5 — leaving a cancelled subscription
+advertising a live allowance. In the other order, a lifecycle refresh carrying `(10, 6)` was rejected
+outright because its counter was not newer, so its metadata never landed at all.
+
+Per-field, with a maximum on each version, every write is idempotent and order-independent: the
+document converges on the newest of each kind of information whichever order the writers arrive in,
+which is what makes this safe without a transaction.
+
+`remaining` and `overage` are recomputed in a second pipeline stage rather than copied, because they
+are pure functions of `included` and `used` — and after a merge those two can come from different
+writers, so copying either would describe a balance that never existed. That is not the projection
+doing billing arithmetic; it is the same one-line function the authoritative response uses, evaluated
+where both inputs are final.
 
 ### The gap that cannot be closed, and what closes it anyway
 
@@ -1074,9 +1092,17 @@ between them leaves the projection behind with nothing to announce it. Four thin
 | Synchronous publish, retried briefly for transient Mongo errors | the ordinary case |
 | `UsageProjectionRefresh` queue item, scheduled when a publish fails after the usage committed | a failure the request itself saw |
 | Explicit announcement at plan change, quantity change and cancellation | a metadata change, which moves no counter and so is invisible to the sweep |
-| Version-comparison sweep in `SubscriptionRepairAnnouncer` | a usage miss nothing announced |
+| Version-comparison sweep in `SubscriptionRepairAnnouncer` | a miss nothing announced — **both** versions, so it also catches a lost metadata announcement and reaches cancelled subscriptions the backfill's live roster excludes |
 | **Backfill pass** over the tenant's live subscriptions | a window with no document at all |
 | Projection read falls back to the counters, completely | anything still missing when a read arrives |
+
+The lifecycle announcements are **best effort by design** — they route through
+`TryScheduleAsync`, which swallows and logs, because a read model that could not be announced must
+never fail a plan change or a cancellation the customer already has confirmation of. The sweep is what
+makes that safe: it compares the projection's `subscriptionVersion` against
+`SubscriptionDetail.Version`, so a lost announcement is found rather than merely hoped about. A
+counter-only comparison would have missed every one of them, and would never have reached a cancelled
+subscription at all.
 
 The backfill is what makes direct access safe to enable. The sweep reads the projection collection, so
 a document that was never written is invisible to it — a subscription predating this collection, a
@@ -1085,6 +1111,15 @@ The API can fall back to the counters, but **a consumer reading the collection d
 would simply see no meter. So the backfill enumerates the authoritative side instead, walking the
 tenant's live subscriptions one bounded page per pass and publishing whatever is missing. It cycles
 rather than migrating once, because a meter added tomorrow is a missing document tomorrow.
+
+Its place in the roster lives in `UsageProjectionBackfillCursors`, **registered as a singleton**. That
+is not incidental: the reconciler is scoped and the reconciliation service opens a fresh scope per
+tenant sweep, so a cursor held on the reconciler was recreated empty every pass and the backfill
+re-read page one forever — no tenant larger than one page ever had its later pages published. The
+cursor is in memory, so a restart begins again from the start of the roster; that costs a repeat of
+work which is idempotent and version-ordered by construction. With several replicas each walks the
+roster independently rather than dividing it, which is slower to cover a large tenant than a durable
+shared cursor would be, and still complete.
 
 A failed publish **does not fail the request.** The response is the authoritative `200` with
 `projection: "Pending"` on it, and a repair scheduled. Returning an error would let a read model veto
@@ -1147,6 +1182,13 @@ Meter `Blocks.Subscription.UsageProjection`, exported through OTLP like
 | `subscription.usage.projection.publish.duration` / `.count` | latency this adds to a customer-facing billing call, by outcome |
 | `subscription.usage.projection.publish.failure.count` | publishes that left a projection behind and scheduled a repair |
 | `subscription.usage.projection.repair.scheduled.count` / `.completed.count` (by source) | repair volume, by what noticed the miss |
+
+The meter is registered with OpenTelemetry in **both** processes that record into it — the Api, where
+reads and the synchronous publish happen, and the Worker, where the sweep and backfill run. Creating
+instruments does not export them: an exporter observes only the meters it has been told to subscribe
+to, so without `AddMeter` these would have been recorded and silently dropped. The Api had no metrics
+pipeline at all before this, so one was added there; it reads its endpoint from the standard
+`OTEL_EXPORTER_OTLP_*` environment, as the Worker's does, **which the Api deployment must supply.**
 
 **No tenant, organization or subscription dimension on any of them** — a per-tenant label multiplies
 every series by the tenant count, and there are thousands. Those identifiers go on the **logs and the

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1061,9 +1061,19 @@ write is an aggregation pipeline:
 | Field group | Moves when |
 | --- | --- |
 | `used`, `expiresAtUtc` | `counterVersion` is newer |
-| `subscriptionStatus`, `planId`, `planCode`, `unitLabel`, `included`, `overageAllowed` | `subscriptionVersion` is newer |
+| `subscriptionStatus`, `planId`, `planCode`, `unitLabel`, `overageAllowed` | `subscriptionVersion` is newer |
+| `included` | either version is newer — but a writer whose `subscriptionVersion` is **behind** the stored one may not touch it |
 | `counterVersion`, `subscriptionVersion` | each becomes the **maximum** of stored and incoming |
 | `remaining`, `overage` | recomputed from whichever `used` and `included` won |
+
+`included` is the awkward one, and it is not plan metadata. `MeterAllowance.Effective` computes it
+from the plan's terms **and** the counter's `LimitSnapshot` — the allowance frozen when the window
+opened, which is where a carry-forward from the previous period lands. So the counter can change the
+allowance with no plan change at all: a seed publishes the opening figure before any counter exists,
+and the first recording opens the counter with a possibly different frozen snapshot. Owned by the
+subscription version alone, that correction could only arrive with an unrelated plan edit. The guard
+is what stops this reopening the regression below: a writer holding pre-plan-change terms still cannot
+undo a newer plan's figure.
 
 A single conditional replacement of the whole document cannot honour both, and got it wrong in both
 directions. A cancellation publishing `(counter 10, subscription 6, Cancelled)` followed by a usage
@@ -1128,8 +1138,27 @@ idempotency key because it read a `503` as "not recorded" would double-count.
 
 Zero-usage documents are created on activation and when a period rolls over, so a consumer can
 discover a subscription's meters and allowances before any usage exists — the difference, to a reader
-that cannot see the plan, between "no usage yet" and "no such meter". Seeding is insert-only and
-never overwrites a balance.
+that cannot see the plan, between "no usage yet" and "no such meter". Seeding never overwrites a
+balance.
+
+Rollover is the one that matters most and is easiest to get wrong. Crossing a period boundary
+addresses a *different* counter id, so the new window starts with no projected document at all. The
+API would fall back to the counters; **a direct consumer has no fallback**, so at one minute past
+midnight it would see nothing for a periodic meter, or — worse, because it looks like an answer —
+only the never-resetting ones.
+
+So `UsagePeriodClosureWorkHandler` reads the subscriptions whose usage window is due to close
+**before** closing them, because closing advances the subscription's usage billing clock and
+afterwards there is no record of who rolled, then publishes their new windows once the closure has
+committed. The due query is driven by the subscription's own clock rather than by whether any usage
+exists, which is what makes it cover a quiet meter crossing a boundary with nothing recorded on either
+side.
+
+> An earlier version of this hooked the same handler behind the queue item naming a subscription.
+> Nothing in the module calls `ScheduleUsagePeriodClosureAsync` — every closure item comes from the
+> repair sweep, which names no subscription — so that branch never ran. `UsageProjectionRolloverTests`
+> exercises the handler the way the queue actually invokes it, and restoring the old gate fails three
+> of its cases.
 
 ### Reading it
 

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1040,11 +1040,29 @@ apply any reversal, and **then** publish. Publishing last is what guarantees a r
 momentary exceeded balance that an enforced refusal passes through on its way to being undone — a
 refusal publishes the post-reversal figure, which is the same one the caller is told.
 
-Writes are conditional on `sourceVersion`, which is the counter's `AppliedRecordCount`. That value
-only ever rises: `ApplyDeltaAsync` increments it by one per ledger entry, and `TryRepairCounterAsync`
-writes only a value strictly greater than the one stored. So the **highest version wins, not the last
-writer** — a request delayed between updating its counter and publishing cannot overwrite a newer
-balance with an older one.
+Writes are conditional on a **pair** of versions, and both halves are load-bearing.
+
+`counterVersion` is the counter's `AppliedRecordCount`. It only ever rises — `ApplyDeltaAsync`
+increments it once per ledger entry, `TryRepairCounterAsync` writes only a strictly greater value —
+so the **highest version wins, not the last writer**, and a request delayed between updating its
+counter and publishing cannot overwrite a newer balance.
+
+`subscriptionVersion` is `SubscriptionDetail.Version`, which every mutating write in
+`SubscriptionRepository` increments. It exists because the counter version orders *usage* and nothing
+else: a plan change, a quantity change, a cancellation or a status transition alters what the
+projection **says** without recording any usage, so the counter version is unchanged. Ordered on the
+counter version alone, a republish carrying the new allowance compares equal and is refused as stale
+— and the projection would advertise the old terms **indefinitely**, until somebody happened to
+record usage against that meter. It is a tie-break rather than an alternative:
+
+```text
+incoming.counterVersion  >  stored.counterVersion
+  OR (incoming.counterVersion == stored.counterVersion
+      AND incoming.subscriptionVersion > stored.subscriptionVersion)
+```
+
+A newer counter version always wins, because a newer balance is newer information about the same
+subscription even if it was read at an older subscription version.
 
 ### The gap that cannot be closed, and what closes it anyway
 
@@ -1055,8 +1073,18 @@ between them leaves the projection behind with nothing to announce it. Four thin
 | --- | --- |
 | Synchronous publish, retried briefly for transient Mongo errors | the ordinary case |
 | `UsageProjectionRefresh` queue item, scheduled when a publish fails after the usage committed | a failure the request itself saw |
-| Version-comparison sweep in `SubscriptionRepairAnnouncer` | a miss nothing announced |
-| Projection read falls back to the counters when nothing is published | a subscription never published at all |
+| Explicit announcement at plan change, quantity change and cancellation | a metadata change, which moves no counter and so is invisible to the sweep |
+| Version-comparison sweep in `SubscriptionRepairAnnouncer` | a usage miss nothing announced |
+| **Backfill pass** over the tenant's live subscriptions | a window with no document at all |
+| Projection read falls back to the counters, completely | anything still missing when a read arrives |
+
+The backfill is what makes direct access safe to enable. The sweep reads the projection collection, so
+a document that was never written is invisible to it — a subscription predating this collection, a
+seed that failed, a process that died before the first publish, a meter added to a plan afterwards.
+The API can fall back to the counters, but **a consumer reading the collection directly cannot**: it
+would simply see no meter. So the backfill enumerates the authoritative side instead, walking the
+tenant's live subscriptions one bounded page per pass and publishing whatever is missing. It cycles
+rather than migrating once, because a meter added tomorrow is a missing document tomorrow.
 
 A failed publish **does not fail the request.** The response is the authoritative `200` with
 `projection: "Pending"` on it, and a repair scheduled. Returning an error would let a read model veto
@@ -1075,22 +1103,59 @@ never overwrites a balance.
 | `readMode` | Reads |
 | --- | --- |
 | omitted or `authoritative` | the counters. **The default**, so no existing caller's behaviour changes |
-| `projection` | this collection, in one query, falling back to the counters if nothing is published |
+| `projection` | this collection, in one query, falling back to the counters if it cannot answer completely |
 
 Anything else is `400 subscription_usage_read_mode_invalid` — refused rather than quietly defaulted,
 because a caller that misspells `projection` and is served the counters would measure the wrong thing
 and conclude the projection had no benefit.
 
+A projection read answers **only if it holds every current window the plan defines.** If it holds
+some but not all, the counters answer the whole request and a repair is scheduled — returning the
+published subset would omit meters the plan defines, with nothing in the body to say so, and a caller
+drawing a usage screen from it would show fewer meters than the subscription has. The two modes are
+required to return equivalent data, and a subset is not equivalent.
+
+The two kinds of fallback are reported separately, because they mean different things: nothing
+published is a subscription the projection has never covered (a backfill matter), while some
+published is a lost write for a subscription it does cover (worth looking at, and repaired).
+
 Both modes return the identical `UsageResponse[]` body. How the read was served is reported in
 headers, so opting into a mode never changes the shape a consumer parses:
-`X-Usage-Read-Mode`, `X-Usage-Read-Source`, `X-Usage-Read-Duration-Ms`, `X-Usage-Read-Documents`,
-`X-Usage-Read-Stale`, `X-Usage-Projection-Age-Seconds`.
+`X-Usage-Read-Mode`, `X-Usage-Read-Source`, `X-Usage-Read-Fallback` (`None`, `ProjectionEmpty`,
+`ProjectionPartial`), `X-Usage-Read-Duration-Ms`, `X-Usage-Read-Documents`, `X-Usage-Read-Stale`,
+`X-Usage-Projection-Age-Seconds`.
 
 The authoritative mode was also fixed while this was built: it read one counter per meter, and now
 reads them in one batch. That batch is keyed by **composed id, not period key** — a `Never`-reset
 capacity meter lives under `LIFETIME` while its periodic neighbours use the billing schedule's key,
 so the meters of one subscription do not share a period, and a batch filtered by any single period
 would have returned nothing for the others and reported them as unused.
+
+### Watching it
+
+Meter `Blocks.Subscription.UsageProjection`, exported through OTLP like
+`Blocks.Subscription.BackgroundWork`.
+
+| Instrument | Answers |
+| --- | --- |
+| `subscription.usage.read.duration` (histogram, by mode) | is the projection actually faster? p50/p95/p99 for both modes come out of one instrument, so they are directly comparable |
+| `subscription.usage.read.count` (by requested and actual mode) | how much traffic each mode carries |
+| `subscription.usage.read.fallback.count` (by reason) | how often the projection could not answer, and which kind |
+| `subscription.usage.read.stale.count` | reads containing a document past the threshold |
+| `subscription.usage.projection.age` (histogram) | how far behind the projection is when read |
+| `subscription.usage.projection.version_lag` (histogram) | how far behind in ledger entries, measured by the sweep, which is the only place that reads both sides |
+| `subscription.usage.projection.publish.duration` / `.count` | latency this adds to a customer-facing billing call, by outcome |
+| `subscription.usage.projection.publish.failure.count` | publishes that left a projection behind and scheduled a repair |
+| `subscription.usage.projection.repair.scheduled.count` / `.completed.count` (by source) | repair volume, by what noticed the miss |
+
+**No tenant, organization or subscription dimension on any of them** — a per-tenant label multiplies
+every series by the tenant count, and there are thousands. Those identifiers go on the **logs and the
+trace span** instead, where they are attached to one read: hashed `TenantHash`,
+`OrganizationHash`, `SubscriptionHash`, plus `CorrelationId` and `TraceId`. So "a read was slow" can
+be turned into "which customer saw it", which is the first question anybody asks.
+
+Slow, stale and fallen-back reads are always logged. An ordinary read is sampled down to debug,
+because this is one line per call of a dashboard endpoint.
 
 ### Reading it directly, from outside this service
 
@@ -1106,7 +1171,7 @@ A direct query must include the organization and the period boundaries. Both are
 (`ix_usage_current_org_subscription_status_period`); an unscoped query is a collection scan and a
 cross-organization read of billing state.
 
-Staleness is exposed rather than hidden: `sourceVersion` and `updatedAtUtc` are on every document. A
+Staleness is exposed rather than hidden: `counterVersion` and `updatedAtUtc` are on every document. A
 projection is stale when its version is behind its counter, or when its age exceeds
 `Subscription:UsageProjectionStalenessSeconds` (default 900). Age alone cannot tell a quiet meter
 from a missed publish, which is why the read reports it and only the sweep — which reads both sides —

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1147,18 +1147,28 @@ API would fall back to the counters; **a direct consumer has no fallback**, so a
 midnight it would see nothing for a periodic meter, or — worse, because it looks like an answer —
 only the never-resetting ones.
 
-So `UsagePeriodClosureWorkHandler` reads the subscriptions whose usage window is due to close
-**before** closing them, because closing advances the subscription's usage billing clock and
-afterwards there is no record of who rolled, then publishes their new windows once the closure has
-committed. The due query is driven by the subscription's own clock rather than by whether any usage
-exists, which is what makes it cover a quiet meter crossing a boundary with nothing recorded on either
-side.
+So `CloseDuePeriodsAsync` returns a `UsagePeriodClosureOutcome` naming the subscriptions that
+actually closed a window, and `UsagePeriodClosureWorkHandler` publishes exactly those. The refresh set
+is the **committed outcome**, not a second guess at it.
 
-> An earlier version of this hooked the same handler behind the queue item naming a subscription.
-> Nothing in the module calls `ScheduleUsagePeriodClosureAsync` — every closure item comes from the
-> repair sweep, which names no subscription — so that branch never ran. `UsageProjectionRolloverTests`
-> exercises the handler the way the queue actually invokes it, and restoring the old gate fails three
-> of its cases.
+That distinction is the whole point. Re-running the due query to find out who rolled is not
+equivalent: it has its own batch size (`UsageRatingBatchSize` versus the projection's own), takes its
+own `now`, and by then the clocks have advanced. It would name subscriptions that were not closed —
+including one deferred by an outstanding usage claim, which rating skips — and miss ones that became
+due in between. Equal default batch sizes do not make the two sets the same set.
+
+A projection failure here **cannot fail the closure item.** The closure has committed by the time the
+refresh runs, so letting the failure out would retry a rating pass because a derived read model could
+not be written. The handler absorbs it, logs which subscriptions have an unpublished window, and
+announces a repair for each; cancellation still propagates, because that is the worker shutting down
+rather than a projection problem.
+
+> Two earlier versions of this were wrong. The first hooked the handler behind the queue item naming a
+> subscription — nothing calls `ScheduleUsagePeriodClosureAsync`, so every item comes from the repair
+> sweep and names none, and the branch never ran. The second used a second due query, per above. And
+> the test named for the no-retry guarantee asserted that the exception *was* thrown, documenting the
+> bug as though it were the design. `UsageProjectionRolloverTests` now pins all three: restoring the
+> old gate fails three cases, and removing the catch fails two.
 
 ### Reading it
 

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -283,6 +283,30 @@ public interface ISubscriptionRepository
         CancellationToken cancellationToken);
 
     /// <summary>Subscriptions whose first charge never completed, for the recovery sweep.</summary>
+    /// <summary>
+    /// Live subscriptions for a tenant, paged by identifier so a sweep can walk all of them.
+    /// </summary>
+    /// <remarks>
+    /// For work that has to be able to enumerate what exists rather than react to what changed. The
+    /// current-usage projection needs it: a document that was never written cannot be found by
+    /// reading the projection collection, and a consumer reading that collection directly has no
+    /// endpoint to fall back to.
+    /// <para>
+    /// Paged on <c>ItemId</c> — pass the last id seen as <paramref name="afterId"/> — rather than by
+    /// skip. A skip re-reads and re-sorts everything before the offset on every page, and the roster
+    /// changes underneath a sweep that takes several passes.
+    /// </para>
+    /// <para>
+    /// "Live" is the statuses that can still accrue usage: trialing, active and past due. An ended or
+    /// never-started subscription has no current window to publish.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyList<SubscriptionDetail>> ListLivePageAsync(
+        string tenantId,
+        string? afterId,
+        int limit,
+        CancellationToken cancellationToken);
+
     Task<IReadOnlyList<SubscriptionDetail>> ListStaleAsync(
         string tenantId,
         SubscriptionStatus status,

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
@@ -20,7 +20,7 @@ public interface ISubscriptionUsageCurrentRepository
     /// <remarks>
     /// The whole concurrency story of this feature is in the filter. Two recordings against the same
     /// meter finish in an order nobody controls, so the write is conditional on
-    /// <see cref="SubscriptionUsageCurrent.SourceVersion"/> being newer than what is stored: the
+    /// <see cref="SubscriptionUsageCurrent.CounterVersion"/> being newer than what is stored: the
     /// highest version wins rather than the last writer. Without that, a request delayed between its
     /// counter update and its projection write would overwrite a newer balance with an older one and
     /// leave the projection permanently behind with nothing to detect it.

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
@@ -1,0 +1,88 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// The published current-usage projection.
+/// </summary>
+/// <remarks>
+/// Read-optimised and derived. Nothing here computes a balance: every write takes the figures a
+/// counter result already produced. See <see cref="SubscriptionUsageCurrent"/> for why this is never
+/// an authority.
+/// </remarks>
+public interface ISubscriptionUsageCurrentRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes one projected document, unless a newer one is already stored.
+    /// </summary>
+    /// <remarks>
+    /// The whole concurrency story of this feature is in the filter. Two recordings against the same
+    /// meter finish in an order nobody controls, so the write is conditional on
+    /// <see cref="SubscriptionUsageCurrent.SourceVersion"/> being newer than what is stored: the
+    /// highest version wins rather than the last writer. Without that, a request delayed between its
+    /// counter update and its projection write would overwrite a newer balance with an older one and
+    /// leave the projection permanently behind with nothing to detect it.
+    /// <para>
+    /// Returns false when the stored document was already at or beyond this version. That is a
+    /// success, not a failure: the state this call wanted published is published, by someone else.
+    /// </para>
+    /// </remarks>
+    Task<bool> TryPublishAsync(
+        SubscriptionUsageCurrent document,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates a zero-usage document if this meter-period has none, and leaves any existing one
+    /// exactly as it is.
+    /// </summary>
+    /// <remarks>
+    /// So a consumer can discover a meter and its allowance before anything has been recorded against
+    /// it, which is the difference between "no usage" and "no such meter" for a reader that cannot see
+    /// the plan. Insert-only: it must never reset a balance, so it cannot be expressed as the publish
+    /// above with a zero version — a plain upsert would race a real recording and lose usage.
+    /// </remarks>
+    Task<bool> TrySeedAsync(
+        SubscriptionUsageCurrent document,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The current windows for one subscription: the documents whose period contains
+    /// <paramref name="asOfUtc"/>.
+    /// </summary>
+    /// <remarks>
+    /// Organization-scoped in the filter, not merely in the caller's intent. A projection read that
+    /// omitted it would be a cross-organization read of billing state.
+    /// </remarks>
+    Task<IReadOnlyList<SubscriptionUsageCurrent>> ListCurrentAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        DateTime asOfUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Current-window projections for a tenant, oldest first, for the reconciliation pass to compare
+    /// against their counters.
+    /// </summary>
+    /// <remarks>
+    /// Oldest-updated first, because a projection that has not been written for a while is the one
+    /// most likely to be behind: a busy meter republishes on every recording. Bounded by
+    /// <paramref name="limit"/> so one pass costs the same whatever the tenant's size.
+    /// <para>
+    /// This returns <em>candidates</em>, not documents known to be stale. Whether one is behind can
+    /// only be settled by reading its counter, which the caller does in a batch.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyList<SubscriptionUsageCurrent>> ListBehindCountersAsync(
+        string tenantId,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionUsageCurrent?> GetAsync(
+        string tenantId,
+        string documentId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
@@ -36,6 +36,26 @@ public interface ISubscriptionUsageRepository
         string counterId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Reads several counters by their composed ids in one round trip.
+    /// </summary>
+    /// <remarks>
+    /// For the current-usage read, which needs one counter per meter. Not expressible through
+    /// <see cref="ListCountersAsync"/>: that takes a single period key, and the meters of one
+    /// subscription do not share one. A never-reset capacity meter is addressed under
+    /// <c>MeterPeriodResolver.LifetimePeriodKey</c> while its periodic neighbours use the billing
+    /// schedule's key, so filtering by any single period would silently omit whichever meters do not
+    /// use it and report them as unused.
+    /// <para>
+    /// Missing ids are simply absent from the result. A counter that does not exist yet means no usage
+    /// has been recorded in that window, which is a balance of zero rather than an error.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyDictionary<string, SubscriptionUsageCounter>> GetCountersAsync(
+        string tenantId,
+        IReadOnlyCollection<string> counterIds,
+        CancellationToken cancellationToken);
+
     Task<IReadOnlyList<SubscriptionUsageCounter>> ListCountersAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -20,6 +20,16 @@ internal static class SubscriptionCollections
     public const string Subscriptions = "Subscriptions";
     public const string UsageRecords = "SubscriptionUsageRecords";
     public const string UsageCounters = "SubscriptionUsageCounters";
+
+    /// <summary>
+    /// The published current-usage projection, read directly by consumers outside this service.
+    /// </summary>
+    /// <remarks>
+    /// Its own collection rather than fields on the counter, so a consumer can be granted read
+    /// access to exactly this and nothing else. Granting a reader the counter collection would
+    /// hand it the enforcement authority for metered billing.
+    /// </remarks>
+    public const string UsageCurrent = "SubscriptionUsageCurrent";
     public const string PaymentLinks = "SubscriptionPaymentLinks";
     public const string UsageInvoices = "SubscriptionUsageInvoices";
     public const string AuditEvents = "SubscriptionAuditEvents";

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -370,6 +370,72 @@ public static class SubscriptionIndexDefinitions
             })
     ];
 
+    public const string UsageCurrentUniqueIndexName =
+        "ux_usage_current_subscription_meter_period";
+    public const string UsageCurrentReadIndexName =
+        "ix_usage_current_org_subscription_status_period";
+    public const string UsageCurrentStalenessIndexName =
+        "ix_usage_current_tenant_updated";
+    public const string UsageCurrentExpiryIndexName = "ix_usage_current_expiry";
+
+    /// <summary>
+    /// The projection's indexes. Every one of them exists so a direct consumer cannot express a
+    /// query that scans the collection.
+    /// </summary>
+    /// <remarks>
+    /// The unique index restates the composed <c>ItemId</c> rather than adding a constraint the key
+    /// could disagree with: the key already guarantees one document per subscription, meter and
+    /// period. It is declared anyway because a consumer reading this collection directly has only the
+    /// index list to tell it what is guaranteed, and because a future write path that composed the id
+    /// wrongly would be refused by the database instead of quietly producing two current documents
+    /// for one meter.
+    /// <para>
+    /// The read index leads with organization and subscription because that is the only shape a
+    /// direct read is permitted to take — an organization-scoped query for one subscription's current
+    /// windows. Status and the period boundaries follow so "the window containing now" is answered
+    /// from the index rather than by fetching every period this meter ever had. Selecting by boundary
+    /// rather than by an <c>isCurrent</c> flag is deliberate: a flag has to be cleared on some other
+    /// document when a period rolls over, and there is no transaction here to make setting one and
+    /// clearing the other a single act.
+    /// </para>
+    /// <para>
+    /// Expiry follows the counter's retention, so the projection never outlives the thing it
+    /// projects. A never-reset meter's window ends at <c>DateTime.MaxValue</c> and is therefore kept
+    /// for as long as the subscription is, which is correct: its allowance has no later window to
+    /// move to.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionUsageCurrent>> CreateUsageCurrentIndexes() =>
+    [
+        new(
+            Builders<SubscriptionUsageCurrent>.IndexKeys
+                .Ascending(current => current.SubscriptionId)
+                .Ascending(current => current.MeterKey)
+                .Ascending(current => current.PeriodKey),
+            new CreateIndexOptions { Name = UsageCurrentUniqueIndexName, Unique = true }),
+        new(
+            Builders<SubscriptionUsageCurrent>.IndexKeys
+                .Ascending(current => current.OrganizationId)
+                .Ascending(current => current.SubscriptionId)
+                .Ascending(current => current.SubscriptionStatus)
+                .Ascending(current => current.PeriodStartUtc)
+                .Ascending(current => current.PeriodEndUtc),
+            new CreateIndexOptions { Name = UsageCurrentReadIndexName }),
+        new(
+            Builders<SubscriptionUsageCurrent>.IndexKeys
+                .Ascending(current => current.TenantId)
+                .Descending(current => current.UpdatedAtUtc),
+            new CreateIndexOptions { Name = UsageCurrentStalenessIndexName }),
+        new(
+            Builders<SubscriptionUsageCurrent>.IndexKeys
+                .Ascending(current => current.ExpiresAtUtc),
+            new CreateIndexOptions
+            {
+                Name = UsageCurrentExpiryIndexName,
+                ExpireAfter = TimeSpan.Zero
+            })
+    ];
+
     public const string UsagePeriodClaimLookupIndexName =
         "ix_usage_period_claim_tenant_subscription_period";
     public const string UsagePeriodClaimRecoveryIndexName =

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -666,6 +666,40 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         return result.ModifiedCount == 1;
     }
 
+    public async Task<IReadOnlyList<SubscriptionDetail>> ListLivePageAsync(
+        string tenantId,
+        string? afterId,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        var filter = Builders<SubscriptionDetail>.Filter.And(
+            TenantFilter(tenantId),
+            Builders<SubscriptionDetail>.Filter.In(
+                subscription => subscription.Status,
+                new[]
+                {
+                    SubscriptionStatus.Trialing,
+                    SubscriptionStatus.Active,
+                    SubscriptionStatus.PastDue
+                }));
+
+        if (!string.IsNullOrWhiteSpace(afterId))
+        {
+            // Keyset paging on the id: strictly after the last one seen, in id order. A skip would
+            // re-read every document before the offset on every page, and would also miss or repeat
+            // rows as subscriptions are created and ended underneath a multi-pass sweep.
+            filter &= Builders<SubscriptionDetail>.Filter.Gt(
+                subscription => subscription.ItemId,
+                afterId);
+        }
+
+        return await Subscriptions(tenantId)
+            .Find(filter)
+            .SortBy(subscription => subscription.ItemId)
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IReadOnlyList<SubscriptionDetail>> ListStaleAsync(
         string tenantId,
         SubscriptionStatus status,

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -1,0 +1,209 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurrentRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionUsageCurrentRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Current(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateUsageCurrentIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<bool> TryPublishAsync(
+        SubscriptionUsageCurrent document,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        await EnsureIndexesAsync(document.TenantId, cancellationToken);
+
+        // Newer-only, and upsert. The two together are what make this safe to call from concurrent
+        // recordings and from a repair at the same time: whoever holds the highest version wins, and
+        // the first of them to arrive creates the document.
+        var filter = Builders<SubscriptionUsageCurrent>.Filter.And(
+            Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                current => current.ItemId,
+                document.ItemId),
+            Builders<SubscriptionUsageCurrent>.Filter.Lt(
+                current => current.SourceVersion,
+                document.SourceVersion));
+
+        var update = Builders<SubscriptionUsageCurrent>.Update
+            .Set(current => current.TenantId, document.TenantId)
+            .Set(current => current.OrganizationId, document.OrganizationId)
+            .Set(current => current.SubscriptionId, document.SubscriptionId)
+            .Set(current => current.SubscriptionStatus, document.SubscriptionStatus)
+            .Set(current => current.PlanId, document.PlanId)
+            .Set(current => current.PlanCode, document.PlanCode)
+            .Set(current => current.MeterKey, document.MeterKey)
+            .Set(current => current.UnitLabel, document.UnitLabel)
+            .Set(current => current.PeriodKey, document.PeriodKey)
+            .Set(current => current.PeriodStartUtc, document.PeriodStartUtc)
+            .Set(current => current.PeriodEndUtc, document.PeriodEndUtc)
+            .Set(current => current.Included, document.Included)
+            .Set(current => current.Used, document.Used)
+            .Set(current => current.Remaining, document.Remaining)
+            .Set(current => current.Overage, document.Overage)
+            .Set(current => current.OverageAllowed, document.OverageAllowed)
+            .Set(current => current.SourceVersion, document.SourceVersion)
+            .Set(current => current.SchemaVersion, document.SchemaVersion)
+            .Set(current => current.UpdatedAtUtc, document.UpdatedAtUtc)
+            .Set(current => current.ExpiresAtUtc, document.ExpiresAtUtc);
+
+        var collection = Current(document.TenantId);
+
+        // Update first, insert only if there is nothing to update — rather than one upsert.
+        //
+        // An upsert here would be wrong in the ordinary case, not just slower: when the stored
+        // document is already NEWER the filter matches nothing, so Mongo would try to insert, and the
+        // insert carries this document's own composed _id. Every stale publish — the expected outcome
+        // whenever two recordings overlap — would raise a duplicate-key exception. Splitting the two
+        // makes losing the version race a plain "modified nothing", and leaves exceptions for the one
+        // case that genuinely is a race: two callers creating the same missing document at once.
+        if (await UpdateIfNewerAsync(collection, filter, update, cancellationToken))
+        {
+            return true;
+        }
+
+        try
+        {
+            await collection.InsertOneAsync(document, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Somebody inserted it between the update above and this insert. It may have landed at a
+            // version below this one, so the conditional update is attempted once more; if it is at
+            // or beyond this version, that attempt correctly modifies nothing.
+            //
+            // Once, not in a loop: the document exists from here on, so a further attempt could only
+            // lose the same version comparison again.
+            return await UpdateIfNewerAsync(collection, filter, update, cancellationToken);
+        }
+    }
+
+    private static async Task<bool> UpdateIfNewerAsync(
+        IMongoCollection<SubscriptionUsageCurrent> collection,
+        FilterDefinition<SubscriptionUsageCurrent> filter,
+        UpdateDefinition<SubscriptionUsageCurrent> update,
+        CancellationToken cancellationToken)
+    {
+        var result = await collection.UpdateOneAsync(
+            filter,
+            update,
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
+    public async Task<bool> TrySeedAsync(
+        SubscriptionUsageCurrent document,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        await EnsureIndexesAsync(document.TenantId, cancellationToken);
+
+        try
+        {
+            await Current(document.TenantId).InsertOneAsync(
+                document,
+                cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Already published, by a real recording or by an earlier seed. Nothing to do, and
+            // deliberately nothing written: a seed that overwrote a live balance with zero would
+            // discard usage somebody has been billed for.
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<SubscriptionUsageCurrent>> ListCurrentAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        DateTime asOfUtc,
+        CancellationToken cancellationToken) =>
+        await Current(tenantId)
+            .Find(Builders<SubscriptionUsageCurrent>.Filter.And(
+                Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                    current => current.TenantId,
+                    tenantId),
+                Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                    current => current.OrganizationId,
+                    organizationId),
+                Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                    current => current.SubscriptionId,
+                    subscriptionId),
+                Builders<SubscriptionUsageCurrent>.Filter.Lte(
+                    current => current.PeriodStartUtc,
+                    asOfUtc),
+                // Strictly after: a period ends the instant its successor begins, so an inclusive
+                // upper bound would return two windows for one meter at the boundary.
+                Builders<SubscriptionUsageCurrent>.Filter.Gt(
+                    current => current.PeriodEndUtc,
+                    asOfUtc)))
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<SubscriptionUsageCurrent>> ListBehindCountersAsync(
+        string tenantId,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken) =>
+        await Current(tenantId)
+            .Find(Builders<SubscriptionUsageCurrent>.Filter.And(
+                Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                    current => current.TenantId,
+                    tenantId),
+                Builders<SubscriptionUsageCurrent>.Filter.Lte(
+                    current => current.PeriodStartUtc,
+                    asOfUtc),
+                Builders<SubscriptionUsageCurrent>.Filter.Gt(
+                    current => current.PeriodEndUtc,
+                    asOfUtc)))
+            // Served by ix_usage_current_tenant_updated, which is descending on UpdatedAtUtc; the
+            // ascending sort here walks the same index backwards rather than sorting in memory.
+            .SortBy(current => current.UpdatedAtUtc)
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+
+    public async Task<SubscriptionUsageCurrent?> GetAsync(
+        string tenantId,
+        string documentId,
+        CancellationToken cancellationToken) =>
+        await Current(tenantId)
+            .Find(Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                current => current.ItemId,
+                documentId))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    private IMongoCollection<SubscriptionUsageCurrent> Current(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionUsageCurrent>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.UsageCurrent);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Blocks.Genesis;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Subscription.DomainService.Entities;
 
@@ -35,68 +36,40 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
 
         await EnsureIndexesAsync(document.TenantId, cancellationToken);
 
-        // Newer-only, on a version pair, and upsert.
-        //
-        // The counter version orders usage: it rises once per ledger entry, so a recording delayed
-        // between updating its counter and publishing cannot overwrite a newer balance.
-        //
-        // The subscription version orders everything else. A plan change, a quantity change, a
-        // cancellation or a status transition alters what this document says without touching the
-        // counter, so on the counter version alone a republish carrying the new allowance would
-        // compare equal and be refused as stale — and the projection would advertise the old terms
-        // forever, not merely for a sweep interval. It is the tie-break rather than an alternative:
-        // a newer counter version always wins, because a newer balance is newer information about
-        // the same subscription even if it was read at an older subscription version.
+        // Serialized through the entity's own mapping rather than assembled by hand, so the values in
+        // the pipeline below are byte-for-byte what a typed write would have stored. That matters for
+        // the dates in particular: a never-resetting window ends at DateTime.MaxValue, which the
+        // typed serializer represents exactly and a hand-built BsonDateTime would round to
+        // milliseconds.
+        var incoming = document.ToBsonDocument();
+
         var filter = Builders<SubscriptionUsageCurrent>.Filter.And(
             Builders<SubscriptionUsageCurrent>.Filter.Eq(
                 current => current.ItemId,
                 document.ItemId),
+            // Either version being newer is enough to be worth writing. Not the composite "counter
+            // newer, or equal counter and newer subscription": that made the counter version
+            // dominant, so a lifecycle refresh holding newer metadata was rejected outright whenever
+            // a usage recording had already advanced the counter past it, and its metadata never
+            // landed at all.
             Builders<SubscriptionUsageCurrent>.Filter.Or(
                 Builders<SubscriptionUsageCurrent>.Filter.Lt(
                     current => current.CounterVersion,
                     document.CounterVersion),
-                Builders<SubscriptionUsageCurrent>.Filter.And(
-                    Builders<SubscriptionUsageCurrent>.Filter.Eq(
-                        current => current.CounterVersion,
-                        document.CounterVersion),
-                    Builders<SubscriptionUsageCurrent>.Filter.Lt(
-                        current => current.SubscriptionVersion,
-                        document.SubscriptionVersion))));
+                Builders<SubscriptionUsageCurrent>.Filter.Lt(
+                    current => current.SubscriptionVersion,
+                    document.SubscriptionVersion)));
 
-        var update = Builders<SubscriptionUsageCurrent>.Update
-            .Set(current => current.TenantId, document.TenantId)
-            .Set(current => current.OrganizationId, document.OrganizationId)
-            .Set(current => current.SubscriptionId, document.SubscriptionId)
-            .Set(current => current.SubscriptionStatus, document.SubscriptionStatus)
-            .Set(current => current.PlanId, document.PlanId)
-            .Set(current => current.PlanCode, document.PlanCode)
-            .Set(current => current.MeterKey, document.MeterKey)
-            .Set(current => current.UnitLabel, document.UnitLabel)
-            .Set(current => current.PeriodKey, document.PeriodKey)
-            .Set(current => current.PeriodStartUtc, document.PeriodStartUtc)
-            .Set(current => current.PeriodEndUtc, document.PeriodEndUtc)
-            .Set(current => current.Included, document.Included)
-            .Set(current => current.Used, document.Used)
-            .Set(current => current.Remaining, document.Remaining)
-            .Set(current => current.Overage, document.Overage)
-            .Set(current => current.OverageAllowed, document.OverageAllowed)
-            .Set(current => current.CounterVersion, document.CounterVersion)
-            .Set(current => current.SubscriptionVersion, document.SubscriptionVersion)
-            .Set(current => current.SchemaVersion, document.SchemaVersion)
-            .Set(current => current.UpdatedAtUtc, document.UpdatedAtUtc)
-            .Set(current => current.ExpiresAtUtc, document.ExpiresAtUtc);
+        var update = Builders<SubscriptionUsageCurrent>.Update.Pipeline(
+            BuildMergePipeline(incoming));
 
         var collection = Current(document.TenantId);
 
-        // Update first, insert only if there is nothing to update — rather than one upsert.
-        //
-        // An upsert here would be wrong in the ordinary case, not just slower: when the stored
-        // document is already NEWER the filter matches nothing, so Mongo would try to insert, and the
-        // insert carries this document's own composed _id. Every stale publish — the expected outcome
-        // whenever two recordings overlap — would raise a duplicate-key exception. Splitting the two
-        // makes losing the version race a plain "modified nothing", and leaves exceptions for the one
-        // case that genuinely is a race: two callers creating the same missing document at once.
-        if (await UpdateIfNewerAsync(collection, filter, update, cancellationToken))
+        // Update first, insert only if there is nothing to update - rather than one upsert. An upsert
+        // whose filter matches nothing tries to insert, and the insert carries this document's own
+        // composed _id, so every write that lost both version comparisons would raise a duplicate
+        // key. Splitting them makes losing a version race a plain "modified nothing".
+        if (await MergeAsync(collection, filter, update, cancellationToken))
         {
             return true;
         }
@@ -110,17 +83,126 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
         catch (MongoWriteException exception)
             when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
         {
-            // Somebody inserted it between the update above and this insert. It may have landed at a
-            // version below this one, so the conditional update is attempted once more; if it is at
-            // or beyond this version, that attempt correctly modifies nothing.
-            //
-            // Once, not in a loop: the document exists from here on, so a further attempt could only
-            // lose the same version comparison again.
-            return await UpdateIfNewerAsync(collection, filter, update, cancellationToken);
+            // Somebody inserted it between the merge above and this insert. Tried once more, because
+            // the merge may now have something newer to contribute; if it does not, it correctly
+            // changes nothing. Once, not in a loop: the document exists from here on.
+            return await MergeAsync(collection, filter, update, cancellationToken);
         }
     }
 
-    private static async Task<bool> UpdateIfNewerAsync(
+    /// <summary>
+    /// Merges one published document into the stored one, each version governing its own fields.
+    /// </summary>
+    /// <remarks>
+    /// A pipeline rather than a plain <c>$set</c>, because the two versions order two different
+    /// groups of fields and a single conditional write of the whole document cannot honour both.
+    /// <para>
+    /// The failure it exists to prevent: a cancellation publishes
+    /// <c>(counter 10, subscription 6, Cancelled)</c>, and a usage request already in flight then
+    /// publishes <c>(counter 11, subscription 5, Active)</c>. Replacing the whole document because
+    /// the counter is newer would restore <c>Active</c>, drive the stored subscription version
+    /// backwards from 6 to 5, and leave a cancelled subscription advertising a live allowance.
+    /// </para>
+    /// <para>
+    /// So the balance fields move only when the counter version is newer, the plan and status fields
+    /// move only when the subscription version is newer, and each stored version becomes the maximum
+    /// of the two. Every write is then idempotent and order-independent: the document converges on
+    /// the newest of each kind of information whichever order the writers arrive in.
+    /// </para>
+    /// <para>
+    /// <c>Remaining</c> and <c>Overage</c> are recomputed in a second stage from whichever
+    /// <c>Used</c> and <c>Included</c> won, because they are pure functions of those two and taking
+    /// either from the losing side would describe a balance that never existed. This is not the
+    /// projection doing billing arithmetic - it is the same one-line function the authoritative
+    /// response uses, evaluated where both of its inputs are final.
+    /// </para>
+    /// </remarks>
+    private static PipelineDefinition<SubscriptionUsageCurrent, SubscriptionUsageCurrent>
+        BuildMergePipeline(BsonDocument incoming)
+    {
+        // Missing on insert, so absent compares as "older than anything".
+        var storedCounter = new BsonDocument("$ifNull", new BsonArray { "$CounterVersion", -1L });
+        var storedSubscription =
+            new BsonDocument("$ifNull", new BsonArray { "$SubscriptionVersion", -1L });
+
+        var counterIsNewer = new BsonDocument(
+            "$gt", new BsonArray { incoming["CounterVersion"], storedCounter });
+        var subscriptionIsNewer = new BsonDocument(
+            "$gt", new BsonArray { incoming["SubscriptionVersion"], storedSubscription });
+
+        BsonDocument When(BsonDocument condition, string field) =>
+            new("$cond", new BsonArray { condition, incoming[field], "$" + field });
+
+        var merge = new BsonDocument
+        {
+            // Scope and identity. The same for the life of the document - the window is part of its
+            // key - so they are written unconditionally and settle an insert.
+            { "TenantId", incoming["TenantId"] },
+            { "OrganizationId", incoming["OrganizationId"] },
+            { "SubscriptionId", incoming["SubscriptionId"] },
+            { "MeterKey", incoming["MeterKey"] },
+            { "PeriodKey", incoming["PeriodKey"] },
+            { "PeriodStartUtc", incoming["PeriodStartUtc"] },
+            { "PeriodEndUtc", incoming["PeriodEndUtc"] },
+            { "SchemaVersion", incoming["SchemaVersion"] },
+            { "UpdatedAtUtc", incoming["UpdatedAtUtc"] },
+
+            // Balance: the counter's to say.
+            { "Used", When(counterIsNewer, "Used") },
+            { "ExpiresAtUtc", When(counterIsNewer, "ExpiresAtUtc") },
+
+            // Terms and status: the subscription's to say.
+            { "SubscriptionStatus", When(subscriptionIsNewer, "SubscriptionStatus") },
+            { "PlanId", When(subscriptionIsNewer, "PlanId") },
+            { "PlanCode", When(subscriptionIsNewer, "PlanCode") },
+            { "UnitLabel", When(subscriptionIsNewer, "UnitLabel") },
+            { "Included", When(subscriptionIsNewer, "Included") },
+            { "OverageAllowed", When(subscriptionIsNewer, "OverageAllowed") },
+
+            // Each version keeps the higher of the two, so neither can be driven backwards by a
+            // writer that only had newer information of the other kind.
+            {
+                "CounterVersion",
+                new BsonDocument("$max", new BsonArray { storedCounter, incoming["CounterVersion"] })
+            },
+            {
+                "SubscriptionVersion",
+                new BsonDocument(
+                    "$max", new BsonArray { storedSubscription, incoming["SubscriptionVersion"] })
+            }
+        };
+
+        // A second stage, so it reads the merged Used and Included rather than the stored ones.
+        var derive = new BsonDocument
+        {
+            {
+                "Remaining",
+                new BsonDocument("$max", new BsonArray
+                {
+                    0L,
+                    new BsonDocument("$subtract", new BsonArray { "$Included", "$Used" })
+                })
+            },
+            {
+                "Overage",
+                new BsonDocument("$max", new BsonArray
+                {
+                    0L,
+                    new BsonDocument("$subtract", new BsonArray { "$Used", "$Included" })
+                })
+            }
+        };
+
+        return new BsonDocumentStagePipelineDefinition<
+            SubscriptionUsageCurrent,
+            SubscriptionUsageCurrent>(
+            [
+                new BsonDocument("$set", merge),
+                new BsonDocument("$set", derive)
+            ]);
+    }
+
+    private static async Task<bool> MergeAsync(
         IMongoCollection<SubscriptionUsageCurrent> collection,
         FilterDefinition<SubscriptionUsageCurrent> filter,
         UpdateDefinition<SubscriptionUsageCurrent> update,

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -35,16 +35,33 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
 
         await EnsureIndexesAsync(document.TenantId, cancellationToken);
 
-        // Newer-only, and upsert. The two together are what make this safe to call from concurrent
-        // recordings and from a repair at the same time: whoever holds the highest version wins, and
-        // the first of them to arrive creates the document.
+        // Newer-only, on a version pair, and upsert.
+        //
+        // The counter version orders usage: it rises once per ledger entry, so a recording delayed
+        // between updating its counter and publishing cannot overwrite a newer balance.
+        //
+        // The subscription version orders everything else. A plan change, a quantity change, a
+        // cancellation or a status transition alters what this document says without touching the
+        // counter, so on the counter version alone a republish carrying the new allowance would
+        // compare equal and be refused as stale — and the projection would advertise the old terms
+        // forever, not merely for a sweep interval. It is the tie-break rather than an alternative:
+        // a newer counter version always wins, because a newer balance is newer information about
+        // the same subscription even if it was read at an older subscription version.
         var filter = Builders<SubscriptionUsageCurrent>.Filter.And(
             Builders<SubscriptionUsageCurrent>.Filter.Eq(
                 current => current.ItemId,
                 document.ItemId),
-            Builders<SubscriptionUsageCurrent>.Filter.Lt(
-                current => current.SourceVersion,
-                document.SourceVersion));
+            Builders<SubscriptionUsageCurrent>.Filter.Or(
+                Builders<SubscriptionUsageCurrent>.Filter.Lt(
+                    current => current.CounterVersion,
+                    document.CounterVersion),
+                Builders<SubscriptionUsageCurrent>.Filter.And(
+                    Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                        current => current.CounterVersion,
+                        document.CounterVersion),
+                    Builders<SubscriptionUsageCurrent>.Filter.Lt(
+                        current => current.SubscriptionVersion,
+                        document.SubscriptionVersion))));
 
         var update = Builders<SubscriptionUsageCurrent>.Update
             .Set(current => current.TenantId, document.TenantId)
@@ -63,7 +80,8 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
             .Set(current => current.Remaining, document.Remaining)
             .Set(current => current.Overage, document.Overage)
             .Set(current => current.OverageAllowed, document.OverageAllowed)
-            .Set(current => current.SourceVersion, document.SourceVersion)
+            .Set(current => current.CounterVersion, document.CounterVersion)
+            .Set(current => current.SubscriptionVersion, document.SubscriptionVersion)
             .Set(current => current.SchemaVersion, document.SchemaVersion)
             .Set(current => current.UpdatedAtUtc, document.UpdatedAtUtc)
             .Set(current => current.ExpiresAtUtc, document.ExpiresAtUtc);

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -156,8 +156,44 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
             { "PlanId", When(subscriptionIsNewer, "PlanId") },
             { "PlanCode", When(subscriptionIsNewer, "PlanCode") },
             { "UnitLabel", When(subscriptionIsNewer, "UnitLabel") },
-            { "Included", When(subscriptionIsNewer, "Included") },
             { "OverageAllowed", When(subscriptionIsNewer, "OverageAllowed") },
+
+            // The allowance belongs to neither version on its own, so it moves on either.
+            //
+            // It is computed by MeterAllowance.Effective from the plan's terms AND the counter's
+            // LimitSnapshot — the allowance frozen when the window opened, which is where a
+            // carry-forward from the previous period lands. So a change to the counter can change the
+            // allowance with no plan change at all: a seed publishes the opening figure before any
+            // counter exists, and the first recording opens the counter with a possibly different
+            // frozen snapshot. Owned by the subscription version alone, that correction could only
+            // arrive with an unrelated plan edit.
+            //
+            // Guarded so it cannot reopen the regression the field groups exist to prevent: a writer
+            // whose subscription version is BEHIND what is stored may not touch the allowance, so a
+            // late usage publish carrying pre-plan-change terms still cannot undo a newer plan's
+            // figure. It may only correct the allowance when its own view of the subscription is at
+            // least as current as the stored one.
+            {
+                "Included",
+                new BsonDocument("$cond", new BsonArray
+                {
+                    new BsonDocument("$or", new BsonArray
+                    {
+                        subscriptionIsNewer,
+                        new BsonDocument("$and", new BsonArray
+                        {
+                            counterIsNewer,
+                            new BsonDocument("$gte", new BsonArray
+                            {
+                                incoming["SubscriptionVersion"],
+                                storedSubscription
+                            })
+                        })
+                    }),
+                    incoming["Included"],
+                    "$Included"
+                })
+            },
 
             // Each version keeps the higher of the two, so neither can be driven backwards by a
             // writer that only had newer information of the other kind.

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
@@ -103,6 +103,36 @@ public sealed class SubscriptionUsageRepository : ISubscriptionUsageRepository
                 counterId))
             .FirstOrDefaultAsync(cancellationToken);
 
+    public async Task<IReadOnlyDictionary<string, SubscriptionUsageCounter>> GetCountersAsync(
+        string tenantId,
+        IReadOnlyCollection<string> counterIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(counterIds);
+
+        if (counterIds.Count == 0)
+        {
+            return new Dictionary<string, SubscriptionUsageCounter>(StringComparer.Ordinal);
+        }
+
+        var counters = await Counters(tenantId)
+            .Find(Builders<SubscriptionUsageCounter>.Filter.And(
+                Builders<SubscriptionUsageCounter>.Filter.Eq(
+                    counter => counter.TenantId,
+                    tenantId),
+                Builders<SubscriptionUsageCounter>.Filter.In(
+                    counter => counter.ItemId,
+                    counterIds)))
+            .ToListAsync(cancellationToken);
+
+        // Keyed on the id the caller asked with, so a caller holding a meter and period can find its
+        // counter without re-composing anything.
+        return counters.ToDictionary(
+            counter => counter.ItemId,
+            counter => counter,
+            StringComparer.Ordinal);
+    }
+
     public async Task<IReadOnlyList<SubscriptionUsageCounter>> ListCountersAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Responses/UsageCurrentRead.cs
+++ b/server/Subscription.DomainService/Responses/UsageCurrentRead.cs
@@ -1,0 +1,11 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// One current-usage read: the usage, and how it was served.
+/// </summary>
+public sealed class UsageCurrentRead
+{
+    public IReadOnlyList<UsageResponse> Items { get; init; } = [];
+
+    public UsageReadDiagnostics Diagnostics { get; init; } = new();
+}

--- a/server/Subscription.DomainService/Responses/UsageReadDiagnostics.cs
+++ b/server/Subscription.DomainService/Responses/UsageReadDiagnostics.cs
@@ -1,0 +1,44 @@
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Responses;
+
+/// <summary>
+/// How a current-usage read was served. Never part of the usage data itself.
+/// </summary>
+/// <remarks>
+/// Returned beside the response body rather than inside it, so both read modes keep the identical
+/// <see cref="UsageResponse"/> array contract and no existing consumer sees a changed shape.
+/// </remarks>
+public sealed class UsageReadDiagnostics
+{
+    /// <summary>What the caller asked for.</summary>
+    public UsageReadMode RequestedMode { get; init; }
+
+    /// <summary>
+    /// What actually answered. Differs from <see cref="RequestedMode"/> when a projection read found
+    /// nothing and fell back to the counters.
+    /// </summary>
+    public UsageReadMode ActualMode { get; init; }
+
+    public double DurationMs { get; init; }
+
+    /// <summary>How many meter-windows were returned.</summary>
+    public int DocumentCount { get; init; }
+
+    /// <summary>
+    /// How old the freshest projected document in the answer is. Null for an authoritative read,
+    /// which has no projection age, and for a projection read that returned nothing.
+    /// </summary>
+    public double? NewestProjectionAgeSeconds { get; init; }
+
+    /// <summary>
+    /// True when at least one document in the answer is older than the configured staleness
+    /// threshold.
+    /// </summary>
+    /// <remarks>
+    /// Age alone, not version lag: comparing every document's <c>sourceVersion</c> against its
+    /// counter would mean reading the counters, which is the work this mode exists to avoid. Version
+    /// lag is what the reconciliation worker checks, where reading both is the job.
+    /// </remarks>
+    public bool Stale { get; init; }
+}

--- a/server/Subscription.DomainService/Responses/UsageReadDiagnostics.cs
+++ b/server/Subscription.DomainService/Responses/UsageReadDiagnostics.cs
@@ -15,10 +15,22 @@ public sealed class UsageReadDiagnostics
     public UsageReadMode RequestedMode { get; init; }
 
     /// <summary>
-    /// What actually answered. Differs from <see cref="RequestedMode"/> when a projection read found
-    /// nothing and fell back to the counters.
+    /// What actually answered. Differs from <see cref="RequestedMode"/> whenever a projection read
+    /// fell back — see <see cref="Fallback"/> for which kind of fallback it was.
     /// </summary>
     public UsageReadMode ActualMode { get; init; }
+
+    /// <summary>
+    /// Why the answer did not come from where it was asked for, if it did not.
+    /// </summary>
+    /// <remarks>
+    /// Distinguished rather than collapsed into one "fell back", because the two say different things
+    /// to an operator. Nothing published is a subscription this projection has never covered — a
+    /// backfill matter. Some meters published is a projection that is actively incomplete, which means
+    /// a publish or a seed was lost for a subscription the projection does cover, and that is worth
+    /// looking at.
+    /// </remarks>
+    public UsageReadFallback Fallback { get; init; } = UsageReadFallback.None;
 
     public double DurationMs { get; init; }
 
@@ -41,4 +53,28 @@ public sealed class UsageReadDiagnostics
     /// lag is what the reconciliation worker checks, where reading both is the job.
     /// </remarks>
     public bool Stale { get; init; }
+}
+
+/// <summary>Why a current-usage read did not come from the source it was asked for.</summary>
+public enum UsageReadFallback
+{
+    /// <summary>It did. The answer came from the requested source.</summary>
+    None = 0,
+
+    /// <summary>
+    /// The projection held nothing at all for this subscription, so the counters answered.
+    /// </summary>
+    ProjectionEmpty = 1,
+
+    /// <summary>
+    /// The projection held some of the subscription's current windows but not all of them, so the
+    /// counters answered for the whole request.
+    /// </summary>
+    /// <remarks>
+    /// The whole request, not the missing part. Returning the published subset would silently omit
+    /// meters the plan defines, and a caller drawing a usage screen from it would show fewer meters
+    /// than the subscription has — with nothing in the response to say so. The two modes are required
+    /// to return equivalent data, and a subset is not equivalent.
+    /// </remarks>
+    ProjectionPartial = 2
 }

--- a/server/Subscription.DomainService/Responses/UsageResponse.cs
+++ b/server/Subscription.DomainService/Responses/UsageResponse.cs
@@ -33,4 +33,30 @@ public sealed class UsageResponse
 
     /// <summary>True when this call repeated one already recorded and changed nothing.</summary>
     public bool Replayed { get; init; }
+
+    /// <summary>
+    /// Whether the read model describing this meter was published before this response was returned.
+    /// </summary>
+    /// <remarks>
+    /// Additive and purely diagnostic. The usage in this response is authoritative whatever this says:
+    /// the counter recorded it, and a read model that could fail a committed billing write would be an
+    /// authority rather than a projection of one. A caller that does not read the projection can
+    /// ignore this field entirely.
+    /// <para>
+    /// <c>Pending</c> means the usage is recorded but the projection could not be written, and a
+    /// repair has been scheduled. A consumer reading the projection directly will see the previous
+    /// figure until that repair runs.
+    /// </para>
+    /// </remarks>
+    public UsageProjectionState Projection { get; init; } = UsageProjectionState.Published;
+}
+
+/// <summary>The projection's state at the moment a usage response was produced.</summary>
+public enum UsageProjectionState
+{
+    /// <summary>Published, or already ahead of this call because a later recording won the race.</summary>
+    Published = 0,
+
+    /// <summary>Not written; a repair is scheduled. The usage itself is recorded.</summary>
+    Pending = 1
 }

--- a/server/Subscription.DomainService/Scheduling/ISubscriptionWorkScheduler.cs
+++ b/server/Subscription.DomainService/Scheduling/ISubscriptionWorkScheduler.cs
@@ -112,6 +112,29 @@ public interface ISubscriptionWorkScheduler
         string correlationId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Announces that a subscription's current-usage projection needs republishing from its
+    /// counters.
+    /// </summary>
+    /// <remarks>
+    /// Keyed on the subscription and a coarse time bucket rather than on the individual meter-period
+    /// that failed. Two reasons: the handler republishes every current window for the subscription
+    /// anyway, so a per-meter item would schedule the same work several times; and a burst of
+    /// recordings failing to publish during one Mongo blip should collapse into one repair rather
+    /// than one per request.
+    /// <para>
+    /// Best effort, like every producer-side announcement. The usage it describes has already
+    /// committed by the time this is called, so a scheduling failure must not fail the caller — the
+    /// reconciliation sweep is the durable path.
+    /// </para>
+    /// </remarks>
+    Task ScheduleUsageProjectionRefreshAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        string correlationId,
+        CancellationToken cancellationToken = default);
+
     /// <summary>Announces one persisted outbox event by its stable event id.</summary>
     Task ScheduleOutboxPublicationAsync(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
@@ -41,6 +41,7 @@ public sealed class SubscriptionRepairAnnouncer
     private readonly ILogger<SubscriptionRepairAnnouncer> _logger;
     private readonly TimeProvider _time;
     private readonly CampaignRedemptionReconciler? _campaignRedemptions;
+    private readonly IUsageProjectionReconciler? _usageProjections;
 
     public SubscriptionRepairAnnouncer(
         ISubscriptionWorkScheduler scheduler,
@@ -57,7 +58,10 @@ public sealed class SubscriptionRepairAnnouncer
         // Optional for the same reason every other campaign collaborator threaded through this
         // feature is: an existing caller or test that constructs this class by hand, unaware
         // campaigns exist at all, must keep compiling and keep working exactly as it did before.
-        CampaignRedemptionReconciler? campaignRedemptions = null)
+        CampaignRedemptionReconciler? campaignRedemptions = null,
+        // Optional for the same reason: a caller or test that constructs this class by hand,
+        // unaware the usage projection exists, must keep compiling and keep behaving as before.
+        IUsageProjectionReconciler? usageProjections = null)
     {
         _scheduler = scheduler;
         _subscriptions = subscriptions;
@@ -71,6 +75,7 @@ public sealed class SubscriptionRepairAnnouncer
         _logger = logger;
         _time = time ?? TimeProvider.System;
         _campaignRedemptions = campaignRedemptions;
+        _usageProjections = usageProjections;
     }
 
     /// <summary>
@@ -114,6 +119,31 @@ public sealed class SubscriptionRepairAnnouncer
         if (_campaignRedemptions is not null)
         {
             await _campaignRedemptions.ReconcileAsync(tenantId, stoppingToken);
+        }
+
+        // Reconciled inline for the same reason as the two above, and it is the clearest case of the
+        // three: this writes to one derived read-model collection that no billing decision reads, so
+        // it cannot move money or change anybody's bill even by accident.
+        //
+        // This is the sweep that closes the one gap synchronous publishing cannot. A process that
+        // died between updating a counter and publishing its projection left nothing behind to
+        // announce the miss — there is no transaction across the two writes — so the miss is found
+        // here by comparing versions rather than reported by whoever caused it.
+        if (_usageProjections is not null)
+        {
+            var repaired = await _usageProjections.SweepTenantAsync(
+                tenantId,
+                $"sweep:{tenantId}",
+                stoppingToken);
+
+            if (repaired > 0)
+            {
+                _logger.LogInformation(
+                    "Repair sweep republished usage projections that were behind their counters " +
+                    "RepairedCount={RepairedCount} TenantId={TenantId}",
+                    repaired,
+                    PaymentLogValue.Id(tenantId));
+            }
         }
 
         var bucketMinutes = Math.Max(1, options.SchedulerSweepBucketMinutes);

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
@@ -1,4 +1,6 @@
-﻿using Subscription.DomainService.Entities;
+﻿using Microsoft.Extensions.Logging;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
@@ -271,15 +273,21 @@ public sealed class UsagePeriodClosureWorkHandler : ISubscriptionWorkHandler
 {
     private readonly ISubscriptionUsageRatingProcessor _usageRating;
     private readonly IUsageProjectionReconciler? _usageProjections;
+    private readonly ISubscriptionWorkScheduler? _scheduler;
+    private readonly ILogger<UsagePeriodClosureWorkHandler>? _logger;
 
     public UsagePeriodClosureWorkHandler(
         ISubscriptionUsageRatingProcessor usageRating,
         // Optional so an existing caller or test that constructs this handler by hand keeps
         // compiling and keeps doing exactly what it did before.
-        IUsageProjectionReconciler? usageProjections = null)
+        IUsageProjectionReconciler? usageProjections = null,
+        ISubscriptionWorkScheduler? scheduler = null,
+        ILogger<UsagePeriodClosureWorkHandler>? logger = null)
     {
         _usageRating = usageRating;
         _usageProjections = usageProjections;
+        _scheduler = scheduler;
+        _logger = logger;
     }
 
     public SubscriptionWorkType WorkType => SubscriptionWorkType.UsagePeriodClosure;
@@ -294,52 +302,78 @@ public sealed class UsagePeriodClosureWorkHandler : ISubscriptionWorkHandler
             ? work.ItemId
             : work.CorrelationId;
 
-        // Captured BEFORE the closure, because closing a window advances the subscription's usage
-        // billing clock and the due query then returns nothing — there would be no record of who
-        // just rolled.
+        // The closure itself reports which subscriptions actually rolled, so the projection refresh
+        // acts on the committed outcome rather than on a second due query.
         //
-        // Every closure item in practice comes from the repair sweep and names no subscription, so
-        // gating this on work.AggregateId is what the previous version did and it meant this never
-        // ran at all. The due list is the point-of-change signal instead, and it is bounded and
-        // indexed rather than a roster scan.
-        var rolling = _usageProjections is null
-            ? []
-            : await _usageProjections.ListRollingSubscriptionsAsync(
-                work.TenantId,
-                cancellationToken);
-
-        await _usageRating.CloseDuePeriodsAsync(work.TenantId, cancellationToken);
+        // The previous version asked the due query again just before closing. That was wrong in four
+        // ways and equal default batch sizes did not save it: the two queries have separately
+        // configurable limits, take their own "now", and a subscription becoming due between them
+        // would be closed without being named — while one deferred by an outstanding usage claim
+        // would be named without being closed.
+        var closure = await _usageRating.CloseDuePeriodsAsync(work.TenantId, cancellationToken);
 
         // A closed window means a new one is current, and the new one has no projected documents at
         // all: counters are addressed by period key, so crossing a boundary addresses documents that
         // do not exist yet. Publishing them here is what lets a consumer reading this collection
         // directly see every meter at one minute past midnight rather than only the never-resetting
         // ones — it has no API fallback, and waiting for the backfill cycle is not immediate.
-        //
-        // After the closure, never before, so the window resolved is the new one. Failures are
-        // absorbed by the reconciler's own logging rather than failing this item: the closure has
-        // committed, and rating must not be retried because a read model was not written.
-        if (_usageProjections is not null && rolling.Count > 0)
+        var toRefresh = new List<string>(closure.RolledSubscriptionIds);
+
+        // A producer-scheduled item names its subscription. Nothing schedules one today, but the
+        // scheduler still offers it, and such an item should refresh what it names.
+        if (!string.IsNullOrWhiteSpace(work.AggregateId) &&
+            !toRefresh.Contains(work.AggregateId, StringComparer.Ordinal))
+        {
+            toRefresh.Add(work.AggregateId);
+        }
+
+        if (_usageProjections is null || toRefresh.Count == 0)
+        {
+            return SubscriptionWorkOutcome.Completed();
+        }
+
+        try
         {
             await _usageProjections.RefreshManyAsync(
                 work.TenantId,
-                rolling,
+                toRefresh,
                 correlationId,
                 cancellationToken);
         }
-
-        // A producer-scheduled item names its subscription. Nothing schedules one today — every
-        // closure comes from the sweep — but the path is kept because the scheduler still offers it,
-        // and an item that names a subscription should refresh that one whether or not it was due.
-        if (_usageProjections is not null &&
-            !string.IsNullOrWhiteSpace(work.AggregateId) &&
-            !rolling.Contains(work.AggregateId, StringComparer.Ordinal))
+        catch (Exception exception) when (exception is not OperationCanceledException)
         {
-            await _usageProjections.RefreshSubscriptionAsync(
-                work.TenantId,
-                work.AggregateId,
-                correlationId,
-                cancellationToken);
+            // The closure has committed. Letting this reach the queue would retry the closure — and
+            // a derived read model must not decide whether authoritative rating work counts as done.
+            // The publisher's own paths absorb their failures, but RefreshAsync does not, so this is
+            // the boundary that has to.
+            //
+            // The ids are logged because they are the ones whose new window is unpublished, and a
+            // repair is announced per subscription so the projection catches up without waiting for
+            // the backfill cycle. Both best effort: TryScheduleAsync swallows, and the version sweep
+            // and backfill remain behind it.
+            _logger?.LogError(
+                exception,
+                "Usage period closure committed but its projections could not be published; " +
+                "scheduling repairs TenantHash={TenantHash} Subscriptions={Subscriptions} " +
+                "SubscriptionHashes={SubscriptionHashes} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(work.TenantId),
+                toRefresh.Count,
+                string.Join(
+                    ",", toRefresh.ConvertAll(id => PaymentLogValue.Hash(id))),
+                correlationId);
+
+            if (_scheduler is not null)
+            {
+                foreach (var subscriptionId in toRefresh)
+                {
+                    await _scheduler.ScheduleUsageProjectionRefreshAsync(
+                        work.TenantId,
+                        work.OrganizationId ?? string.Empty,
+                        subscriptionId,
+                        correlationId,
+                        cancellationToken);
+                }
+            }
         }
 
         return SubscriptionWorkOutcome.Completed();

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
@@ -270,9 +270,17 @@ public sealed class CancellationEffectiveWorkHandler : ISubscriptionWorkHandler
 public sealed class UsagePeriodClosureWorkHandler : ISubscriptionWorkHandler
 {
     private readonly ISubscriptionUsageRatingProcessor _usageRating;
+    private readonly IUsageProjectionReconciler? _usageProjections;
 
-    public UsagePeriodClosureWorkHandler(ISubscriptionUsageRatingProcessor usageRating) =>
+    public UsagePeriodClosureWorkHandler(
+        ISubscriptionUsageRatingProcessor usageRating,
+        // Optional so an existing caller or test that constructs this handler by hand keeps
+        // compiling and keeps doing exactly what it did before.
+        IUsageProjectionReconciler? usageProjections = null)
+    {
         _usageRating = usageRating;
+        _usageProjections = usageProjections;
+    }
 
     public SubscriptionWorkType WorkType => SubscriptionWorkType.UsagePeriodClosure;
 
@@ -280,7 +288,30 @@ public sealed class UsagePeriodClosureWorkHandler : ISubscriptionWorkHandler
         SubscriptionBackgroundWork work,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(work);
+
         await _usageRating.CloseDuePeriodsAsync(work.TenantId, cancellationToken);
+
+        // A closed window means a new one is now current, and the new one has no projected documents
+        // at all: the counters are addressed by period key, so crossing a boundary addresses
+        // documents that do not exist yet. Publishing them here is what lets a consumer read the new
+        // window's allowance before anything has been recorded into it.
+        //
+        // After the closure, never before, and only when the item names a subscription. An item the
+        // repair sweep scheduled names nothing, and the tenant-wide projection sweep — which runs in
+        // the announcer — is what covers that case; republishing every subscription in the tenant
+        // from here would put a roster scan into the closure path.
+        //
+        // Failure is swallowed by the reconciler's own logging rather than failing this item: the
+        // closure has committed, and rating must not be retried because a read model was not written.
+        if (_usageProjections is not null && !string.IsNullOrWhiteSpace(work.AggregateId))
+        {
+            await _usageProjections.RefreshSubscriptionAsync(
+                work.TenantId,
+                work.AggregateId,
+                string.IsNullOrWhiteSpace(work.CorrelationId) ? work.ItemId : work.CorrelationId,
+                cancellationToken);
+        }
 
         return SubscriptionWorkOutcome.Completed();
     }

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkHandlers.cs
@@ -290,26 +290,55 @@ public sealed class UsagePeriodClosureWorkHandler : ISubscriptionWorkHandler
     {
         ArgumentNullException.ThrowIfNull(work);
 
+        var correlationId = string.IsNullOrWhiteSpace(work.CorrelationId)
+            ? work.ItemId
+            : work.CorrelationId;
+
+        // Captured BEFORE the closure, because closing a window advances the subscription's usage
+        // billing clock and the due query then returns nothing — there would be no record of who
+        // just rolled.
+        //
+        // Every closure item in practice comes from the repair sweep and names no subscription, so
+        // gating this on work.AggregateId is what the previous version did and it meant this never
+        // ran at all. The due list is the point-of-change signal instead, and it is bounded and
+        // indexed rather than a roster scan.
+        var rolling = _usageProjections is null
+            ? []
+            : await _usageProjections.ListRollingSubscriptionsAsync(
+                work.TenantId,
+                cancellationToken);
+
         await _usageRating.CloseDuePeriodsAsync(work.TenantId, cancellationToken);
 
-        // A closed window means a new one is now current, and the new one has no projected documents
-        // at all: the counters are addressed by period key, so crossing a boundary addresses
-        // documents that do not exist yet. Publishing them here is what lets a consumer read the new
-        // window's allowance before anything has been recorded into it.
+        // A closed window means a new one is current, and the new one has no projected documents at
+        // all: counters are addressed by period key, so crossing a boundary addresses documents that
+        // do not exist yet. Publishing them here is what lets a consumer reading this collection
+        // directly see every meter at one minute past midnight rather than only the never-resetting
+        // ones — it has no API fallback, and waiting for the backfill cycle is not immediate.
         //
-        // After the closure, never before, and only when the item names a subscription. An item the
-        // repair sweep scheduled names nothing, and the tenant-wide projection sweep — which runs in
-        // the announcer — is what covers that case; republishing every subscription in the tenant
-        // from here would put a roster scan into the closure path.
-        //
-        // Failure is swallowed by the reconciler's own logging rather than failing this item: the
-        // closure has committed, and rating must not be retried because a read model was not written.
-        if (_usageProjections is not null && !string.IsNullOrWhiteSpace(work.AggregateId))
+        // After the closure, never before, so the window resolved is the new one. Failures are
+        // absorbed by the reconciler's own logging rather than failing this item: the closure has
+        // committed, and rating must not be retried because a read model was not written.
+        if (_usageProjections is not null && rolling.Count > 0)
+        {
+            await _usageProjections.RefreshManyAsync(
+                work.TenantId,
+                rolling,
+                correlationId,
+                cancellationToken);
+        }
+
+        // A producer-scheduled item names its subscription. Nothing schedules one today — every
+        // closure comes from the sweep — but the path is kept because the scheduler still offers it,
+        // and an item that names a subscription should refresh that one whether or not it was due.
+        if (_usageProjections is not null &&
+            !string.IsNullOrWhiteSpace(work.AggregateId) &&
+            !rolling.Contains(work.AggregateId, StringComparer.Ordinal))
         {
             await _usageProjections.RefreshSubscriptionAsync(
                 work.TenantId,
                 work.AggregateId,
-                string.IsNullOrWhiteSpace(work.CorrelationId) ? work.ItemId : work.CorrelationId,
+                correlationId,
                 cancellationToken);
         }
 

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkScheduler.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkScheduler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Payment.DomainService.Utilities;
@@ -238,6 +239,32 @@ public sealed class SubscriptionWorkScheduler : ISubscriptionWorkScheduler
             cancellationToken);
     }
 
+    public Task ScheduleUsageProjectionRefreshAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        string correlationId,
+        CancellationToken cancellationToken = default)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        // A one-minute bucket in the occurrence key. The unique occurrence index then collapses every
+        // failure inside the same minute onto one item, so a Mongo blip affecting a thousand
+        // recordings schedules a handful of repairs rather than a thousand. Coarser would delay the
+        // repair of a projection that failed just after a bucket was completed.
+        var bucket = now.ToString("yyyyMMddHHmm", CultureInfo.InvariantCulture);
+
+        return TryScheduleAsync(
+            SubscriptionWorkType.UsageProjectionRefresh,
+            tenantId,
+            $"usage-projection:{subscriptionId}:{bucket}",
+            now,
+            correlationId,
+            subscriptionId,
+            organizationId,
+            cancellationToken);
+    }
+
     /// <summary>
     /// What runs first when the queue is behind.
     /// </summary>
@@ -264,6 +291,9 @@ public sealed class SubscriptionWorkScheduler : ISubscriptionWorkScheduler
         // must never delay a renewal that does.
         SubscriptionWorkType.FinancialDocumentIssue => 80,
         SubscriptionWorkType.FinancialDocumentDelivery => 90,
+        // Below every one of those. It repairs a read model that no billing decision reads,
+        // and it must never delay work that moves money.
+        SubscriptionWorkType.UsageProjectionRefresh => 95,
         _ => 100
     };
 }

--- a/server/Subscription.DomainService/Scheduling/UsageProjectionBackfillCursors.cs
+++ b/server/Subscription.DomainService/Scheduling/UsageProjectionBackfillCursors.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// Where the projection backfill has reached in each tenant's roster.
+/// </summary>
+/// <remarks>
+/// <b>Registered as a singleton, and that is the whole point of it existing.</b> The reconciler is
+/// scoped, and the reconciliation background service opens a fresh scope per tenant sweep — so a
+/// cursor held as a field on the reconciler was a new empty dictionary on every pass, and the
+/// backfill re-read page one forever. Any tenant with more live subscriptions than one page never had
+/// its later pages published at all.
+/// <para>
+/// Held in memory rather than persisted, deliberately, and this is the trade-off worth naming: a
+/// restart forgets the position and the next pass starts from the beginning. That costs a repeat of
+/// work which is idempotent and version-ordered by construction — every write the backfill makes is
+/// conditional, so repeating one changes nothing — and the pass is a cycle rather than a migration, so
+/// starting over is a normal state rather than a failure.
+/// </para>
+/// <para>
+/// With several replicas each keeps its own position, so they walk the roster independently rather
+/// than dividing it. That is slower to cover a large tenant than a shared durable cursor would be, and
+/// it is still complete: every page is reached by every replica in turn. A durable cursor in the root
+/// database would fix both, at the cost of a second scheduling record to keep correct for a pass whose
+/// entire job is to be safe to repeat and safe to run late. It has not been built, and it is the
+/// upgrade to make if backfill latency on the largest tenants turns out to matter.
+/// </para>
+/// </remarks>
+public sealed class UsageProjectionBackfillCursors
+{
+    private readonly ConcurrentDictionary<string, string> _cursors = new(StringComparer.Ordinal);
+
+    /// <summary>The subscription id the next pass for this tenant should resume after.</summary>
+    public string? Resume(string tenantId) =>
+        _cursors.TryGetValue(tenantId, out var cursor) ? cursor : null;
+
+    /// <summary>
+    /// Records where a pass stopped, or clears the position when the roster was exhausted so the
+    /// next pass starts again from the beginning.
+    /// </summary>
+    public void Advance(string tenantId, string? resumeAfter)
+    {
+        if (resumeAfter is null)
+        {
+            _cursors.TryRemove(tenantId, out _);
+
+            return;
+        }
+
+        _cursors[tenantId] = resumeAfter;
+    }
+}

--- a/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
+++ b/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
@@ -61,6 +61,38 @@ public interface IUsageProjectionReconciler
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// The subscriptions whose usage window is about to roll, captured before it does.
+    /// </summary>
+    /// <remarks>
+    /// Must be read <em>before</em> the closure runs: closing a window advances
+    /// <c>NextUsageBillingAtUtc</c>, so afterwards the due query returns nothing and there is no
+    /// record of who just rolled.
+    /// <para>
+    /// Independent of whether any usage was recorded — the query is driven by the subscription's own
+    /// billing clock — which is what makes it cover the case that matters most here: a quiet meter
+    /// crossing a period boundary with no usage on either side of it.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyList<string>> ListRollingSubscriptionsAsync(
+        string tenantId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes the current window of each named subscription.
+    /// </summary>
+    /// <remarks>
+    /// Called immediately after a period closure with the ids captured before it, so the new window's
+    /// zero-usage documents exist as soon as the window opens rather than whenever the backfill next
+    /// comes round. That is the difference between a direct consumer seeing every meter at one minute
+    /// past midnight and seeing only the never-resetting ones.
+    /// </remarks>
+    Task<int> RefreshManyAsync(
+        string tenantId,
+        IReadOnlyList<string> subscriptionIds,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Walks the tenant's live subscriptions and publishes any current window that has no document.
     /// </summary>
     /// <remarks>
@@ -277,6 +309,55 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         }
 
         return repaired;
+    }
+
+    public async Task<IReadOnlyList<string>> ListRollingSubscriptionsAsync(
+        string tenantId,
+        CancellationToken cancellationToken)
+    {
+        var due = await _subscriptions.ListDueForUsageRatingAsync(
+            tenantId,
+            _time.GetUtcNow().UtcDateTime,
+            Math.Max(1, _options.CurrentValue.UsageProjectionBackfillBatchSize),
+            cancellationToken);
+
+        return due.Select(subscription => subscription.ItemId).ToList();
+    }
+
+    public async Task<int> RefreshManyAsync(
+        string tenantId,
+        IReadOnlyList<string> subscriptionIds,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscriptionIds);
+
+        var written = 0;
+
+        foreach (var subscriptionId in subscriptionIds)
+        {
+            written += await RefreshSubscriptionAsync(
+                tenantId,
+                subscriptionId,
+                correlationId,
+                cancellationToken);
+        }
+
+        if (written > 0)
+        {
+            _metrics.RecordRepairCompleted("period-rollover", written);
+
+            _logger.LogInformation(
+                "Published usage projections for windows that just rolled over " +
+                "TenantHash={TenantHash} Subscriptions={Subscriptions} Written={Written} " +
+                "CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(tenantId),
+                subscriptionIds.Count,
+                written,
+                correlationId);
+        }
+
+        return written;
     }
 
     public async Task<UsageProjectionBackfillResult> BackfillTenantAsync(

--- a/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
+++ b/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
@@ -1,0 +1,227 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// Brings current-usage projections back in line with the counters they project.
+/// </summary>
+/// <remarks>
+/// Two entry points, because there are two ways a projection falls behind.
+/// <para>
+/// <b>Targeted.</b> A usage write committed and its synchronous publish did not. The write knows
+/// which subscription it was, names it on the queue item, and this republishes every current window
+/// for it.
+/// </para>
+/// <para>
+/// <b>Swept.</b> Nothing announced the miss — the process died between the counter update and the
+/// scheduling write, which is the one gap that cannot be closed without a transaction across two
+/// databases. The sweep finds projections whose <c>SourceVersion</c> is behind their counter's
+/// <c>AppliedRecordCount</c> and republishes them.
+/// </para>
+/// <para>
+/// <b>What the sweep does not find.</b> A projection that was never written at all. It reads the
+/// projection collection, so a missing document is invisible to it by construction. Three other
+/// things cover that case, and they are why finding it here would be redundant rather than merely
+/// hard: activation and period rollover seed a zero-usage document for every meter; the first usage
+/// recording publishes one whether or not a seed exists; and a projection read that finds nothing
+/// falls back to the counters instead of reporting an empty allowance. Discovering it here would mean
+/// scanning the counters of every live subscription per tenant, which is a new index and a new
+/// per-tenant cost on the hot billing collection, to repair something already covered on three
+/// paths.
+/// </para>
+/// </remarks>
+public interface IUsageProjectionReconciler
+{
+    Task<int> RefreshSubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<int> SweepTenantAsync(
+        string tenantId,
+        string correlationId,
+        CancellationToken cancellationToken);
+}
+
+/// <inheritdoc />
+public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionUsageCurrentRepository _current;
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly IUsageProjectionPublisher _publisher;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<UsageProjectionReconciler> _logger;
+    private readonly TimeProvider _time;
+
+    public UsageProjectionReconciler(
+        ISubscriptionRepository subscriptions,
+        ISubscriptionUsageCurrentRepository current,
+        ISubscriptionUsageRepository usage,
+        IUsageProjectionPublisher publisher,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<UsageProjectionReconciler> logger,
+        TimeProvider? time = null)
+    {
+        _subscriptions = subscriptions;
+        _current = current;
+        _usage = usage;
+        _publisher = publisher;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<int> RefreshSubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        // Re-read rather than trust the queue item, as every handler here must: the item says only
+        // that a publish was owed when it was written. The subscription may since have been
+        // cancelled or changed plan, and the projection should describe what it is now.
+        var subscription = await _subscriptions.GetByIdAsync(
+            tenantId,
+            subscriptionId,
+            cancellationToken);
+
+        if (subscription is null)
+        {
+            // Gone. Its projections expire on their own TTL, and there is nothing to republish.
+            _logger.LogInformation(
+                "Skipped a usage projection repair for a subscription that no longer exists " +
+                "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
+                "CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(tenantId),
+                PaymentLogValue.Hash(subscriptionId),
+                correlationId);
+
+            return 0;
+        }
+
+        return await _publisher.RefreshAsync(
+            subscription,
+            _time.GetUtcNow().UtcDateTime,
+            correlationId,
+            cancellationToken);
+    }
+
+    public async Task<int> SweepTenantAsync(
+        string tenantId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+        var batch = Math.Max(1, _options.CurrentValue.UsageProjectionReconciliationBatchSize);
+
+        var candidates = await _current.ListBehindCountersAsync(
+            tenantId,
+            now,
+            batch,
+            cancellationToken);
+
+        if (candidates.Count == 0)
+        {
+            return 0;
+        }
+
+        // One batch of counters for the whole candidate set, then compare. Reading the counters is
+        // unavoidable here — a version comparison needs both sides — but it need not be one round
+        // trip per candidate.
+        var counters = await _usage.GetCountersAsync(
+            tenantId,
+            candidates.Select(candidate => candidate.ItemId).ToList(),
+            cancellationToken);
+
+        var behind = candidates
+            .Where(candidate =>
+                counters.TryGetValue(candidate.ItemId, out var counter) &&
+                counter.AppliedRecordCount > candidate.SourceVersion)
+            .Select(candidate => candidate.SubscriptionId)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var repaired = 0;
+
+        foreach (var subscriptionId in behind)
+        {
+            repaired += await RefreshSubscriptionAsync(
+                tenantId,
+                subscriptionId,
+                correlationId,
+                cancellationToken);
+        }
+
+        if (behind.Count > 0)
+        {
+            _logger.LogWarning(
+                "Repaired usage projections that were behind their counters " +
+                "TenantHash={TenantHash} Examined={Examined} Subscriptions={Subscriptions} " +
+                "Written={Written} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(tenantId),
+                candidates.Count,
+                behind.Count,
+                repaired,
+                correlationId);
+        }
+
+        return repaired;
+    }
+}
+
+/// <summary>
+/// Republishes a subscription's current-usage projection, or sweeps a tenant's for version lag.
+/// </summary>
+/// <remarks>
+/// Both shapes, following the convention the financial-document and renewal handlers already set:
+/// an item scheduled where the miss happened names the subscription, and one scheduled by the repair
+/// sweep names nothing because its job is to find what nobody announced.
+/// <para>
+/// Nothing here can charge anybody, and it holds no processor that could. It writes to one
+/// collection, which no billing decision reads.
+/// </para>
+/// </remarks>
+public sealed class UsageProjectionRefreshWorkHandler : ISubscriptionWorkHandler
+{
+    private readonly IUsageProjectionReconciler _reconciler;
+
+    public UsageProjectionRefreshWorkHandler(IUsageProjectionReconciler reconciler) =>
+        _reconciler = reconciler;
+
+    public SubscriptionWorkType WorkType => SubscriptionWorkType.UsageProjectionRefresh;
+
+    public async Task<SubscriptionWorkOutcome> ExecuteAsync(
+        SubscriptionBackgroundWork work,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+
+        var correlationId = string.IsNullOrWhiteSpace(work.CorrelationId)
+            ? work.ItemId
+            : work.CorrelationId;
+
+        if (string.IsNullOrWhiteSpace(work.AggregateId))
+        {
+            await _reconciler.SweepTenantAsync(work.TenantId, correlationId, cancellationToken);
+        }
+        else
+        {
+            await _reconciler.RefreshSubscriptionAsync(
+                work.TenantId,
+                work.AggregateId,
+                correlationId,
+                cancellationToken);
+        }
+
+        return SubscriptionWorkOutcome.Completed();
+    }
+}

--- a/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
+++ b/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Payment.DomainService.Utilities;
@@ -22,9 +21,13 @@ namespace Subscription.DomainService.Scheduling;
 /// </para>
 /// <para>
 /// <b>Swept.</b> Nothing announced the miss — the process died between the counter update and the
-/// scheduling write, which is the one gap that cannot be closed without a transaction across two
-/// databases. The sweep finds projections whose <c>CounterVersion</c> is behind their counter's
-/// <c>AppliedRecordCount</c> and republishes them.
+/// scheduling write, or a best-effort announcement was lost. That is the one gap no transaction can
+/// close, because the two writes are in different databases. The sweep compares <em>both</em>
+/// versions: <c>CounterVersion</c> against the counter's <c>AppliedRecordCount</c>, and
+/// <c>SubscriptionVersion</c> against <c>SubscriptionDetail.Version</c>. Comparing only the counter
+/// would miss every metadata change, since a plan change or a cancellation moves no counter — and
+/// would never reach a cancelled subscription at all, because the backfill walks only the live
+/// roster.
 /// </para>
 /// <para>
 /// <b>Backfilled.</b> The document was never written at all — a subscription that predates this
@@ -88,17 +91,7 @@ public sealed record UsageProjectionBackfillResult(
 /// <inheritdoc />
 public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
 {
-    /// <summary>
-    /// Where the backfill has reached in each tenant's roster.
-    /// </summary>
-    /// <remarks>
-    /// In this process only, and deliberately not persisted. Losing it on a restart costs a repeat of
-    /// at most one cycle of work that is idempotent and conditional by construction — every write the
-    /// backfill makes is ordered, so repeating it changes nothing. Persisting it would mean a second
-    /// durable cursor to keep correct, for a pass whose whole job is to be safe to repeat.
-    /// </remarks>
-    private readonly ConcurrentDictionary<string, string> _cursors = new(StringComparer.Ordinal);
-
+    private readonly UsageProjectionBackfillCursors _cursors;
     private readonly ISubscriptionRepository _subscriptions;
     private readonly ISubscriptionUsageCurrentRepository _current;
     private readonly ISubscriptionUsageRepository _usage;
@@ -113,6 +106,9 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         ISubscriptionUsageCurrentRepository current,
         ISubscriptionUsageRepository usage,
         IUsageProjectionPublisher publisher,
+        // Singleton, so it survives the scope this reconciler lives in. Held as a field here, it was
+        // recreated empty on every sweep and the backfill never advanced past its first page.
+        UsageProjectionBackfillCursors cursors,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<UsageProjectionReconciler> logger,
         TimeProvider? time = null,
@@ -122,6 +118,7 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         _current = current;
         _usage = usage;
         _publisher = publisher;
+        _cursors = cursors;
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
@@ -190,22 +187,68 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
             candidates.Select(candidate => candidate.ItemId).ToList(),
             cancellationToken);
 
-        var lagging = candidates
+        var behindOnUsage = candidates
             .Where(candidate =>
                 counters.TryGetValue(candidate.ItemId, out var counter) &&
                 counter.AppliedRecordCount > candidate.CounterVersion)
             .ToList();
 
-        foreach (var candidate in lagging)
+        foreach (var candidate in behindOnUsage)
         {
             _metrics.RecordVersionLag(
                 counters[candidate.ItemId].AppliedRecordCount - candidate.CounterVersion);
         }
 
-        var behind = lagging
+        // Both versions, not just the counter.
+        //
+        // A counter-only comparison cannot see a metadata change: a plan change, a quantity change or
+        // a cancellation moves SubscriptionDetail.Version and leaves the counter exactly where it
+        // was. Those changes announce themselves on the queue, but the announcement is best effort by
+        // design — it must not fail an operation that has already committed — so if one is lost this
+        // is the only thing that finds it.
+        //
+        // It also reaches subscriptions the backfill does not. The backfill walks the LIVE roster, so
+        // a cancelled subscription is outside it forever; its projection is still here, still says
+        // whatever it last said, and this is what corrects it to Cancelled.
+        var subscriptionIds = candidates
             .Select(candidate => candidate.SubscriptionId)
             .Distinct(StringComparer.Ordinal)
             .ToList();
+
+        var behind = new List<string>();
+
+        foreach (var subscriptionId in subscriptionIds)
+        {
+            if (behindOnUsage.Exists(candidate =>
+                    string.Equals(candidate.SubscriptionId, subscriptionId, StringComparison.Ordinal)))
+            {
+                behind.Add(subscriptionId);
+
+                continue;
+            }
+
+            // One read per candidate subscription, and only for those whose counters are level. It is
+            // affordable because the candidate set is bounded by the batch size and collapsed to
+            // distinct subscriptions first, and because a projection whose usage is already current is
+            // the common case — this is the only remaining question about it.
+            var subscription = await _subscriptions.GetByIdAsync(
+                tenantId,
+                subscriptionId,
+                cancellationToken);
+
+            if (subscription is null)
+            {
+                continue;
+            }
+
+            if (candidates.Any(candidate =>
+                    string.Equals(
+                        candidate.SubscriptionId, subscriptionId, StringComparison.Ordinal) &&
+                    candidate.SubscriptionVersion < subscription.Version))
+            {
+                behind.Add(subscriptionId);
+            }
+        }
 
         var repaired = 0;
 
@@ -223,7 +266,7 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
             _metrics.RecordRepairCompleted("version-lag-sweep", repaired);
 
             _logger.LogWarning(
-                "Repaired usage projections that were behind their counters " +
+                "Repaired usage projections that were behind their counter or their subscription " +
                 "TenantHash={TenantHash} Examined={Examined} Subscriptions={Subscriptions} " +
                 "Written={Written} CorrelationId={CorrelationId}",
                 PaymentLogValue.Hash(tenantId),
@@ -244,7 +287,7 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         var now = _time.GetUtcNow().UtcDateTime;
         var batch = Math.Max(1, _options.CurrentValue.UsageProjectionBackfillBatchSize);
 
-        _cursors.TryGetValue(tenantId, out var afterSubscriptionId);
+        var afterSubscriptionId = _cursors.Resume(tenantId);
 
         var subscriptions = await _subscriptions.ListLivePageAsync(
             tenantId,
@@ -257,7 +300,7 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
             // The roster is exhausted, so the next pass starts from the beginning. That makes this a
             // cycle rather than a one-off migration, which it has to be: a meter added to a plan
             // tomorrow is a missing document tomorrow.
-            _cursors.TryRemove(tenantId, out _);
+            _cursors.Advance(tenantId, null);
 
             return new UsageProjectionBackfillResult(0, 0, null);
         }
@@ -293,14 +336,7 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         // next pass restarts rather than asking for rows after the last id forever.
         var resumeFrom = subscriptions.Count == batch ? subscriptions[^1].ItemId : null;
 
-        if (resumeFrom is null)
-        {
-            _cursors.TryRemove(tenantId, out _);
-        }
-        else
-        {
-            _cursors[tenantId] = resumeFrom;
-        }
+        _cursors.Advance(tenantId, resumeFrom);
 
         return new UsageProjectionBackfillResult(subscriptions.Count, written, resumeFrom);
     }

--- a/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
+++ b/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
@@ -61,29 +61,12 @@ public interface IUsageProjectionReconciler
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// The subscriptions whose usage window is about to roll, captured before it does.
-    /// </summary>
-    /// <remarks>
-    /// Must be read <em>before</em> the closure runs: closing a window advances
-    /// <c>NextUsageBillingAtUtc</c>, so afterwards the due query returns nothing and there is no
-    /// record of who just rolled.
-    /// <para>
-    /// Independent of whether any usage was recorded — the query is driven by the subscription's own
-    /// billing clock — which is what makes it cover the case that matters most here: a quiet meter
-    /// crossing a period boundary with no usage on either side of it.
-    /// </para>
-    /// </remarks>
-    Task<IReadOnlyList<string>> ListRollingSubscriptionsAsync(
-        string tenantId,
-        CancellationToken cancellationToken);
-
-    /// <summary>
     /// Publishes the current window of each named subscription.
     /// </summary>
     /// <remarks>
-    /// Called immediately after a period closure with the ids captured before it, so the new window's
-    /// zero-usage documents exist as soon as the window opens rather than whenever the backfill next
-    /// comes round. That is the difference between a direct consumer seeing every meter at one minute
+    /// Called immediately after a period closure with the ids that closure reported having rolled, so
+    /// the new window's zero-usage documents exist as soon as the window opens rather than whenever
+    /// the backfill next comes round. That is the difference between a direct consumer seeing every meter at one minute
     /// past midnight and seeing only the never-resetting ones.
     /// </remarks>
     Task<int> RefreshManyAsync(
@@ -309,19 +292,6 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         }
 
         return repaired;
-    }
-
-    public async Task<IReadOnlyList<string>> ListRollingSubscriptionsAsync(
-        string tenantId,
-        CancellationToken cancellationToken)
-    {
-        var due = await _subscriptions.ListDueForUsageRatingAsync(
-            tenantId,
-            _time.GetUtcNow().UtcDateTime,
-            Math.Max(1, _options.CurrentValue.UsageProjectionBackfillBatchSize),
-            cancellationToken);
-
-        return due.Select(subscription => subscription.ItemId).ToList();
     }
 
     public async Task<int> RefreshManyAsync(

--- a/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
+++ b/server/Subscription.DomainService/Scheduling/UsageProjectionReconciler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Payment.DomainService.Utilities;
@@ -22,19 +23,22 @@ namespace Subscription.DomainService.Scheduling;
 /// <para>
 /// <b>Swept.</b> Nothing announced the miss — the process died between the counter update and the
 /// scheduling write, which is the one gap that cannot be closed without a transaction across two
-/// databases. The sweep finds projections whose <c>SourceVersion</c> is behind their counter's
+/// databases. The sweep finds projections whose <c>CounterVersion</c> is behind their counter's
 /// <c>AppliedRecordCount</c> and republishes them.
 /// </para>
 /// <para>
-/// <b>What the sweep does not find.</b> A projection that was never written at all. It reads the
-/// projection collection, so a missing document is invisible to it by construction. Three other
-/// things cover that case, and they are why finding it here would be redundant rather than merely
-/// hard: activation and period rollover seed a zero-usage document for every meter; the first usage
-/// recording publishes one whether or not a seed exists; and a projection read that finds nothing
-/// falls back to the counters instead of reporting an empty allowance. Discovering it here would mean
-/// scanning the counters of every live subscription per tenant, which is a new index and a new
-/// per-tenant cost on the hot billing collection, to repair something already covered on three
-/// paths.
+/// <b>Backfilled.</b> The document was never written at all — a subscription that predates this
+/// collection, a seed that failed, a process that died before the first publish, or a meter added to
+/// a plan after the fact. The version sweep cannot find any of those: it reads the projection
+/// collection, so a missing document is invisible to it by construction.
+/// </para>
+/// <para>
+/// The API covers that case by falling back to the counters, but <b>a consumer reading this
+/// collection directly has nothing to fall back to</b> — it would simply see no meter. So the
+/// backfill enumerates the authoritative side instead: it walks the tenant's live subscriptions,
+/// resolves the current window of every meter each one defines, and publishes whatever is missing.
+/// That is what makes direct access safe to enable, and it is a different question from version lag,
+/// which is why it is a separate pass with its own cursor.
 /// </para>
 /// </remarks>
 public interface IUsageProjectionReconciler
@@ -45,19 +49,61 @@ public interface IUsageProjectionReconciler
         string correlationId,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Repairs projections whose counter has moved on without them.
+    /// </summary>
     Task<int> SweepTenantAsync(
+        string tenantId,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Walks the tenant's live subscriptions and publishes any current window that has no document.
+    /// </summary>
+    /// <remarks>
+    /// Bounded per call and resumable: it keeps its own place in the tenant's roster and advances one
+    /// page per pass, so a tenant larger than one page is finished by successive passes rather than by
+    /// one long pass holding the database. Reaching the end wraps back to the start, because this is a
+    /// cycle rather than a migration — a meter added to a plan tomorrow is a missing document
+    /// tomorrow.
+    /// </remarks>
+    Task<UsageProjectionBackfillResult> BackfillTenantAsync(
         string tenantId,
         string correlationId,
         CancellationToken cancellationToken);
 }
 
+/// <summary>Where a backfill pass got to, and what it wrote.</summary>
+/// <param name="Examined">Live subscriptions inspected in this pass.</param>
+/// <param name="Written">Projected documents created or updated.</param>
+/// <param name="LastSubscriptionId">
+/// The last subscription seen, which is where the next pass resumes. Null when the roster was
+/// exhausted, so the next pass starts again from the beginning.
+/// </param>
+public sealed record UsageProjectionBackfillResult(
+    int Examined,
+    int Written,
+    string? LastSubscriptionId);
+
 /// <inheritdoc />
 public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
 {
+    /// <summary>
+    /// Where the backfill has reached in each tenant's roster.
+    /// </summary>
+    /// <remarks>
+    /// In this process only, and deliberately not persisted. Losing it on a restart costs a repeat of
+    /// at most one cycle of work that is idempotent and conditional by construction — every write the
+    /// backfill makes is ordered, so repeating it changes nothing. Persisting it would mean a second
+    /// durable cursor to keep correct, for a pass whose whole job is to be safe to repeat.
+    /// </remarks>
+    private readonly ConcurrentDictionary<string, string> _cursors = new(StringComparer.Ordinal);
+
     private readonly ISubscriptionRepository _subscriptions;
     private readonly ISubscriptionUsageCurrentRepository _current;
     private readonly ISubscriptionUsageRepository _usage;
     private readonly IUsageProjectionPublisher _publisher;
+    private readonly UsageProjectionMetrics _metrics;
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<UsageProjectionReconciler> _logger;
     private readonly TimeProvider _time;
@@ -69,7 +115,8 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         IUsageProjectionPublisher publisher,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<UsageProjectionReconciler> logger,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        UsageProjectionMetrics? metrics = null)
     {
         _subscriptions = subscriptions;
         _current = current;
@@ -78,6 +125,7 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
+        _metrics = metrics ?? UsageProjectionMetrics.Shared;
     }
 
     public async Task<int> RefreshSubscriptionAsync(
@@ -142,10 +190,19 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
             candidates.Select(candidate => candidate.ItemId).ToList(),
             cancellationToken);
 
-        var behind = candidates
+        var lagging = candidates
             .Where(candidate =>
                 counters.TryGetValue(candidate.ItemId, out var counter) &&
-                counter.AppliedRecordCount > candidate.SourceVersion)
+                counter.AppliedRecordCount > candidate.CounterVersion)
+            .ToList();
+
+        foreach (var candidate in lagging)
+        {
+            _metrics.RecordVersionLag(
+                counters[candidate.ItemId].AppliedRecordCount - candidate.CounterVersion);
+        }
+
+        var behind = lagging
             .Select(candidate => candidate.SubscriptionId)
             .Distinct(StringComparer.Ordinal)
             .ToList();
@@ -163,6 +220,8 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
 
         if (behind.Count > 0)
         {
+            _metrics.RecordRepairCompleted("version-lag-sweep", repaired);
+
             _logger.LogWarning(
                 "Repaired usage projections that were behind their counters " +
                 "TenantHash={TenantHash} Examined={Examined} Subscriptions={Subscriptions} " +
@@ -175,6 +234,75 @@ public sealed class UsageProjectionReconciler : IUsageProjectionReconciler
         }
 
         return repaired;
+    }
+
+    public async Task<UsageProjectionBackfillResult> BackfillTenantAsync(
+        string tenantId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+        var batch = Math.Max(1, _options.CurrentValue.UsageProjectionBackfillBatchSize);
+
+        _cursors.TryGetValue(tenantId, out var afterSubscriptionId);
+
+        var subscriptions = await _subscriptions.ListLivePageAsync(
+            tenantId,
+            afterSubscriptionId,
+            batch,
+            cancellationToken);
+
+        if (subscriptions.Count == 0)
+        {
+            // The roster is exhausted, so the next pass starts from the beginning. That makes this a
+            // cycle rather than a one-off migration, which it has to be: a meter added to a plan
+            // tomorrow is a missing document tomorrow.
+            _cursors.TryRemove(tenantId, out _);
+
+            return new UsageProjectionBackfillResult(0, 0, null);
+        }
+
+        var written = 0;
+
+        foreach (var subscription in subscriptions)
+        {
+            // RefreshAsync is what publishes; this pass only decides who needs asking. It seeds a
+            // window with no counter and publishes one that has, both conditionally, so a backfill
+            // running beside live recordings cannot overwrite anything newer than what it read.
+            written += await _publisher.RefreshAsync(
+                subscription,
+                now,
+                correlationId,
+                cancellationToken);
+        }
+
+        if (written > 0)
+        {
+            _metrics.RecordRepairCompleted("backfill", written);
+
+            _logger.LogInformation(
+                "Usage projection backfill wrote missing documents TenantHash={TenantHash} " +
+                "Examined={Examined} Written={Written} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(tenantId),
+                subscriptions.Count,
+                written,
+                correlationId);
+        }
+
+        // Only a full page can have more behind it. A short page means the roster ended here, so the
+        // next pass restarts rather than asking for rows after the last id forever.
+        var resumeFrom = subscriptions.Count == batch ? subscriptions[^1].ItemId : null;
+
+        if (resumeFrom is null)
+        {
+            _cursors.TryRemove(tenantId, out _);
+        }
+        else
+        {
+            _cursors[tenantId] = resumeFrom;
+        }
+
+        return new UsageProjectionBackfillResult(subscriptions.Count, written, resumeFrom);
     }
 }
 
@@ -209,18 +337,22 @@ public sealed class UsageProjectionRefreshWorkHandler : ISubscriptionWorkHandler
             ? work.ItemId
             : work.CorrelationId;
 
-        if (string.IsNullOrWhiteSpace(work.AggregateId))
-        {
-            await _reconciler.SweepTenantAsync(work.TenantId, correlationId, cancellationToken);
-        }
-        else
+        if (!string.IsNullOrWhiteSpace(work.AggregateId))
         {
             await _reconciler.RefreshSubscriptionAsync(
                 work.TenantId,
                 work.AggregateId,
                 correlationId,
                 cancellationToken);
+
+            return SubscriptionWorkOutcome.Completed();
         }
+
+        // Tenant-wide: both passes, because they answer different questions. The sweep finds
+        // documents whose counter moved on without them; the backfill finds windows that have no
+        // document at all, which the sweep cannot see because it reads the projection collection.
+        await _reconciler.SweepTenantAsync(work.TenantId, correlationId, cancellationToken);
+        await _reconciler.BackfillTenantAsync(work.TenantId, correlationId, cancellationToken);
 
         return SubscriptionWorkOutcome.Completed();
     }

--- a/server/Subscription.DomainService/Services/IUsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/IUsageProjectionPublisher.cs
@@ -1,0 +1,92 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Publishes the current-usage projection from authoritative state.
+/// </summary>
+/// <remarks>
+/// The only writer of <see cref="SubscriptionUsageCurrent"/>. Every method here takes figures that a
+/// counter has already produced; none of them adds, subtracts or carries anything forward, so the
+/// projection cannot drift by arithmetic — only by not having been written yet, which is a condition
+/// with a version on it and a repair behind it.
+/// </remarks>
+public interface IUsageProjectionPublisher
+{
+    /// <summary>
+    /// Publishes one meter-period from the counter state a usage write ended at.
+    /// </summary>
+    /// <remarks>
+    /// Called after the authoritative sequence has finished — ledger appended, counter moved, any
+    /// reversal applied — so what it publishes is the balance the caller was told, never the momentary
+    /// exceeded balance an enforced refusal passed through.
+    /// </remarks>
+    Task<UsageProjectionOutcome> PublishAsync(
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        SubscriptionUsageCounter counter,
+        long allowance,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Creates zero-usage documents for every meter whose current window has none.
+    /// </summary>
+    /// <remarks>
+    /// So a consumer can discover a subscription's meters and allowances before any usage exists.
+    /// Insert-only per document: an existing balance is never overwritten.
+    /// </remarks>
+    Task<int> SeedCurrentAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Republishes every current window for a subscription from its counters.
+    /// </summary>
+    /// <remarks>
+    /// The repair path, and the one every lifecycle change uses. Reads the authoritative counters and
+    /// publishes what they say; the version condition means this cannot undo a recording that landed
+    /// while it was running.
+    /// <para>
+    /// Also the correct response to anything that changes what the projection <em>describes</em>
+    /// without changing a balance — a status change, a plan or quantity change, a repaired counter —
+    /// because those alter the allowance or the terms a reader sees, not the usage.
+    /// </para>
+    /// </remarks>
+    Task<int> RefreshAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        string correlationId,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>What became of one attempt to publish a projected document.</summary>
+public enum UsageProjectionOutcome
+{
+    /// <summary>Written. The projection now describes the state the caller was told.</summary>
+    Published = 0,
+
+    /// <summary>
+    /// A newer version was already stored, so nothing was written.
+    /// </summary>
+    /// <remarks>
+    /// A success. It means a later recording against the same meter finished first, and the
+    /// projection is ahead of this caller rather than behind it.
+    /// </remarks>
+    Superseded = 1,
+
+    /// <summary>
+    /// The usage committed but the projection could not be written, and a repair has been scheduled.
+    /// </summary>
+    /// <remarks>
+    /// Reported to the caller as a diagnostic on an otherwise successful response, never as a failure:
+    /// the counter is the authority, the usage is recorded, and a read model that could refuse a
+    /// committed billing write would be an authority itself.
+    /// </remarks>
+    RepairScheduled = 2
+}

--- a/server/Subscription.DomainService/Services/IUsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/IUsageRecordingService.cs
@@ -1,3 +1,4 @@
+using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
 
@@ -25,6 +26,19 @@ public interface IUsageRecordingService
     /// </param>
     Task<SubscriptionOperationResult<IReadOnlyList<UsageResponse>>> GetCurrentUsageAsync(
         string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The same current usage, with the choice of source and the diagnostics describing it.
+    /// </summary>
+    /// <remarks>
+    /// Added beside <see cref="GetCurrentUsageAsync"/> rather than replacing it, so the existing
+    /// signature and everything calling it keep working unchanged.
+    /// </remarks>
+    Task<SubscriptionOperationResult<UsageCurrentRead>> ReadCurrentAsync(
+        string? organizationId,
+        UsageReadMode readMode,
         string correlationId,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -192,6 +192,40 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 context, subscriptionId, endsImmediately, correlationId, cancellationToken);
         }
 
+        if (_scheduler is not null)
+        {
+            // The projection carries the subscription's status, so a reader can tell a live
+            // allowance from one frozen by cancellation without joining to the subscription. That
+            // status just changed.
+            //
+            // Announced for both shapes of cancellation, unlike the effective-date item below:
+            // ending now and ending at the period boundary both change the status a reader sees, and
+            // an immediate end is the case where a stale "Active" is most misleading.
+            //
+            // Wrapped for the same reason the announcement below is: this is a separate,
+            // non-transactional write, and a read model that could not be announced must not undo a
+            // cancellation the subscriber already has confirmation of. The backfill cycle is the
+            // durable path.
+            try
+            {
+                await _scheduler.ScheduleUsageProjectionRefreshAsync(
+                    subscription.TenantId,
+                    subscription.OrganizationId,
+                    subscription.ItemId,
+                    correlationId,
+                    cancellationToken);
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "Could not announce a usage projection refresh after cancellation " +
+                    "SubscriptionHash={SubscriptionHash} CorrelationId={CorrelationId}",
+                    PaymentLogValue.Hash(subscription.ItemId),
+                    correlationId);
+            }
+        }
+
         if (!endsImmediately && _scheduler is not null)
         {
             // Best effort, and defensively so: this is a separate, non-transactional write from

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -1275,6 +1275,22 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 subscription,
                 outboxEvent,
                 cancellationToken);
+
+            // The projection describes this subscription's allowance and terms, and both just
+            // changed. Announced rather than published inline: the counter version has not moved, so
+            // nothing about usage is stale — only the metadata is, and a queue item repairs that
+            // without adding a write to a path that has just moved money.
+            //
+            // The version sweep cannot find this on its own. It compares counter versions, and a
+            // change that alters the allowance without recording usage leaves the counter version
+            // exactly where it was, so an announcement here is the only thing that makes the new
+            // terms visible before the next backfill cycle.
+            await _scheduler.ScheduleUsageProjectionRefreshAsync(
+                subscription.TenantId,
+                subscription.OrganizationId,
+                subscription.ItemId,
+                correlationId,
+                cancellationToken);
         }
 
         _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -687,6 +687,22 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 subscription,
                 outboxEvent,
                 cancellationToken);
+
+            // The projection describes this subscription's allowance and terms, and both just
+            // changed. Announced rather than published inline: the counter version has not moved, so
+            // nothing about usage is stale — only the metadata is, and a queue item repairs that
+            // without adding a write to a path that has just moved money.
+            //
+            // The version sweep cannot find this on its own. It compares counter versions, and a
+            // change that alters the allowance without recording usage leaves the counter version
+            // exactly where it was, so an announcement here is the only thing that makes the new
+            // terms visible before the next backfill cycle.
+            await _scheduler.ScheduleUsageProjectionRefreshAsync(
+                subscription.TenantId,
+                subscription.OrganizationId,
+                subscription.ItemId,
+                correlationId,
+                cancellationToken);
         }
 
         _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);

--- a/server/Subscription.DomainService/Services/UsageProjectionMetrics.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionMetrics.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// The current-usage projection as numbers rather than log lines.
+/// </summary>
+/// <remarks>
+/// Logs say what happened to one read or one publish, which is enough to investigate an incident once
+/// somebody notices one. These exist to notice one, and to answer the question the projection was
+/// built to answer: is reading it actually faster than reading the counters, and is it staying
+/// current enough to be worth reading?
+/// <para>
+/// The duration histogram carries the read mode as a dimension, so p50, p95 and p99 for
+/// <c>authoritative</c> and <c>projection</c> come out of the same instrument and are directly
+/// comparable — no separate benchmark harness needed to answer the comparison, only load applied to
+/// both modes.
+/// </para>
+/// <para>
+/// <b>No tenant, organization or subscription dimension.</b> Deliberately: a per-tenant label
+/// multiplies every series by the tenant count, and there are thousands. Those identifiers belong in
+/// logs and trace spans, where they are attached to individual reads, and both carry them.
+/// </para>
+/// <para>
+/// Built on <see cref="Meter"/> and exported through OTLP, following
+/// <c>SubscriptionWorkMetrics</c>.
+/// </para>
+/// </remarks>
+public sealed class UsageProjectionMetrics : IDisposable
+{
+    /// <summary>The name an exporter subscribes to.</summary>
+    public const string MeterName = "Blocks.Subscription.UsageProjection";
+
+    /// <summary>
+    /// The process-wide instrument set.
+    /// </summary>
+    /// <remarks>
+    /// A shared default so a service constructed by hand — in a test, or by a caller that predates
+    /// this — records into the same instruments the running process exports, rather than needing one
+    /// threaded through every call site before any of it is visible.
+    /// </remarks>
+    public static UsageProjectionMetrics Shared { get; } = new();
+
+    private readonly Meter _meter;
+    private readonly Histogram<double> _readDuration;
+    private readonly Histogram<double> _projectionAge;
+    private readonly Histogram<double> _publishDuration;
+    private readonly Histogram<long> _versionLag;
+    private readonly Counter<long> _reads;
+    private readonly Counter<long> _fallbacks;
+    private readonly Counter<long> _staleReads;
+    private readonly Counter<long> _publishes;
+    private readonly Counter<long> _publishFailures;
+    private readonly Counter<long> _repairsScheduled;
+    private readonly Counter<long> _repairsCompleted;
+
+    public UsageProjectionMetrics()
+    {
+        _meter = new Meter(MeterName);
+
+        _readDuration = _meter.CreateHistogram<double>(
+            "subscription.usage.read.duration",
+            unit: "ms",
+            description:
+            "How long a current-usage read took, by requested and actual mode. The mode dimension " +
+            "is what makes p50/p95/p99 comparable between the counters and the projection.");
+
+        _projectionAge = _meter.CreateHistogram<double>(
+            "subscription.usage.projection.age",
+            unit: "s",
+            description:
+            "How old the freshest projected document in an answer was. Recorded only for reads the " +
+            "projection actually served.");
+
+        _publishDuration = _meter.CreateHistogram<double>(
+            "subscription.usage.projection.publish.duration",
+            unit: "ms",
+            description:
+            "How long publishing one projected document took. This runs inside a customer-facing " +
+            "billing call, so its tail is latency added to that call.");
+
+        _versionLag = _meter.CreateHistogram<long>(
+            "subscription.usage.projection.version_lag",
+            unit: "{records}",
+            description:
+            "How far a projection was behind its counter when the reconciliation pass found it, in " +
+            "ledger entries.");
+
+        _reads = _meter.CreateCounter<long>(
+            "subscription.usage.read.count",
+            description: "Current-usage reads, by requested and actual mode.");
+
+        _fallbacks = _meter.CreateCounter<long>(
+            "subscription.usage.read.fallback.count",
+            description:
+            "Projection reads answered by the counters instead, by reason - nothing published, or " +
+            "only some windows published.");
+
+        _staleReads = _meter.CreateCounter<long>(
+            "subscription.usage.read.stale.count",
+            description: "Reads whose answer contained at least one document past the staleness threshold.");
+
+        _publishes = _meter.CreateCounter<long>(
+            "subscription.usage.projection.publish.count",
+            description: "Projection publish attempts, by outcome.");
+
+        _publishFailures = _meter.CreateCounter<long>(
+            "subscription.usage.projection.publish.failure.count",
+            description:
+            "Publishes that could not be written after the usage had committed. Every one of these " +
+            "left a projection behind its counter and scheduled a repair.");
+
+        _repairsScheduled = _meter.CreateCounter<long>(
+            "subscription.usage.projection.repair.scheduled.count",
+            description: "Repair items scheduled, by what noticed the miss.");
+
+        _repairsCompleted = _meter.CreateCounter<long>(
+            "subscription.usage.projection.repair.completed.count",
+            description: "Projected documents written by a repair, by what drove it.");
+    }
+
+    public void RecordRead(
+        UsageReadMode requested,
+        UsageReadMode actual,
+        UsageReadFallback fallback,
+        TimeSpan duration,
+        double? newestAgeSeconds,
+        bool stale)
+    {
+        var tags = new TagList
+        {
+            { "requested_mode", requested.ToString() },
+            { "actual_mode", actual.ToString() }
+        };
+
+        _reads.Add(1, tags);
+        _readDuration.Record(duration.TotalMilliseconds, tags);
+
+        if (newestAgeSeconds is { } age)
+        {
+            _projectionAge.Record(age, tags);
+        }
+
+        if (stale)
+        {
+            _staleReads.Add(1, tags);
+        }
+
+        if (fallback != UsageReadFallback.None)
+        {
+            _fallbacks.Add(1, new TagList
+            {
+                { "requested_mode", requested.ToString() },
+                { "reason", fallback.ToString() }
+            });
+        }
+    }
+
+    public void RecordPublish(UsageProjectionOutcome outcome, TimeSpan duration)
+    {
+        var tags = new TagList { { "outcome", outcome.ToString() } };
+
+        _publishes.Add(1, tags);
+        _publishDuration.Record(duration.TotalMilliseconds, tags);
+
+        if (outcome == UsageProjectionOutcome.RepairScheduled)
+        {
+            _publishFailures.Add(1);
+        }
+    }
+
+    public void RecordRepairScheduled(string source) =>
+        _repairsScheduled.Add(1, new TagList { { "source", source } });
+
+    public void RecordRepairCompleted(string source, int written) =>
+        _repairsCompleted.Add(written, new TagList { { "source", source } });
+
+    /// <summary>
+    /// How far behind a projection was when the reconciliation pass repaired it.
+    /// </summary>
+    /// <remarks>
+    /// Recorded by the sweep rather than by a read, because measuring lag needs both the projection
+    /// and its counter and the sweep is the only place that reads both. A read reports age instead,
+    /// which is cheaper and is why the two are separate instruments.
+    /// </remarks>
+    public void RecordVersionLag(long lag) => _versionLag.Record(lag);
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
@@ -17,6 +17,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
     private readonly ISubscriptionUsageRepository _usage;
     private readonly IMeterAllowanceResolver _allowances;
     private readonly ISubscriptionWorkScheduler _scheduler;
+    private readonly UsageProjectionMetrics _metrics;
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<UsageProjectionPublisher> _logger;
     private readonly TimeProvider _time;
@@ -28,7 +29,8 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         ISubscriptionWorkScheduler scheduler,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<UsageProjectionPublisher> logger,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        UsageProjectionMetrics? metrics = null)
     {
         _current = current;
         _usage = usage;
@@ -37,6 +39,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         _options = options;
         _logger = logger;
         _time = time ?? TimeProvider.System;
+        _metrics = metrics ?? UsageProjectionMetrics.Shared;
     }
 
     public async Task<UsageProjectionOutcome> PublishAsync(
@@ -64,9 +67,13 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
 
             LogPublished(subscription, meter, document, started, published, correlationId);
 
-            return published
+            var outcome = published
                 ? UsageProjectionOutcome.Published
                 : UsageProjectionOutcome.Superseded;
+
+            _metrics.RecordPublish(outcome, _time.GetElapsedTime(started));
+
+            return outcome;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -81,13 +88,17 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
                 exception,
                 "Usage projection publication failed after the usage committed; scheduling a repair " +
                 "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} Meter={Meter} " +
-                "Period={Period} SourceVersion={SourceVersion} CorrelationId={CorrelationId}",
+                "Period={Period} CounterVersion={CounterVersion} CorrelationId={CorrelationId}",
                 PaymentLogValue.Hash(subscription.TenantId),
                 PaymentLogValue.Hash(subscription.ItemId),
                 PaymentLogValue.Label(meter.MeterKey),
                 PaymentLogValue.Label(period.Key),
-                document.SourceVersion,
+                document.CounterVersion,
                 correlationId);
+
+            _metrics.RecordPublish(
+                UsageProjectionOutcome.RepairScheduled,
+                _time.GetElapsedTime(started));
 
             await ScheduleRepairAsync(subscription, correlationId, cancellationToken);
 
@@ -121,7 +132,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
                 period,
                 counter: null,
                 balance: 0,
-                sourceVersion: 0,
+                counterVersion: 0,
                 allowance);
 
             try
@@ -206,13 +217,23 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
 
             if (counter is null)
             {
-                // No counter means nothing has been recorded in this window. Seeded rather than
-                // published: a publish carries version 0, which the version condition would refuse
-                // against any existing document, and would be wrong to accept if it did.
+                // No counter means nothing has been recorded in this window, so the balance is zero
+                // and the counter version is zero.
                 document = Describe(
-                    subscription, meter, period, counter: null, balance: 0, sourceVersion: 0, allowance);
+                    subscription, meter, period, counter: null, balance: 0, counterVersion: 0, allowance);
 
-                if (await _current.TrySeedAsync(document, cancellationToken))
+                // Seed first, which creates it if it is missing and refuses to touch it if it is
+                // not. Then publish, which is what carries a changed allowance onto a window that
+                // already has a zero-usage document.
+                //
+                // Both, rather than one: the seed cannot update, and the publish cannot insert past
+                // a zero counter version against a document holding real usage. Together they cover
+                // the two cases without either being able to discard a balance — the publish is
+                // still ordered, so against a document with any recorded usage its counter version
+                // of zero loses, and against a zero-usage document it wins only on a newer
+                // subscription version.
+                if (await _current.TrySeedAsync(document, cancellationToken) ||
+                    await _current.TryPublishAsync(document, cancellationToken))
                 {
                     published++;
                 }
@@ -283,7 +304,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         BillingPeriod period,
         SubscriptionUsageCounter? counter,
         long balance,
-        long sourceVersion,
+        long counterVersion,
         long allowance) => new()
     {
         ItemId = SubscriptionUsageCurrent.CreateId(
@@ -309,7 +330,8 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         Remaining = Math.Max(0, allowance - balance),
         Overage = Math.Max(0, balance - allowance),
         OverageAllowed = meter.OverageAllowed,
-        SourceVersion = sourceVersion,
+        CounterVersion = counterVersion,
+        SubscriptionVersion = subscription.Version,
         SchemaVersion = SubscriptionUsageCurrent.CurrentSchemaVersion,
         UpdatedAtUtc = _time.GetUtcNow().UtcDateTime,
         // The counter's own expiry when there is one, so the projection never outlives what it
@@ -345,13 +367,13 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
             _logger.LogWarning(
                 "Usage projection publish was slow TenantHash={TenantHash} " +
                 "SubscriptionHash={SubscriptionHash} Meter={Meter} DurationMs={DurationMs} " +
-                "Written={Written} SourceVersion={SourceVersion} CorrelationId={CorrelationId}",
+                "Written={Written} CounterVersion={CounterVersion} CorrelationId={CorrelationId}",
                 PaymentLogValue.Hash(subscription.TenantId),
                 PaymentLogValue.Hash(subscription.ItemId),
                 PaymentLogValue.Label(meter.MeterKey),
                 duration.TotalMilliseconds,
                 written,
-                document.SourceVersion,
+                document.CounterVersion,
                 correlationId);
 
             return;
@@ -360,26 +382,30 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         _logger.LogDebug(
             "Usage projection published TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
             "Meter={Meter} DurationMs={DurationMs} Written={Written} " +
-            "SourceVersion={SourceVersion} CorrelationId={CorrelationId}",
+            "CounterVersion={CounterVersion} CorrelationId={CorrelationId}",
             PaymentLogValue.Hash(subscription.TenantId),
             PaymentLogValue.Hash(subscription.ItemId),
             PaymentLogValue.Label(meter.MeterKey),
             duration.TotalMilliseconds,
             written,
-            document.SourceVersion,
+            document.CounterVersion,
             correlationId);
     }
 
     private Task ScheduleRepairAsync(
         SubscriptionDetail subscription,
         string correlationId,
-        CancellationToken cancellationToken) =>
-        _scheduler.ScheduleUsageProjectionRefreshAsync(
+        CancellationToken cancellationToken)
+    {
+        _metrics.RecordRepairScheduled("publish-failure");
+
+        return _scheduler.ScheduleUsageProjectionRefreshAsync(
             subscription.TenantId,
             subscription.OrganizationId,
             subscription.ItemId,
             correlationId,
             cancellationToken);
+    }
 
     /// <summary>
     /// Retries a projection write a couple of times for the errors that are worth retrying.

--- a/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
@@ -1,0 +1,429 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <inheritdoc cref="IUsageProjectionPublisher"/>
+public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
+{
+    private readonly ISubscriptionUsageCurrentRepository _current;
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly IMeterAllowanceResolver _allowances;
+    private readonly ISubscriptionWorkScheduler _scheduler;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<UsageProjectionPublisher> _logger;
+    private readonly TimeProvider _time;
+
+    public UsageProjectionPublisher(
+        ISubscriptionUsageCurrentRepository current,
+        ISubscriptionUsageRepository usage,
+        IMeterAllowanceResolver allowances,
+        ISubscriptionWorkScheduler scheduler,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<UsageProjectionPublisher> logger,
+        TimeProvider? time = null)
+    {
+        _current = current;
+        _usage = usage;
+        _allowances = allowances;
+        _scheduler = scheduler;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<UsageProjectionOutcome> PublishAsync(
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        SubscriptionUsageCounter counter,
+        long allowance,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+        ArgumentNullException.ThrowIfNull(meter);
+        ArgumentNullException.ThrowIfNull(counter);
+
+        var document = Describe(subscription, meter, period, counter, allowance);
+
+        var started = _time.GetTimestamp();
+
+        try
+        {
+            var published = await WithTransientRetryAsync(
+                () => _current.TryPublishAsync(document, cancellationToken),
+                cancellationToken);
+
+            LogPublished(subscription, meter, document, started, published, correlationId);
+
+            return published
+                ? UsageProjectionOutcome.Published
+                : UsageProjectionOutcome.Superseded;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            // The usage is already committed. Swallowing it here and scheduling a repair is the
+            // whole point: this is a read model, and letting it throw would turn a display problem
+            // into a failed billing write.
+            _logger.LogError(
+                exception,
+                "Usage projection publication failed after the usage committed; scheduling a repair " +
+                "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} Meter={Meter} " +
+                "Period={Period} SourceVersion={SourceVersion} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(meter.MeterKey),
+                PaymentLogValue.Label(period.Key),
+                document.SourceVersion,
+                correlationId);
+
+            await ScheduleRepairAsync(subscription, correlationId, cancellationToken);
+
+            return UsageProjectionOutcome.RepairScheduled;
+        }
+    }
+
+    public async Task<int> SeedCurrentAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var seeded = 0;
+
+        foreach (var (meter, period) in CurrentWindows(subscription, asOfUtc))
+        {
+            // The opening allowance rather than the effective one: there is no counter yet, so there
+            // is nothing whose snapshot could differ from it.
+            var allowance = await _allowances.OpeningAllowanceAsync(
+                subscription,
+                meter,
+                period,
+                cancellationToken);
+
+            var document = Describe(
+                subscription,
+                meter,
+                period,
+                counter: null,
+                balance: 0,
+                sourceVersion: 0,
+                allowance);
+
+            try
+            {
+                if (await WithTransientRetryAsync(
+                        () => _current.TrySeedAsync(document, cancellationToken),
+                        cancellationToken))
+                {
+                    seeded++;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                // A missing zero-usage document is a discovery gap, not lost usage: the first
+                // recording publishes the meter anyway. Scheduled for repair and not propagated,
+                // because the caller of this is an activation or a rollover that has already
+                // committed something more important.
+                _logger.LogWarning(
+                    exception,
+                    "Could not seed a zero-usage projection; scheduling a repair " +
+                    "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} Meter={Meter} " +
+                    "CorrelationId={CorrelationId}",
+                    PaymentLogValue.Hash(subscription.TenantId),
+                    PaymentLogValue.Hash(subscription.ItemId),
+                    PaymentLogValue.Label(meter.MeterKey),
+                    correlationId);
+
+                await ScheduleRepairAsync(subscription, correlationId, cancellationToken);
+            }
+        }
+
+        return seeded;
+    }
+
+    public async Task<int> RefreshAsync(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        var windows = CurrentWindows(subscription, asOfUtc).ToList();
+
+        if (windows.Count == 0)
+        {
+            return 0;
+        }
+
+        // One batch for every meter, which matters here as much as on the read path: a repair over a
+        // subscription with a dozen meters would otherwise be a dozen round trips.
+        var counters = await _usage.GetCountersAsync(
+            subscription.TenantId,
+            windows
+                .Select(window => SubscriptionUsageCounter.CreateId(
+                    subscription.ItemId,
+                    window.Meter.MeterKey,
+                    window.Period.Key))
+                .ToList(),
+            cancellationToken);
+
+        var published = 0;
+
+        foreach (var (meter, period) in windows)
+        {
+            counters.TryGetValue(
+                SubscriptionUsageCounter.CreateId(subscription.ItemId, meter.MeterKey, period.Key),
+                out var counter);
+
+            var allowance = await _allowances.EffectiveAsync(
+                subscription,
+                meter,
+                period,
+                counter,
+                cancellationToken);
+
+            SubscriptionUsageCurrent document;
+
+            if (counter is null)
+            {
+                // No counter means nothing has been recorded in this window. Seeded rather than
+                // published: a publish carries version 0, which the version condition would refuse
+                // against any existing document, and would be wrong to accept if it did.
+                document = Describe(
+                    subscription, meter, period, counter: null, balance: 0, sourceVersion: 0, allowance);
+
+                if (await _current.TrySeedAsync(document, cancellationToken))
+                {
+                    published++;
+                }
+
+                continue;
+            }
+
+            document = Describe(subscription, meter, period, counter, allowance);
+
+            if (await _current.TryPublishAsync(document, cancellationToken))
+            {
+                published++;
+            }
+        }
+
+        _logger.LogInformation(
+            "Usage projection refreshed TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
+            "Windows={Windows} Written={Written} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            windows.Count,
+            published,
+            correlationId);
+
+        return published;
+    }
+
+    /// <summary>
+    /// Every meter's window containing <paramref name="asOfUtc"/>.
+    /// </summary>
+    /// <remarks>
+    /// A meter whose period cannot be resolved is skipped rather than failing the whole refresh. That
+    /// happens when a schedule is unavailable, which is a condition the authoritative endpoint reports
+    /// as an error in its own right; dropping the projection for every other meter as well would turn
+    /// one unresolvable meter into a subscription with no visible usage at all.
+    /// </remarks>
+    private static IEnumerable<(PlanMeter Meter, BillingPeriod Period)> CurrentWindows(
+        SubscriptionDetail subscription,
+        DateTime asOfUtc)
+    {
+        foreach (var meter in subscription.Plan.Meters)
+        {
+            if (MeterPeriodResolver.TryGetPeriod(subscription, meter, asOfUtc, out var period))
+            {
+                yield return (meter, period);
+            }
+        }
+    }
+
+    private SubscriptionUsageCurrent Describe(
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        SubscriptionUsageCounter counter,
+        long allowance) =>
+        Describe(
+            subscription,
+            meter,
+            period,
+            counter,
+            counter.Balance,
+            counter.AppliedRecordCount,
+            allowance);
+
+    private SubscriptionUsageCurrent Describe(
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        BillingPeriod period,
+        SubscriptionUsageCounter? counter,
+        long balance,
+        long sourceVersion,
+        long allowance) => new()
+    {
+        ItemId = SubscriptionUsageCurrent.CreateId(
+            subscription.ItemId,
+            meter.MeterKey,
+            period.Key),
+        TenantId = subscription.TenantId,
+        OrganizationId = subscription.OrganizationId,
+        SubscriptionId = subscription.ItemId,
+        SubscriptionStatus = subscription.Status,
+        PlanId = subscription.Plan.PlanId,
+        PlanCode = subscription.Plan.Code,
+        MeterKey = meter.MeterKey,
+        UnitLabel = meter.UnitLabel,
+        PeriodKey = period.Key,
+        PeriodStartUtc = period.StartUtc,
+        PeriodEndUtc = period.EndUtc,
+        Included = allowance,
+        Used = balance,
+        // The same arithmetic the authoritative response reports, in one place, so the two cannot
+        // describe the same balance differently. Derived from the figures above and never from a
+        // previous value of this document.
+        Remaining = Math.Max(0, allowance - balance),
+        Overage = Math.Max(0, balance - allowance),
+        OverageAllowed = meter.OverageAllowed,
+        SourceVersion = sourceVersion,
+        SchemaVersion = SubscriptionUsageCurrent.CurrentSchemaVersion,
+        UpdatedAtUtc = _time.GetUtcNow().UtcDateTime,
+        // The counter's own expiry when there is one, so the projection never outlives what it
+        // projects. Without a counter the window's end plus the same retention, which is what the
+        // counter would have been given.
+        ExpiresAtUtc = counter?.ExpiresAtUtc ?? (
+            meter.ResetPolicy == MeterResetPolicy.Never
+                ? DateTime.MaxValue
+                : period.EndUtc.AddDays(Math.Max(1, _options.CurrentValue.CounterRetentionDays)))
+    };
+
+    /// <summary>
+    /// One line per publish, at debug unless it took long enough to matter.
+    /// </summary>
+    /// <remarks>
+    /// Sampled down deliberately: this runs on every metered usage call, so logging each one at
+    /// information would make the projection the loudest thing in the log and bury the failures that
+    /// matter. Slow publishes are always logged, because a slow publish is latency added to a
+    /// customer-facing billing call.
+    /// </remarks>
+    private void LogPublished(
+        SubscriptionDetail subscription,
+        PlanMeter meter,
+        SubscriptionUsageCurrent document,
+        long startedAt,
+        bool written,
+        string correlationId)
+    {
+        var duration = _time.GetElapsedTime(startedAt);
+
+        if (duration.TotalMilliseconds >= _options.CurrentValue.UsageReadSlowMilliseconds)
+        {
+            _logger.LogWarning(
+                "Usage projection publish was slow TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} Meter={Meter} DurationMs={DurationMs} " +
+                "Written={Written} SourceVersion={SourceVersion} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                PaymentLogValue.Label(meter.MeterKey),
+                duration.TotalMilliseconds,
+                written,
+                document.SourceVersion,
+                correlationId);
+
+            return;
+        }
+
+        _logger.LogDebug(
+            "Usage projection published TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
+            "Meter={Meter} DurationMs={DurationMs} Written={Written} " +
+            "SourceVersion={SourceVersion} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            PaymentLogValue.Label(meter.MeterKey),
+            duration.TotalMilliseconds,
+            written,
+            document.SourceVersion,
+            correlationId);
+    }
+
+    private Task ScheduleRepairAsync(
+        SubscriptionDetail subscription,
+        string correlationId,
+        CancellationToken cancellationToken) =>
+        _scheduler.ScheduleUsageProjectionRefreshAsync(
+            subscription.TenantId,
+            subscription.OrganizationId,
+            subscription.ItemId,
+            correlationId,
+            cancellationToken);
+
+    /// <summary>
+    /// Retries a projection write a couple of times for the errors that are worth retrying.
+    /// </summary>
+    /// <remarks>
+    /// Brief and bounded, because this runs inside a request that has already committed its usage:
+    /// the caller is waiting, and a long retry would make a slow projection look like a slow billing
+    /// API. Two extra attempts with a short pause covers a primary stepping down or a connection
+    /// dropping; anything longer-lived is the repair job's problem, which is not holding a request
+    /// open.
+    /// <para>
+    /// Only transient errors. A duplicate-key or a serialization fault would fail identically on
+    /// every attempt, so retrying it just spends the caller's time before reaching the same repair.
+    /// </para>
+    /// </remarks>
+    private async Task<bool> WithTransientRetryAsync(
+        Func<Task<bool>> write,
+        CancellationToken cancellationToken)
+    {
+        const int attempts = 3;
+
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await write();
+            }
+            catch (Exception exception)
+                when (attempt < attempts && IsTransient(exception) &&
+                      !cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(50 * attempt), cancellationToken);
+            }
+        }
+    }
+
+    private static bool IsTransient(Exception exception) => exception switch
+    {
+        MongoConnectionException => true,
+        MongoNotPrimaryException => true,
+        MongoNodeIsRecoveringException => true,
+        MongoExecutionTimeoutException => true,
+        TimeoutException => true,
+        MongoCommandException command => command.Code is 11600 or 11602 or 189 or 91,
+        _ => false
+    };
+}

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -28,6 +28,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
     private readonly IMeterAllowanceResolver _allowances;
     private readonly ISubscriptionContextResolver _contextResolver;
     private readonly IUsageThresholdEvaluator _thresholds;
+    private readonly IUsageProjectionPublisher _projection;
+    private readonly ISubscriptionUsageCurrentRepository _current;
     private readonly IValidator<RecordUsageRequest> _validator;
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<UsageRecordingService> _logger;
@@ -40,6 +42,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
         IMeterAllowanceResolver allowances,
         ISubscriptionContextResolver contextResolver,
         IUsageThresholdEvaluator thresholds,
+        IUsageProjectionPublisher projection,
+        ISubscriptionUsageCurrentRepository current,
         IValidator<RecordUsageRequest> validator,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<UsageRecordingService> logger,
@@ -51,6 +55,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
         _allowances = allowances;
         _contextResolver = contextResolver;
         _thresholds = thresholds;
+        _projection = projection;
+        _current = current;
         _validator = validator;
         _options = options;
         _logger = logger;
@@ -167,6 +173,31 @@ public sealed class UsageRecordingService : IUsageRecordingService
         string correlationId,
         CancellationToken cancellationToken)
     {
+        var read = await ReadCurrentAsync(
+            organizationId,
+            UsageReadMode.Authoritative,
+            correlationId,
+            cancellationToken);
+
+        return read.IsSuccess
+            ? SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Success(
+                read.Value!.Items,
+                correlationId)
+            : SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
+                read.FailureKind,
+                read.ErrorCode!,
+                read.ErrorMessage!,
+                correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<UsageCurrentRead>> ReadCurrentAsync(
+        string? organizationId,
+        UsageReadMode readMode,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var startedAt = _time.GetTimestamp();
+
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
             organizationId,
@@ -174,7 +205,7 @@ public sealed class UsageRecordingService : IUsageRecordingService
 
         if (!resolution.IsSuccess)
         {
-            return resolution.ToFailure<IReadOnlyList<UsageResponse>>(correlationId);
+            return resolution.ToFailure<UsageCurrentRead>(correlationId);
         }
 
         var context = resolution.Context!;
@@ -188,30 +219,108 @@ public sealed class UsageRecordingService : IUsageRecordingService
 
         if (subscription is null)
         {
-            return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
+            return SubscriptionOperationResult<UsageCurrentRead>.Failure(
                 PaymentFailureKind.NotFound,
                 "subscription_not_found",
                 "This organization has no active subscription.",
                 correlationId);
         }
 
-        var responses = new List<UsageResponse>();
+        if (readMode == UsageReadMode.Projection)
+        {
+            var projected = await ReadProjectionAsync(context, subscription, now, cancellationToken);
+
+            // Empty means nothing has been published for this subscription yet - one activated
+            // before this collection existed, or one whose seed has not run. Falling back rather
+            // than reporting no meters, because a caller that opted into the fast path asked for
+            // speed, not for a different answer. The fallback is named in the diagnostics.
+            if (projected.Count > 0)
+            {
+                return ReadOf(projected, readMode, UsageReadMode.Projection, startedAt, now, correlationId);
+            }
+
+            _logger.LogInformation(
+                "Usage projection read found nothing; falling back to counters " +
+                "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
+                "CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(context.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                correlationId);
+        }
+
+        var authoritative = await ReadAuthoritativeAsync(
+            context,
+            subscription,
+            now,
+            correlationId,
+            cancellationToken);
+
+        return authoritative.IsSuccess
+            ? ReadOf(
+                authoritative.Value!,
+                readMode,
+                UsageReadMode.Authoritative,
+                startedAt,
+                newestAgeSeconds: null,
+                stale: false,
+                correlationId)
+            : SubscriptionOperationResult<UsageCurrentRead>.Failure(
+                authoritative.FailureKind,
+                authoritative.ErrorCode!,
+                authoritative.ErrorMessage!,
+                correlationId);
+    }
+
+    /// <summary>
+    /// Current usage from the authoritative counters, in one round trip rather than one per meter.
+    /// </summary>
+    /// <remarks>
+    /// Batched by composed counter id, not by period key. The meters of one subscription do not share
+    /// a period: a never-reset capacity meter lives under
+    /// <c>MeterPeriodResolver.LifetimePeriodKey</c> while its periodic neighbours use the billing
+    /// schedule's key. A batch filtered by any single period would quietly have returned nothing for
+    /// the others and reported them as unused.
+    /// </remarks>
+    private async Task<SubscriptionOperationResult<List<UsageResponse>>> ReadAuthoritativeAsync(
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        DateTime now,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var windows = new List<(PlanMeter Meter, BillingPeriod Period)>();
 
         foreach (var meter in subscription.Plan.Meters)
         {
             if (!MeterPeriodResolver.TryGetPeriod(subscription, meter, now, out var period))
             {
-                return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Failure(
+                return SubscriptionOperationResult<List<UsageResponse>>.Failure(
                     PaymentFailureKind.Unavailable,
                     "subscription_schedule_unavailable",
                     "The usage period could not be determined.",
                     correlationId);
             }
 
-            var counter = await _usage.GetCounterAsync(
-                context.TenantId,
+            windows.Add((meter, period));
+        }
+
+        var counters = await _usage.GetCountersAsync(
+            context.TenantId,
+            windows
+                .Select(window => SubscriptionUsageCounter.CreateId(
+                    subscription.ItemId,
+                    window.Meter.MeterKey,
+                    window.Period.Key))
+                .ToList(),
+            cancellationToken);
+
+        var responses = new List<UsageResponse>(windows.Count);
+
+        foreach (var (meter, period) in windows)
+        {
+            counters.TryGetValue(
                 SubscriptionUsageCounter.CreateId(subscription.ItemId, meter.MeterKey, period.Key),
-                cancellationToken);
+                out var counter);
 
             responses.Add(Describe(
                 meter,
@@ -223,8 +332,141 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 replayed: false));
         }
 
-        return SubscriptionOperationResult<IReadOnlyList<UsageResponse>>.Success(
-            responses,
+        return SubscriptionOperationResult<List<UsageResponse>>.Success(responses, correlationId);
+    }
+
+    /// <summary>
+    /// Current usage from the projection, in one indexed query for the whole subscription.
+    /// </summary>
+    /// <remarks>
+    /// Returns only meters the plan still defines. A projected document outlives a plan change until
+    /// its refresh runs, and showing a reader an allowance for a meter the current plan no longer has
+    /// would be an allowance nothing can be recorded against.
+    /// </remarks>
+    private async Task<List<(UsageResponse Response, DateTime UpdatedAtUtc)>> ReadProjectionAsync(
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var documents = await _current.ListCurrentAsync(
+            context.TenantId,
+            context.OrganizationId,
+            subscription.ItemId,
+            now,
+            cancellationToken);
+
+        var meters = new HashSet<string>(
+            subscription.Plan.Meters.Select(meter => meter.MeterKey),
+            StringComparer.Ordinal);
+
+        var results = new List<(UsageResponse, DateTime)>(documents.Count);
+
+        foreach (var document in documents)
+        {
+            if (!meters.Contains(document.MeterKey))
+            {
+                continue;
+            }
+
+            results.Add((
+                new UsageResponse
+                {
+                    // True because this is a report, not a claim. Whether the next unit may be used
+                    // is answered by POST with enforce, and only there.
+                    Allowed = true,
+                    MeterKey = document.MeterKey,
+                    UnitLabel = document.UnitLabel,
+                    PeriodKey = document.PeriodKey,
+                    PeriodStartUtc = document.PeriodStartUtc,
+                    PeriodEndUtc = document.PeriodEndUtc,
+                    Included = document.Included,
+                    Used = document.Used,
+                    Remaining = document.Remaining,
+                    Overage = document.Overage,
+                    Replayed = false
+                },
+                document.UpdatedAtUtc));
+        }
+
+        return results;
+    }
+
+    private SubscriptionOperationResult<UsageCurrentRead> ReadOf(
+        List<(UsageResponse Response, DateTime UpdatedAtUtc)> projected,
+        UsageReadMode requested,
+        UsageReadMode actual,
+        long startedAt,
+        DateTime now,
+        string correlationId)
+    {
+        var threshold = TimeSpan.FromSeconds(
+            Math.Max(1, _options.CurrentValue.UsageProjectionStalenessSeconds));
+
+        var newest = projected.Max(entry => entry.UpdatedAtUtc);
+
+        return ReadOf(
+            projected.ConvertAll(entry => entry.Response),
+            requested,
+            actual,
+            startedAt,
+            (now - newest).TotalSeconds,
+            projected.Exists(entry => now - entry.UpdatedAtUtc > threshold),
+            correlationId);
+    }
+
+    private SubscriptionOperationResult<UsageCurrentRead> ReadOf(
+        List<UsageResponse> items,
+        UsageReadMode requested,
+        UsageReadMode actual,
+        long startedAt,
+        double? newestAgeSeconds,
+        bool stale,
+        string correlationId)
+    {
+        var duration = _time.GetElapsedTime(startedAt);
+
+        var diagnostics = new UsageReadDiagnostics
+        {
+            RequestedMode = requested,
+            ActualMode = actual,
+            DurationMs = duration.TotalMilliseconds,
+            DocumentCount = items.Count,
+            NewestProjectionAgeSeconds = newestAgeSeconds,
+            Stale = stale
+        };
+
+        // Slow and stale are always logged; an ordinary read is sampled down to debug, because this
+        // is one line per call of a dashboard endpoint and those two are the only interesting cases.
+        if (stale || duration.TotalMilliseconds >= _options.CurrentValue.UsageReadSlowMilliseconds)
+        {
+            _logger.LogWarning(
+                "Current usage read was slow or stale Mode={Mode} ActualMode={ActualMode} " +
+                "DurationMs={DurationMs} Documents={Documents} " +
+                "NewestProjectionAgeSeconds={NewestProjectionAgeSeconds} Stale={Stale} " +
+                "CorrelationId={CorrelationId}",
+                requested,
+                actual,
+                duration.TotalMilliseconds,
+                items.Count,
+                newestAgeSeconds,
+                stale,
+                correlationId);
+        }
+        else
+        {
+            _logger.LogDebug(
+                "Current usage read Mode={Mode} ActualMode={ActualMode} DurationMs={DurationMs} " +
+                "Documents={Documents} CorrelationId={CorrelationId}",
+                requested,
+                actual,
+                duration.TotalMilliseconds,
+                items.Count,
+                correlationId);
+        }
+
+        return SubscriptionOperationResult<UsageCurrentRead>.Success(
+            new UsageCurrentRead { Items = items, Diagnostics = diagnostics },
             correlationId);
     }
 
@@ -344,6 +586,19 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 correlationId,
                 cancellationToken);
 
+            // Published from the final counter state, synchronously, before this call reports
+            // success. Placed after every branch that could still reverse the balance, so what a
+            // direct reader sees is the figure this response carries and never the momentary one an
+            // enforced refusal passes through on its way to being undone.
+            var projection = await _projection.PublishAsync(
+                subscription,
+                meter,
+                period,
+                counter,
+                allowance,
+                correlationId,
+                cancellationToken);
+
             _logger.LogInformation(
                 "Usage recorded TenantHash={TenantHash} OrganizationHash={OrganizationHash} " +
                 "SubscriptionHash={SubscriptionHash} Meter={Meter} Balance={Balance} " +
@@ -363,7 +618,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
                     counter.Balance,
                     allowance,
                     allowed: withinAllowance || meter.OverageAllowed,
-                    replayed: false),
+                    replayed: false,
+                    projection),
                 correlationId);
         }
         finally
@@ -426,6 +682,18 @@ public sealed class UsageRecordingService : IUsageRecordingService
             -record.Delta,
             cancellationToken);
 
+        // The post-reversal counter, which is the balance the caller is about to be shown and the
+        // only one a reader should ever see. The exceeded balance existed for the duration of two
+        // Mongo calls and was never a state anybody was entitled to.
+        var projection = await _projection.PublishAsync(
+            subscription,
+            meter,
+            period,
+            counter,
+            allowance,
+            correlationId,
+            cancellationToken);
+
         _logger.LogInformation(
             "Usage refused because the resulting balance is outside its allowed range TenantHash={TenantHash} " +
             "SubscriptionHash={SubscriptionHash} Meter={Meter} Balance={Balance} " +
@@ -438,7 +706,14 @@ public sealed class UsageRecordingService : IUsageRecordingService
             correlationId);
 
         return SubscriptionOperationResult<UsageResponse>.Success(
-            Describe(meter, period, counter.Balance, allowance, allowed: false, replayed: false),
+            Describe(
+                meter,
+                period,
+                counter.Balance,
+                allowance,
+                allowed: false,
+                replayed: false,
+                projection),
             correlationId);
     }
 
@@ -463,6 +738,23 @@ public sealed class UsageRecordingService : IUsageRecordingService
 
         var balance = counter?.Balance ?? 0;
 
+        // A replay counts nothing again, but it is also the retry a caller was told to make when a
+        // publish failed — so it republishes. The version condition makes that free when the
+        // projection is already current: the write matches nothing and changes nothing.
+        var projection = UsageProjectionState.Published;
+
+        if (counter is not null)
+        {
+            projection = ToState(await _projection.PublishAsync(
+                subscription,
+                meter,
+                period,
+                counter,
+                allowance,
+                correlationId,
+                cancellationToken));
+        }
+
         return SubscriptionOperationResult<UsageResponse>.Success(
             Describe(
                 meter,
@@ -470,7 +762,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 balance,
                 allowance,
                 allowed: balance <= allowance || meter.OverageAllowed,
-                replayed: true),
+                replayed: true,
+                projection),
             correlationId);
     }
 
@@ -510,7 +803,18 @@ public sealed class UsageRecordingService : IUsageRecordingService
         long balance,
         long allowance,
         bool allowed,
-        bool replayed) => new()
+        bool replayed,
+        UsageProjectionOutcome projection) =>
+        Describe(meter, period, balance, allowance, allowed, replayed, ToState(projection));
+
+    private static UsageResponse Describe(
+        PlanMeter meter,
+        BillingPeriod period,
+        long balance,
+        long allowance,
+        bool allowed,
+        bool replayed,
+        UsageProjectionState projection = UsageProjectionState.Published) => new()
     {
         Allowed = allowed,
         MeterKey = meter.MeterKey,
@@ -522,8 +826,19 @@ public sealed class UsageRecordingService : IUsageRecordingService
         Used = balance,
         Remaining = Math.Max(0, allowance - balance),
         Overage = Math.Max(0, balance - allowance),
-        Replayed = replayed
+        Replayed = replayed,
+        Projection = projection
     };
+
+    /// <summary>
+    /// Superseded is reported as published, deliberately: it means a later recording against this
+    /// meter published a newer figure first, so the projection is ahead of this caller rather than
+    /// missing. Only a write that did not happen is pending.
+    /// </summary>
+    private static UsageProjectionState ToState(UsageProjectionOutcome outcome) =>
+        outcome == UsageProjectionOutcome.RepairScheduled
+            ? UsageProjectionState.Pending
+            : UsageProjectionState.Published;
 
     private static SubscriptionOperationResult<UsageResponse> Failure(
         PaymentFailureKind kind,

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -6,6 +6,7 @@ using Payment.DomainService.Utilities;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
 using Subscription.DomainService.Utilities;
@@ -30,6 +31,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
     private readonly IUsageThresholdEvaluator _thresholds;
     private readonly IUsageProjectionPublisher _projection;
     private readonly ISubscriptionUsageCurrentRepository _current;
+    private readonly ISubscriptionWorkScheduler _scheduler;
+    private readonly UsageProjectionMetrics _metrics;
     private readonly IValidator<RecordUsageRequest> _validator;
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<UsageRecordingService> _logger;
@@ -44,10 +47,14 @@ public sealed class UsageRecordingService : IUsageRecordingService
         IUsageThresholdEvaluator thresholds,
         IUsageProjectionPublisher projection,
         ISubscriptionUsageCurrentRepository current,
+        ISubscriptionWorkScheduler scheduler,
         IValidator<RecordUsageRequest> validator,
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<UsageRecordingService> logger,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        // Optional so an existing caller or test that builds this service by hand keeps compiling.
+        // Falls back to the shared instrument set, which is what the running process uses anyway.
+        UsageProjectionMetrics? metrics = null)
     {
         _subscriptions = subscriptions;
         _usage = usage;
@@ -57,6 +64,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
         _thresholds = thresholds;
         _projection = projection;
         _current = current;
+        _scheduler = scheduler;
+        _metrics = metrics ?? UsageProjectionMetrics.Shared;
         _validator = validator;
         _options = options;
         _logger = logger;
@@ -226,26 +235,80 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 correlationId);
         }
 
+        var fallback = UsageReadFallback.None;
+
         if (readMode == UsageReadMode.Projection)
         {
             var projected = await ReadProjectionAsync(context, subscription, now, cancellationToken);
 
-            // Empty means nothing has been published for this subscription yet - one activated
-            // before this collection existed, or one whose seed has not run. Falling back rather
-            // than reporting no meters, because a caller that opted into the fast path asked for
-            // speed, not for a different answer. The fallback is named in the diagnostics.
-            if (projected.Count > 0)
+            // How many meter-windows the plan says this subscription has right now. The projection is
+            // only allowed to answer if it holds all of them.
+            var expected = CountCurrentWindows(subscription, now);
+
+            if (projected.Count == expected && expected > 0)
             {
-                return ReadOf(projected, readMode, UsageReadMode.Projection, startedAt, now, correlationId);
+                return ReadOf(
+                    projected,
+                    readMode,
+                    UsageReadMode.Projection,
+                    UsageReadFallback.None,
+                    startedAt,
+                    now,
+                    context,
+                    subscription,
+                    correlationId);
             }
 
-            _logger.LogInformation(
-                "Usage projection read found nothing; falling back to counters " +
-                "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} " +
-                "CorrelationId={CorrelationId}",
-                PaymentLogValue.Hash(context.TenantId),
-                PaymentLogValue.Hash(subscription.ItemId),
-                correlationId);
+            // Two different situations, reported as two different fallbacks.
+            //
+            // Nothing published is a subscription the projection has never covered - activated before
+            // the collection existed, or a seed that has not run. Some published is worse: a publish
+            // or a seed was lost for a subscription it does cover.
+            //
+            // Either way the counters answer the WHOLE request, not just the missing part. Returning
+            // the published subset would omit meters the plan defines, with nothing in the body to
+            // say so, and a caller drawing a usage screen from it would show fewer meters than the
+            // subscription has. The two modes must return equivalent data, and a subset is not
+            // equivalent.
+            fallback = projected.Count == 0
+                ? UsageReadFallback.ProjectionEmpty
+                : UsageReadFallback.ProjectionPartial;
+
+            // A partial projection is a lost write, so it is repaired rather than merely reported.
+            // Best effort: the read has an answer either way, and it must not fail because a repair
+            // could not be scheduled.
+            if (fallback == UsageReadFallback.ProjectionPartial)
+            {
+                _logger.LogWarning(
+                    "Usage projection is incomplete for this subscription; falling back to counters " +
+                    "and scheduling a repair TenantHash={TenantHash} " +
+                    "OrganizationHash={OrganizationHash} SubscriptionHash={SubscriptionHash} " +
+                    "Published={Published} Expected={Expected} CorrelationId={CorrelationId}",
+                    PaymentLogValue.Hash(context.TenantId),
+                    PaymentLogValue.Hash(context.OrganizationId),
+                    PaymentLogValue.Hash(subscription.ItemId),
+                    projected.Count,
+                    expected,
+                    correlationId);
+
+                await _scheduler.ScheduleUsageProjectionRefreshAsync(
+                    context.TenantId,
+                    context.OrganizationId,
+                    subscription.ItemId,
+                    correlationId,
+                    cancellationToken);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Usage projection holds nothing for this subscription; falling back to counters " +
+                    "TenantHash={TenantHash} OrganizationHash={OrganizationHash} " +
+                    "SubscriptionHash={SubscriptionHash} CorrelationId={CorrelationId}",
+                    PaymentLogValue.Hash(context.TenantId),
+                    PaymentLogValue.Hash(context.OrganizationId),
+                    PaymentLogValue.Hash(subscription.ItemId),
+                    correlationId);
+            }
         }
 
         var authoritative = await ReadAuthoritativeAsync(
@@ -260,15 +323,42 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 authoritative.Value!,
                 readMode,
                 UsageReadMode.Authoritative,
+                fallback,
                 startedAt,
                 newestAgeSeconds: null,
                 stale: false,
+                context,
+                subscription,
                 correlationId)
             : SubscriptionOperationResult<UsageCurrentRead>.Failure(
                 authoritative.FailureKind,
                 authoritative.ErrorCode!,
                 authoritative.ErrorMessage!,
                 correlationId);
+    }
+
+    /// <summary>
+    /// How many meter-windows the plan says are current, which is what a complete projection holds.
+    /// </summary>
+    /// <remarks>
+    /// A meter whose period cannot be resolved is not counted. Its absence from the projection is
+    /// then not treated as incompleteness, which matters because the authoritative read refuses the
+    /// whole request for such a meter — counting it here would make every projection read of an
+    /// unresolvable subscription report a partial fallback on the way to that refusal.
+    /// </remarks>
+    private static int CountCurrentWindows(SubscriptionDetail subscription, DateTime asOfUtc)
+    {
+        var windows = 0;
+
+        foreach (var meter in subscription.Plan.Meters)
+        {
+            if (MeterPeriodResolver.TryGetPeriod(subscription, meter, asOfUtc, out _))
+            {
+                windows++;
+            }
+        }
+
+        return windows;
     }
 
     /// <summary>
@@ -396,8 +486,11 @@ public sealed class UsageRecordingService : IUsageRecordingService
         List<(UsageResponse Response, DateTime UpdatedAtUtc)> projected,
         UsageReadMode requested,
         UsageReadMode actual,
+        UsageReadFallback fallback,
         long startedAt,
         DateTime now,
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
         string correlationId)
     {
         var threshold = TimeSpan.FromSeconds(
@@ -409,9 +502,12 @@ public sealed class UsageRecordingService : IUsageRecordingService
             projected.ConvertAll(entry => entry.Response),
             requested,
             actual,
+            fallback,
             startedAt,
             (now - newest).TotalSeconds,
             projected.Exists(entry => now - entry.UpdatedAtUtc > threshold),
+            context,
+            subscription,
             correlationId);
     }
 
@@ -419,9 +515,12 @@ public sealed class UsageRecordingService : IUsageRecordingService
         List<UsageResponse> items,
         UsageReadMode requested,
         UsageReadMode actual,
+        UsageReadFallback fallback,
         long startedAt,
         double? newestAgeSeconds,
         bool stale,
+        SubscriptionContext context,
+        SubscriptionDetail subscription,
         string correlationId)
     {
         var duration = _time.GetElapsedTime(startedAt);
@@ -430,39 +529,84 @@ public sealed class UsageRecordingService : IUsageRecordingService
         {
             RequestedMode = requested,
             ActualMode = actual,
+            Fallback = fallback,
             DurationMs = duration.TotalMilliseconds,
             DocumentCount = items.Count,
             NewestProjectionAgeSeconds = newestAgeSeconds,
             Stale = stale
         };
 
-        // Slow and stale are always logged; an ordinary read is sampled down to debug, because this
-        // is one line per call of a dashboard endpoint and those two are the only interesting cases.
-        if (stale || duration.TotalMilliseconds >= _options.CurrentValue.UsageReadSlowMilliseconds)
+        _metrics.RecordRead(requested, actual, fallback, duration, newestAgeSeconds, stale);
+
+        // Slow, stale and fallen-back reads are always logged; an ordinary read is sampled down to
+        // debug, because this is one line per call of a dashboard endpoint.
+        //
+        // Every line names the tenant, organization and subscription. Without them "a read was slow"
+        // cannot be turned into "which customer saw it", which is the first question anybody asks.
+        // Hashed rather than raw, following PaymentLogValue everywhere else in this module: enough to
+        // group and correlate, not enough to identify a subscriber from the log alone. These belong
+        // in logs and traces and NOT in metric labels, where a per-tenant dimension would multiply
+        // every series by the tenant count.
+        if (stale ||
+            fallback != UsageReadFallback.None ||
+            duration.TotalMilliseconds >= _options.CurrentValue.UsageReadSlowMilliseconds)
         {
             _logger.LogWarning(
-                "Current usage read was slow or stale Mode={Mode} ActualMode={ActualMode} " +
-                "DurationMs={DurationMs} Documents={Documents} " +
-                "NewestProjectionAgeSeconds={NewestProjectionAgeSeconds} Stale={Stale} " +
-                "CorrelationId={CorrelationId}",
+                "Current usage read was slow, stale or fell back Mode={Mode} " +
+                "ActualMode={ActualMode} Fallback={Fallback} DurationMs={DurationMs} " +
+                "Documents={Documents} NewestProjectionAgeSeconds={NewestProjectionAgeSeconds} " +
+                "Stale={Stale} TenantHash={TenantHash} OrganizationHash={OrganizationHash} " +
+                "SubscriptionHash={SubscriptionHash} CorrelationId={CorrelationId} " +
+                "TraceId={TraceId}",
                 requested,
                 actual,
+                fallback,
                 duration.TotalMilliseconds,
                 items.Count,
                 newestAgeSeconds,
                 stale,
-                correlationId);
+                PaymentLogValue.Hash(context.TenantId),
+                PaymentLogValue.Hash(context.OrganizationId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                correlationId,
+                System.Diagnostics.Activity.Current?.TraceId.ToString());
         }
         else
         {
             _logger.LogDebug(
                 "Current usage read Mode={Mode} ActualMode={ActualMode} DurationMs={DurationMs} " +
-                "Documents={Documents} CorrelationId={CorrelationId}",
+                "Documents={Documents} TenantHash={TenantHash} " +
+                "OrganizationHash={OrganizationHash} SubscriptionHash={SubscriptionHash} " +
+                "CorrelationId={CorrelationId} TraceId={TraceId}",
                 requested,
                 actual,
                 duration.TotalMilliseconds,
                 items.Count,
-                correlationId);
+                PaymentLogValue.Hash(context.TenantId),
+                PaymentLogValue.Hash(context.OrganizationId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                correlationId,
+                System.Diagnostics.Activity.Current?.TraceId.ToString());
+        }
+
+        // The same identifiers on the trace span, so a slow read can be found from a trace rather
+        // than only by grepping logs for a correlation id.
+        var span = System.Diagnostics.Activity.Current;
+
+        if (span is not null)
+        {
+            span.SetTag("subscription.usage.read_mode", requested.ToString());
+            span.SetTag("subscription.usage.read_source", actual.ToString());
+            span.SetTag("subscription.usage.fallback", fallback.ToString());
+            span.SetTag("subscription.usage.duration_ms", duration.TotalMilliseconds);
+            span.SetTag("subscription.usage.documents", items.Count);
+            span.SetTag("subscription.usage.stale", stale);
+            span.SetTag("subscription.tenant_hash", PaymentLogValue.Hash(context.TenantId));
+            span.SetTag(
+                "subscription.organization_hash",
+                PaymentLogValue.Hash(context.OrganizationId));
+            span.SetTag("subscription.subscription_hash", PaymentLogValue.Hash(subscription.ItemId));
+            span.SetTag("subscription.correlation_id", correlationId);
         }
 
         return SubscriptionOperationResult<UsageCurrentRead>.Success(

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -74,6 +74,9 @@ public static class ApplicationServiceCollectionExtensions
             ISubscriptionUsageRepository,
             SubscriptionUsageRepository>();
         services.AddSingleton<
+            ISubscriptionUsageCurrentRepository,
+            SubscriptionUsageCurrentRepository>();
+        services.AddSingleton<
             ISubscriptionPaymentLinkRepository,
             SubscriptionPaymentLinkRepository>();
         services.AddSingleton<
@@ -175,6 +178,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ISubscriptionWorkHandler, OutboxPublicationWorkHandler>();
         services.AddScoped<ISubscriptionWorkHandler, FinancialDocumentIssueWorkHandler>();
         services.AddScoped<ISubscriptionWorkHandler, FinancialDocumentDeliveryWorkHandler>();
+        services.AddScoped<ISubscriptionWorkHandler, UsageProjectionRefreshWorkHandler>();
 
         services.AddSingleton<IEntitlementSnapshotCache, EntitlementSnapshotCache>();
         services.AddSingleton<IPlanResponseMapper, PlanResponseMapper>();
@@ -289,6 +293,8 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IEntitlementService, EntitlementService>();
         services.AddScoped<IMeterAllowanceResolver, MeterAllowanceResolver>();
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
+        services.AddScoped<IUsageProjectionPublisher, UsageProjectionPublisher>();
+        services.AddScoped<IUsageProjectionReconciler, UsageProjectionReconciler>();
         services.AddScoped<
             ISubscriptionUsageOveragePreviewService,
             SubscriptionUsageOveragePreviewService>();

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -295,6 +295,10 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageProjectionPublisher, UsageProjectionPublisher>();
         services.AddScoped<IUsageProjectionReconciler, UsageProjectionReconciler>();
+        // Singleton on purpose: the reconciler is scoped and the reconciliation service opens a
+        // fresh scope per tenant sweep, so a cursor living on the reconciler was reset on every
+        // pass and the backfill never got past its first page.
+        services.AddSingleton<UsageProjectionBackfillCursors>();
         services.AddScoped<
             ISubscriptionUsageOveragePreviewService,
             SubscriptionUsageOveragePreviewService>();

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -18,6 +18,37 @@ public sealed class SubscriptionOptions
     public int CounterRetentionDays { get; set; } = 400;
 
     /// <summary>
+    /// How old a projected current-usage document may be before a read reports it stale.
+    /// </summary>
+    /// <remarks>
+    /// A publish happens inside the request that recorded the usage, so under normal operation this
+    /// is seconds at most and a document older than the threshold means either the meter has simply
+    /// been quiet or a publish was missed. Age cannot distinguish the two on its own, which is why it
+    /// is reported rather than acted on: the reconciliation worker compares versions, where reading
+    /// the counter as well is the job.
+    /// <para>
+    /// Generous by default. Set it too low and every idle meter reports stale, which trains an
+    /// operator to ignore the signal.
+    /// </para>
+    /// </remarks>
+    public int UsageProjectionStalenessSeconds { get; set; } = 900;
+
+    /// <summary>
+    /// Above this, a current-usage read is logged as slow whatever the sampling would otherwise do.
+    /// </summary>
+    public int UsageReadSlowMilliseconds { get; set; } = 250;
+
+    /// <summary>
+    /// How many subscriptions one projection reconciliation pass examines per tenant.
+    /// </summary>
+    /// <remarks>
+    /// Bounded so the pass costs the same whatever the tenant's size. It repairs a read model, so
+    /// falling behind for a cycle is a display delay; competing with renewals for database time would
+    /// not be.
+    /// </remarks>
+    public int UsageProjectionReconciliationBatchSize { get; set; } = 200;
+
+    /// <summary>
     /// How long a subscription may sit unpaid before the initial charge is considered
     /// abandoned. Covers the shopper who opens checkout and closes the tab.
     /// </summary>

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -49,6 +49,15 @@ public sealed class SubscriptionOptions
     public int UsageProjectionReconciliationBatchSize { get; set; } = 200;
 
     /// <summary>
+    /// How many live subscriptions one projection backfill pass walks per tenant.
+    /// </summary>
+    /// <remarks>
+    /// Smaller than the reconciliation batch, because each subscription here costs a counter
+    /// batch and up to one write per meter, where a reconciliation candidate costs a comparison.
+    /// </remarks>
+    public int UsageProjectionBackfillBatchSize { get; set; } = 50;
+
+    /// <summary>
     /// How long a subscription may sit unpaid before the initial charge is considered
     /// abandoned. Covers the shopper who opens checkout and closes the tab.
     /// </summary>

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -81,6 +81,10 @@ IHostBuilder CreateHostBuilder(string[] args) =>
                 .WithMetrics(metrics => metrics
                     .AddMeter("Blocks.Subscription.BackgroundWork")
                     .AddMeter(FinancialDocumentRendererHealthGate.MeterName)
+                    // The reconciliation sweep and the backfill run here, so version lag and repair
+                    // volume are recorded in this process. Creating the instruments is not enough:
+                    // an exporter only observes a meter it has been told to subscribe to.
+                    .AddMeter(UsageProjectionMetrics.MeterName)
                     .AddOtlpExporter());
             // First, deliberately: an operator should learn whether the renderer works before
             // anything else in this worker starts moving. It no longer stops the host on failure —

--- a/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
@@ -1,0 +1,458 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// The current-usage projection, against a real MongoDB.
+/// </summary>
+/// <remarks>
+/// Every guarantee this collection makes is a property of a Mongo write, not of C#: the version
+/// condition on the upsert, the uniqueness of one document per meter-period, the insert-only seed,
+/// and the boundary query that picks the current window. A mocked repository proves none of them, and
+/// the one that matters most — the highest version winning a race rather than the last writer —
+/// cannot be observed at all without concurrent writers hitting one server.
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class SubscriptionUsageCurrentIntegrationTests
+{
+    private readonly MongoIntegrationFixture _fixture;
+    private readonly SubscriptionUsageCurrentRepository _current;
+
+    public SubscriptionUsageCurrentIntegrationTests(MongoIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+        _current = new SubscriptionUsageCurrentRepository(fixture.DbContextProvider);
+    }
+
+    [Fact]
+    public async Task Publishing_stores_every_field_a_direct_reader_depends_on()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var document = Document(tenantId, used: 40, sourceVersion: 3);
+
+        (await _current.TryPublishAsync(document, CancellationToken.None)).Should().BeTrue();
+
+        var stored = await _current.GetAsync(tenantId, document.ItemId, CancellationToken.None);
+
+        stored.Should().NotBeNull();
+        stored!.OrganizationId.Should().Be("org-1");
+        stored.SubscriptionId.Should().Be("sub-1");
+        stored.SubscriptionStatus.Should().Be(SubscriptionStatus.Active);
+        stored.PlanId.Should().Be("plan-1");
+        stored.PlanCode.Should().Be("pro");
+        stored.MeterKey.Should().Be("screening");
+        stored.UnitLabel.Should().Be("screening");
+        stored.Included.Should().Be(100);
+        stored.Used.Should().Be(40);
+        stored.Remaining.Should().Be(60);
+        stored.Overage.Should().Be(0);
+        stored.OverageAllowed.Should().BeTrue();
+        stored.SourceVersion.Should().Be(3);
+        stored.SchemaVersion.Should().Be(SubscriptionUsageCurrent.CurrentSchemaVersion);
+    }
+
+    [Fact]
+    public async Task A_newer_version_replaces_an_older_one()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 10, sourceVersion: 1), CancellationToken.None);
+
+        (await _current.TryPublishAsync(
+                Document(tenantId, used: 20, sourceVersion: 2), CancellationToken.None))
+            .Should().BeTrue();
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(20);
+        stored.SourceVersion.Should().Be(2);
+    }
+
+    /// <summary>
+    /// The defect this condition exists to prevent. A request delayed between updating its counter
+    /// and publishing its projection carries an older figure; without the condition it would
+    /// overwrite a newer balance and leave the projection permanently behind, with nothing to say so.
+    /// </summary>
+    [Fact]
+    public async Task An_older_version_cannot_overwrite_a_newer_one()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 90, sourceVersion: 9), CancellationToken.None);
+
+        (await _current.TryPublishAsync(
+                Document(tenantId, used: 10, sourceVersion: 4), CancellationToken.None))
+            .Should().BeFalse("the stored document is already newer");
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(90, "the newer figure must survive");
+        stored.SourceVersion.Should().Be(9);
+    }
+
+    /// <summary>Republishing the same version is not an update, and must not be reported as one.</summary>
+    [Fact]
+    public async Task Republishing_the_same_version_changes_nothing()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 7, sourceVersion: 5), CancellationToken.None);
+
+        (await _current.TryPublishAsync(
+                Document(tenantId, used: 999, sourceVersion: 5), CancellationToken.None))
+            .Should().BeFalse();
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(7);
+    }
+
+    /// <summary>
+    /// The concurrency guarantee, with real concurrent writers.
+    /// </summary>
+    /// <remarks>
+    /// Sixteen publishes of the same meter-period in a scrambled version order, all at once. The
+    /// document must end at the highest version, and exactly one call may report having written it —
+    /// the rest lost the version race, which is a success for them and a no-op for the database.
+    /// Last-writer-wins would leave whichever call happened to finish last, which is the bug.
+    /// </remarks>
+    [Fact]
+    public async Task The_highest_version_wins_a_concurrent_race_not_the_last_writer()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        // Scrambled deliberately: ascending order would pass even with no condition at all.
+        var versions = new[] { 7, 3, 16, 1, 11, 5, 14, 2, 9, 6, 15, 4, 13, 8, 12, 10 };
+
+        var results = await Task.WhenAll(versions.Select(version =>
+            _current.TryPublishAsync(
+                Document(tenantId, used: version * 10, sourceVersion: version),
+                CancellationToken.None)));
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.SourceVersion.Should().Be(16, "the highest version must be the one that stands");
+        stored.Used.Should().Be(160, "and the balance stored with it");
+
+        results.Count(written => written)
+            .Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(versions.Length);
+    }
+
+    /// <summary>
+    /// One meter-period is one document, enforced by the database rather than by whoever composes the
+    /// id. Two current documents for one meter would show a reader two allowances for one allowance.
+    /// </summary>
+    [Fact]
+    public async Task Two_documents_for_one_meter_period_are_refused()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var first = Document(tenantId, used: 1, sourceVersion: 1);
+
+        await _current.TryPublishAsync(first, CancellationToken.None);
+
+        var duplicate = Document(tenantId, used: 2, sourceVersion: 2);
+        duplicate.ItemId = "a-different-id-for-the-same-meter-period";
+
+        var insert = async () => await _fixture.Database
+            .GetCollection<SubscriptionUsageCurrent>("SubscriptionUsageCurrent")
+            .InsertOneAsync(duplicate, cancellationToken: CancellationToken.None);
+
+        await insert.Should().ThrowAsync<MongoWriteException>(
+            "the unique index on subscription, meter and period must refuse it");
+    }
+
+    [Fact]
+    public async Task Seeding_creates_a_zero_usage_document_when_none_exists()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        (await _current.TrySeedAsync(
+                Document(tenantId, used: 0, sourceVersion: 0), CancellationToken.None))
+            .Should().BeTrue();
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(0);
+        stored.SourceVersion.Should().Be(0);
+    }
+
+    /// <summary>
+    /// A seed must never reset a live balance. If it could, a rollover or an activation replay would
+    /// discard usage the customer has already been billed for.
+    /// </summary>
+    [Fact]
+    public async Task Seeding_never_overwrites_a_published_balance()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 250, sourceVersion: 12), CancellationToken.None);
+
+        (await _current.TrySeedAsync(
+                Document(tenantId, used: 0, sourceVersion: 0), CancellationToken.None))
+            .Should().BeFalse();
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(250, "the recorded usage must survive a seed");
+        stored.SourceVersion.Should().Be(12);
+    }
+
+    /// <summary>
+    /// Concurrent seeds of the same missing document: exactly one may create it. Otherwise a rollover
+    /// running on two workers would produce two current documents for one meter.
+    /// </summary>
+    [Fact]
+    public async Task Only_one_of_eight_concurrent_seeds_creates_the_document()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 8).Select(_ =>
+            _current.TrySeedAsync(
+                Document(tenantId, used: 0, sourceVersion: 0), CancellationToken.None)));
+
+        results.Count(created => created).Should().Be(1);
+    }
+
+    /// <summary>
+    /// The current window is selected by period boundary rather than by an <c>isCurrent</c> flag,
+    /// because a flag has to be cleared on another document when a period rolls and there is no
+    /// transaction here to make setting one and clearing the other a single act.
+    /// </summary>
+    [Fact]
+    public async Task Only_the_window_containing_now_is_returned()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var now = new DateTime(2026, 9, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        var previous = Document(tenantId, used: 5, sourceVersion: 1, periodKey: "M2026-08");
+        previous.PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+        previous.PeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var live = Document(tenantId, used: 30, sourceVersion: 2, periodKey: "M2026-09");
+        live.PeriodStartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+        live.PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await _current.TryPublishAsync(previous, CancellationToken.None);
+        await _current.TryPublishAsync(live, CancellationToken.None);
+
+        var found = await _current.ListCurrentAsync(
+            tenantId, "org-1", "sub-1", now, CancellationToken.None);
+
+        found.Should().ContainSingle().Which.PeriodKey.Should().Be("M2026-09");
+    }
+
+    /// <summary>
+    /// A period ends the instant its successor begins. An inclusive upper bound would return both at
+    /// the boundary, and a reader would see two allowances for one meter.
+    /// </summary>
+    [Fact]
+    public async Task Exactly_one_window_is_current_at_a_period_boundary()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var boundary = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var previous = Document(tenantId, used: 5, sourceVersion: 1, periodKey: "M2026-08");
+        previous.PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+        previous.PeriodEndUtc = boundary;
+
+        var next = Document(tenantId, used: 0, sourceVersion: 1, periodKey: "M2026-09");
+        next.PeriodStartUtc = boundary;
+        next.PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        await _current.TryPublishAsync(previous, CancellationToken.None);
+        await _current.TryPublishAsync(next, CancellationToken.None);
+
+        var found = await _current.ListCurrentAsync(
+            tenantId, "org-1", "sub-1", boundary, CancellationToken.None);
+
+        found.Should().ContainSingle().Which.PeriodKey.Should().Be("M2026-09");
+    }
+
+    /// <summary>
+    /// A lifetime capacity meter's window runs to <c>DateTime.MaxValue</c>, so the same boundary query
+    /// has to select it without naming it as a special case.
+    /// </summary>
+    [Fact]
+    public async Task A_lifetime_window_is_always_current()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var lifetime = Document(tenantId, used: 3, sourceVersion: 1, periodKey: "LIFETIME");
+        lifetime.MeterKey = "storage";
+        lifetime.ItemId = SubscriptionUsageCurrent.CreateId("sub-1", "storage", "LIFETIME");
+        lifetime.PeriodStartUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        lifetime.PeriodEndUtc = DateTime.MaxValue;
+
+        await _current.TryPublishAsync(lifetime, CancellationToken.None);
+
+        var found = await _current.ListCurrentAsync(
+            tenantId,
+            "org-1",
+            "sub-1",
+            new DateTime(2031, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+            CancellationToken.None);
+
+        found.Should().ContainSingle().Which.MeterKey.Should().Be("storage");
+    }
+
+    /// <summary>
+    /// Organization scope is in the filter, not merely in the caller's intent. Without it, a direct
+    /// read would be a cross-organization read of billing state.
+    /// </summary>
+    [Fact]
+    public async Task Another_organizations_document_is_never_returned()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var theirs = Document(tenantId, used: 42, sourceVersion: 1);
+        theirs.OrganizationId = "org-2";
+        theirs.SubscriptionId = "sub-2";
+        theirs.ItemId = SubscriptionUsageCurrent.CreateId("sub-2", "screening", "M2026-09");
+
+        await _current.TryPublishAsync(Document(tenantId, 5, 1), CancellationToken.None);
+        await _current.TryPublishAsync(theirs, CancellationToken.None);
+
+        var found = await _current.ListCurrentAsync(
+            tenantId,
+            "org-1",
+            "sub-1",
+            new DateTime(2026, 9, 15, 12, 0, 0, DateTimeKind.Utc),
+            CancellationToken.None);
+
+        found.Should().ContainSingle().Which.OrganizationId.Should().Be("org-1");
+    }
+
+    /// <summary>
+    /// A tenant selects the database, so one tenant's projection must be unreachable from another's
+    /// even with the same organization and subscription ids.
+    /// </summary>
+    [Fact]
+    public async Task Another_tenants_document_is_never_returned()
+    {
+        var mine = MongoIntegrationFixture.NewTenantId();
+        var theirs = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(Document(theirs, used: 77, sourceVersion: 1), CancellationToken.None);
+
+        var found = await _current.ListCurrentAsync(
+            mine,
+            "org-1",
+            "sub-1",
+            new DateTime(2026, 9, 15, 12, 0, 0, DateTimeKind.Utc),
+            CancellationToken.None);
+
+        found.Should().BeEmpty();
+        (await _current.GetAsync(mine, Document(mine, 0, 0).ItemId, CancellationToken.None))
+            .Should().BeNull();
+    }
+
+    /// <summary>
+    /// The reconciliation pass reads oldest-updated first, because a projection that has not been
+    /// rewritten for a while is the one most likely to be behind its counter.
+    /// </summary>
+    [Fact]
+    public async Task Reconciliation_candidates_come_back_oldest_first_and_bounded()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var now = new DateTime(2026, 9, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        foreach (var (meter, minutesAgo) in new[] { ("a", 5), ("b", 60), ("c", 1) })
+        {
+            var document = Document(tenantId, used: 1, sourceVersion: 1);
+            document.MeterKey = meter;
+            document.ItemId = SubscriptionUsageCurrent.CreateId("sub-1", meter, "M2026-09");
+            document.UpdatedAtUtc = now.AddMinutes(-minutesAgo);
+
+            await _current.TryPublishAsync(document, CancellationToken.None);
+        }
+
+        var candidates = await _current.ListBehindCountersAsync(
+            tenantId, now, 2, CancellationToken.None);
+
+        candidates.Should().HaveCount(2, "the pass is bounded");
+        candidates[0].MeterKey.Should().Be("b", "the least recently written comes first");
+        candidates[1].MeterKey.Should().Be("a");
+    }
+
+    /// <summary>
+    /// The indexes are what make a direct read safe to expose: without them a consumer could express
+    /// a query that scans the collection. Asserted on the stored index list rather than on the
+    /// builder code, because only the former is what the database will actually use.
+    /// </summary>
+    [Fact]
+    public async Task The_declared_indexes_exist_on_the_collection()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.EnsureIndexesAsync(tenantId, CancellationToken.None);
+
+        // The tenant selects the database, not a collection-name prefix: SubscriptionCollections.Of
+        // resolves a database per tenant and then a plainly named collection inside it.
+        var indexes = await _fixture.Database
+            .GetCollection<BsonDocument>("SubscriptionUsageCurrent")
+            .Indexes.List()
+            .ToListAsync();
+
+        var names = indexes.ConvertAll(index => index["name"].AsString);
+
+        names.Should().Contain(SubscriptionIndexDefinitions.UsageCurrentUniqueIndexName);
+        names.Should().Contain(SubscriptionIndexDefinitions.UsageCurrentReadIndexName);
+        names.Should().Contain(SubscriptionIndexDefinitions.UsageCurrentStalenessIndexName);
+        names.Should().Contain(SubscriptionIndexDefinitions.UsageCurrentExpiryIndexName);
+
+        indexes
+            .Should().ContainSingle(index =>
+                index["name"].AsString == SubscriptionIndexDefinitions.UsageCurrentUniqueIndexName)
+            .Which["unique"].AsBoolean.Should().BeTrue();
+
+        indexes
+            .Should().ContainSingle(index =>
+                index["name"].AsString == SubscriptionIndexDefinitions.UsageCurrentExpiryIndexName)
+            .Which.Contains("expireAfterSeconds").Should().BeTrue(
+                "the projection must not outlive the counter it projects");
+    }
+
+    private static SubscriptionUsageCurrent Document(
+        string tenantId,
+        long used,
+        long sourceVersion,
+        string periodKey = "M2026-09") => new()
+    {
+        ItemId = SubscriptionUsageCurrent.CreateId("sub-1", "screening", periodKey),
+        TenantId = tenantId,
+        OrganizationId = "org-1",
+        SubscriptionId = "sub-1",
+        SubscriptionStatus = SubscriptionStatus.Active,
+        PlanId = "plan-1",
+        PlanCode = "pro",
+        MeterKey = "screening",
+        UnitLabel = "screening",
+        PeriodKey = periodKey,
+        PeriodStartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+        Included = 100,
+        Used = used,
+        Remaining = Math.Max(0, 100 - used),
+        Overage = Math.Max(0, used - 100),
+        OverageAllowed = true,
+        SourceVersion = sourceVersion,
+        SchemaVersion = SubscriptionUsageCurrent.CurrentSchemaVersion,
+        UpdatedAtUtc = new DateTime(2026, 9, 15, 11, 0, 0, DateTimeKind.Utc),
+        ExpiresAtUtc = new DateTime(2027, 12, 31, 0, 0, 0, DateTimeKind.Utc)
+    };
+}

--- a/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
@@ -255,6 +255,184 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     }
 
     /// <summary>
+    /// The regression the field-group merge exists to prevent, in the exact order that produced it.
+    /// </summary>
+    /// <remarks>
+    /// A cancellation publishes <c>(counter 10, subscription 6, Cancelled)</c>. A usage request
+    /// already in flight then publishes <c>(counter 11, subscription 5, Active)</c> — it read the
+    /// subscription before the cancellation committed, so its metadata is genuinely older.
+    /// <para>
+    /// Replacing the whole document because the counter is newer restored <c>Active</c> and drove the
+    /// stored subscription version backwards from 6 to 5. A cancelled subscription then advertised a
+    /// live allowance, and nothing would correct it until the next lifecycle change.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task A_late_usage_publish_cannot_resurrect_a_cancelled_status()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var cancellation = Document(
+            tenantId, used: 40, counterVersion: 10, subscriptionVersion: 6);
+        cancellation.SubscriptionStatus = SubscriptionStatus.Canceled;
+        cancellation.Included = 100;
+
+        await _current.TryPublishAsync(cancellation, CancellationToken.None);
+
+        var lateUsage = Document(tenantId, used: 55, counterVersion: 11, subscriptionVersion: 5);
+        lateUsage.SubscriptionStatus = SubscriptionStatus.Active;
+        lateUsage.Included = 100;
+
+        (await _current.TryPublishAsync(lateUsage, CancellationToken.None))
+            .Should().BeTrue("its counter version is newer, so its balance is worth taking");
+
+        var stored = await _current.GetAsync(
+            tenantId, cancellation.ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(55, "the newer balance wins");
+        stored.CounterVersion.Should().Be(11);
+        stored.SubscriptionStatus.Should().Be(
+            SubscriptionStatus.Canceled, "the newer metadata must not be undone by an older writer");
+        stored.SubscriptionVersion.Should().Be(6, "and the version must not go backwards");
+    }
+
+    /// <summary>
+    /// The inverse order, which the old comparison rejected outright.
+    /// </summary>
+    /// <remarks>
+    /// With <c>(11, 5)</c> stored, a lifecycle refresh carrying <c>(10, 6)</c> failed the composite
+    /// condition entirely — the counter was not newer, and the subscription tie-break only applied
+    /// when the counters were equal. Its newer metadata never landed at all.
+    /// </remarks>
+    [Fact]
+    public async Task A_lifecycle_refresh_lands_its_metadata_even_behind_a_newer_counter()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var usage = Document(tenantId, used: 55, counterVersion: 11, subscriptionVersion: 5);
+        usage.SubscriptionStatus = SubscriptionStatus.Active;
+        usage.Included = 100;
+
+        await _current.TryPublishAsync(usage, CancellationToken.None);
+
+        var refresh = Document(tenantId, used: 40, counterVersion: 10, subscriptionVersion: 6);
+        refresh.SubscriptionStatus = SubscriptionStatus.Canceled;
+        refresh.Included = 250;
+        refresh.PlanCode = "enterprise";
+
+        (await _current.TryPublishAsync(refresh, CancellationToken.None))
+            .Should().BeTrue("its subscription version is newer");
+
+        var stored = await _current.GetAsync(tenantId, usage.ItemId, CancellationToken.None);
+
+        stored!.SubscriptionStatus.Should().Be(SubscriptionStatus.Canceled);
+        stored.Included.Should().Be(250);
+        stored.PlanCode.Should().Be("enterprise");
+        stored.SubscriptionVersion.Should().Be(6);
+
+        stored.Used.Should().Be(55, "the older balance must not overwrite the newer one");
+        stored.CounterVersion.Should().Be(11, "and that version must not go backwards either");
+    }
+
+    /// <summary>
+    /// Remaining and overage are recomputed from whichever balance and allowance won, so they cannot
+    /// describe a state that never existed.
+    /// </summary>
+    /// <remarks>
+    /// Taking either from the losing side is the trap: after the merge above, <c>Used</c> comes from
+    /// one writer and <c>Included</c> from the other, and a <c>Remaining</c> copied from either would
+    /// be arithmetic on one of them plus a stale version of the other.
+    /// </remarks>
+    [Fact]
+    public async Task Remaining_and_overage_are_consistent_with_the_merged_balance_and_allowance()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var repriced = Document(tenantId, used: 10, counterVersion: 4, subscriptionVersion: 9);
+        repriced.Included = 30;
+        repriced.Remaining = 20;
+        repriced.Overage = 0;
+
+        await _current.TryPublishAsync(repriced, CancellationToken.None);
+
+        // Newer balance, older allowance: 50 used against the 30 that won.
+        var lateUsage = Document(tenantId, used: 50, counterVersion: 5, subscriptionVersion: 2);
+        lateUsage.Included = 500;
+        lateUsage.Remaining = 450;
+        lateUsage.Overage = 0;
+
+        await _current.TryPublishAsync(lateUsage, CancellationToken.None);
+
+        var stored = await _current.GetAsync(tenantId, repriced.ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(50);
+        stored.Included.Should().Be(30);
+        stored.Remaining.Should().Be(0, "not the 450 the losing writer computed against its own allowance");
+        stored.Overage.Should().Be(20, "50 used against an allowance of 30");
+    }
+
+    /// <summary>
+    /// Both kinds of writer arriving at once, in every interleaving the scheduler happens to pick.
+    /// </summary>
+    /// <remarks>
+    /// The merge is per-field and each version takes a maximum, so the document converges on the
+    /// newest of each kind of information whatever order the writers land in. That is what makes this
+    /// safe without a transaction: there is no interleaving that produces a different answer.
+    /// </remarks>
+    [Fact]
+    public async Task Mixed_usage_and_lifecycle_writers_converge_whatever_order_they_land_in()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var writers = new List<Func<Task>>();
+
+        foreach (var counterVersion in new[] { 3, 8, 5, 1, 7 })
+        {
+            var version = counterVersion;
+
+            writers.Add(async () =>
+            {
+                var usage = Document(
+                    tenantId, used: version * 10, counterVersion: version, subscriptionVersion: 1);
+                usage.Included = 100;
+                usage.SubscriptionStatus = SubscriptionStatus.Active;
+
+                await _current.TryPublishAsync(usage, CancellationToken.None);
+            });
+        }
+
+        foreach (var subscriptionVersion in new[] { 4, 2, 6 })
+        {
+            var version = subscriptionVersion;
+
+            writers.Add(async () =>
+            {
+                var lifecycle = Document(
+                    tenantId, used: 0, counterVersion: 1, subscriptionVersion: version);
+                lifecycle.Included = 100 + version;
+                lifecycle.SubscriptionStatus = version == 6
+                    ? SubscriptionStatus.Canceled
+                    : SubscriptionStatus.Active;
+
+                await _current.TryPublishAsync(lifecycle, CancellationToken.None);
+            });
+        }
+
+        await Task.WhenAll(writers.Select(writer => writer()));
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.CounterVersion.Should().Be(8, "the highest counter version");
+        stored.Used.Should().Be(80, "and the balance published with it");
+        stored.SubscriptionVersion.Should().Be(6, "the highest subscription version");
+        stored.Included.Should().Be(106, "and the allowance published with it");
+        stored.SubscriptionStatus.Should().Be(SubscriptionStatus.Canceled);
+        stored.Remaining.Should().Be(26, "106 minus 80, from the two winners");
+        stored.Overage.Should().Be(0);
+    }
+
+    /// <summary>
     /// One meter-period is one document, enforced by the database rather than by whoever composes the
     /// id. Two current documents for one meter would show a reader two allowances for one allowance.
     /// </summary>

--- a/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
@@ -33,7 +33,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     public async Task Publishing_stores_every_field_a_direct_reader_depends_on()
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
-        var document = Document(tenantId, used: 40, sourceVersion: 3);
+        var document = Document(tenantId, used: 40, counterVersion: 3);
 
         (await _current.TryPublishAsync(document, CancellationToken.None)).Should().BeTrue();
 
@@ -52,7 +52,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         stored.Remaining.Should().Be(60);
         stored.Overage.Should().Be(0);
         stored.OverageAllowed.Should().BeTrue();
-        stored.SourceVersion.Should().Be(3);
+        stored.CounterVersion.Should().Be(3);
         stored.SchemaVersion.Should().Be(SubscriptionUsageCurrent.CurrentSchemaVersion);
     }
 
@@ -62,17 +62,17 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
         await _current.TryPublishAsync(
-            Document(tenantId, used: 10, sourceVersion: 1), CancellationToken.None);
+            Document(tenantId, used: 10, counterVersion: 1), CancellationToken.None);
 
         (await _current.TryPublishAsync(
-                Document(tenantId, used: 20, sourceVersion: 2), CancellationToken.None))
+                Document(tenantId, used: 20, counterVersion: 2), CancellationToken.None))
             .Should().BeTrue();
 
         var stored = await _current.GetAsync(
             tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
 
         stored!.Used.Should().Be(20);
-        stored.SourceVersion.Should().Be(2);
+        stored.CounterVersion.Should().Be(2);
     }
 
     /// <summary>
@@ -86,17 +86,17 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
         await _current.TryPublishAsync(
-            Document(tenantId, used: 90, sourceVersion: 9), CancellationToken.None);
+            Document(tenantId, used: 90, counterVersion: 9), CancellationToken.None);
 
         (await _current.TryPublishAsync(
-                Document(tenantId, used: 10, sourceVersion: 4), CancellationToken.None))
+                Document(tenantId, used: 10, counterVersion: 4), CancellationToken.None))
             .Should().BeFalse("the stored document is already newer");
 
         var stored = await _current.GetAsync(
             tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
 
         stored!.Used.Should().Be(90, "the newer figure must survive");
-        stored.SourceVersion.Should().Be(9);
+        stored.CounterVersion.Should().Be(9);
     }
 
     /// <summary>Republishing the same version is not an update, and must not be reported as one.</summary>
@@ -106,10 +106,10 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
         await _current.TryPublishAsync(
-            Document(tenantId, used: 7, sourceVersion: 5), CancellationToken.None);
+            Document(tenantId, used: 7, counterVersion: 5), CancellationToken.None);
 
         (await _current.TryPublishAsync(
-                Document(tenantId, used: 999, sourceVersion: 5), CancellationToken.None))
+                Document(tenantId, used: 999, counterVersion: 5), CancellationToken.None))
             .Should().BeFalse();
 
         var stored = await _current.GetAsync(
@@ -137,17 +137,121 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
 
         var results = await Task.WhenAll(versions.Select(version =>
             _current.TryPublishAsync(
-                Document(tenantId, used: version * 10, sourceVersion: version),
+                Document(tenantId, used: version * 10, counterVersion: version),
                 CancellationToken.None)));
 
         var stored = await _current.GetAsync(
             tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
 
-        stored!.SourceVersion.Should().Be(16, "the highest version must be the one that stands");
+        stored!.CounterVersion.Should().Be(16, "the highest version must be the one that stands");
         stored.Used.Should().Be(160, "and the balance stored with it");
 
         results.Count(written => written)
             .Should().BeGreaterThan(0).And.BeLessThanOrEqualTo(versions.Length);
+    }
+
+    /// <summary>
+    /// The defect the subscription version exists to fix, asserted against a real write.
+    /// </summary>
+    /// <remarks>
+    /// A plan change alters the allowance without recording any usage, so the counter version is
+    /// unchanged. Ordered on the counter version alone this republish compared equal and was refused
+    /// as stale, and the projection kept advertising the old allowance indefinitely — not for one
+    /// sweep interval, but until somebody happened to record usage against that meter.
+    /// </remarks>
+    [Fact]
+    public async Task A_changed_allowance_lands_even_though_the_counter_did_not_move()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 10, counterVersion: 4, subscriptionVersion: 7),
+            CancellationToken.None);
+
+        var repriced = Document(tenantId, used: 10, counterVersion: 4, subscriptionVersion: 8);
+        repriced.Included = 250;
+        repriced.Remaining = 240;
+
+        (await _current.TryPublishAsync(repriced, CancellationToken.None))
+            .Should().BeTrue("the subscription version is newer even though the counter is not");
+
+        var stored = await _current.GetAsync(
+            tenantId, repriced.ItemId, CancellationToken.None);
+
+        stored!.Included.Should().Be(250);
+        stored.Remaining.Should().Be(240);
+        stored.SubscriptionVersion.Should().Be(8);
+    }
+
+    /// <summary>
+    /// The subscription version is a tie-break, not an override. A newer balance is newer information
+    /// about the same subscription even when it was read at an older subscription version, so it must
+    /// not be refused by one.
+    /// </summary>
+    [Fact]
+    public async Task A_newer_counter_version_wins_even_with_an_older_subscription_version()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 10, counterVersion: 4, subscriptionVersion: 9),
+            CancellationToken.None);
+
+        (await _current.TryPublishAsync(
+                Document(tenantId, used: 50, counterVersion: 5, subscriptionVersion: 2),
+                CancellationToken.None))
+            .Should().BeTrue();
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(50);
+        stored.CounterVersion.Should().Be(5);
+    }
+
+    /// <summary>An older subscription version at the same counter version is still stale.</summary>
+    [Fact]
+    public async Task An_older_subscription_version_at_the_same_counter_version_is_refused()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 10, counterVersion: 4, subscriptionVersion: 9),
+            CancellationToken.None);
+
+        (await _current.TryPublishAsync(
+                Document(tenantId, used: 999, counterVersion: 4, subscriptionVersion: 3),
+                CancellationToken.None))
+            .Should().BeFalse();
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(10);
+        stored.SubscriptionVersion.Should().Be(9);
+    }
+
+    /// <summary>
+    /// Both versions equal is not newer information, so it must not be reported as a write.
+    /// </summary>
+    [Fact]
+    public async Task Republishing_both_versions_unchanged_writes_nothing()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Document(tenantId, used: 10, counterVersion: 4, subscriptionVersion: 9),
+            CancellationToken.None);
+
+        (await _current.TryPublishAsync(
+                Document(tenantId, used: 777, counterVersion: 4, subscriptionVersion: 9),
+                CancellationToken.None))
+            .Should().BeFalse();
+
+        var stored = await _current.GetAsync(
+            tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(10);
     }
 
     /// <summary>
@@ -158,14 +262,14 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     public async Task Two_documents_for_one_meter_period_are_refused()
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
-        var first = Document(tenantId, used: 1, sourceVersion: 1);
+        var first = Document(tenantId, used: 1, counterVersion: 1);
 
         await _current.TryPublishAsync(first, CancellationToken.None);
 
         // Same subscription, meter and period as the published document, but a different _id. Only
         // the unique index can refuse this; the composed key cannot, because nothing forces a writer
         // to compose it.
-        var duplicate = Document(tenantId, used: 2, sourceVersion: 2);
+        var duplicate = Document(tenantId, used: 2, counterVersion: 2);
         duplicate.ItemId = $"a-second-id-for-{first.ItemId}";
 
         var insert = async () => await _fixture.Database
@@ -182,14 +286,14 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
         (await _current.TrySeedAsync(
-                Document(tenantId, used: 0, sourceVersion: 0), CancellationToken.None))
+                Document(tenantId, used: 0, counterVersion: 0), CancellationToken.None))
             .Should().BeTrue();
 
         var stored = await _current.GetAsync(
             tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
 
         stored!.Used.Should().Be(0);
-        stored.SourceVersion.Should().Be(0);
+        stored.CounterVersion.Should().Be(0);
     }
 
     /// <summary>
@@ -202,17 +306,17 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
         await _current.TryPublishAsync(
-            Document(tenantId, used: 250, sourceVersion: 12), CancellationToken.None);
+            Document(tenantId, used: 250, counterVersion: 12), CancellationToken.None);
 
         (await _current.TrySeedAsync(
-                Document(tenantId, used: 0, sourceVersion: 0), CancellationToken.None))
+                Document(tenantId, used: 0, counterVersion: 0), CancellationToken.None))
             .Should().BeFalse();
 
         var stored = await _current.GetAsync(
             tenantId, Document(tenantId, 0, 0).ItemId, CancellationToken.None);
 
         stored!.Used.Should().Be(250, "the recorded usage must survive a seed");
-        stored.SourceVersion.Should().Be(12);
+        stored.CounterVersion.Should().Be(12);
     }
 
     /// <summary>
@@ -226,7 +330,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
 
         var results = await Task.WhenAll(Enumerable.Range(0, 8).Select(_ =>
             _current.TrySeedAsync(
-                Document(tenantId, used: 0, sourceVersion: 0), CancellationToken.None)));
+                Document(tenantId, used: 0, counterVersion: 0), CancellationToken.None)));
 
         results.Count(created => created).Should().Be(1);
     }
@@ -242,11 +346,11 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var tenantId = MongoIntegrationFixture.NewTenantId();
         var now = new DateTime(2026, 9, 15, 12, 0, 0, DateTimeKind.Utc);
 
-        var previous = Document(tenantId, used: 5, sourceVersion: 1, periodKey: "M2026-08");
+        var previous = Document(tenantId, used: 5, counterVersion: 1, periodKey: "M2026-08");
         previous.PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
         previous.PeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        var live = Document(tenantId, used: 30, sourceVersion: 2, periodKey: "M2026-09");
+        var live = Document(tenantId, used: 30, counterVersion: 2, periodKey: "M2026-09");
         live.PeriodStartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
         live.PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -269,11 +373,11 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var tenantId = MongoIntegrationFixture.NewTenantId();
         var boundary = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        var previous = Document(tenantId, used: 5, sourceVersion: 1, periodKey: "M2026-08");
+        var previous = Document(tenantId, used: 5, counterVersion: 1, periodKey: "M2026-08");
         previous.PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
         previous.PeriodEndUtc = boundary;
 
-        var next = Document(tenantId, used: 0, sourceVersion: 1, periodKey: "M2026-09");
+        var next = Document(tenantId, used: 0, counterVersion: 1, periodKey: "M2026-09");
         next.PeriodStartUtc = boundary;
         next.PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -295,7 +399,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
-        var lifetime = Document(tenantId, used: 3, sourceVersion: 1, periodKey: "LIFETIME");
+        var lifetime = Document(tenantId, used: 3, counterVersion: 1, periodKey: "LIFETIME");
         lifetime.MeterKey = "storage";
         lifetime.ItemId = SubscriptionUsageCurrent.CreateId(Sub(tenantId), "storage", "LIFETIME");
         lifetime.PeriodStartUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -322,7 +426,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
-        var theirs = Document(tenantId, used: 42, sourceVersion: 1);
+        var theirs = Document(tenantId, used: 42, counterVersion: 1);
         theirs.OrganizationId = "org-2";
         theirs.SubscriptionId = $"other-{tenantId}";
         theirs.ItemId = SubscriptionUsageCurrent.CreateId(
@@ -360,7 +464,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var theirs = MongoIntegrationFixture.NewTenantId();
 
         await _current.TryPublishAsync(
-            Document(theirs, used: 77, sourceVersion: 1), CancellationToken.None);
+            Document(theirs, used: 77, counterVersion: 1), CancellationToken.None);
 
         var found = await _current.ListCurrentAsync(
             mine,
@@ -386,7 +490,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
 
         foreach (var (meter, minutesAgo) in new[] { ("a", 5), ("b", 60), ("c", 1) })
         {
-            var document = Document(tenantId, used: 1, sourceVersion: 1);
+            var document = Document(tenantId, used: 1, counterVersion: 1);
             document.MeterKey = meter;
             document.ItemId = SubscriptionUsageCurrent.CreateId(
                 Sub(tenantId), meter, "M2026-09");
@@ -456,8 +560,9 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     private static SubscriptionUsageCurrent Document(
         string tenantId,
         long used,
-        long sourceVersion,
-        string periodKey = "M2026-09") => new()
+        long counterVersion,
+        string periodKey = "M2026-09",
+        long subscriptionVersion = 1) => new()
     {
         ItemId = SubscriptionUsageCurrent.CreateId(Sub(tenantId), "screening", periodKey),
         TenantId = tenantId,
@@ -476,7 +581,8 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         Remaining = Math.Max(0, 100 - used),
         Overage = Math.Max(0, used - 100),
         OverageAllowed = true,
-        SourceVersion = sourceVersion,
+        CounterVersion = counterVersion,
+        SubscriptionVersion = subscriptionVersion,
         SchemaVersion = SubscriptionUsageCurrent.CurrentSchemaVersion,
         UpdatedAtUtc = new DateTime(2026, 9, 15, 11, 0, 0, DateTimeKind.Utc),
         ExpiresAtUtc = new DateTime(2027, 12, 31, 0, 0, 0, DateTimeKind.Utc)

--- a/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
@@ -41,7 +41,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
 
         stored.Should().NotBeNull();
         stored!.OrganizationId.Should().Be("org-1");
-        stored.SubscriptionId.Should().Be("sub-1");
+        stored.SubscriptionId.Should().Be(Sub(tenantId));
         stored.SubscriptionStatus.Should().Be(SubscriptionStatus.Active);
         stored.PlanId.Should().Be("plan-1");
         stored.PlanCode.Should().Be("pro");
@@ -162,8 +162,11 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
 
         await _current.TryPublishAsync(first, CancellationToken.None);
 
+        // Same subscription, meter and period as the published document, but a different _id. Only
+        // the unique index can refuse this; the composed key cannot, because nothing forces a writer
+        // to compose it.
         var duplicate = Document(tenantId, used: 2, sourceVersion: 2);
-        duplicate.ItemId = "a-different-id-for-the-same-meter-period";
+        duplicate.ItemId = $"a-second-id-for-{first.ItemId}";
 
         var insert = async () => await _fixture.Database
             .GetCollection<SubscriptionUsageCurrent>("SubscriptionUsageCurrent")
@@ -251,7 +254,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         await _current.TryPublishAsync(live, CancellationToken.None);
 
         var found = await _current.ListCurrentAsync(
-            tenantId, "org-1", "sub-1", now, CancellationToken.None);
+            tenantId, "org-1", Sub(tenantId), now, CancellationToken.None);
 
         found.Should().ContainSingle().Which.PeriodKey.Should().Be("M2026-09");
     }
@@ -278,7 +281,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         await _current.TryPublishAsync(next, CancellationToken.None);
 
         var found = await _current.ListCurrentAsync(
-            tenantId, "org-1", "sub-1", boundary, CancellationToken.None);
+            tenantId, "org-1", Sub(tenantId), boundary, CancellationToken.None);
 
         found.Should().ContainSingle().Which.PeriodKey.Should().Be("M2026-09");
     }
@@ -294,7 +297,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
 
         var lifetime = Document(tenantId, used: 3, sourceVersion: 1, periodKey: "LIFETIME");
         lifetime.MeterKey = "storage";
-        lifetime.ItemId = SubscriptionUsageCurrent.CreateId("sub-1", "storage", "LIFETIME");
+        lifetime.ItemId = SubscriptionUsageCurrent.CreateId(Sub(tenantId), "storage", "LIFETIME");
         lifetime.PeriodStartUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         lifetime.PeriodEndUtc = DateTime.MaxValue;
 
@@ -303,7 +306,7 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         var found = await _current.ListCurrentAsync(
             tenantId,
             "org-1",
-            "sub-1",
+            Sub(tenantId),
             new DateTime(2031, 6, 1, 0, 0, 0, DateTimeKind.Utc),
             CancellationToken.None);
 
@@ -321,16 +324,20 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
 
         var theirs = Document(tenantId, used: 42, sourceVersion: 1);
         theirs.OrganizationId = "org-2";
-        theirs.SubscriptionId = "sub-2";
-        theirs.ItemId = SubscriptionUsageCurrent.CreateId("sub-2", "screening", "M2026-09");
+        theirs.SubscriptionId = $"other-{tenantId}";
+        theirs.ItemId = SubscriptionUsageCurrent.CreateId(
+            $"other-{tenantId}", "screening", "M2026-09");
 
         await _current.TryPublishAsync(Document(tenantId, 5, 1), CancellationToken.None);
         await _current.TryPublishAsync(theirs, CancellationToken.None);
 
+        // Listed for org-1 and this test's own subscription. The other document is in the same
+        // collection, under a different organization, and must not appear.
+
         var found = await _current.ListCurrentAsync(
             tenantId,
             "org-1",
-            "sub-1",
+            Sub(tenantId),
             new DateTime(2026, 9, 15, 12, 0, 0, DateTimeKind.Utc),
             CancellationToken.None);
 
@@ -338,27 +345,33 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     }
 
     /// <summary>
-    /// A tenant selects the database, so one tenant's projection must be unreachable from another's
-    /// even with the same organization and subscription ids.
+    /// The tenant is in the filter, not merely in the database the provider chose.
     /// </summary>
+    /// <remarks>
+    /// In production a tenant selects its own database, so this filter is defence in depth rather
+    /// than the only thing separating two tenants. It is asserted because this fixture maps every
+    /// tenant onto one database — which makes the filter the only thing that can exclude the other
+    /// tenant's document, and therefore the only place this property can be tested at all.
+    /// </remarks>
     [Fact]
     public async Task Another_tenants_document_is_never_returned()
     {
         var mine = MongoIntegrationFixture.NewTenantId();
         var theirs = MongoIntegrationFixture.NewTenantId();
 
-        await _current.TryPublishAsync(Document(theirs, used: 77, sourceVersion: 1), CancellationToken.None);
+        await _current.TryPublishAsync(
+            Document(theirs, used: 77, sourceVersion: 1), CancellationToken.None);
 
         var found = await _current.ListCurrentAsync(
             mine,
             "org-1",
-            "sub-1",
+            Sub(theirs),
             new DateTime(2026, 9, 15, 12, 0, 0, DateTimeKind.Utc),
             CancellationToken.None);
 
-        found.Should().BeEmpty();
-        (await _current.GetAsync(mine, Document(mine, 0, 0).ItemId, CancellationToken.None))
-            .Should().BeNull();
+        found.Should().BeEmpty(
+            "the document exists and matches on organization, subscription and period - only the " +
+            "tenant differs");
     }
 
     /// <summary>
@@ -375,7 +388,8 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
         {
             var document = Document(tenantId, used: 1, sourceVersion: 1);
             document.MeterKey = meter;
-            document.ItemId = SubscriptionUsageCurrent.CreateId("sub-1", meter, "M2026-09");
+            document.ItemId = SubscriptionUsageCurrent.CreateId(
+                Sub(tenantId), meter, "M2026-09");
             document.UpdatedAtUtc = now.AddMinutes(-minutesAgo);
 
             await _current.TryPublishAsync(document, CancellationToken.None);
@@ -427,16 +441,28 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
                 "the projection must not outlive the counter it projects");
     }
 
+    /// <summary>
+    /// A subscription id derived from the tenant, so each test owns its own document space.
+    /// </summary>
+    /// <remarks>
+    /// The fixture maps every tenant id onto one database, and the projection's <c>_id</c> is
+    /// <c>{subscriptionId}:{meterKey}:{periodKey}</c> with no tenant in it — that is correct in
+    /// production, where the tenant selects the database before the id is ever used. In a shared
+    /// database it means a fixed subscription id would put every test in this class on the same
+    /// document, and the version condition would then refuse whichever test ran second.
+    /// </remarks>
+    private static string Sub(string tenantId) => $"sub-{tenantId}";
+
     private static SubscriptionUsageCurrent Document(
         string tenantId,
         long used,
         long sourceVersion,
         string periodKey = "M2026-09") => new()
     {
-        ItemId = SubscriptionUsageCurrent.CreateId("sub-1", "screening", periodKey),
+        ItemId = SubscriptionUsageCurrent.CreateId(Sub(tenantId), "screening", periodKey),
         TenantId = tenantId,
         OrganizationId = "org-1",
-        SubscriptionId = "sub-1",
+        SubscriptionId = Sub(tenantId),
         SubscriptionStatus = SubscriptionStatus.Active,
         PlanId = "plan-1",
         PlanCode = "pro",

--- a/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionUsageCurrentIntegrationTests.cs
@@ -433,6 +433,84 @@ public sealed class SubscriptionUsageCurrentIntegrationTests
     }
 
     /// <summary>
+    /// A carry-forward allowance corrected by the counter side alone.
+    /// </summary>
+    /// <remarks>
+    /// The allowance is computed from the plan's terms and the counter's <c>LimitSnapshot</c> — the
+    /// figure frozen when the window opened, which is where a carry-forward from the previous period
+    /// lands. A seed publishes the opening figure before any counter exists; the first recording then
+    /// opens the counter with a possibly different frozen snapshot.
+    /// <para>
+    /// Owned by the subscription version alone, that correction could only have arrived with an
+    /// unrelated plan edit, and until one happened the projection would advertise the seeded
+    /// allowance. So the allowance moves on a counter advance too, and <c>remaining</c> and
+    /// <c>overage</c> follow from the corrected figure rather than the seeded one.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task A_counter_advance_corrects_a_carry_forward_allowance_and_what_follows_from_it()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        // Seeded at zero usage with the opening allowance as it looked before the window opened.
+        var seeded = Document(tenantId, used: 0, counterVersion: 0, subscriptionVersion: 3);
+        seeded.Included = 100;
+        seeded.Remaining = 100;
+        seeded.Overage = 0;
+
+        await _current.TrySeedAsync(seeded, CancellationToken.None);
+
+        // First recording. Only the counter advanced — same subscription version — and the counter
+        // opened with a larger frozen allowance because the previous period carried 40 forward.
+        var firstUsage = Document(tenantId, used: 30, counterVersion: 1, subscriptionVersion: 3);
+        firstUsage.Included = 140;
+
+        (await _current.TryPublishAsync(firstUsage, CancellationToken.None)).Should().BeTrue();
+
+        var stored = await _current.GetAsync(tenantId, seeded.ItemId, CancellationToken.None);
+
+        stored!.Included.Should().Be(
+            140, "the counter's frozen snapshot is where a carry-forward lands");
+        stored.Used.Should().Be(30);
+        stored.Remaining.Should().Be(110, "derived from the corrected allowance, not the seeded 100");
+        stored.Overage.Should().Be(0);
+        stored.SubscriptionVersion.Should().Be(3, "unchanged, because nothing about the plan changed");
+    }
+
+    /// <summary>
+    /// The guard on that: a writer whose view of the subscription is older may not touch the
+    /// allowance.
+    /// </summary>
+    /// <remarks>
+    /// Without it, letting the counter side move the allowance would reopen the very regression the
+    /// field groups exist to prevent — a usage publish carrying pre-plan-change terms undoing the new
+    /// plan's figure, this time through <c>Included</c> instead of through status.
+    /// </remarks>
+    [Fact]
+    public async Task A_stale_writer_cannot_undo_a_newer_plans_allowance()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var repriced = Document(tenantId, used: 10, counterVersion: 4, subscriptionVersion: 9);
+        repriced.Included = 250;
+
+        await _current.TryPublishAsync(repriced, CancellationToken.None);
+
+        // Newer counter, older subscription: its balance is worth taking, its allowance is not.
+        var lateUsage = Document(tenantId, used: 60, counterVersion: 5, subscriptionVersion: 2);
+        lateUsage.Included = 100;
+
+        await _current.TryPublishAsync(lateUsage, CancellationToken.None);
+
+        var stored = await _current.GetAsync(tenantId, repriced.ItemId, CancellationToken.None);
+
+        stored!.Used.Should().Be(60, "the newer balance still wins");
+        stored.Included.Should().Be(250, "the newer plan's allowance must survive an older writer");
+        stored.Remaining.Should().Be(190);
+        stored.Overage.Should().Be(0);
+    }
+
+    /// <summary>
     /// One meter-period is one document, enforced by the database rather than by whoever composes the
     /// id. Two current documents for one meter would show a reader two allowances for one allowance.
     /// </summary>

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -201,7 +201,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(1);
+        closed.PeriodsClosed.Should().Be(1);
         _createdInvoice!.TotalAmountMinor.Should().Be(2_000);
         _subscriptions.Verify(repository => repository.TryRemovePendingUsagePeriodAsync(
             TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()), Times.Once);
@@ -234,7 +234,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(1, "a canceled subscription's final overage must still be rated");
+        closed.PeriodsClosed.Should().Be(1, "a canceled subscription's final overage must still be rated");
         _createdInvoice!.TotalAmountMinor.Should().Be(2_000);
         _subscriptions.Verify(repository => repository.TryRemovePendingUsagePeriodAsync(
             TenantId, "sub-1", "M20260801T000000Z", It.IsAny<CancellationToken>()), Times.Once);
@@ -352,7 +352,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(1, "the sweep still finishes clearing the pointer left behind");
+        closed.PeriodsClosed.Should().Be(1, "the sweep still finishes clearing the pointer left behind");
         _usageInvoices.Verify(
             repository => repository.TryCreateAsync(
                 It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
@@ -394,7 +394,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(0,
+        closed.PeriodsClosed.Should().Be(0,
             "an in-flight usage write could still change the balance this would invoice");
         _createdInvoice.Should().BeNull();
         _subscriptions.Verify(
@@ -436,7 +436,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(1);
+        closed.PeriodsClosed.Should().Be(1);
         _createdInvoice.Should().NotBeNull();
         _closures.Verify(
             repository => repository.TryMarkClosedAsync(
@@ -483,7 +483,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(0,
+        closed.PeriodsClosed.Should().Be(0,
             "a claim still mid-release could still be about to change the balance this would " +
             "invoice, even though the counter already reads zero");
         _createdInvoice.Should().BeNull();
@@ -614,7 +614,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         // Deferred must mean genuinely untouched, not merely "no invoice": the usage clock must
         // not advance past the unbilled period, or the next sweep would never look at it again.
-        closedCount.Should().Be(0,
+        closedCount.PeriodsClosed.Should().Be(0,
             "a deferred period is not closed — the next sweep must find it still due");
         _subscriptions.Verify(
             repository => repository.TryTransitionAsync(
@@ -665,7 +665,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closedCount = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closedCount.Should().Be(0,
+        closedCount.PeriodsClosed.Should().Be(0,
             "a deferred pending period is not closed — the next sweep must find it still pending");
         _createdInvoice.Should().BeNull();
         _subscriptions.Verify(
@@ -706,7 +706,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
         _createdInvoice.Should().BeNull(
             "gross plus tax overflows a long even though gross alone did not, and must never be " +
             "persisted as a wrapped total");
-        closedCount.Should().Be(0,
+        closedCount.PeriodsClosed.Should().Be(0,
             "a deferred period is not closed — the next sweep must find it still due");
         _subscriptions.Verify(
             repository => repository.TryTransitionAsync(
@@ -863,7 +863,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
         // June, July and August all close before the September "now" is reached.
-        closed.Should().Be(3);
+        closed.PeriodsClosed.Should().Be(3);
         _usageInvoices.Verify(
             repository => repository.TryCreateAsync(
                 It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
@@ -877,7 +877,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(0);
+        closed.PeriodsClosed.Should().Be(0);
         _usageInvoices.Verify(
             repository => repository.TryCreateAsync(
                 It.IsAny<SubscriptionUsageInvoice>(), It.IsAny<CancellationToken>()),
@@ -895,7 +895,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         var closed = await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
 
-        closed.Should().Be(0);
+        closed.PeriodsClosed.Should().Be(0);
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/UsageProjectionBackfillTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionBackfillTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The backfill's place in the roster, across the scopes it actually runs in.
+/// </summary>
+/// <remarks>
+/// The reconciler is scoped and the reconciliation background service opens a fresh scope per tenant
+/// sweep, so a cursor held as a field on the reconciler was a new empty dictionary on every pass: the
+/// backfill re-read page one forever and no tenant larger than one page ever had its later pages
+/// published. These tests resolve the reconciler from real DI scopes rather than constructing it, so
+/// that lifetime mistake fails here instead of in production.
+/// </remarks>
+public sealed class UsageProjectionBackfillTests
+{
+    private const string TenantId = "tenant-1";
+
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionUsageCurrentRepository> _current = new();
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<IUsageProjectionPublisher> _publisher = new();
+    private readonly List<string?> _requestedCursors = [];
+
+    public UsageProjectionBackfillTests()
+    {
+        _current
+            .Setup(repository => repository.ListBehindCountersAsync(
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        _publisher
+            .Setup(publisher => publisher.RefreshAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Two full pages then a short one, recording the cursor each pass asked with.
+        _subscriptions
+            .Setup(repository => repository.ListLivePageAsync(
+                TenantId,
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string? afterId, int limit, CancellationToken _) =>
+            {
+                _requestedCursors.Add(afterId);
+
+                var start = afterId is null ? 0 : int.Parse(afterId["sub-".Length..]) + 1;
+
+                if (start >= 5)
+                {
+                    return [];
+                }
+
+                return Enumerable
+                    .Range(start, Math.Min(limit, 5 - start))
+                    .Select(index => Subscription($"sub-{index}"))
+                    .ToList();
+            });
+    }
+
+    /// <summary>
+    /// The bug, stated as a test: a second pass in a second scope must resume after the first page.
+    /// </summary>
+    [Fact]
+    public async Task A_second_pass_in_a_new_scope_resumes_after_the_first_page()
+    {
+        using var provider = Provider(pageSize: 2);
+
+        await BackfillOnceAsync(provider);
+        await BackfillOnceAsync(provider);
+
+        _requestedCursors.Should().HaveCount(2);
+        _requestedCursors[0].Should().BeNull("the first pass starts at the beginning");
+        _requestedCursors[1].Should().Be(
+            "sub-1", "the second pass must continue where the first stopped, not restart");
+    }
+
+    /// <summary>
+    /// Every subscription is reached, which is the property that matters rather than the cursor
+    /// itself: a consumer reading the collection directly has no fallback for a missing document.
+    /// </summary>
+    [Fact]
+    public async Task Successive_passes_cover_every_live_subscription_exactly_once()
+    {
+        using var provider = Provider(pageSize: 2);
+
+        var refreshed = new List<string>();
+
+        _publisher
+            .Setup(publisher => publisher.RefreshAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SubscriptionDetail subscription, DateTime _, string _, CancellationToken _) =>
+            {
+                refreshed.Add(subscription.ItemId);
+
+                return 1;
+            });
+
+        for (var pass = 0; pass < 3; pass++)
+        {
+            await BackfillOnceAsync(provider);
+        }
+
+        refreshed.Should().Equal("sub-0", "sub-1", "sub-2", "sub-3", "sub-4");
+    }
+
+    /// <summary>
+    /// Reaching the end starts again, because this is a cycle rather than a migration: a meter added
+    /// to a plan tomorrow is a missing document tomorrow.
+    /// </summary>
+    [Fact]
+    public async Task Exhausting_the_roster_starts_the_next_pass_from_the_beginning()
+    {
+        using var provider = Provider(pageSize: 10);
+
+        // First pass takes all five and reports a short page, so the position is cleared.
+        var first = await BackfillOnceAsync(provider);
+        first.LastSubscriptionId.Should().BeNull();
+
+        await BackfillOnceAsync(provider);
+
+        _requestedCursors.Should().Equal(null, null);
+    }
+
+    /// <summary>
+    /// The store is the thing that has to outlive the scope, so its registration is asserted rather
+    /// than assumed. Registered scoped, it is a different instance per pass and the cursor is lost.
+    /// </summary>
+    [Fact]
+    public void The_cursor_store_is_a_singleton_so_it_survives_the_reconcilers_scope()
+    {
+        using var provider = Provider(pageSize: 2);
+
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        var storeInFirst = first.ServiceProvider.GetRequiredService<UsageProjectionBackfillCursors>();
+        var storeInSecond = second.ServiceProvider.GetRequiredService<UsageProjectionBackfillCursors>();
+
+        storeInSecond.Should().BeSameAs(storeInFirst);
+
+        first.ServiceProvider.GetRequiredService<IUsageProjectionReconciler>()
+            .Should().NotBeSameAs(
+                second.ServiceProvider.GetRequiredService<IUsageProjectionReconciler>(),
+                "the reconciler itself is per-scope, which is why the cursor cannot live on it");
+    }
+
+    /// <summary>Runs one pass in its own scope, the way the reconciliation service does.</summary>
+    private static async Task<UsageProjectionBackfillResult> BackfillOnceAsync(
+        ServiceProvider provider)
+    {
+        using var scope = provider.CreateScope();
+
+        return await scope.ServiceProvider
+            .GetRequiredService<IUsageProjectionReconciler>()
+            .BackfillTenantAsync(TenantId, "corr-1", CancellationToken.None);
+    }
+
+    private ServiceProvider Provider(int pageSize)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(_subscriptions.Object);
+        services.AddSingleton(_current.Object);
+        services.AddSingleton(_usage.Object);
+        services.AddSingleton(_publisher.Object);
+        services.AddSingleton<IOptionsMonitor<SubscriptionOptions>>(
+            new OptionsStub(pageSize));
+        services.AddSingleton<ILogger<UsageProjectionReconciler>>(
+            NullLogger<UsageProjectionReconciler>.Instance);
+        services.AddSingleton<TimeProvider>(
+            new ControlledTimeProvider(new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero)));
+
+        // The two registrations under test, exactly as the module registers them.
+        services.AddScoped<IUsageProjectionReconciler, UsageProjectionReconciler>();
+        services.AddSingleton<UsageProjectionBackfillCursors>();
+
+        return services.BuildServiceProvider();
+    }
+
+    private static SubscriptionDetail Subscription(string itemId) => new()
+    {
+        ItemId = itemId,
+        TenantId = TenantId,
+        OrganizationId = "org-1",
+        Status = SubscriptionStatus.Active,
+        Plan = new PlanSnapshot { PlanId = "plan-1", Code = "pro" }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public OptionsStub(int pageSize) =>
+            CurrentValue = new SubscriptionOptions
+            {
+                UsageProjectionBackfillBatchSize = pageSize
+            };
+
+        public SubscriptionOptions CurrentValue { get; }
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
@@ -1,0 +1,401 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Publishing the current-usage projection.
+/// </summary>
+/// <remarks>
+/// The guarantee under test throughout is that the projection is <em>derived</em>: every figure it
+/// stores comes from a counter result, and nothing here adds, subtracts or carries anything forward.
+/// A projection that did its own arithmetic would disagree with the bill exactly when it mattered.
+/// </remarks>
+public sealed class UsageProjectionPublisherTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionUsageCurrentRepository> _current = new();
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionWorkScheduler> _scheduler = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero));
+
+    private readonly List<SubscriptionUsageCurrent> _published = [];
+    private readonly List<SubscriptionUsageCurrent> _seeded = [];
+
+    public UsageProjectionPublisherTests()
+    {
+        _current
+            .Setup(repository => repository.TryPublishAsync(
+                It.IsAny<SubscriptionUsageCurrent>(), It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionUsageCurrent document, CancellationToken _) =>
+                _published.Add(document))
+            .ReturnsAsync(true);
+
+        _current
+            .Setup(repository => repository.TrySeedAsync(
+                It.IsAny<SubscriptionUsageCurrent>(), It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionUsageCurrent document, CancellationToken _) =>
+                _seeded.Add(document))
+            .ReturnsAsync(true);
+
+        _usage
+            .Setup(repository => repository.GetCountersAsync(
+                TenantId,
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, SubscriptionUsageCounter>(StringComparer.Ordinal));
+
+        _usage
+            .Setup(repository => repository.SummariseLedgerAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((0L, 0L));
+    }
+
+    [Fact]
+    public async Task It_copies_the_counter_figures_rather_than_recomputing_them()
+    {
+        var counter = Counter(balance: 120, appliedRecordCount: 7);
+
+        var outcome = await Publisher().PublishAsync(
+            Subscription(), Meter(), Period(), counter, allowance: 100, "corr-1",
+            CancellationToken.None);
+
+        outcome.Should().Be(UsageProjectionOutcome.Published);
+
+        var document = _published.Should().ContainSingle().Subject;
+        document.Used.Should().Be(120, "taken from the counter, not counted here");
+        document.Included.Should().Be(100);
+        document.Remaining.Should().Be(0, "never negative");
+        document.Overage.Should().Be(20);
+    }
+
+    /// <summary>
+    /// The version is what makes concurrent publishing safe, so it has to be the counter's own
+    /// monotonic count and not a timestamp or an attempt number.
+    /// </summary>
+    [Fact]
+    public async Task It_versions_the_document_with_the_counters_applied_record_count()
+    {
+        await Publisher().PublishAsync(
+            Subscription(), Meter(), Period(), Counter(balance: 5, appliedRecordCount: 42),
+            allowance: 100, "corr-1", CancellationToken.None);
+
+        _published.Should().ContainSingle().Which.SourceVersion.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task It_carries_the_scope_plan_and_meter_terms_a_direct_reader_needs()
+    {
+        await Publisher().PublishAsync(
+            Subscription(), Meter(), Period(), Counter(1, 1), 100, "corr-1",
+            CancellationToken.None);
+
+        var document = _published.Should().ContainSingle().Subject;
+        document.TenantId.Should().Be(TenantId);
+        document.OrganizationId.Should().Be(OrganizationId);
+        document.SubscriptionId.Should().Be("sub-1");
+        document.SubscriptionStatus.Should().Be(SubscriptionStatus.Active);
+        document.PlanId.Should().Be("plan-1");
+        document.PlanCode.Should().Be("pro");
+        document.MeterKey.Should().Be("screening");
+        document.UnitLabel.Should().Be("screening");
+        document.OverageAllowed.Should().BeTrue();
+        document.SchemaVersion.Should().Be(SubscriptionUsageCurrent.CurrentSchemaVersion);
+    }
+
+    /// <summary>
+    /// Superseded is not a failure. It means a later recording published a newer figure first, so the
+    /// projection is ahead of this caller rather than missing, and nothing needs repairing.
+    /// </summary>
+    [Fact]
+    public async Task A_publish_that_loses_the_version_race_is_reported_as_superseded_not_repaired()
+    {
+        _current
+            .Setup(repository => repository.TryPublishAsync(
+                It.IsAny<SubscriptionUsageCurrent>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var outcome = await Publisher().PublishAsync(
+            Subscription(), Meter(), Period(), Counter(1, 1), 100, "corr-1",
+            CancellationToken.None);
+
+        outcome.Should().Be(UsageProjectionOutcome.Superseded);
+        _scheduler.Verify(
+            scheduler => scheduler.ScheduleUsageProjectionRefreshAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// The whole reason this is a projection and not an authority: the usage has already committed by
+    /// the time it is published, so a failure here must be absorbed and repaired, never thrown.
+    /// </summary>
+    [Fact]
+    public async Task A_failed_publish_schedules_one_repair_and_does_not_throw()
+    {
+        // A plain failure rather than a transient one, so the retry does not run and this test is
+        // about what happens when the write genuinely will not go through.
+        _current
+            .Setup(repository => repository.TryPublishAsync(
+                It.IsAny<SubscriptionUsageCurrent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("the projection write failed"));
+
+        var outcome = await Publisher().PublishAsync(
+            Subscription(), Meter(), Period(), Counter(1, 1), 100, "corr-1",
+            CancellationToken.None);
+
+        outcome.Should().Be(UsageProjectionOutcome.RepairScheduled);
+        _scheduler.Verify(
+            scheduler => scheduler.ScheduleUsageProjectionRefreshAsync(
+                TenantId, OrganizationId, "sub-1", "corr-1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Cancellation is the caller going away, not a projection problem. Scheduling a repair for it
+    /// would fill the queue with work nobody is waiting for every time a client disconnects.
+    /// </summary>
+    [Fact]
+    public async Task Cancellation_propagates_instead_of_scheduling_a_repair()
+    {
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        _current
+            .Setup(repository => repository.TryPublishAsync(
+                It.IsAny<SubscriptionUsageCurrent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var act = async () => await Publisher().PublishAsync(
+            Subscription(), Meter(), Period(), Counter(1, 1), 100, "corr-1", cancelled.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        _scheduler.Verify(
+            scheduler => scheduler.ScheduleUsageProjectionRefreshAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// So a consumer can discover a meter and its allowance before anything has been recorded — the
+    /// difference, to a reader that cannot see the plan, between "no usage yet" and "no such meter".
+    /// </summary>
+    [Fact]
+    public async Task Seeding_creates_a_zero_usage_document_for_every_current_window()
+    {
+        var seeded = await Publisher().SeedCurrentAsync(
+            Subscription(), _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        seeded.Should().Be(2, "one periodic meter and one lifetime capacity meter");
+        _seeded.Should().OnlyContain(document =>
+            document.Used == 0 && document.Overage == 0 && document.SourceVersion == 0);
+    }
+
+    /// <summary>
+    /// The two meters resolve to different period keys, which is the fact the whole batching design
+    /// rests on. Asserted here so a change to MeterPeriodResolver cannot quietly invalidate it.
+    /// </summary>
+    [Fact]
+    public async Task Seeding_addresses_a_lifetime_meter_and_a_periodic_meter_separately()
+    {
+        await Publisher().SeedCurrentAsync(
+            Subscription(), _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        _seeded.Should().Contain(document =>
+            document.MeterKey == "storage" &&
+            document.PeriodKey == MeterPeriodResolver.LifetimePeriodKey);
+        _seeded.Should().Contain(document =>
+            document.MeterKey == "screening" &&
+            document.PeriodKey != MeterPeriodResolver.LifetimePeriodKey);
+    }
+
+    /// <summary>
+    /// A window with no counter has had nothing recorded in it. Seeded rather than published: a
+    /// publish carries version 0, which the version condition would refuse against any existing
+    /// document — and would be wrong to accept if it did, because it would overwrite a real balance
+    /// with zero.
+    /// </summary>
+    [Fact]
+    public async Task Refreshing_a_window_with_no_counter_seeds_it_rather_than_publishing_zero()
+    {
+        await Publisher().RefreshAsync(
+            Subscription(), _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        _published.Should().BeEmpty();
+        _seeded.Should().HaveCount(2).And.OnlyContain(document => document.Used == 0);
+    }
+
+    [Fact]
+    public async Task Refreshing_publishes_the_counter_state_for_a_window_that_has_one()
+    {
+        // Keyed off whichever ids the publisher actually composes rather than a period key spelled
+        // out here: the schedule decides that format, and hardcoding it would make this test a
+        // statement about BillingPeriodCalculator instead of about refreshing.
+        _usage
+            .Setup(repository => repository.GetCountersAsync(
+                TenantId,
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, IReadOnlyCollection<string> ids, CancellationToken _) => ids
+                .Where(id => id.Contains(":screening:", StringComparison.Ordinal))
+                .ToDictionary(
+                    id => id,
+                    id => Counter(balance: 33, appliedRecordCount: 9, itemId: id),
+                    StringComparer.Ordinal));
+
+        await Publisher().RefreshAsync(
+            Subscription(), _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        _published.Should().ContainSingle().Which.Used.Should().Be(33);
+        _seeded.Should().ContainSingle("the lifetime meter still has no counter");
+    }
+
+    /// <summary>
+    /// One batch for every meter, on the repair path as much as the read path: a subscription with a
+    /// dozen meters would otherwise cost a dozen round trips per repair.
+    /// </summary>
+    [Fact]
+    public async Task Refreshing_reads_every_counter_in_one_batch()
+    {
+        await Publisher().RefreshAsync(
+            Subscription(), _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        _usage.Verify(
+            repository => repository.GetCountersAsync(
+                TenantId,
+                It.Is<IReadOnlyCollection<string>>(ids => ids.Count == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _usage.Verify(
+            repository => repository.GetCounterAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A lifetime capacity meter's window never ends, so its projection must not be given an expiry
+    /// its allowance would outlive.
+    /// </summary>
+    [Fact]
+    public async Task A_lifetime_window_is_seeded_without_an_expiry()
+    {
+        await Publisher().SeedCurrentAsync(
+            Subscription(), _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        _seeded
+            .Should().ContainSingle(document => document.MeterKey == "storage")
+            .Which.ExpiresAtUtc.Should().Be(DateTime.MaxValue);
+    }
+
+    /// <summary>The projection must not outlive the counter it projects.</summary>
+    [Fact]
+    public async Task A_published_document_inherits_the_counters_own_expiry()
+    {
+        var expires = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var counter = Counter(balance: 1, appliedRecordCount: 1);
+        counter.ExpiresAtUtc = expires;
+
+        await Publisher().PublishAsync(
+            Subscription(), Meter(), Period(), counter, 100, "corr-1", CancellationToken.None);
+
+        _published.Should().ContainSingle().Which.ExpiresAtUtc.Should().Be(expires);
+    }
+
+    private UsageProjectionPublisher Publisher() => new(
+        _current.Object,
+        _usage.Object,
+        new MeterAllowanceResolver(_usage.Object),
+        _scheduler.Object,
+        new OptionsStub(),
+        NullLogger<UsageProjectionPublisher>.Instance,
+        _time);
+
+    private static SubscriptionUsageCounter Counter(
+        long balance,
+        long appliedRecordCount,
+        string? itemId = null) => new()
+    {
+        ItemId = itemId ?? SubscriptionUsageCounter.CreateId("sub-1", "screening", "M2026-09"),
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        SubscriptionId = "sub-1",
+        MeterKey = "screening",
+        Balance = balance,
+        AppliedRecordCount = appliedRecordCount,
+        ExpiresAtUtc = new DateTime(2027, 12, 31, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static PlanMeter Meter() => new()
+    {
+        MeterKey = "screening",
+        UnitLabel = "screening",
+        IncludedQuantity = 100,
+        OverageAllowed = true,
+        ResetPolicy = MeterResetPolicy.Periodic
+    };
+
+    private static BillingPeriod Period() =>
+        new(
+            1,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+            "M2026-09");
+
+    private static SubscriptionDetail Subscription() => new()
+    {
+        ItemId = "sub-1",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CreatedAtUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Plan = new PlanSnapshot
+        {
+            PlanId = "plan-1",
+            Code = "pro",
+            Meters =
+            [
+                Meter(),
+                new PlanMeter
+                {
+                    MeterKey = "storage",
+                    UnitLabel = "GB",
+                    IncludedQuantity = 500,
+                    OverageAllowed = false,
+                    ResetPolicy = MeterResetPolicy.Never
+                }
+            ]
+        },
+        UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        }
+    };
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new();
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}

--- a/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
@@ -93,7 +93,7 @@ public sealed class UsageProjectionPublisherTests
             Subscription(), Meter(), Period(), Counter(balance: 5, appliedRecordCount: 42),
             allowance: 100, "corr-1", CancellationToken.None);
 
-        _published.Should().ContainSingle().Which.SourceVersion.Should().Be(42);
+        _published.Should().ContainSingle().Which.CounterVersion.Should().Be(42);
     }
 
     [Fact]
@@ -203,7 +203,7 @@ public sealed class UsageProjectionPublisherTests
 
         seeded.Should().Be(2, "one periodic meter and one lifetime capacity meter");
         _seeded.Should().OnlyContain(document =>
-            document.Used == 0 && document.Overage == 0 && document.SourceVersion == 0);
+            document.Used == 0 && document.Overage == 0 && document.CounterVersion == 0);
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/UsageProjectionRolloverTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionRolloverTests.cs
@@ -1,0 +1,214 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Outbox;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Scheduling;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// A new usage window getting its zero-usage documents the moment it opens.
+/// </summary>
+/// <remarks>
+/// This is the guarantee a direct consumer depends on and cannot work around. The API falls back to
+/// the counters when the projection cannot answer; something reading the collection over Mongo has no
+/// fallback, so at one minute past midnight on a new period it would see either nothing for a
+/// periodic meter or — worse, because it looks like an answer — only the never-resetting ones.
+/// <para>
+/// The previous version of this hooked the closure handler behind
+/// <c>work.AggregateId</c> being set. Nothing in the module calls
+/// <c>ScheduleUsagePeriodClosureAsync</c>, so every closure item comes from the repair sweep and names
+/// no subscription: the hook never ran. These tests exercise the handler the way the queue actually
+/// invokes it — a tenant-wide item with no aggregate id — so that mistake cannot be made again
+/// silently.
+/// </para>
+/// </remarks>
+public sealed class UsageProjectionRolloverTests
+{
+    private const string TenantId = "tenant-1";
+
+    private readonly Mock<ISubscriptionUsageRatingProcessor> _rating = new();
+    private readonly Mock<IUsageProjectionReconciler> _projections = new();
+    private readonly List<string> _capturedBeforeClosure = [];
+    private bool _closed;
+
+    public UsageProjectionRolloverTests()
+    {
+        _projections
+            .Setup(reconciler => reconciler.ListRollingSubscriptionsAsync(
+                TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                // Answers only while the window is still open, the way the real due query does: a
+                // closure advances the subscription's usage billing clock, after which nothing is
+                // due and the roster of who just rolled is gone.
+                _capturedBeforeClosure.Add(_closed ? "after" : "before");
+
+                return _closed ? [] : ["sub-1", "sub-2"];
+            });
+
+        _rating
+            .Setup(processor => processor.CloseDuePeriodsAsync(
+                TenantId, It.IsAny<CancellationToken>()))
+            .Callback(() => _closed = true)
+            .ReturnsAsync(0);
+    }
+
+    /// <summary>
+    /// The bug, as a test: the queue only ever delivers a tenant-wide closure item, and the rollover
+    /// refresh has to happen on that path.
+    /// </summary>
+    [Fact]
+    public async Task A_tenant_wide_closure_publishes_the_new_windows()
+    {
+        await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+
+        _projections.Verify(
+            reconciler => reconciler.RefreshManyAsync(
+                TenantId,
+                It.Is<IReadOnlyList<string>>(ids => ids.Count == 2 && ids.Contains("sub-1")),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Captured before the closure, because afterwards there is no record of who rolled.
+    /// </summary>
+    [Fact]
+    public async Task The_rolling_subscriptions_are_captured_before_the_closure_runs()
+    {
+        await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+
+        // Asking after the closure returns nothing, and the new windows would never be published.
+        _capturedBeforeClosure.Should().ContainSingle().Which.Should().Be("before");
+    }
+
+    /// <summary>Published after, so the window it resolves is the new one rather than the closed one.</summary>
+    [Fact]
+    public async Task The_new_windows_are_published_after_the_closure_commits()
+    {
+        var order = new List<string>();
+
+        _rating
+            .Setup(processor => processor.CloseDuePeriodsAsync(
+                TenantId, It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                _closed = true;
+                order.Add("close");
+            })
+            .ReturnsAsync(0);
+
+        _projections
+            .Setup(reconciler => reconciler.RefreshManyAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("publish"))
+            .ReturnsAsync(2);
+
+        await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+
+        order.Should().Equal("close", "publish");
+    }
+
+    /// <summary>
+    /// Rating must not be retried because a read model could not be written. The closure has
+    /// committed by then, and retrying it would re-rate a period.
+    /// </summary>
+    [Fact]
+    public async Task A_failed_projection_refresh_does_not_fail_the_closure_item()
+    {
+        _projections
+            .Setup(reconciler => reconciler.RefreshManyAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("the projection write failed"));
+
+        var act = async () => await Handler()
+            .ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+
+        // The reconciler absorbs its own failures, so this asserts the handler does not add a path
+        // that turns one into a retry of the rating.
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            "this test documents that the handler itself does not catch — the reconciler does, and " +
+            "if that ever stops being true the closure would start retrying");
+    }
+
+    /// <summary>
+    /// A subscription named on the item is refreshed even when it was not in the due set, and is not
+    /// refreshed twice when it was.
+    /// </summary>
+    [Fact]
+    public async Task A_named_subscription_is_refreshed_once_and_not_twice()
+    {
+        await Handler().ExecuteAsync(Work(aggregateId: "sub-9"), CancellationToken.None);
+
+        _projections.Verify(
+            reconciler => reconciler.RefreshSubscriptionAsync(
+                TenantId, "sub-9", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _projections.Invocations.Clear();
+
+        // Reset, because the first run above closed the window and the due list is empty afterwards.
+        // Without this the second run sees no rolling set at all and the assertion below would pass
+        // for the wrong reason.
+        _closed = false;
+
+        await Handler().ExecuteAsync(Work(aggregateId: "sub-1"), CancellationToken.None);
+
+        _projections.Verify(
+            reconciler => reconciler.RefreshSubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "sub-1 is already in the batch, and refreshing it twice writes the same document twice");
+    }
+
+    /// <summary>
+    /// Nothing due is the ordinary case — the sweep announces closure on a timer — so it must not
+    /// cost a projection write.
+    /// </summary>
+    [Fact]
+    public async Task Nothing_due_publishes_nothing()
+    {
+        _projections
+            .Setup(reconciler => reconciler.ListRollingSubscriptionsAsync(
+                TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+
+        _projections.Verify(
+            reconciler => reconciler.RefreshManyAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private UsagePeriodClosureWorkHandler Handler() =>
+        new(_rating.Object, _projections.Object);
+
+    private static SubscriptionBackgroundWork Work(string aggregateId) => new()
+    {
+        ItemId = "work-1",
+        TenantId = TenantId,
+        AggregateId = aggregateId,
+        WorkType = SubscriptionWorkType.UsagePeriodClosure,
+        CorrelationId = "corr-1"
+    };
+}

--- a/server/XUnitTest/Subscription/UsageProjectionRolloverTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionRolloverTests.cs
@@ -1,16 +1,9 @@
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
-using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
-using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Scheduling;
-using Subscription.DomainService.Services;
-using Subscription.DomainService.Utilities;
-using XUnitTest.Payment;
 
 namespace XUnitTest.Subscription;
 
@@ -23,12 +16,10 @@ namespace XUnitTest.Subscription;
 /// fallback, so at one minute past midnight on a new period it would see either nothing for a
 /// periodic meter or — worse, because it looks like an answer — only the never-resetting ones.
 /// <para>
-/// The previous version of this hooked the closure handler behind
-/// <c>work.AggregateId</c> being set. Nothing in the module calls
-/// <c>ScheduleUsagePeriodClosureAsync</c>, so every closure item comes from the repair sweep and names
-/// no subscription: the hook never ran. These tests exercise the handler the way the queue actually
-/// invokes it — a tenant-wide item with no aggregate id — so that mistake cannot be made again
-/// silently.
+/// Two mistakes were made here before, and both are pinned below. The refresh was first gated on the
+/// queue item naming a subscription, which nothing does — every closure item comes from the repair
+/// sweep — so it never ran. It was then driven by a second due query, which is not the set the closure
+/// actually closed.
 /// </para>
 /// </remarks>
 public sealed class UsageProjectionRolloverTests
@@ -37,62 +28,72 @@ public sealed class UsageProjectionRolloverTests
 
     private readonly Mock<ISubscriptionUsageRatingProcessor> _rating = new();
     private readonly Mock<IUsageProjectionReconciler> _projections = new();
-    private readonly List<string> _capturedBeforeClosure = [];
-    private bool _closed;
+    private readonly Mock<ISubscriptionWorkScheduler> _scheduler = new();
 
-    public UsageProjectionRolloverTests()
-    {
-        _projections
-            .Setup(reconciler => reconciler.ListRollingSubscriptionsAsync(
-                TenantId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
-            {
-                // Answers only while the window is still open, the way the real due query does: a
-                // closure advances the subscription's usage billing clock, after which nothing is
-                // due and the roster of who just rolled is gone.
-                _capturedBeforeClosure.Add(_closed ? "after" : "before");
-
-                return _closed ? [] : ["sub-1", "sub-2"];
-            });
-
-        _rating
-            .Setup(processor => processor.CloseDuePeriodsAsync(
-                TenantId, It.IsAny<CancellationToken>()))
-            .Callback(() => _closed = true)
-            .ReturnsAsync(0);
-    }
+    public UsageProjectionRolloverTests() => Closes("sub-1", "sub-2");
 
     /// <summary>
-    /// The bug, as a test: the queue only ever delivers a tenant-wide closure item, and the rollover
-    /// refresh has to happen on that path.
+    /// The refresh set comes from the closure's own committed outcome.
     /// </summary>
+    /// <remarks>
+    /// Not from a second due query. That query has its own batch size and its own <c>now</c>, and by
+    /// the time it runs the clocks have advanced — so it could name subscriptions that were not closed
+    /// and miss ones that were.
+    /// </remarks>
     [Fact]
-    public async Task A_tenant_wide_closure_publishes_the_new_windows()
+    public async Task Exactly_the_subscriptions_the_closure_rolled_are_refreshed()
     {
-        await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+        await Handler().ExecuteAsync(Work(), CancellationToken.None);
 
         _projections.Verify(
             reconciler => reconciler.RefreshManyAsync(
                 TenantId,
-                It.Is<IReadOnlyList<string>>(ids => ids.Count == 2 && ids.Contains("sub-1")),
+                It.Is<IReadOnlyList<string>>(ids =>
+                    ids.Count == 2 && ids.Contains("sub-1") && ids.Contains("sub-2")),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
     /// <summary>
-    /// Captured before the closure, because afterwards there is no record of who rolled.
+    /// A subscription the closure did not roll is not refreshed: its window did not move, so nothing
+    /// about its current projection changed. That covers the one deferred by an outstanding usage
+    /// claim, which rating skips and picks up on a later pass — and which a second due query would
+    /// have named.
     /// </summary>
     [Fact]
-    public async Task The_rolling_subscriptions_are_captured_before_the_closure_runs()
+    public async Task A_due_subscription_that_closed_nothing_is_not_refreshed()
+    {
+        await Handler().ExecuteAsync(Work(), CancellationToken.None);
+
+        _projections.Verify(
+            reconciler => reconciler.RefreshManyAsync(
+                It.IsAny<string>(),
+                It.Is<IReadOnlyList<string>>(ids => !ids.Contains("sub-deferred")),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// The queue only ever delivers a tenant-wide closure item, so the refresh has to happen on that
+    /// path. Gated on the aggregate id, as it once was, this never ran at all.
+    /// </summary>
+    [Fact]
+    public async Task A_tenant_wide_item_with_no_aggregate_id_still_publishes()
     {
         await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
 
-        // Asking after the closure returns nothing, and the new windows would never be published.
-        _capturedBeforeClosure.Should().ContainSingle().Which.Should().Be("before");
+        _projections.Verify(
+            reconciler => reconciler.RefreshManyAsync(
+                TenantId,
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
-    /// <summary>Published after, so the window it resolves is the new one rather than the closed one.</summary>
+    /// <summary>Published after the closure, so the window it resolves is the new one.</summary>
     [Fact]
     public async Task The_new_windows_are_published_after_the_closure_commits()
     {
@@ -101,12 +102,8 @@ public sealed class UsageProjectionRolloverTests
         _rating
             .Setup(processor => processor.CloseDuePeriodsAsync(
                 TenantId, It.IsAny<CancellationToken>()))
-            .Callback(() =>
-            {
-                _closed = true;
-                order.Add("close");
-            })
-            .ReturnsAsync(0);
+            .Callback(() => order.Add("close"))
+            .ReturnsAsync(new UsagePeriodClosureOutcome(1, ["sub-1"]));
 
         _projections
             .Setup(reconciler => reconciler.RefreshManyAsync(
@@ -115,19 +112,63 @@ public sealed class UsageProjectionRolloverTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .Callback(() => order.Add("publish"))
-            .ReturnsAsync(2);
+            .ReturnsAsync(1);
 
-        await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+        await Handler().ExecuteAsync(Work(), CancellationToken.None);
 
-        order.Should().Equal("close", "publish");
+        order.Should().Equal(["close", "publish"]);
     }
 
     /// <summary>
-    /// Rating must not be retried because a read model could not be written. The closure has
-    /// committed by then, and retrying it would re-rate a period.
+    /// A projection failure must not decide whether authoritative rating work is done.
     /// </summary>
+    /// <remarks>
+    /// The closure has committed by the time the refresh runs. Letting the failure out would retry
+    /// the closure item, so a derived read model would be controlling whether a rating pass counts as
+    /// complete.
+    /// <para>
+    /// The earlier version of this test asserted the exception <em>was</em> thrown, under a name
+    /// saying it was not — it documented the bug as though it were the design.
+    /// </para>
+    /// </remarks>
     [Fact]
     public async Task A_failed_projection_refresh_does_not_fail_the_closure_item()
+    {
+        FailTheRefresh();
+
+        var outcome = await Handler().ExecuteAsync(Work(), CancellationToken.None);
+
+        outcome.Result.Should().Be(SubscriptionWorkResult.Completed);
+        outcome.ErrorCode.Should().BeNull();
+    }
+
+    /// <summary>And the projection is not simply abandoned: a repair is announced per subscription.</summary>
+    [Fact]
+    public async Task A_failed_projection_refresh_schedules_a_repair_for_each_rolled_subscription()
+    {
+        FailTheRefresh();
+
+        await Handler().ExecuteAsync(Work(), CancellationToken.None);
+
+        foreach (var subscriptionId in new[] { "sub-1", "sub-2" })
+        {
+            _scheduler.Verify(
+                scheduler => scheduler.ScheduleUsageProjectionRefreshAsync(
+                    TenantId,
+                    It.IsAny<string>(),
+                    subscriptionId,
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+
+    /// <summary>
+    /// Cancellation is the worker shutting down, not a projection problem, so it propagates and the
+    /// item is left to be reclaimed rather than reported complete.
+    /// </summary>
+    [Fact]
+    public async Task Cancellation_is_not_swallowed()
     {
         _projections
             .Setup(reconciler => reconciler.RefreshManyAsync(
@@ -135,59 +176,52 @@ public sealed class UsageProjectionRolloverTests
                 It.IsAny<IReadOnlyList<string>>(),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("the projection write failed"));
+            .ThrowsAsync(new OperationCanceledException());
 
-        var act = async () => await Handler()
-            .ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
+        var act = async () => await Handler().ExecuteAsync(Work(), CancellationToken.None);
 
-        // The reconciler absorbs its own failures, so this asserts the handler does not add a path
-        // that turns one into a retry of the rating.
-        await act.Should().ThrowAsync<InvalidOperationException>(
-            "this test documents that the handler itself does not catch — the reconciler does, and " +
-            "if that ever stops being true the closure would start retrying");
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
     /// <summary>
-    /// A subscription named on the item is refreshed even when it was not in the due set, and is not
-    /// refreshed twice when it was.
+    /// A subscription named on the item is refreshed even when the closure did not roll it, and is
+    /// not listed twice when it did.
     /// </summary>
     [Fact]
-    public async Task A_named_subscription_is_refreshed_once_and_not_twice()
+    public async Task A_named_subscription_is_added_once()
     {
         await Handler().ExecuteAsync(Work(aggregateId: "sub-9"), CancellationToken.None);
 
         _projections.Verify(
-            reconciler => reconciler.RefreshSubscriptionAsync(
-                TenantId, "sub-9", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            reconciler => reconciler.RefreshManyAsync(
+                TenantId,
+                It.Is<IReadOnlyList<string>>(ids => ids.Count == 3 && ids.Contains("sub-9")),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
             Times.Once);
 
         _projections.Invocations.Clear();
 
-        // Reset, because the first run above closed the window and the due list is empty afterwards.
-        // Without this the second run sees no rolling set at all and the assertion below would pass
-        // for the wrong reason.
-        _closed = false;
-
         await Handler().ExecuteAsync(Work(aggregateId: "sub-1"), CancellationToken.None);
 
         _projections.Verify(
-            reconciler => reconciler.RefreshSubscriptionAsync(
-                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never,
-            "sub-1 is already in the batch, and refreshing it twice writes the same document twice");
+            reconciler => reconciler.RefreshManyAsync(
+                TenantId,
+                It.Is<IReadOnlyList<string>>(ids => ids.Count == 2),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "sub-1 was already rolled, and one document must not be written twice");
     }
 
     /// <summary>
-    /// Nothing due is the ordinary case — the sweep announces closure on a timer — so it must not
+    /// Nothing rolled is the ordinary case — the sweep announces closure on a timer — so it must not
     /// cost a projection write.
     /// </summary>
     [Fact]
-    public async Task Nothing_due_publishes_nothing()
+    public async Task Nothing_rolled_publishes_nothing()
     {
-        _projections
-            .Setup(reconciler => reconciler.ListRollingSubscriptionsAsync(
-                TenantId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
+        Closes();
 
         await Handler().ExecuteAsync(Work(aggregateId: ""), CancellationToken.None);
 
@@ -200,13 +234,35 @@ public sealed class UsageProjectionRolloverTests
             Times.Never);
     }
 
-    private UsagePeriodClosureWorkHandler Handler() =>
-        new(_rating.Object, _projections.Object);
+    private void Closes(params string[] rolledSubscriptionIds) =>
+        _rating
+            .Setup(processor => processor.CloseDuePeriodsAsync(
+                TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsagePeriodClosureOutcome(
+                rolledSubscriptionIds.Length,
+                rolledSubscriptionIds));
 
-    private static SubscriptionBackgroundWork Work(string aggregateId) => new()
+    private void FailTheRefresh() =>
+        _projections
+            .Setup(reconciler => reconciler.RefreshManyAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("the projection write failed"));
+
+    private UsagePeriodClosureWorkHandler Handler() =>
+        new(
+            _rating.Object,
+            _projections.Object,
+            _scheduler.Object,
+            NullLogger<UsagePeriodClosureWorkHandler>.Instance);
+
+    private static SubscriptionBackgroundWork Work(string aggregateId = "") => new()
     {
         ItemId = "work-1",
         TenantId = TenantId,
+        OrganizationId = "org-1",
         AggregateId = aggregateId,
         WorkType = SubscriptionWorkType.UsagePeriodClosure,
         CorrelationId = "corr-1"

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -28,6 +28,8 @@ public sealed class UsageRecordingServiceTests
     private readonly Mock<IUsagePeriodClosureRepository> _closures = new();
     private readonly Mock<ISubscriptionContextResolver> _contextResolver = new();
     private readonly Mock<IUsageThresholdEvaluator> _thresholds = new();
+    private readonly Mock<IUsageProjectionPublisher> _projection = new();
+    private readonly Mock<ISubscriptionUsageCurrentRepository> _current = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
 
@@ -101,6 +103,31 @@ public sealed class UsageRecordingServiceTests
             .Setup(repository => repository.ListCountersAsync(
                 TenantId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(() => []);
+
+        // The batch the current-usage read uses. Answers for whatever ids it is handed, so a meter
+        // whose counter is absent is simply missing from the dictionary — which is how a window with
+        // no usage reaches the response as a balance of zero.
+        _usage
+            .Setup(repository => repository.GetCountersAsync(
+                TenantId,
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, IReadOnlyCollection<string> ids, CancellationToken _) =>
+                ids.ToDictionary(
+                    id => id,
+                    id => new SubscriptionUsageCounter { ItemId = id, Balance = _balance },
+                    StringComparer.Ordinal));
+
+        _projection
+            .Setup(publisher => publisher.PublishAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<PlanMeter>(),
+                It.IsAny<BillingPeriod>(),
+                It.IsAny<SubscriptionUsageCounter>(),
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UsageProjectionOutcome.Published);
     }
 
     [Fact]
@@ -425,15 +452,27 @@ public sealed class UsageRecordingServiceTests
 
         await Service().GetCurrentUsageAsync(null, "corr-1", CancellationToken.None);
 
-        _usage.Verify(repository => repository.GetCounterAsync(
-            TenantId,
-            SubscriptionUsageCounter.CreateId(
-                "sub-1", "storage", MeterPeriodResolver.LifetimePeriodKey),
-            It.IsAny<CancellationToken>()), Times.Once);
-        _usage.Verify(repository => repository.GetCounterAsync(
-            TenantId,
-            It.Is<string>(id => id.StartsWith("sub-1:screening:M", StringComparison.Ordinal)),
-            It.IsAny<CancellationToken>()), Times.Once);
+        // One batch for every meter, not one point read per meter.
+        //
+        // The two ids in it are also why the batch cannot be filtered by a single period key: a
+        // never-reset capacity meter is addressed under LIFETIME while its periodic neighbour uses
+        // the billing schedule's key, so one subscription's meters do not share a period. Filtering
+        // by either one would have returned nothing for the other and reported it as unused.
+        _usage.Verify(
+            repository => repository.GetCountersAsync(
+                TenantId,
+                It.Is<IReadOnlyCollection<string>>(ids =>
+                    ids.Count == 2 &&
+                    ids.Contains(SubscriptionUsageCounter.CreateId(
+                        "sub-1", "storage", MeterPeriodResolver.LifetimePeriodKey)) &&
+                    ids.Any(id => id.StartsWith("sub-1:screening:M", StringComparison.Ordinal))),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _usage.Verify(
+            repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the read must not fall back to a query per meter");
     }
 
     [Fact]
@@ -470,6 +509,8 @@ public sealed class UsageRecordingServiceTests
         new MeterAllowanceResolver(_usage.Object),
         _contextResolver.Object,
         _thresholds.Object,
+        _projection.Object,
+        _current.Object,
         new RecordUsageRequestValidator(new OptionsStub()),
         new OptionsStub(),
         NullLogger<UsageRecordingService>.Instance,

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -8,6 +8,8 @@ using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Scheduling;
 using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 using Subscription.DomainService.Validators;
@@ -30,6 +32,7 @@ public sealed class UsageRecordingServiceTests
     private readonly Mock<IUsageThresholdEvaluator> _thresholds = new();
     private readonly Mock<IUsageProjectionPublisher> _projection = new();
     private readonly Mock<ISubscriptionUsageCurrentRepository> _current = new();
+    private readonly Mock<ISubscriptionWorkScheduler> _scheduler = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
 
@@ -502,6 +505,174 @@ public sealed class UsageRecordingServiceTests
             "SubscriptionContextResolver — this only proves the value reaches it");
     }
 
+    /// <summary>
+    /// The projection may only answer when it holds every current window.
+    /// </summary>
+    /// <remarks>
+    /// This subscription has two meters. With one document published, the earlier version of this
+    /// returned that one meter and silently omitted the other — a caller drawing a usage screen from
+    /// it would have shown half the meters, with nothing in the body to say so. Falling back is for
+    /// the whole request, because a subset is not equivalent data.
+    /// </remarks>
+    [Fact]
+    public async Task A_partly_published_projection_falls_back_to_the_counters_for_the_whole_request()
+    {
+        AddLifetimeMeter();
+
+        _current
+            .Setup(repository => repository.ListCurrentAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Projected("screening")]);
+
+        var read = await Service().ReadCurrentAsync(
+            null, UsageReadMode.Projection, "corr-1", CancellationToken.None);
+
+        read.IsSuccess.Should().BeTrue();
+        read.Value!.Items.Should().HaveCount(2, "both meters, from the counters");
+        read.Value.Diagnostics.ActualMode.Should().Be(UsageReadMode.Authoritative);
+        read.Value.Diagnostics.Fallback.Should().Be(UsageReadFallback.ProjectionPartial);
+    }
+
+    /// <summary>An incomplete projection is a lost write, so it is repaired and not merely reported.</summary>
+    [Fact]
+    public async Task A_partly_published_projection_schedules_a_repair()
+    {
+        AddLifetimeMeter();
+
+        _current
+            .Setup(repository => repository.ListCurrentAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Projected("screening")]);
+
+        await Service().ReadCurrentAsync(
+            null, UsageReadMode.Projection, "corr-1", CancellationToken.None);
+
+        _scheduler.Verify(
+            scheduler => scheduler.ScheduleUsageProjectionRefreshAsync(
+                TenantId, OrganizationId, "sub-1", "corr-1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Nothing published is a different situation from some published, and is reported as such: it is
+    /// a subscription the projection has never covered, which is a backfill matter rather than a lost
+    /// write.
+    /// </summary>
+    [Fact]
+    public async Task An_empty_projection_falls_back_and_says_it_was_empty_rather_than_partial()
+    {
+        AddLifetimeMeter();
+
+        _current
+            .Setup(repository => repository.ListCurrentAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var read = await Service().ReadCurrentAsync(
+            null, UsageReadMode.Projection, "corr-1", CancellationToken.None);
+
+        read.Value!.Items.Should().HaveCount(2);
+        read.Value.Diagnostics.Fallback.Should().Be(UsageReadFallback.ProjectionEmpty);
+        _scheduler.Verify(
+            scheduler => scheduler.ScheduleUsageProjectionRefreshAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a subscription the projection has never covered is not a lost write");
+    }
+
+    [Fact]
+    public async Task A_complete_projection_answers_the_read_without_touching_the_counters()
+    {
+        AddLifetimeMeter();
+
+        _current
+            .Setup(repository => repository.ListCurrentAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Projected("screening"), Projected("storage")]);
+
+        var read = await Service().ReadCurrentAsync(
+            null, UsageReadMode.Projection, "corr-1", CancellationToken.None);
+
+        read.Value!.Items.Should().HaveCount(2);
+        read.Value.Diagnostics.ActualMode.Should().Be(UsageReadMode.Projection);
+        read.Value.Diagnostics.Fallback.Should().Be(UsageReadFallback.None);
+
+        _usage.Verify(
+            repository => repository.GetCountersAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyCollection<string>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "answering from the projection is the entire point of the mode");
+    }
+
+    /// <summary>
+    /// The default is unchanged, so no existing caller of this endpoint starts depending on a read
+    /// model having been published.
+    /// </summary>
+    [Fact]
+    public async Task The_default_read_is_authoritative()
+    {
+        var read = await Service().ReadCurrentAsync(
+            null, UsageReadMode.Authoritative, "corr-1", CancellationToken.None);
+
+        read.Value!.Diagnostics.ActualMode.Should().Be(UsageReadMode.Authoritative);
+        read.Value.Diagnostics.Fallback.Should().Be(UsageReadFallback.None);
+
+        _current.Verify(
+            repository => repository.ListCurrentAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Gives the subscription a second meter, so "the projection holds every window" is a claim about
+    /// two of them rather than one. With a single meter, a partly-published projection cannot exist.
+    /// </summary>
+    private void AddLifetimeMeter() =>
+        _subscription.Plan.Meters.Add(new PlanMeter
+        {
+            MeterKey = "storage",
+            UnitLabel = "byte",
+            IncludedQuantity = 5_000,
+            ResetPolicy = MeterResetPolicy.Never
+        });
+
+    private static SubscriptionUsageCurrent Projected(string meterKey) => new()
+    {
+        ItemId = $"sub-1:{meterKey}:P",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        SubscriptionId = "sub-1",
+        MeterKey = meterKey,
+        UnitLabel = meterKey,
+        PeriodKey = "P",
+        PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        PeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        Included = 500,
+        Used = 3,
+        Remaining = 497,
+        UpdatedAtUtc = new DateTime(2026, 8, 14, 11, 59, 0, DateTimeKind.Utc)
+    };
+
     private UsageRecordingService Service() => new(
         _subscriptions.Object,
         _usage.Object,
@@ -511,6 +682,7 @@ public sealed class UsageRecordingServiceTests
         _thresholds.Object,
         _projection.Object,
         _current.Object,
+        _scheduler.Object,
         new RecordUsageRequestValidator(new OptionsStub()),
         new OptionsStub(),
         NullLogger<UsageRecordingService>.Instance,


### PR DESCRIPTION
# Immediate subscription usage read model

`SubscriptionUsageCurrent` — one document per subscription, meter and usage period, in the **tenant's
own database**, published synchronously by the call that moved the counter. It turns "how much is
left?" into a single indexed read.

## Grounded before anything was written

Every load-bearing premise in the brief was checked against the code rather than assumed:

| Premise | Verified |
| --- | --- |
| No Mongo transactions available | ✅ zero `StartSession` / `WithTransaction` in the repo |
| `AppliedRecordCount` usable as a monotonic `sourceVersion` | ✅ `TryRepairCounterAsync` filters `AppliedRecordCount < new`, so it **only rises**; `ApplyDeltaAsync` does `.Inc(…, 1)` |
| A durable queue exists for the repair job | ✅ `ISubscriptionWorkScheduler.TryScheduleAsync`, idempotent per `workKey` |
| Reversal already leaves the corrected balance | ✅ `RefuseAsync` appends a compensating entry then `ApplyDeltaAsync(-delta)` |
| A retention policy to follow | ✅ `CounterRetentionDays = 400`, TTL on `ExpiresAtUtc` |
| `GET /current` already exists | ✅ so `readMode` is a **parameter on it**, not a new route |

## Three problems in the brief, and what I did about them

### 1 · Batching "all current counters" by period key would have broken lifetime meters

`MeterPeriodResolver` gives a `MeterResetPolicy.Never` meter the period key `LIFETIME`; every other
meter uses the billing schedule's key. **One subscription's meters do not share a period.** The
existing `ListCountersAsync` takes a *single* period key, so batching through it would have returned
nothing for capacity meters and reported them as `0` used.

Batched by **composed counter id** instead. This wasn't theoretical — the existing test at
`UsageRecordingServiceTests` already asserted one point read for `sub-1:storage:LIFETIME` and another
for `sub-1:screening:M…`, which is exactly the two-period case. That test now asserts the batch, and
also asserts `GetCounterAsync` is never called, so a silent regression to N+1 fails.

### 2 · The `503` would have let a read model veto a committed billing write

The brief's own principle is that the counter is the authority and the projection is "informational".
But `503 subscription_usage_projection_pending` fires *after* usage has committed — so a projection
blip fails an authoritative write. A caller treating non-2xx as "not recorded" either retries under a
new idempotency key (**double-count**) or, with `enforce: true`, refuses the end user's action for a
reason unrelated to their allowance.

**I asked before building.** Confirmed: return `200` with the authoritative result and
`projection: "Pending"`, plus a scheduled repair.

**This deviates from a named acceptance criterion** ("Projection failure after committed usage returns
the explicit pending error"). The repair job half is implemented and tested; the error-status half is
deliberately not. Say the word and I'll add it behind an opt-in request flag.

### 3 · The read-only credential cannot be created from this repository

There is no Agent Microservice here — the `Agent` matches are MagicLink user-agent strings. A Mongo
role scoped to one collection is provisioned where database users are managed. What this PR *can* do,
and does: keep the projection in **its own collection** so the grant is expressible at all. Granting
a reader `SubscriptionUsageCounters` would hand it the enforcement authority for metered billing.
The README says plainly that provisioning is elsewhere rather than implying it's done.

## Correctness

**Derived, never computed.** `used`, `remaining`, `overage` are copied from the counter result. Nothing
increments this document — a projection with its own arithmetic would be a second set of billing rules
that disagreed with the bill exactly when it mattered.

**Highest version wins, not last writer.** The upsert is conditional on `sourceVersion`. A request
delayed between its counter update and its publish cannot overwrite a newer balance.

I also caught a flaw in my own first version of that upsert: with `IsUpsert`, a *stale* publish
matches nothing, so Mongo attempts an insert carrying the same composed `_id` — meaning **every**
losing race would have thrown a duplicate-key exception. Restructured to update-then-insert, so
losing the version race is a plain "modified nothing" and exceptions are left for the one genuine
race.

**Published last.** After every branch that could still reverse the balance, so a reader never sees
the momentary exceeded figure an enforced refusal passes through. A refusal publishes the
post-reversal balance — the same figure the caller is told.

**The untransactable gap.** A process dying between the counter write and the publish leaves nothing
to announce the miss. Four paths cover it:

| Path | Covers |
| --- | --- |
| Synchronous publish, briefly retried for transient Mongo errors | the ordinary case |
| `UsageProjectionRefresh` queue item on publish failure | a failure the request saw |
| Version-comparison sweep in `SubscriptionRepairAnnouncer` | a miss nothing announced |
| Projection read falls back to counters when nothing is published | a subscription never published |

The sweep is reconciled **inline** in the announcer, following the two precedents already there
(stale closures, campaign redemptions) and for the strongest version of their reason: it writes one
derived collection that no billing decision reads, so it cannot move money even by accident.

**What the sweep does *not* find**, stated rather than glossed: a projection never written at all. It
reads the projection collection, so a missing document is invisible to it. Covered by the three other
paths, which is why finding it here would mean a new index and a new per-tenant scan of the hot
counter collection to repair something already handled three ways.

## Nothing existing breaks

- `readMode` **defaults to authoritative** — the endpoint's existing behaviour, unchanged.
- Diagnostics go on `X-Usage-Read-*` **headers**, not in the body, so both modes keep the identical
  `UsageResponse[]` contract. An unrecognised `readMode` is refused (`400`) rather than defaulted, so
  a misspelled `projection` can't quietly measure the wrong path.
- `GetCurrentUsageAsync` is kept and delegates to the new method; `UsageResponse.Projection` is an
  additive field.
- Every new collaborator is an **optional** constructor argument, so existing callers and hand-built
  test fixtures compile and behave as before.
- Projection reads return only meters the plan still defines — a projected document outlives a plan
  change until its refresh runs.

## Verification

| | |
| --- | --- |
| Unit suite | **3369 passed, 5 failed** — the unchanged pre-existing baseline |
| New unit tests | 20 (`UsageProjectionPublisherTests` + the reworked batch assertions) |
| New integration tests | 16, added to the CI filter |
| `dotnet build` Api + XUnitTest | clean |

The 5 failures are the known baseline: 4 `SubscriptionSimulation*` permission-guard and 1
`FinancialDocumentRendererHealthMonitorTests`. Confirmed present on `dev` before this branch.

**Docker isn't running here, so the 16 integration tests are built and filtered but not executed
locally.** They are in `subscription-scheduling-integration.yml` — without that they'd run nowhere,
which has bitten this repo three times. CI provides `mongo:8.0`; I'll report the count verbatim, and
if any fail I'll say so rather than re-running.

They cover what only a real database can prove: the version condition both ways, the unique index,
the insert-only seed, the boundary query at an exact period boundary, tenant and organization
isolation, a lifetime window always being current, and **sixteen concurrent publishes in scrambled
version order ending at the highest rather than the last**.

## Not in this PR

Stated plainly rather than implied:

- **Load tests** comparing p50/p95/p99 across modes. The endpoint now emits duration and mode on every
  read, which is what a load test would measure, but no benchmark harness is included.
- **Metrics.** Structured logging is in (slow and stale always logged, ordinary reads sampled to
  debug); no counter/histogram registration.
- **Explicit refresh hooks** on plan change, quantity change, cancellation and status change. These are
  reached by the version sweep rather than announced at each point of change. That is slower — one
  sweep interval — and it avoids touching four money paths for a read model. Activation and period
  rollover *are* hooked directly, since they create documents the sweep cannot find.
- **`UsageResponse.Projection` is not set on the projection read path** — it describes a write, and a
  read performs none.
