### PR TITLE
feat(subscription): let a meter count in fractions, opt-in per meter

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -74,6 +74,14 @@ jobs:
       # silently keeps the old annual figures, and the money has already moved by the time anyone
       # could notice. Left out of this filter that would be demonstrated nowhere.
       #
+      # FractionalUsageQuantityIntegrationTests is named because the claim that fractional
+      # quantities need no data migration is a claim about a MongoDB write and nothing else: an
+      # $inc carrying a Decimal128 onto a field that currently holds a NumberLong has to promote
+      # that field in place. Every counter and ledger row already written holds NumberLong, so if
+      # that were false the append-only usage ledger would have to be rewritten — and that ledger
+      # is the authority every past invoice was computed from. A mocked repository demonstrates
+      # none of it.
+      #
       # Several integration classes are still outside this filter and so run nowhere. Widening it
       # further belongs in its own change, since whatever it turns up would arrive as unrelated
       # failures on whichever pull request happened to widen it.
@@ -81,5 +89,5 @@ jobs:
         run: >-
           dotnet test server/XUnitTest/XUnitTest.csproj
           --no-restore
-          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests|FullyQualifiedName~OpeningStubUpgradeRecoveryIntegrationTests|FullyQualifiedName~SubscriptionUsageCurrentIntegrationTests"
+          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests|FullyQualifiedName~OpeningStubUpgradeRecoveryIntegrationTests|FullyQualifiedName~SubscriptionUsageCurrentIntegrationTests|FullyQualifiedName~FractionalUsageQuantityIntegrationTests"
           --verbosity minimal

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../constants/subscription.constants";
 import type { PlanPrice } from "../../models/subscription-plan.model";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import { METER_QUANTITY_MAX_SCALE, stepFor } from "../../utilities/meter-quantity";
 import { CardListItem, CardListShell } from "./card-list-shell";
 import { MeterRateTableFields } from "./meter-rate-table-fields";
 import { PlanPriceFields } from "./plan-price-fields";
@@ -207,6 +208,7 @@ export const StepPricingModel = ({
               unitLabel: "",
               aggregation: 0,
               resetPolicy: 0,
+              quantityScale: 0,
               includedQuantity: 0,
               overageAllowed: true,
               thresholdPercents: [],
@@ -259,6 +261,24 @@ export const StepPricingModel = ({
               </div>
               <FormField
                 control={control}
+                name={`meters.${index}.quantityScale`}
+                render={({ field: inputField }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Decimal places</FormLabel>
+                    <FormControl>
+                      <Input {...inputField} type="number" min={0} max={METER_QUANTITY_MAX_SCALE} />
+                    </FormControl>
+                    <p className="text-xs text-muted-foreground">
+                      Leave at 0 to count whole units. Raise it for a meter measured in fractions,
+                      such as gigabytes or hours — 3 accepts 512.5 and 0.001, and refuses anything
+                      finer.
+                    </p>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
                 name={`meters.${index}.includedQuantity`}
                 render={({ field: inputField }) => (
                   <FormItem>
@@ -268,7 +288,14 @@ export const StepPricingModel = ({
                         : "Included per period"}
                     </FormLabel>
                     <FormControl>
-                      <Input {...inputField} type="number" min={0} />
+                      {/* Stepped to the meter's own granularity. Without it the browser's own
+                          number validation refuses a fraction before the form's ever sees it. */}
+                      <Input
+                        {...inputField}
+                        type="number"
+                        min={0}
+                        step={stepFor(meterValues?.[index]?.quantityScale ?? 0)}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -329,7 +356,8 @@ export const StepPricingModel = ({
                           {...inputField}
                           value={inputField.value ?? ""}
                           type="number"
-                          min={1}
+                          min={stepFor(meterValues?.[index]?.quantityScale ?? 0)}
+                          step={stepFor(meterValues?.[index]?.quantityScale ?? 0)}
                         />
                       </FormControl>
                       <p className="text-xs text-muted-foreground">

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui-kits/select/select";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import { stepFor } from "../../utilities/meter-quantity";
 import { CardListItem, CardListShell } from "./card-list-shell";
 
 /** Not a server value — selecting this clears the trial fields entirely. */
@@ -53,6 +54,13 @@ export const StepTrial = () => {
     name: "trialRequiresPaymentMethod",
   });
   const meters = useWatch({ control, name: "meters" });
+  const grantValues = useWatch({ control, name: "trialGrants" });
+
+  // Zero — whole units — until a meter is chosen, matching how the server reads a meter that
+  // declared no scale.
+  const scaleOfNamedMeter = (index: number) =>
+    (meters ?? []).find((meter) => meter.meterKey === grantValues?.[index]?.meterKey)
+      ?.quantityScale ?? 0;
 
   return (
     <div className="space-y-5">
@@ -207,7 +215,14 @@ export const StepTrial = () => {
                     <FormItem>
                       <FormLabel className="text-xs">Included during trial</FormLabel>
                       <FormControl>
-                        <Input {...inputField} type="number" min={0} />
+                        {/* Stepped to the granularity of the meter this grant replaces, since a
+                            grant it cannot hold is refused. */}
+                        <Input
+                          {...inputField}
+                          type="number"
+                          min={0}
+                          step={stepFor(scaleOfNamedMeter(index))}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
+++ b/client/app/cross-modules/utilities/subscription/models/subscription-plan.model.ts
@@ -115,6 +115,13 @@ export interface PlanMeter {
    * CarryForward meters reset but open with whatever the previous window left.
    */
   resetPolicy?: MeterResetPolicyName;
+  /**
+   * How many decimal places this meter's quantities carry. Zero means whole units only.
+   *
+   * Optional because a plan stored before fractional quantities existed has no such field, and
+   * absent has to read the same as zero — a meter that never opted in counts whole units.
+   */
+  quantityScale?: number;
   /** The most one window may carry in. Present only on a carry-forward meter. */
   carryForwardCap?: number | null;
   includedQuantity: number;
@@ -295,6 +302,7 @@ export interface CreatePlanMeterRequest {
   unitLabel: string;
   aggregation: number;
   resetPolicy: number;
+  quantityScale: number;
   carryForwardCap?: number;
   includedQuantity: number;
   overageAllowed: boolean;

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
@@ -582,4 +582,152 @@ describe("quantity discount bands", () => {
 
     expect(result.success).toBe(false);
   });
+
+  // ---------------------------------------------------------------- fractional quantities
+
+  const meter = (overrides: Record<string, unknown> = {}) => ({
+    meterKey: "storage-gb",
+    displayName: "Storage",
+    unitLabel: "GB",
+    aggregation: 0,
+    resetPolicy: 0,
+    includedQuantity: 500,
+    overageAllowed: true,
+    thresholdPercents: [],
+    rateTables: [],
+    ...overrides,
+  });
+
+  /**
+   * A meter that names no scale parses, and parses as whole units. This is the shape every meter
+   * fixture in this file and every plan already stored has, so absent has to mean zero.
+   */
+  it("defaults a meter with no declared scale to whole units", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter()],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.meters[0].quantityScale).toBe(0);
+    }
+  });
+
+  it("rejects a fractional allowance on a whole-unit meter", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ includedQuantity: 512.5 })],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["meters", 0, "includedQuantity"]);
+  });
+
+  it("accepts a fractional allowance once the meter declares the places for it", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ quantityScale: 1, includedQuantity: 512.5 })],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an allowance finer than the declared scale", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ quantityScale: 2, includedQuantity: 512.005 })],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["meters", 0, "includedQuantity"]);
+  });
+
+  it("rejects a scale beyond six places", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ quantityScale: 7 })],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  /** The band's edge would otherwise sit between two quantities the meter can represent. */
+  it("rejects a rate band bound finer than the meter's scale", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [
+        meter({
+          quantityScale: 1,
+          rateTables: [
+            {
+              currencyCode: "EUR",
+              tiers: [{ upToQuantity: 400.05, unitAmount: 1 }],
+            },
+          ],
+        }),
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual([
+      "meters",
+      0,
+      "rateTables",
+      0,
+      "tiers",
+      0,
+      "upToQuantity",
+    ]);
+  });
+
+  it("rejects a carry-forward cap finer than the meter's scale", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ quantityScale: 1, resetPolicy: 2, carryForwardCap: 50.05 })],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["meters", 0, "carryForwardCap"]);
+  });
+
+  /** A grant replaces its meter's allowance, so it is held to that meter's own scale. */
+  it("rejects a trial grant finer than its own meter's scale", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ quantityScale: 1 })],
+      trialGrants: [{ meterKey: "storage-gb", includedQuantity: 25.25 }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["trialGrants", 0, "includedQuantity"]);
+  });
+
+  it("accepts a trial grant within its own meter's scale", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ quantityScale: 2 })],
+      trialGrants: [{ meterKey: "storage-gb", includedQuantity: 25.25 }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  /**
+   * A meter's scale governs only its own quantities. A plan mixing a fractional storage meter with
+   * a whole-unit screening meter is the case this whole design exists for.
+   */
+  it("holds each meter to its own scale rather than to the plan's finest", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [
+        meter({ quantityScale: 3, includedQuantity: 512.5 }),
+        meter({ meterKey: "screening", unitLabel: "screening", includedQuantity: 0.5 }),
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["meters", 1, "includedQuantity"]);
+    expect(issuePaths(result)).not.toContainEqual(["meters", 0, "includedQuantity"]);
+  });
 });

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -12,6 +12,11 @@ import {
   subscriptionPriceFieldsSchema,
 } from "./subscription-price.schema";
 import {
+  isWithinMagnitude,
+  isWithinScale,
+  METER_QUANTITY_MAX_SCALE,
+} from "../utilities/meter-quantity";
+import {
   isRepresentableInMinorUnits,
   minorUnitExponent,
 } from "../utilities/subscription-format";
@@ -39,7 +44,7 @@ const isJsonObject = (value: string): boolean => {
 };
 
 const meterTierSchema = z.object({
-  upToQuantity: z.coerce.number().int().positive().optional(),
+  upToQuantity: z.coerce.number().positive().optional(),
   /**
    * What one unit past the allowance costs, in the currency's own units.
    *
@@ -110,8 +115,18 @@ const meterSchema = z.object({
   unitLabel: key("unit label"),
   aggregation: z.coerce.number().int().min(0).max(2),
   resetPolicy: z.coerce.number().int().min(0).max(2).default(0),
-  includedQuantity: z.coerce.number().int().min(0),
-  carryForwardCap: z.coerce.number().int().positive().optional(),
+  /**
+   * Decimal places this meter accepts. Zero is whole units only, and is the default so that a
+   * meter nobody opts in stays exactly as strict as it was before fractions existed.
+   */
+  quantityScale: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(METER_QUANTITY_MAX_SCALE)
+    .default(0),
+  includedQuantity: z.coerce.number().min(0),
+  carryForwardCap: z.coerce.number().positive().optional(),
   overageAllowed: z.boolean(),
   thresholdPercents: z.array(z.number().int().min(1).max(100)),
   rateTables: z.array(meterRateTableSchema),
@@ -258,7 +273,9 @@ const entitlementSchema = z
 
 const trialGrantSchema = z.object({
   meterKey: key("meter"),
-  includedQuantity: z.coerce.number().int().min(0),
+  // Granularity is checked against the meter this grant replaces, at plan level, because that is
+  // the only place the meter's own scale is in scope.
+  includedQuantity: z.coerce.number().min(0),
 });
 
 /** What identifies a price to the server, so two rows that would collide can be caught here. */
@@ -404,6 +421,44 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
           });
         }
 
+        // Every quantity the meter carries has to be one the meter can hold. Reported against the
+        // field that is wrong rather than against the scale, so the author is taken to the number
+        // they have to change.
+        const holds = (value: number): boolean =>
+          isWithinScale(value, meter.quantityScale) && isWithinMagnitude(value);
+
+        const tooFine = meter.quantityScale === 0
+          ? "This meter counts whole units. Raise its decimal places to accept a fraction."
+          : `This meter counts to ${meter.quantityScale} decimal places.`;
+
+        if (!holds(meter.includedQuantity)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["meters", index, "includedQuantity"],
+            message: tooFine,
+          });
+        }
+
+        if (meter.carryForwardCap !== undefined && !holds(meter.carryForwardCap)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["meters", index, "carryForwardCap"],
+            message: tooFine,
+          });
+        }
+
+        meter.rateTables.forEach((table, tableIndex) => {
+          table.tiers.forEach((tier, tierIndex) => {
+            if (tier.upToQuantity !== undefined && !holds(tier.upToQuantity)) {
+              context.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["meters", index, "rateTables", tableIndex, "tiers", tierIndex, "upToQuantity"],
+                message: tooFine,
+              });
+            }
+          });
+        });
+
         if (meter.resetPolicy === 1 && (meter.overageAllowed || meter.rateTables.length > 0)) {
           context.addIssue({
             code: z.ZodIssueCode.custom,
@@ -437,6 +492,24 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
             path: ["trialGrants", index, "meterKey"],
             message: "A lifetime capacity cannot have a separate trial allowance.",
           });
+        } else {
+          // A grant replaces its meter's allowance, so it has to be a quantity that meter can hold.
+          const meter = plan.meters.find((candidate) => candidate.meterKey === grant.meterKey);
+
+          if (
+            meter &&
+            (!isWithinScale(grant.includedQuantity, meter.quantityScale) ||
+              !isWithinMagnitude(grant.includedQuantity))
+          ) {
+            context.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["trialGrants", index, "includedQuantity"],
+              message:
+                meter.quantityScale === 0
+                  ? "This meter counts whole units."
+                  : `This meter counts to ${meter.quantityScale} decimal places.`,
+            });
+          }
         }
       });
 

--- a/client/app/cross-modules/utilities/subscription/utilities/meter-quantity.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/meter-quantity.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatQuantity,
+  isWithinMagnitude,
+  isWithinScale,
+  METER_QUANTITY_MAX_MAGNITUDE,
+  METER_QUANTITY_MAX_SCALE,
+  scaleOf,
+  stepFor,
+} from "./meter-quantity";
+
+describe("scaleOf", () => {
+  it.each([
+    [0, 0],
+    [1, 0],
+    [-7, 0],
+    [0.5, 1],
+    [512.5, 1],
+    [0.001, 3],
+    [-0.25, 2],
+  ])("reads %s as %s decimal places", (value, expected) => {
+    expect(scaleOf(value)).toBe(expected);
+  });
+
+  /**
+   * JavaScript renders anything below 1e-6 in exponent form, and 1e-6 is the first quantity a
+   * six-place meter can hold — so the boundary of what is allowed is exactly where the string
+   * representation changes shape.
+   */
+  it("reads exponent form as the places it stands for", () => {
+    expect(scaleOf(1e-7)).toBe(7);
+    expect(scaleOf(1.5e-7)).toBe(8);
+    expect(scaleOf(0.000001)).toBe(6);
+  });
+
+  it("does not count trailing zeroes, which a number never carries anyway", () => {
+    expect(scaleOf(1.5)).toBe(1);
+    expect(scaleOf(500.0)).toBe(0);
+  });
+
+  it("treats a large integer in exponent form as whole", () => {
+    expect(scaleOf(1e21)).toBe(0);
+  });
+});
+
+describe("isWithinScale", () => {
+  /** The state of every meter authored before fractions existed. */
+  it.each([
+    [100, true],
+    [0, true],
+    [0.5, false],
+    [100.1, false],
+  ])("at scale zero, %s is %s", (value, expected) => {
+    expect(isWithinScale(value, 0)).toBe(expected);
+  });
+
+  it.each([
+    [512.5, 3, true],
+    [512.001, 3, true],
+    [512.0001, 3, false],
+    [512, 3, true],
+  ])("at a declared scale, %s with %s places is %s", (value, scale, expected) => {
+    expect(isWithinScale(value, scale)).toBe(expected);
+  });
+
+  /**
+   * The check that a naive implementation gets wrong: scaling by a power of ten to look for a
+   * remainder makes 1.15 * 100 come out as 114.99999999999999.
+   */
+  it("does not report a remainder for a value binary arithmetic cannot hold", () => {
+    expect(isWithinScale(1.15, 2)).toBe(true);
+    expect(isWithinScale(8.165, 3)).toBe(true);
+  });
+
+  it("rejects anything when the scale itself is out of range", () => {
+    expect(isWithinScale(0.5, METER_QUANTITY_MAX_SCALE)).toBe(true);
+    expect(isWithinScale(0.5, -1)).toBe(false);
+  });
+});
+
+describe("isWithinMagnitude", () => {
+  it("bounds the range in both directions", () => {
+    expect(isWithinMagnitude(METER_QUANTITY_MAX_MAGNITUDE)).toBe(true);
+    expect(isWithinMagnitude(-METER_QUANTITY_MAX_MAGNITUDE)).toBe(true);
+    expect(isWithinMagnitude(METER_QUANTITY_MAX_MAGNITUDE + 1)).toBe(false);
+  });
+
+  it("refuses what is not a number at all", () => {
+    expect(isWithinMagnitude(Number.NaN)).toBe(false);
+    expect(isWithinMagnitude(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+});
+
+describe("stepFor", () => {
+  /**
+   * A whole-unit meter keeps the step the input already had, so nothing about an existing form
+   * changes. Without a matching step the browser's own number validation refuses a fraction
+   * before the form's validation is ever consulted.
+   */
+  it.each([
+    [0, "1"],
+    [1, "0.1"],
+    [3, "0.001"],
+    [6, "0.000001"],
+  ])("steps a scale of %s by %s", (scale, expected) => {
+    expect(stepFor(scale)).toBe(expected);
+  });
+});
+
+describe("formatQuantity", () => {
+  it("does not show places the author never typed", () => {
+    expect(formatQuantity(500)).toBe("500");
+    expect(formatQuantity(512.5)).toBe("512.5");
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/meter-quantity.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/meter-quantity.ts
@@ -1,0 +1,74 @@
+/**
+ * The granularity rules a metered quantity obeys, mirroring the server's `MeterQuantity`.
+ *
+ * Fractions are opt-in per meter: a meter's `quantityScale` is how many decimal places it accepts,
+ * and zero — the default, and what a meter authored before fractions existed reports — means whole
+ * units only. Checking it here is so the author is told in the form rather than by a rejected
+ * request; the server refuses the same values regardless of what happens in the browser.
+ */
+
+/** The finest granularity any meter may declare. Must match `MeterQuantity.MaxScale`. */
+export const METER_QUANTITY_MAX_SCALE = 6;
+
+/** The largest magnitude a quantity may take. Must match `MeterQuantity.MaxMagnitude`. */
+export const METER_QUANTITY_MAX_MAGNITUDE = 1_000_000_000_000;
+
+/**
+ * How many decimal places a number actually carries.
+ *
+ * Read off the decimal string rather than by arithmetic, because scaling by a power of ten to
+ * "check for a remainder" is exactly the kind of binary floating-point step that reports 1.15 as
+ * having a remainder. Exponent form is handled because that is how JavaScript renders anything
+ * below 1e-6, which is the first thing a six-place meter can hold.
+ */
+export const scaleOf = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const text = Math.abs(value).toString();
+  const exponentAt = text.indexOf("e");
+
+  if (exponentAt >= 0) {
+    const mantissa = text.slice(0, exponentAt);
+    const power = Number(text.slice(exponentAt + 1));
+    const fraction = mantissa.split(".")[1] ?? "";
+
+    return Math.max(0, fraction.length - power);
+  }
+
+  const pointAt = text.indexOf(".");
+
+  return pointAt < 0 ? 0 : text.length - pointAt - 1;
+};
+
+/** Whether a meter declaring this scale may hold this quantity. */
+export const isWithinScale = (value: number, scale: number): boolean =>
+  Number.isFinite(value) && scaleOf(value) <= scale;
+
+/** Whether a quantity is inside the representable range. */
+export const isWithinMagnitude = (value: number): boolean =>
+  Number.isFinite(value) && Math.abs(value) <= METER_QUANTITY_MAX_MAGNITUDE;
+
+/**
+ * The `step` a number input should take for a meter at this scale.
+ *
+ * Without it the browser's own validation rejects a fraction on a `type="number"` field whose step
+ * defaults to one, before any of the above is ever consulted.
+ */
+export const stepFor = (scale: number): string =>
+  scale <= 0 ? "1" : (1 / 10 ** scale).toFixed(scale);
+
+/**
+ * A quantity as it should be displayed: no trailing zeroes, and no exponent form.
+ *
+ * A figure that came back from the server's Decimal128 arithmetic can carry places the author
+ * never typed, and an allowance of five hundred should not read as `500.000000`.
+ */
+export const formatQuantity = (value: number): string =>
+  Number.isFinite(value)
+    ? value.toLocaleString(undefined, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: METER_QUANTITY_MAX_SCALE,
+      })
+    : "";

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.test.ts
@@ -414,3 +414,39 @@ describe("requiring a card before activation", () => {
     expect(toUpdatePlanRequest(values).requirePaymentMethodUpfront).toBe(false);
   });
 });
+
+describe("a meter's decimal places", () => {
+  /**
+   * A plan stored before fractional quantities existed carries no scale at all, and has to reopen
+   * as the whole-unit meter it has always been rather than as undefined — which the number input
+   * would render as an empty field and the request would then omit.
+   */
+  it("reopens a plan stored without a scale as whole units", () => {
+    const values = planToFormValues(storedPlan());
+
+    expect(values.meters[0].quantityScale).toBe(0);
+  });
+
+  it("round trips a declared scale and the fractional allowance it permits", () => {
+    const plan = storedPlan();
+    plan.meters[0] = { ...plan.meters[0], quantityScale: 3, includedQuantity: 512.5 };
+
+    const request = toUpdatePlanRequest(planToFormValues(plan), "org-1");
+
+    expect(request.meters[0].quantityScale).toBe(3);
+    expect(request.meters[0].includedQuantity).toBe(512.5);
+  });
+
+  /**
+   * The cap was not reaching the server at all, in either direction — see the catalogue service's
+   * own remarks. Pinned here because this mapping is the only client-side path it travels.
+   */
+  it("round trips a carry-forward cap", () => {
+    const plan = storedPlan();
+    plan.meters[0] = { ...plan.meters[0], resetPolicy: "CarryForward", carryForwardCap: 50 };
+
+    const request = toUpdatePlanRequest(planToFormValues(plan), "org-1");
+
+    expect(request.meters[0].carryForwardCap).toBe(50);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-form-mapping.ts
@@ -60,6 +60,7 @@ const toPlanDefinition = (values: CreateSubscriptionPlanFormValues) => ({
     unitLabel: meter.unitLabel.trim(),
     aggregation: meter.aggregation,
     resetPolicy: meter.resetPolicy,
+    quantityScale: meter.quantityScale,
     carryForwardCap: meter.carryForwardCap,
     includedQuantity: meter.includedQuantity,
     overageAllowed: meter.overageAllowed,
@@ -185,6 +186,9 @@ export const planToFormValues = (
     unitLabel: meter.unitLabel,
     aggregation: aggregationValue(meter.aggregation),
     resetPolicy: resetPolicyValue(meter.resetPolicy),
+    // A plan authored before fractions existed carries no scale, and reopens as whole units —
+    // which is what it has always been.
+    quantityScale: meter.quantityScale ?? 0,
     carryForwardCap: meter.carryForwardCap ?? undefined,
     includedQuantity: meter.includedQuantity,
     overageAllowed: meter.overageAllowed,

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -849,8 +849,9 @@
             <tr><td>unitLabel</td><td class="type">string</td><td class="prose">signature, call, export.</td></tr>
             <tr><td>aggregation</td><td class="type">string</td><td class="prose">How recordings combine. <code>Sum</code> adds them up — the supported mode. <code>Max</code> and <code>LastValue</code> exist in the enum but the rater rejects them with <code>subscription_meter_aggregation_unsupported</code>.</td></tr>
             <tr><td>resetPolicy</td><td class="type">string</td><td class="prose"><code>Periodic</code> starts a fresh balance each plan usage window and discards what went unused. <code>Never</code> keeps one balance for the subscription lifetime, suitable for persistent capacity such as storage. <code>CarryForward</code> resets like <code>Periodic</code> but opens each window with the previous window's unused remainder. Requests send <code>0</code>, <code>1</code> or <code>2</code>.</td></tr>
-            <tr><td>carryForwardCap</td><td class="type">long?</td><td class="prose">The most one window may carry in. <strong>Required</strong> when <code>resetPolicy</code> is <code>CarryForward</code> and rejected otherwise. Bounds the amount carried, not the total — <code>includedQuantity</code> is always available on top of it. Required because an uncapped roll lets a dormant subscription bank allowance indefinitely.</td></tr>
-            <tr><td>includedQuantity</td><td class="type">long</td><td class="prose">The allowance per period, or the lifetime allowance when <code>resetPolicy</code> is <code>Never</code>.</td></tr>
+            <tr><td>quantityScale</td><td class="type">int</td><td class="prose">How many decimal places this meter accepts, <code>0</code> to <code>6</code>. <strong>Defaults to <code>0</code> — whole units only</strong>, so a meter that does not opt in refuses a fractional quantity exactly as it always has. Governs this meter's <code>includedQuantity</code>, its <code>carryForwardCap</code>, its rate-band <code>upToQuantity</code> bounds, a trial grant naming it, and every quantity recorded against it. A finer quantity is refused with <code>subscription_meter_quantity_scale_exceeded</code> when authoring and <code>subscription_usage_quantity_scale_invalid</code> when recording.</td></tr>
+            <tr><td>carryForwardCap</td><td class="type">decimal?</td><td class="prose">The most one window may carry in. <strong>Required</strong> when <code>resetPolicy</code> is <code>CarryForward</code> and rejected otherwise. Bounds the amount carried, not the total — <code>includedQuantity</code> is always available on top of it. Required because an uncapped roll lets a dormant subscription bank allowance indefinitely.</td></tr>
+            <tr><td>includedQuantity</td><td class="type">decimal</td><td class="prose">The allowance per period, or the lifetime allowance when <code>resetPolicy</code> is <code>Never</code>. Whole unless <code>quantityScale</code> says otherwise.</td></tr>
             <tr><td>overageAllowed</td><td class="type">bool</td><td class="prose"><code>false</code> blocks past the allowance. <code>true</code> permits and records it. Must be <code>false</code> for a <code>Never</code> meter.</td></tr>
             <tr><td>thresholdPercents</td><td class="type">int[]</td><td class="prose">Percentages that raise a <code>UsageThresholdReached</code> event once per usage period, or once per subscription for a <code>Never</code> meter — for example 80 and 100. The worker forwards the event to the Blocks OS mail module using the subscription billing contact.</td></tr>
             <tr><td>rateTables</td><td class="type">array</td><td class="prose">What overage costs, per currency. <strong>Empty means overage is billed nothing.</strong></td></tr>
@@ -3178,6 +3179,7 @@ POST /api/subscriptions
         "unitLabel": "screening",
         "includedQuantity": 150,
         "resetPolicy": "Periodic",
+        "quantityScale": 0,
         "carryForwardCap": null,
         "overageAllowed": true,
         "overagePricing": {
@@ -3663,7 +3665,7 @@ POST /api/subscriptions
               <thead><tr><th>Field</th><th>Type</th><th>Meaning</th></tr></thead>
               <tbody>
                 <tr><td>meterKey</td><td class="type">string</td><td class="prose">Required.</td></tr>
-                <tr><td>quantity</td><td class="type">long</td><td class="prose">Default 1.</td></tr>
+                <tr><td>quantity</td><td class="type">decimal</td><td class="prose">Default 1. Whole units unless the meter declares a <code>quantityScale</code> above zero, in which case up to that many decimal places are accepted and anything finer is refused with <code>subscription_usage_quantity_scale_invalid</code>. A meter that has not opted in refuses <code>0.5</code> exactly as it always has.</td></tr>
                 <tr><td>idempotencyKey</td><td class="type">string</td><td class="prose"><strong>Mandatory.</strong> Unique per subscription and meter. At-least-once delivery makes a repeat call a certainty, and the second must not be billable.</td></tr>
                 <tr><td>occurredAtUtc</td><td class="type">DateTime?</td><td class="prose">When it happened, if not now. Decides which period it lands in, so a late report still bills the right month.</td></tr>
                 <tr><td>enforce</td><td class="type">bool</td><td class="prose">Refuse and roll back when the allowance is exhausted. <em>Only blocks when the meter disallows overage.</em></td></tr>
@@ -3692,7 +3694,14 @@ POST /api/subscriptions
 }</code></pre>
           <p><code>replayed: true</code> means this call repeated one already recorded and changed nothing.</p>
           <h4>Returns</h4>
-          <p><code>200</code> — including when <code>allowed</code> is <code>false</code> · <code>400</code> missing idempotency key, metadata too large · <code>404</code> no subscription, or the plan has no such meter.</p>
+          <p><code>200</code> — including when <code>allowed</code> is <code>false</code> · <code>400</code> missing idempotency key, metadata too large, quantity finer than the meter's <code>quantityScale</code> · <code>404</code> no subscription, or the plan has no such meter.</p>
+          <p class="prose">
+            <code>included</code>, <code>used</code>, <code>remaining</code> and <code>overage</code>
+            are whole numbers for a meter counting whole units, and <strong>may be fractional</strong>
+            for one that declares a <code>quantityScale</code>. Parse them as decimals, not integers.
+            Display them; do not do arithmetic on them — a JavaScript number is a double, and summing
+            billing quantities in the browser drifts from the exact figures the server holds.
+          </p>
         </div>
       </div>
 

--- a/server/Subscription.DomainService/Entities/CampaignEntitlementOverride.cs
+++ b/server/Subscription.DomainService/Entities/CampaignEntitlementOverride.cs
@@ -26,5 +26,5 @@ public sealed class CampaignEntitlementOverride
     /// own limit for the same key — a campaign can shrink what a subscriber may use, never grow it
     /// past what the plan they are actually on already grants.
     /// </summary>
-    public long Limit { get; set; }
+    public decimal Limit { get; set; }
 }

--- a/server/Subscription.DomainService/Entities/MeterTier.cs
+++ b/server/Subscription.DomainService/Entities/MeterTier.cs
@@ -12,8 +12,15 @@ namespace Subscription.DomainService.Entities;
 [BsonIgnoreExtraElements]
 public sealed class MeterTier
 {
-    /// <summary>Upper bound of the band. Null is the final, unbounded tier.</summary>
-    public long? UpToQuantity { get; set; }
+    /// <summary>
+    /// Upper bound of the band, inclusive. Null is the final, unbounded tier.
+    /// </summary>
+    /// <remarks>
+    /// Bands are half-open below and closed above — <c>(previousBound, UpToQuantity]</c> — so a
+    /// fractional overage lands in exactly one of them. Whole-unit numbering would leave the space
+    /// between one band's bound and the next band's first unit undefined.
+    /// </remarks>
+    public decimal? UpToQuantity { get; set; }
 
     public long UnitAmountMinor { get; set; }
 }

--- a/server/Subscription.DomainService/Entities/PendingUsagePeriod.cs
+++ b/server/Subscription.DomainService/Entities/PendingUsagePeriod.cs
@@ -29,5 +29,5 @@ public sealed class PendingUsagePeriod
     /// subscription's current (post-transition) state for those legacy documents — the same
     /// behavior this type had before the snapshot was added.
     /// </remarks>
-    public Dictionary<string, long>? MeterAllowances { get; set; }
+    public Dictionary<string, decimal>? MeterAllowances { get; set; }
 }

--- a/server/Subscription.DomainService/Entities/PlanEntitlement.cs
+++ b/server/Subscription.DomainService/Entities/PlanEntitlement.cs
@@ -21,7 +21,7 @@ public sealed class PlanEntitlement
         EntitlementLimitKind.Boolean;
 
     /// <summary>The cap, when the kind is a count.</summary>
-    public long? Limit { get; set; }
+    public decimal? Limit { get; set; }
 
     /// <summary>The meter that draws this entitlement down, when the kind is a count.</summary>
     public string? MeterKey { get; set; }

--- a/server/Subscription.DomainService/Entities/PlanMeter.cs
+++ b/server/Subscription.DomainService/Entities/PlanMeter.cs
@@ -25,8 +25,23 @@ public sealed class PlanMeter
     /// <summary>Periodic by default; Never keeps one lifetime balance across renewals.</summary>
     public MeterResetPolicy ResetPolicy { get; set; } = MeterResetPolicy.Periodic;
 
+    /// <summary>
+    /// How many decimal places this meter's quantities may carry.
+    /// </summary>
+    /// <remarks>
+    /// Zero — whole units only — unless the plan author raises it, which is what keeps a meter
+    /// counting screenings from accepting half of one. A meter authored before fractions existed has
+    /// no such field, so it deserializes to zero and cannot behave differently from before.
+    /// <para>
+    /// It governs the allowance and the cap here, this meter's tier bounds, a trial grant for it, and
+    /// every quantity recorded against it. Bounded by
+    /// <see cref="Utilities.MeterQuantity.MaxScale"/>.
+    /// </para>
+    /// </remarks>
+    public int QuantityScale { get; set; }
+
     /// <summary>How much the plan includes per period, or for its lifetime when reset is Never.</summary>
-    public long IncludedQuantity { get; set; }
+    public decimal IncludedQuantity { get; set; }
 
     /// <summary>
     /// The most that may roll into one window under
@@ -38,7 +53,7 @@ public sealed class PlanMeter
     /// subscription that consumes nothing for a year would otherwise arrive at month thirteen
     /// holding twelve months of quota.
     /// </remarks>
-    public long? CarryForwardCap { get; set; }
+    public decimal? CarryForwardCap { get; set; }
 
     /// <summary>Whether usage past the included quantity is permitted and billed.</summary>
     public bool OverageAllowed { get; set; } = true;

--- a/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionLifecycleEvent.cs
@@ -34,9 +34,9 @@ public sealed class SubscriptionLifecycleEvent
 
     public long? ThresholdPercent { get; set; }
 
-    public long? Balance { get; set; }
+    public decimal? Balance { get; set; }
 
-    public long? Limit { get; set; }
+    public decimal? Limit { get; set; }
 
     /// <summary>Set on renewal and dunning events; absent otherwise.</summary>
     public string? PeriodKey { get; set; }

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageCounter.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageCounter.cs
@@ -32,7 +32,7 @@ public sealed class SubscriptionUsageCounter
 
     public string PeriodKey { get; set; } = string.Empty;
 
-    public long Balance { get; set; }
+    public decimal Balance { get; set; }
 
     /// <summary>
     /// How many ledger entries are reflected in the balance. Disagreement with the ledger's own
@@ -44,7 +44,7 @@ public sealed class SubscriptionUsageCounter
     /// The allowance as it stood when this period opened. Copied so that editing a plan
     /// mid-period cannot re-fire thresholds that have already been reported.
     /// </summary>
-    public long? LimitSnapshot { get; set; }
+    public decimal? LimitSnapshot { get; set; }
 
     /// <summary>Threshold percentages already reported. The deduplication authority for alerts.</summary>
     public List<int> NotifiedThresholds { get; set; } = [];

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageCurrent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageCurrent.cs
@@ -69,15 +69,15 @@ public sealed class SubscriptionUsageCurrent
     public DateTime PeriodEndUtc { get; set; }
 
     /// <summary>The allowance in force for this window, after any carry-forward.</summary>
-    public long Included { get; set; }
+    public decimal Included { get; set; }
 
-    public long Used { get; set; }
+    public decimal Used { get; set; }
 
     /// <summary>Never below zero. Copied from the authoritative result, not recomputed here.</summary>
-    public long Remaining { get; set; }
+    public decimal Remaining { get; set; }
 
     /// <summary>How far past the allowance this window has gone. Never below zero.</summary>
-    public long Overage { get; set; }
+    public decimal Overage { get; set; }
 
     /// <summary>
     /// Whether the meter's terms permit going past <see cref="Included"/>. A reader with

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageRecord.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageRecord.cs
@@ -34,8 +34,15 @@ public sealed class SubscriptionUsageRecord
 
     public UsageEntryType EntryType { get; set; } = UsageEntryType.Consumption;
 
-    /// <summary>Signed: consumption raises the balance, a reversal lowers it.</summary>
-    public long Delta { get; set; }
+    /// <summary>
+    /// Signed: consumption raises the balance, a reversal lowers it.
+    /// </summary>
+    /// <remarks>
+    /// Exact decimal rather than binary floating point, so a reversal cancels the entry it
+    /// compensates to the last place. A residue left behind by inexact arithmetic would sit in the
+    /// customer's balance for the life of the period and be billed.
+    /// </remarks>
+    public decimal Delta { get; set; }
 
     /// <summary>
     /// Unique per subscription and meter. The guard against billing a customer twice for one

--- a/server/Subscription.DomainService/Entities/TrialMeterGrant.cs
+++ b/server/Subscription.DomainService/Entities/TrialMeterGrant.cs
@@ -15,5 +15,5 @@ public sealed class TrialMeterGrant
 {
     public string MeterKey { get; set; } = string.Empty;
 
-    public long IncludedQuantity { get; set; }
+    public decimal IncludedQuantity { get; set; }
 }

--- a/server/Subscription.DomainService/Entities/UsageInvoiceLine.cs
+++ b/server/Subscription.DomainService/Entities/UsageInvoiceLine.cs
@@ -15,7 +15,7 @@ public sealed class UsageInvoiceLine
 {
     public string MeterKey { get; set; } = string.Empty;
 
-    public long OverageQuantity { get; set; }
+    public decimal OverageQuantity { get; set; }
 
     public long AmountMinor { get; set; }
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -408,7 +408,7 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
         SubscriptionDetail subscription,
         BillingPeriod period,
         CancellationToken cancellationToken,
-        IReadOnlyDictionary<string, long>? frozenAllowances = null)
+        IReadOnlyDictionary<string, decimal>? frozenAllowances = null)
     {
         var periodKey = period.Key;
         var existing = await _usageInvoices.GetAsync(

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1011,6 +1011,89 @@ Counters expire (`Subscription:CounterRetentionDays`, default 400). **The ledger
 > shared billing store, retained for years and exported for invoicing; anything naming a person
 > belongs in the calling product's own records with an opaque reference here.
 
+## Fractional quantities are opt-in per meter
+
+A meter counts whole units unless it says otherwise. `PlanMeter.QuantityScale` is how many decimal
+places it accepts — `0` by default, up to `6` — and it governs that meter's allowance, its
+carry-forward cap, its rate-band bounds, a trial grant for it, and every quantity recorded against
+it.
+
+Opt-in rather than global, because the two live on the same plan. A storage meter genuinely holds
+512.5 GB; a screening meter has no half. Before quantities were fractional, `{ "quantity": 0.5 }`
+was refused for free — JSON cannot bind a fraction to a `long` — and a global widening would have
+silently spent that guard, making a stray `1.3333` from a calling product recordable and billable.
+A plan already in the database has no `QuantityScale` field, so it deserializes to `0` and **cannot**
+behave differently from before.
+
+Recording validates against the **subscription's own snapshot**, never the catalogue's current
+terms — the same rule its allowance and its rating follow, so editing a plan cannot change what an
+existing subscriber may report. Over the scale, or over `MeterQuantity.MaxMagnitude`, is
+`400 subscription_usage_quantity_scale_invalid`.
+
+> **A carry-forward cap used to be dropped on the way in.** It was validated as mandatory, reported
+> as `null` by every response, and read as "no cap at all" by `MeterAllowance.CarriedIn` — because
+> nothing ever copied it from the request to the stored plan, or from the plan into the
+> subscription's snapshot. A dormant subscription therefore banked allowance forever, which is the
+> outcome requiring the cap is supposed to prevent. Both copies are now made. Unrelated to
+> fractional quantities; found because these are the initializers the scale had to be added to, and
+> invisible to the suite because every test set the field directly on a snapshot.
+
+### Decimal, never double
+
+Quantities are `decimal`, stored as BSON `Decimal128`. A reversal has to cancel the entry it
+compensates to the last place; binary floating point cannot promise that, and the residue would sit
+in the balance for the rest of the period and be billed.
+
+**No data migration was needed, and this is why:** the driver's default `decimal` serializer reads
+`Int64` and `Int32` back as decimals, so every counter and ledger row already written loads
+unchanged, and the next `$inc` promotes the field in place. That mattered because the alternative —
+fixed-point scaled integers — would have required rewriting the append-only ledger, which is the
+authority every past invoice was computed from. `SubscriptionEntitySerializationTests` pins both
+halves: the representation on write, and the tolerance on read.
+
+`AppliedRecordCount` stays a `long`. It counts ledger rows, not units.
+
+### Where a fractional charge becomes money
+
+Half a unit at a rate of three minor units costs one and a half of them, and no invoice has a half
+cent. The policy is **exact through the tiers, rounded once per meter**, half away from zero, in
+`MeterQuantity.ToMinorUnits`:
+
+| | |
+|---|---|
+| Tier arithmetic | exact decimal, no rounding |
+| A band's reported amount | exact, and so possibly fractional |
+| A meter's total | rounded once, to whole minor units |
+| Everything downstream — aggregate, discount, tax | integral, exactly as before |
+
+Rounding once per meter is what makes re-banding a rate table without changing any of its prices
+leave the bill alone. Rounding each band and summing would let the *arrangement* of the table decide
+the total: three bands at one rate would round three times where one band rounds once. It also keeps
+a band breakdown adding up to the figure that was rounded, which a per-band rounding would not.
+
+The preview needed no rounding rule of its own. It already defines the additional charge as
+`Difference(projected, current)` of two fully rated totals, so parity survives by construction —
+see [Metered overage preview](#metered-overage-preview).
+
+Away from zero rather than to even, so a reversal of a charge that rounded up reverses the whole of
+what was charged. Banker's rounding would leave a minor unit behind on half the reversals, and the
+customer would have paid it.
+
+### Bands are closed above and open below
+
+`(previousBound, UpToQuantity]`, so a fractional overage lands in exactly one band. A band's
+reported first quantity is the smallest one its meter can distinguish above that open bound — which
+at scale `0` is the whole unit the band has always started at. A tier with `UpToQuantity = 400`
+still reports units 1 through 400 on a whole-unit meter and the next band still starts at 401; a
+three-place meter reports `400.001`, because `401` would leave everything between undescribed.
+
+> **`UsageResponse` may now carry a non-integral `used`, `remaining`, `included` and `overage`,**
+> and so may the plan and preview responses. A consumer parsing those into an integer breaks. There
+> is no way to version a number's domain, so this is a breaking change to those fields for any
+> caller that meets a meter with a scale above zero. Browsers should treat them as display-only and
+> never sum them: JavaScript numbers are doubles, and client-side arithmetic on a billing quantity
+> would drift from the server's exact decimal.
+
 ## The current-usage projection
 
 `SubscriptionUsageCurrent`, one document per subscription, meter and usage period, in the **tenant's
@@ -1382,6 +1465,7 @@ not place "now" in a period).
       "unitLabel": "screening",
       "includedQuantity": 150,
       "resetPolicy": "Periodic",
+      "quantityScale": 0,
       "carryForwardCap": null,
       "overageAllowed": true,
       "overagePricing": {

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
@@ -28,7 +28,7 @@ public interface ISubscriptionUsageRepository
     /// </remarks>
     Task<SubscriptionUsageCounter> ApplyDeltaAsync(
         SubscriptionUsageCounter seed,
-        long delta,
+        decimal delta,
         CancellationToken cancellationToken);
 
     Task<SubscriptionUsageCounter?> GetCounterAsync(
@@ -79,7 +79,7 @@ public interface ISubscriptionUsageRepository
         CancellationToken cancellationToken);
 
     /// <summary>The ledger's own view of a period, used to rebuild a counter that has drifted.</summary>
-    Task<(long Balance, long RecordCount)> SummariseLedgerAsync(
+    Task<(decimal Balance, long RecordCount)> SummariseLedgerAsync(
         string tenantId,
         string subscriptionId,
         string meterKey,
@@ -89,7 +89,7 @@ public interface ISubscriptionUsageRepository
     Task<bool> TryRepairCounterAsync(
         string tenantId,
         string counterId,
-        long balance,
+        decimal balance,
         long appliedRecordCount,
         CancellationToken cancellationToken);
 

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -11,6 +11,11 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
     private readonly IDbContextProvider _dbContextProvider;
     private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
 
+    /// <summary>
+    /// The floor the derived balances clamp to, typed so the field never changes BSON type.
+    /// </summary>
+    private static readonly BsonDecimal128 ZeroQuantity = new(Decimal128.Zero);
+
     public SubscriptionUsageCurrentRepository(IDbContextProvider dbContextProvider) =>
         _dbContextProvider = dbContextProvider;
 
@@ -215,7 +220,10 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
                 "Remaining",
                 new BsonDocument("$max", new BsonArray
                 {
-                    0L,
+                    // Decimal128 rather than a long zero so the field keeps one BSON type whichever
+                    // side of the floor wins. A consumer reading this collection directly should not
+                    // have to handle Remaining arriving as an integer on the periods that clamped.
+                    ZeroQuantity,
                     new BsonDocument("$subtract", new BsonArray { "$Included", "$Used" })
                 })
             },
@@ -223,7 +231,10 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
                 "Overage",
                 new BsonDocument("$max", new BsonArray
                 {
-                    0L,
+                    // Decimal128 rather than a long zero so the field keeps one BSON type whichever
+                    // side of the floor wins. A consumer reading this collection directly should not
+                    // have to handle Remaining arriving as an integer on the periods that clamped.
+                    ZeroQuantity,
                     new BsonDocument("$subtract", new BsonArray { "$Used", "$Included" })
                 })
             }

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
@@ -57,7 +57,7 @@ public sealed class SubscriptionUsageRepository : ISubscriptionUsageRepository
 
     public async Task<SubscriptionUsageCounter> ApplyDeltaAsync(
         SubscriptionUsageCounter seed,
-        long delta,
+        decimal delta,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(seed);
@@ -199,7 +199,7 @@ public sealed class SubscriptionUsageRepository : ISubscriptionUsageRepository
                     idempotencyKey)))
             .FirstOrDefaultAsync(cancellationToken);
 
-    public async Task<(long Balance, long RecordCount)> SummariseLedgerAsync(
+    public async Task<(decimal Balance, long RecordCount)> SummariseLedgerAsync(
         string tenantId,
         string subscriptionId,
         string meterKey,
@@ -229,7 +229,7 @@ public sealed class SubscriptionUsageRepository : ISubscriptionUsageRepository
     public async Task<bool> TryRepairCounterAsync(
         string tenantId,
         string counterId,
-        long balance,
+        decimal balance,
         long appliedRecordCount,
         CancellationToken cancellationToken)
     {

--- a/server/Subscription.DomainService/Requests/PlanPartRequests.cs
+++ b/server/Subscription.DomainService/Requests/PlanPartRequests.cs
@@ -42,10 +42,16 @@ public sealed class PlanMeterRequest
 
     public MeterResetPolicy ResetPolicy { get; set; } = MeterResetPolicy.Periodic;
 
-    public long IncludedQuantity { get; set; }
+    /// <summary>
+    /// How many decimal places this meter's quantities may carry. Zero — whole units only — unless
+    /// the author raises it, which is what keeps a meter counting screenings refusing half of one.
+    /// </summary>
+    public int QuantityScale { get; set; }
+
+    public decimal IncludedQuantity { get; set; }
 
     /// <summary>Required when the reset policy carries forward; rejected otherwise.</summary>
-    public long? CarryForwardCap { get; set; }
+    public decimal? CarryForwardCap { get; set; }
 
     public bool OverageAllowed { get; set; } = true;
 
@@ -65,7 +71,7 @@ public sealed class MeterRateTableRequest
 public sealed class MeterTierRequest
 {
     /// <summary>Upper bound of the band. Null is the final, unbounded one.</summary>
-    public long? UpToQuantity { get; set; }
+    public decimal? UpToQuantity { get; set; }
 
     public long UnitAmountMinor { get; set; }
 }
@@ -76,7 +82,7 @@ public sealed class PlanEntitlementRequest
 
     public EntitlementLimitKind LimitKind { get; set; } = EntitlementLimitKind.Boolean;
 
-    public long? Limit { get; set; }
+    public decimal? Limit { get; set; }
 
     public string? MeterKey { get; set; }
 
@@ -87,5 +93,5 @@ public sealed class TrialGrantRequest
 {
     public string MeterKey { get; set; } = string.Empty;
 
-    public long IncludedQuantity { get; set; }
+    public decimal IncludedQuantity { get; set; }
 }

--- a/server/Subscription.DomainService/Requests/PreviewUsageOverageRequest.cs
+++ b/server/Subscription.DomainService/Requests/PreviewUsageOverageRequest.cs
@@ -23,5 +23,5 @@ public sealed class PreviewUsageOverageRequest
     /// be zero or negative — a preview of no additional usage is not a question this endpoint
     /// answers.
     /// </summary>
-    public long AdditionalQuantity { get; set; }
+    public decimal AdditionalQuantity { get; set; }
 }

--- a/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
+++ b/server/Subscription.DomainService/Requests/RecordUsageRequest.cs
@@ -8,7 +8,7 @@ public sealed class RecordUsageRequest
     /// <summary>
     /// How much was used. A negative value releases capacity only on a Never-reset meter.
     /// </summary>
-    public long Quantity { get; set; } = 1;
+    public decimal Quantity { get; set; } = 1;
 
     /// <summary>
     /// Unique per subscription and meter. Mandatory, because at-least-once delivery makes a

--- a/server/Subscription.DomainService/Responses/DiscountResponse.cs
+++ b/server/Subscription.DomainService/Responses/DiscountResponse.cs
@@ -31,7 +31,7 @@ public sealed class DiscountResponse
     public bool OneUsePerOrganization { get; init; }
     public bool RequiresPaymentMethodUpfront { get; init; }
     public string? EntitlementOverrideKey { get; init; }
-    public long? EntitlementOverrideLimit { get; init; }
+    public decimal? EntitlementOverrideLimit { get; init; }
 
     /// <summary>How this campaign's effective state reads today, for the catalogue list.</summary>
     /// <remarks>

--- a/server/Subscription.DomainService/Responses/EntitlementResponse.cs
+++ b/server/Subscription.DomainService/Responses/EntitlementResponse.cs
@@ -50,11 +50,11 @@ public sealed class EntitlementResponse
 
     public string LimitKind { get; init; } = string.Empty;
 
-    public long? Limit { get; init; }
+    public decimal? Limit { get; init; }
 
-    public long? Used { get; init; }
+    public decimal? Used { get; init; }
 
-    public long? Remaining { get; init; }
+    public decimal? Remaining { get; init; }
 
     public string? UnitLabel { get; init; }
 }

--- a/server/Subscription.DomainService/Responses/MeterTermsResponse.cs
+++ b/server/Subscription.DomainService/Responses/MeterTermsResponse.cs
@@ -21,13 +21,19 @@ public sealed class MeterTermsResponse
 
     /// <summary>How much this meter includes per period, or for the subscription's lifetime when
     /// <see cref="ResetPolicy"/> is <c>"Never"</c>.</summary>
-    public long IncludedQuantity { get; init; }
+    /// <summary>
+    /// How many decimal places this meter's quantities may carry. Zero means whole units only,
+    /// which is what every meter authored before fractional quantities existed reports.
+    /// </summary>
+    public int QuantityScale { get; init; }
+
+    public decimal IncludedQuantity { get; init; }
 
     /// <summary>"Periodic", "Never", or "CarryForward".</summary>
     public string ResetPolicy { get; init; } = string.Empty;
 
     /// <summary>The most that may roll into one window under <c>CarryForward</c>. Null otherwise.</summary>
-    public long? CarryForwardCap { get; init; }
+    public decimal? CarryForwardCap { get; init; }
 
     /// <summary>Whether usage past the included quantity is permitted and billed at all.</summary>
     public bool OverageAllowed { get; init; }
@@ -60,7 +66,7 @@ public sealed class OveragePricingResponse
 public sealed class OverageTierResponse
 {
     /// <summary>Upper bound of the band, counted in overage units. Null is the final, unbounded tier.</summary>
-    public long? UpToQuantity { get; init; }
+    public decimal? UpToQuantity { get; init; }
 
     public string UnitAmount { get; init; } = string.Empty;
 }

--- a/server/Subscription.DomainService/Responses/PlanResponse.cs
+++ b/server/Subscription.DomainService/Responses/PlanResponse.cs
@@ -136,7 +136,7 @@ public sealed class PlanTrialGrantResponse
 {
     public string MeterKey { get; init; } = string.Empty;
 
-    public long IncludedQuantity { get; init; }
+    public decimal IncludedQuantity { get; init; }
 }
 
 public sealed class QuantityDiscountTierResponse
@@ -182,10 +182,16 @@ public sealed class PlanMeterResponse
 
     public string ResetPolicy { get; init; } = string.Empty;
 
-    /// <summary>The ceiling on what one window may carry in. Null unless the policy carries forward.</summary>
-    public long? CarryForwardCap { get; init; }
+    /// <summary>
+    /// How many decimal places this meter's quantities may carry. Zero means whole units only,
+    /// which is what every meter authored before fractional quantities existed reports.
+    /// </summary>
+    public int QuantityScale { get; init; }
 
-    public long IncludedQuantity { get; init; }
+    /// <summary>The ceiling on what one window may carry in. Null unless the policy carries forward.</summary>
+    public decimal? CarryForwardCap { get; init; }
+
+    public decimal IncludedQuantity { get; init; }
 
     public bool OverageAllowed { get; init; }
 
@@ -213,7 +219,7 @@ public sealed class PlanMeterRateTableResponse
 public sealed class PlanMeterTierResponse
 {
     /// <summary>Upper bound of the band. Null is the final, unbounded one.</summary>
-    public long? UpToQuantity { get; init; }
+    public decimal? UpToQuantity { get; init; }
 
     public long UnitAmountMinor { get; init; }
 }
@@ -224,7 +230,7 @@ public sealed class PlanEntitlementResponse
 
     public string LimitKind { get; init; } = string.Empty;
 
-    public long? Limit { get; init; }
+    public decimal? Limit { get; init; }
 
     public string? MeterKey { get; init; }
 

--- a/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionPreviewResponse.cs
@@ -278,7 +278,7 @@ public sealed class SubscriptionPreviewCampaignResponse
     /// </summary>
     public string? TemporaryEntitlementKey { get; init; }
 
-    public long? TemporaryEntitlementLimit { get; init; }
+    public decimal? TemporaryEntitlementLimit { get; init; }
 }
 
 /// <summary>

--- a/server/Subscription.DomainService/Responses/SubscriptionUsageOveragePreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionUsageOveragePreviewResponse.cs
@@ -29,17 +29,17 @@ public sealed class SubscriptionUsageOveragePreviewResponse
     /// The effective allowance for this window, including a trial grant or carried-forward
     /// allowance — see <c>IMeterAllowanceResolver</c>.
     /// </summary>
-    public long IncludedQuantity { get; init; }
+    public decimal IncludedQuantity { get; init; }
 
-    public long CurrentUsage { get; init; }
+    public decimal CurrentUsage { get; init; }
 
-    public long CurrentOverage { get; init; }
+    public decimal CurrentOverage { get; init; }
 
-    public long AdditionalQuantity { get; init; }
+    public decimal AdditionalQuantity { get; init; }
 
-    public long ProjectedUsage { get; init; }
+    public decimal ProjectedUsage { get; init; }
 
-    public long ProjectedOverage { get; init; }
+    public decimal ProjectedOverage { get; init; }
 
     /// <summary>What the period would already owe, rated from usage recorded so far.</summary>
     public UsageChargeAmountsResponse CurrentCharge { get; init; } = new();
@@ -98,15 +98,15 @@ public sealed class UsageOverageTierAllocationResponse
     /// The first overage unit this band covers, counted from the first overage unit of the whole
     /// period — not from wherever the additional usage itself begins.
     /// </summary>
-    public long FromOverageQuantity { get; init; }
+    public decimal FromOverageQuantity { get; init; }
 
-    public long ToOverageQuantity { get; init; }
+    public decimal ToOverageQuantity { get; init; }
 
-    public long Units { get; init; }
+    public decimal Units { get; init; }
 
     public long UnitAmountMinor { get; init; }
 
-    public long AmountMinor { get; init; }
+    public decimal AmountMinor { get; init; }
 }
 
 /// <summary>

--- a/server/Subscription.DomainService/Responses/UsageResponse.cs
+++ b/server/Subscription.DomainService/Responses/UsageResponse.cs
@@ -21,15 +21,15 @@ public sealed class UsageResponse
 
     public DateTime PeriodEndUtc { get; init; }
 
-    public long Included { get; init; }
+    public decimal Included { get; init; }
 
-    public long Used { get; init; }
+    public decimal Used { get; init; }
 
     /// <summary>How much of the allowance is left. Never below zero.</summary>
-    public long Remaining { get; init; }
+    public decimal Remaining { get; init; }
 
     /// <summary>How much has been used beyond the allowance.</summary>
-    public long Overage { get; init; }
+    public decimal Overage { get; init; }
 
     /// <summary>True when this call repeated one already recorded and changed nothing.</summary>
     public bool Replayed { get; init; }

--- a/server/Subscription.DomainService/Services/EntitlementService.cs
+++ b/server/Subscription.DomainService/Services/EntitlementService.cs
@@ -140,7 +140,7 @@ public sealed class EntitlementService : IEntitlementService
     /// entitlement's own declared limit stays the answer, which keeps this change from quietly
     /// redefining what a limit means on plans that do not use the feature.
     /// </remarks>
-    private sealed record MeterReading(long Balance, long? WindowAllowance);
+    private sealed record MeterReading(decimal Balance, decimal? WindowAllowance);
 
     /// <summary>
     /// The balance of every metered entitlement, read by identifier rather than searched for.
@@ -274,7 +274,7 @@ public sealed class EntitlementService : IEntitlementService
     /// A trial's grant replaces the plan's limit, matching how usage recording measures it.
     /// The two must agree or a caller is told it may act and then refused.
     /// </summary>
-    private static long LimitFor(
+    private static decimal LimitFor(
         SubscriptionDetail subscription,
         PlanEntitlement entitlement,
         DateTime now)

--- a/server/Subscription.DomainService/Services/IMeterAllowanceResolver.cs
+++ b/server/Subscription.DomainService/Services/IMeterAllowanceResolver.cs
@@ -9,7 +9,7 @@ public interface IMeterAllowanceResolver
     /// What a window would open with: the plan's allowance plus whatever the window before it left
     /// behind. The figure a window's counter is seeded with.
     /// </summary>
-    Task<long> OpeningAllowanceAsync(
+    Task<decimal> OpeningAllowanceAsync(
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,
@@ -19,7 +19,7 @@ public interface IMeterAllowanceResolver
     /// The allowance in force: the counter's frozen snapshot where the window has opened, and the
     /// opening allowance where it has not.
     /// </summary>
-    Task<long> EffectiveAsync(
+    Task<decimal> EffectiveAsync(
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,

--- a/server/Subscription.DomainService/Services/IUsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/IUsageProjectionPublisher.cs
@@ -28,7 +28,7 @@ public interface IUsageProjectionPublisher
         PlanMeter meter,
         BillingPeriod period,
         SubscriptionUsageCounter counter,
-        long allowance,
+        decimal allowance,
         string correlationId,
         CancellationToken cancellationToken);
 

--- a/server/Subscription.DomainService/Services/MeterAllowanceResolver.cs
+++ b/server/Subscription.DomainService/Services/MeterAllowanceResolver.cs
@@ -21,7 +21,7 @@ public sealed class MeterAllowanceResolver : IMeterAllowanceResolver
 
     public MeterAllowanceResolver(ISubscriptionUsageRepository usage) => _usage = usage;
 
-    public async Task<long> OpeningAllowanceAsync(
+    public async Task<decimal> OpeningAllowanceAsync(
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,
@@ -41,7 +41,7 @@ public sealed class MeterAllowanceResolver : IMeterAllowanceResolver
         return @base + await CarriedIntoAsync(subscription, meter, period, cancellationToken);
     }
 
-    public async Task<long> EffectiveAsync(
+    public async Task<decimal> EffectiveAsync(
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,
@@ -68,7 +68,7 @@ public sealed class MeterAllowanceResolver : IMeterAllowanceResolver
     /// see <see cref="MeterAllowance.CarriedIn"/> for why that carries the plan's quantity rather
     /// than zero.
     /// </remarks>
-    private async Task<long> CarriedIntoAsync(
+    private async Task<decimal> CarriedIntoAsync(
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,

--- a/server/Subscription.DomainService/Services/MeterAllowanceSnapshot.cs
+++ b/server/Subscription.DomainService/Services/MeterAllowanceSnapshot.cs
@@ -32,7 +32,7 @@ public static class MeterAllowanceSnapshot
     /// caller then queues a <see cref="PendingUsagePeriod"/> with no snapshot, and final rating
     /// falls back to resolving live for it, exactly as it did before this snapshot existed.
     /// </returns>
-    public static async Task<Dictionary<string, long>?> CaptureAsync(
+    public static async Task<Dictionary<string, decimal>?> CaptureAsync(
         SubscriptionDetail subscription,
         BillingPeriod period,
         ISubscriptionUsageRepository? usage,
@@ -51,7 +51,7 @@ public static class MeterAllowanceSnapshot
                 cancellationToken))
             .ToDictionary(counter => counter.MeterKey, StringComparer.Ordinal);
 
-        var snapshot = new Dictionary<string, long>(StringComparer.Ordinal);
+        var snapshot = new Dictionary<string, decimal>(StringComparer.Ordinal);
 
         // Every resetting meter, matching exactly the set SubscriptionUsageRatingProcessor rates
         // for a closed window — Never sits outside per-period rating entirely and never needs an

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -1116,7 +1116,14 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
                 UnitLabel = meter.UnitLabel,
                 Aggregation = meter.Aggregation,
                 ResetPolicy = meter.ResetPolicy,
+                QuantityScale = meter.QuantityScale,
                 IncludedQuantity = meter.IncludedQuantity,
+                // Was never copied here, so a carry-forward meter's cap was validated as
+                // mandatory, reported by three responses as null, and read as "no cap" by
+                // MeterAllowance.CarriedIn — the unbounded roll the validator's own message says
+                // it prevents. Unrelated to fractional quantities; fixed here because this is the
+                // initializer the scale had to be added to.
+                CarryForwardCap = meter.CarryForwardCap,
                 OverageAllowed = meter.OverageAllowed,
                 ThresholdPercents = meter.ThresholdPercents.Distinct().Order().ToList(),
                 RateTables = meter.RateTables

--- a/server/Subscription.DomainService/Services/PlanResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/PlanResponseMapper.cs
@@ -85,6 +85,7 @@ public sealed class PlanResponseMapper : IPlanResponseMapper
                     UnitLabel = meter.UnitLabel,
                     Aggregation = meter.Aggregation.ToString(),
                     ResetPolicy = meter.ResetPolicy.ToString(),
+                    QuantityScale = meter.QuantityScale,
                     CarryForwardCap = meter.CarryForwardCap,
                     IncludedQuantity = meter.IncludedQuantity,
                     OverageAllowed = meter.OverageAllowed,

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -159,6 +159,7 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
         MeterKey = meter.MeterKey,
         DisplayName = meter.DisplayName,
         UnitLabel = meter.UnitLabel,
+        QuantityScale = meter.QuantityScale,
         IncludedQuantity = meter.IncludedQuantity,
         ResetPolicy = meter.ResetPolicy.ToString(),
         CarryForwardCap = meter.CarryForwardCap,

--- a/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionSnapshotBuilder.cs
@@ -44,7 +44,12 @@ internal static class SubscriptionSnapshotBuilder
                     UnitLabel = meter.UnitLabel,
                     Aggregation = meter.Aggregation,
                     ResetPolicy = meter.ResetPolicy,
+                    // Carried into the snapshot because usage recording validates a quantity's
+                    // decimal places against the terms this subscription was sold, never against
+                    // the catalogue's current ones.
+                    QuantityScale = meter.QuantityScale,
                     IncludedQuantity = meter.IncludedQuantity,
+                    CarryForwardCap = meter.CarryForwardCap,
                     OverageAllowed = meter.OverageAllowed,
                     ThresholdPercents = [.. meter.ThresholdPercents],
                     RateTables = meter.RateTables

--- a/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageOveragePreviewService.cs
@@ -120,6 +120,20 @@ public sealed class SubscriptionUsageOveragePreviewService : ISubscriptionUsageO
                 correlationId);
         }
 
+        // The same granularity gate usage recording applies, so a preview cannot quote a quantity
+        // the subsequent recording would refuse.
+        if (!MeterQuantity.IsWithinScale(request.AdditionalQuantity, meter.QuantityScale) ||
+            !MeterQuantity.IsWithinMagnitude(request.AdditionalQuantity))
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_usage_quantity_scale_invalid",
+                meter.QuantityScale == 0
+                    ? "This meter counts whole units."
+                    : $"This meter counts to {meter.QuantityScale} decimal places.",
+                correlationId);
+        }
+
         if (!meter.OverageAllowed)
         {
             return Failure(
@@ -163,18 +177,16 @@ public sealed class SubscriptionUsageOveragePreviewService : ISubscriptionUsageO
         var allowance = await _allowances.EffectiveAsync(
             subscription, meter, period, counter, cancellationToken);
 
-        long projectedUsage;
+        decimal projectedUsage;
 
         try
         {
             // A valid positive request.AdditionalQuantity added to a very large existing balance
-            // could otherwise wrap into a negative projected usage and price a negative "additional"
-            // charge — checked here rather than trusted, since both operands individually pass
-            // validation.
-            checked
-            {
-                projectedUsage = currentUsage + request.AdditionalQuantity;
-            }
+            // could otherwise exceed what a decimal can hold and price a nonsensical "additional"
+            // charge. Decimal addition raises rather than wrapping, so this is caught rather than
+            // guarded — both operands individually pass validation, so neither is enough to trust
+            // the sum.
+            projectedUsage = currentUsage + request.AdditionalQuantity;
         }
         catch (OverflowException)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageRater.cs
@@ -1,4 +1,5 @@
 using Subscription.DomainService.Entities;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
 
@@ -11,14 +12,22 @@ namespace Subscription.DomainService.Services;
 /// place a plan's free allowance lives; a rate table never needs a zero-cost first tier to
 /// represent it.
 /// <para>
-/// Tier bounds are counted from the first overage unit, inclusive: a tier with
-/// <c>UpToQuantity = 400</c> covers overage units 1 through 400, and the next tier starts at
-/// overage unit 401. The final tier (<c>UpToQuantity = null</c>) absorbs whatever remains.
+/// Tier bands are closed above and open below — <c>(previousBound, UpToQuantity]</c> — so a
+/// fractional overage falls into exactly one of them. A band's reported first quantity is the
+/// smallest one its meter can distinguish above that open bound, which at scale zero is the whole
+/// unit the band has always started at: a tier with <c>UpToQuantity = 400</c> still reports units 1
+/// through 400 on a whole-unit meter, and the next band still starts at 401.
+/// </para>
+/// <para>
+/// Quantities are exact decimals and so are the per-band amounts. The single rounding event is the
+/// meter's own total, in <see cref="MeterQuantity.ToMinorUnits"/> — so re-banding a rate table
+/// without changing any of its prices cannot change the bill, and a band breakdown always sums to
+/// the figure that was rounded.
 /// </para>
 /// </remarks>
 public static class SubscriptionUsageRater
 {
-    public static long OverageAmountMinor(PlanMeter meter, long balance, string currencyCode)
+    public static long OverageAmountMinor(PlanMeter meter, decimal balance, string currencyCode)
     {
         ArgumentNullException.ThrowIfNull(meter);
 
@@ -44,9 +53,9 @@ public static class SubscriptionUsageRater
     /// </param>
     public static UsageTierAllocationResult OverageAllocations(
         PlanMeter meter,
-        long overageUnits,
+        decimal overageUnits,
         string currencyCode,
-        long fromOverageUnitsExclusive = 0)
+        decimal fromOverageUnitsExclusive = 0)
     {
         ArgumentNullException.ThrowIfNull(meter);
 
@@ -67,64 +76,71 @@ public static class SubscriptionUsageRater
             return new UsageTierAllocationResult(0, []);
         }
 
-        return WalkTierRange(table.Tiers, fromOverageUnitsExclusive, overageUnits);
+        return WalkTierRange(
+            table.Tiers,
+            meter.QuantityScale,
+            fromOverageUnitsExclusive,
+            overageUnits);
     }
 
     /// <summary>
-    /// Walks the tier table with checked arithmetic throughout, including the <c>Int128</c> tier
-    /// multiplication and every narrowing cast back down to <c>long</c>. A rate table's unit
-    /// amount and a technically valid (merely very large) quantity can each pass validation on
-    /// their own and still multiply, sum or narrow into something that no longer fits a
-    /// <c>long</c> minor-unit amount — silently wrapping there would misprice the charge instead
-    /// of refusing it. <see cref="OverflowException"/> propagates to the caller, which is
-    /// responsible for turning it into a refusal (the preview) or a deferral (period-end rating)
-    /// rather than ever persisting a wrapped amount.
+    /// Walks the tier table in exact decimal arithmetic throughout, rounding once at the end.
     /// </summary>
+    /// <remarks>
+    /// A rate table's unit amount and a technically valid (merely very large) quantity can each
+    /// pass validation on their own and still multiply or sum into something no <c>long</c>
+    /// minor-unit amount can hold. Decimal arithmetic raises <see cref="OverflowException"/> of its
+    /// own accord rather than wrapping, and the final narrowing cast in
+    /// <see cref="MeterQuantity.ToMinorUnits"/> is checked, so an amount that cannot be represented
+    /// is refused rather than mispriced. The exception propagates to the caller, which is
+    /// responsible for turning it into a refusal (the preview) or a deferral (period-end rating).
+    /// </remarks>
     private static UsageTierAllocationResult WalkTierRange(
         List<MeterTier> tiers,
-        long fromOverageUnitsExclusive,
-        long toOverageUnitsInclusive)
+        int quantityScale,
+        decimal fromOverageUnitsExclusive,
+        decimal toOverageUnitsInclusive)
     {
-        var previousBound = 0L;
-        Int128 total = 0;
+        var previousBound = 0m;
+        var total = 0m;
         List<TierAllocation>? allocations = null;
+        var step = MeterQuantity.SmallestStep(quantityScale);
 
-        checked
+        foreach (var tier in tiers)
         {
-            foreach (var tier in tiers)
+            if (previousBound >= toOverageUnitsInclusive)
             {
-                if (previousBound >= toOverageUnitsInclusive)
-                {
-                    break;
-                }
-
-                var tierEnd = tier.UpToQuantity is { } upTo
-                    ? Math.Min(upTo, toOverageUnitsInclusive)
-                    : toOverageUnitsInclusive;
-
-                if (tierEnd > previousBound)
-                {
-                    var rangeStart = Math.Max(previousBound, fromOverageUnitsExclusive);
-
-                    if (tierEnd > rangeStart)
-                    {
-                        var units = tierEnd - rangeStart;
-                        var amount = (Int128)units * tier.UnitAmountMinor;
-                        total += amount;
-                        (allocations ??= []).Add(new TierAllocation(
-                            rangeStart + 1,
-                            tierEnd,
-                            units,
-                            tier.UnitAmountMinor,
-                            (long)amount));
-                    }
-                }
-
-                previousBound = tier.UpToQuantity ?? tierEnd;
+                break;
             }
 
-            return new UsageTierAllocationResult((long)total, allocations ?? []);
+            var tierEnd = tier.UpToQuantity is { } upTo
+                ? Math.Min(upTo, toOverageUnitsInclusive)
+                : toOverageUnitsInclusive;
+
+            if (tierEnd > previousBound)
+            {
+                var rangeStart = Math.Max(previousBound, fromOverageUnitsExclusive);
+
+                if (tierEnd > rangeStart)
+                {
+                    var units = tierEnd - rangeStart;
+                    var amount = units * tier.UnitAmountMinor;
+                    total += amount;
+                    (allocations ??= []).Add(new TierAllocation(
+                        rangeStart + step,
+                        tierEnd,
+                        units,
+                        tier.UnitAmountMinor,
+                        amount));
+                }
+            }
+
+            previousBound = tier.UpToQuantity ?? tierEnd;
         }
+
+        return new UsageTierAllocationResult(
+            MeterQuantity.ToMinorUnits(total),
+            allocations ?? []);
     }
 }
 
@@ -132,18 +148,25 @@ public static class SubscriptionUsageRater
 /// One tier band's slice of a priced overage range: which overage units it covered, at what rate.
 /// </summary>
 /// <param name="FromOverageQuantity">
-/// The first overage unit this band covers, counted from the first overage unit overall (1),
-/// not from wherever the priced range started.
+/// The first quantity this band covers, counted from the first overage unit overall rather than
+/// from wherever the priced range started. The band's lower bound is exclusive, so this is the
+/// smallest quantity above it the meter can distinguish — the whole unit itself on a whole-unit
+/// meter.
 /// </param>
-/// <param name="ToOverageQuantity">The last overage unit this band covers, inclusive.</param>
+/// <param name="ToOverageQuantity">The last overage quantity this band covers, inclusive.</param>
+/// <param name="AmountMinor">
+/// Exact, and so possibly fractional: a third of a unit priced at one minor unit costs a third of
+/// one. Only a meter's total is rounded to whole minor units, which is why these sum to the figure
+/// that was rounded rather than to the rounded figure itself.
+/// </param>
 public readonly record struct TierAllocation(
-    long FromOverageQuantity,
-    long ToOverageQuantity,
-    long Units,
+    decimal FromOverageQuantity,
+    decimal ToOverageQuantity,
+    decimal Units,
     long UnitAmountMinor,
-    long AmountMinor);
+    decimal AmountMinor);
 
-/// <summary>A priced range's total, and the bands that made it up.</summary>
+/// <summary>A priced range's total in whole minor units, and the bands that made it up.</summary>
 public readonly record struct UsageTierAllocationResult(
     long TotalAmountMinor,
     IReadOnlyList<TierAllocation> Allocations);

--- a/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
@@ -47,7 +47,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         PlanMeter meter,
         BillingPeriod period,
         SubscriptionUsageCounter counter,
-        long allowance,
+        decimal allowance,
         string correlationId,
         CancellationToken cancellationToken)
     {
@@ -288,7 +288,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         PlanMeter meter,
         BillingPeriod period,
         SubscriptionUsageCounter counter,
-        long allowance) =>
+        decimal allowance) =>
         Describe(
             subscription,
             meter,
@@ -303,9 +303,9 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         PlanMeter meter,
         BillingPeriod period,
         SubscriptionUsageCounter? counter,
-        long balance,
+        decimal balance,
         long counterVersion,
-        long allowance) => new()
+        decimal allowance) => new()
     {
         ItemId = SubscriptionUsageCurrent.CreateId(
             subscription.ItemId,

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -142,6 +142,22 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 correlationId);
         }
 
+        // Against the meter this subscription was sold, never the catalogue's current terms — the
+        // snapshot is what its allowance and its rating are measured by, so it has to be what its
+        // granularity is measured by too. A meter that never declared a scale reads zero and
+        // refuses any fraction, which is how every meter behaved before fractions existed.
+        if (!MeterQuantity.IsWithinScale(request.Quantity, meter.QuantityScale) ||
+            !MeterQuantity.IsWithinMagnitude(request.Quantity))
+        {
+            return Failure(
+                PaymentFailureKind.Validation,
+                "subscription_usage_quantity_scale_invalid",
+                meter.QuantityScale == 0
+                    ? "This meter counts whole units."
+                    : $"This meter counts to {meter.QuantityScale} decimal places.",
+                correlationId);
+        }
+
         if (request.Quantity < 0 && meter.ResetPolicy != MeterResetPolicy.Never)
         {
             return Failure(
@@ -800,7 +816,7 @@ public sealed class UsageRecordingService : IUsageRecordingService
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,
-        long allowance,
+        decimal allowance,
         string correlationId,
         CancellationToken cancellationToken)
     {
@@ -868,7 +884,7 @@ public sealed class UsageRecordingService : IUsageRecordingService
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,
-        long allowance,
+        decimal allowance,
         string correlationId,
         CancellationToken cancellationToken)
     {
@@ -916,7 +932,7 @@ public sealed class UsageRecordingService : IUsageRecordingService
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod period,
-        long allowance) => new()
+        decimal allowance) => new()
     {
         ItemId = SubscriptionUsageCounter.CreateId(
             subscription.ItemId,
@@ -944,8 +960,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
     private static UsageResponse Describe(
         PlanMeter meter,
         BillingPeriod period,
-        long balance,
-        long allowance,
+        decimal balance,
+        decimal allowance,
         bool allowed,
         bool replayed,
         UsageProjectionOutcome projection) =>
@@ -954,8 +970,8 @@ public sealed class UsageRecordingService : IUsageRecordingService
     private static UsageResponse Describe(
         PlanMeter meter,
         BillingPeriod period,
-        long balance,
-        long allowance,
+        decimal balance,
+        decimal allowance,
         bool allowed,
         bool replayed,
         UsageProjectionState projection = UsageProjectionState.Published) => new()

--- a/server/Subscription.DomainService/Services/UsageThresholdEmailService.cs
+++ b/server/Subscription.DomainService/Services/UsageThresholdEmailService.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Blocks.Genesis;
 using Microsoft.Extensions.Logging;
 using Payment.DomainService.Utilities;
@@ -148,6 +147,14 @@ public sealed class UsageThresholdEmailService : IUsageThresholdEmailService
             lifecycleEvent.EventId);
     }
 
-    private static string Number(long? value) =>
-        value?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
+    /// <summary>
+    /// A quantity as the email should read it.
+    /// </summary>
+    /// <remarks>
+    /// Formatted rather than handed to the default <c>ToString</c>, because a decimal that came
+    /// back from Decimal128 arithmetic can carry trailing zeroes the customer never typed — a
+    /// balance of five hundred should not arrive in an email as <c>500.000000</c>.
+    /// </remarks>
+    private static string Number(decimal? value) =>
+        value is { } quantity ? MeterQuantity.Describe(quantity) : string.Empty;
 }

--- a/server/Subscription.DomainService/Services/UsageThresholdEvaluator.cs
+++ b/server/Subscription.DomainService/Services/UsageThresholdEvaluator.cs
@@ -130,9 +130,9 @@ public sealed class UsageThresholdEvaluator : IUsageThresholdEvaluator
     /// </remarks>
     private static IEnumerable<int> Crossed(
         IEnumerable<int> thresholds,
-        long balance,
-        long limit) =>
+        decimal balance,
+        decimal limit) =>
         thresholds
-            .Where(threshold => balance * 100 >= limit * (long)threshold)
+            .Where(threshold => balance * 100 >= limit * threshold)
             .Order();
 }

--- a/server/Subscription.DomainService/Utilities/MeterAllowance.cs
+++ b/server/Subscription.DomainService/Utilities/MeterAllowance.cs
@@ -21,7 +21,7 @@ public static class MeterAllowance
     /// costs the seller money, a trial that hands out the full monthly quota is an open invitation
     /// to sign up, consume and leave.
     /// </remarks>
-    public static long Base(SubscriptionDetail subscription, PlanMeter meter)
+    public static decimal Base(SubscriptionDetail subscription, PlanMeter meter)
     {
         ArgumentNullException.ThrowIfNull(subscription);
         ArgumentNullException.ThrowIfNull(meter);
@@ -64,7 +64,7 @@ public static class MeterAllowance
     /// that had itself carried something in passes on the plan's quantity, not more.
     /// </para>
     /// </remarks>
-    public static long CarriedIn(
+    public static decimal CarriedIn(
         SubscriptionDetail subscription,
         PlanMeter meter,
         BillingPeriod previousPeriod,
@@ -109,6 +109,6 @@ public static class MeterAllowance
     /// is edited underneath it or the previous window's counter is repaired. The computed value is
     /// only the answer for a window that has not opened yet.
     /// </remarks>
-    public static long Effective(SubscriptionUsageCounter? counter, long computed) =>
+    public static decimal Effective(SubscriptionUsageCounter? counter, decimal computed) =>
         counter?.LimitSnapshot ?? computed;
 }

--- a/server/Subscription.DomainService/Utilities/MeterQuantity.cs
+++ b/server/Subscription.DomainService/Utilities/MeterQuantity.cs
@@ -1,0 +1,123 @@
+using System.Globalization;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// The rules a metered quantity obeys, and the one place a fractional charge becomes money.
+/// </summary>
+/// <remarks>
+/// Quantities are <see cref="decimal"/> — exact base-ten, stored as BSON <c>Decimal128</c> — rather
+/// than <see cref="double"/>. A reversal has to cancel the entry it compensates to the last place,
+/// and binary floating point cannot promise that: <c>0.1 + 0.2 - 0.3</c> leaves a residue that would
+/// sit in a customer's balance forever.
+/// <para>
+/// Fractions are opt-in per meter. A meter's <c>QuantityScale</c> is how many decimal places it
+/// accepts, and it defaults to zero — so a meter that counts screenings keeps refusing half of one,
+/// exactly as it did when these fields were integers. A plan already in the database has no such
+/// field, deserializes to zero, and therefore cannot behave differently.
+/// </para>
+/// </remarks>
+public static class MeterQuantity
+{
+    /// <summary>
+    /// The finest granularity any meter may declare.
+    /// </summary>
+    /// <remarks>
+    /// Six places covers the units that prompted this — storage in GB, time in hours, prorated
+    /// credits — and keeps every quantity below roughly nine billion exactly representable as an
+    /// IEEE-754 double, so a browser renders the figure the server computed rather than one that
+    /// drifted in transit.
+    /// </remarks>
+    public const int MaxScale = 6;
+
+    /// <summary>The largest magnitude a quantity may take.</summary>
+    /// <remarks>
+    /// Decimal128 holds more than <see cref="decimal"/> does, so a value written by something other
+    /// than this service could otherwise overflow on the way back in. Bounding it at authoring and
+    /// recording time means that never happens. Generous enough that no real meter reaches it, and
+    /// it still leaves headroom for the tier multiplication below.
+    /// </remarks>
+    public const decimal MaxMagnitude = 1_000_000_000_000m;
+
+    /// <summary>How many decimal places a value actually carries, trailing zeroes ignored.</summary>
+    /// <remarks>
+    /// Read from the decimal's own scale after normalising, because <c>1.50m</c> and <c>1.5m</c> are
+    /// equal but differently scaled — refusing the first on a one-place meter would be arbitrary.
+    /// </remarks>
+    public static int ScaleOf(decimal value)
+    {
+        var scale = (decimal.GetBits(value)[3] >> 16) & 0xFF;
+
+        // Rounding to one place fewer leaves the value untouched exactly when the last place holds
+        // a zero, so this walks off the trailing zeroes without any string formatting.
+        while (scale > 0 && value == decimal.Round(value, scale - 1))
+        {
+            scale--;
+        }
+
+        return scale;
+    }
+
+    /// <summary>Whether a meter declaring <paramref name="scale"/> may hold this quantity.</summary>
+    public static bool IsWithinScale(decimal value, int scale) =>
+        scale >= 0 &&
+        scale <= MaxScale &&
+        ScaleOf(value) <= scale;
+
+    /// <summary>Whether a quantity is inside the representable range.</summary>
+    public static bool IsWithinMagnitude(decimal value) =>
+        Math.Abs(value) <= MaxMagnitude;
+
+    /// <summary>Whether a scale is one a meter may declare at all.</summary>
+    public static bool IsValidScale(int scale) =>
+        scale is >= 0 and <= MaxScale;
+
+    /// <summary>
+    /// Turns an exactly-computed charge into whole minor units.
+    /// </summary>
+    /// <remarks>
+    /// The single rounding event in usage rating. Tier arithmetic stays exact all the way through —
+    /// so re-banding a rate table without changing any of its prices cannot change the bill — and
+    /// only the meter's own total is rounded, because that total is the invoice line the customer
+    /// actually sees.
+    /// <para>
+    /// Away from zero at the midpoint: half a minor unit rounds up, which is the convention an
+    /// invoice reader expects and which a reversal mirrors symmetrically, since the sign is carried
+    /// through rather than truncated toward it.
+    /// </para>
+    /// </remarks>
+    public static long ToMinorUnits(decimal exactAmountMinor)
+    {
+        var rounded = decimal.Round(exactAmountMinor, 0, MidpointRounding.AwayFromZero);
+
+        // Checked, for the same reason the tier walk is: a technically valid rate and a technically
+        // valid quantity can each pass validation alone and still multiply into something no
+        // long-minor amount can hold. Refusing beats silently wrapping the charge.
+        return checked((long)rounded);
+    }
+
+    /// <summary>
+    /// The smallest quantity a meter at this scale can distinguish: <c>1</c> at scale zero,
+    /// <c>0.001</c> at scale three.
+    /// </summary>
+    /// <remarks>
+    /// Used to name the first quantity inside a rate band whose lower bound is exclusive. At scale
+    /// zero that lands on the whole unit the band has always started at, so a plan authored before
+    /// fractions existed reports exactly the bands it reported before.
+    /// </remarks>
+    public static decimal SmallestStep(int scale) =>
+        scale switch
+        {
+            <= 0 => 1m,
+            1 => 0.1m,
+            2 => 0.01m,
+            3 => 0.001m,
+            4 => 0.0001m,
+            5 => 0.00001m,
+            _ => 0.000001m
+        };
+
+    /// <summary>A quantity as it should appear in a log line or an error message.</summary>
+    public static string Describe(decimal value) =>
+        value.ToString("0.######", CultureInfo.InvariantCulture);
+}

--- a/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FluentValidation;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Validators;
 
@@ -115,6 +116,19 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
                 meter.RuleFor(definition => definition.UnitLabel).NotEmpty().MaximumLength(64);
                 meter.RuleFor(definition => definition.IncludedQuantity)
                     .GreaterThanOrEqualTo(0);
+                meter.RuleFor(definition => definition.QuantityScale)
+                    .InclusiveBetween(0, MeterQuantity.MaxScale)
+                    .WithMessage(
+                        "A meter may count in whole units or in up to six decimal places. " +
+                        "Zero is whole units only.")
+                    .WithErrorCode("subscription_meter_quantity_scale_invalid");
+                meter.RuleFor(definition => definition)
+                    .Must(HaveQuantitiesWithinScale)
+                    .WithName(nameof(PlanMeterRequest.IncludedQuantity))
+                    .WithMessage(
+                        "A quantity is finer than the meter's own scale, or larger than a " +
+                        "quantity may be. Raise the meter's scale to accept more decimal places.")
+                    .WithErrorCode("subscription_meter_quantity_scale_exceeded");
                 meter.RuleFor(definition => definition.ResetPolicy).IsInEnum();
                 meter.RuleFor(definition => definition)
                     .Must(definition =>
@@ -188,7 +202,64 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
             .WithName(nameof(PlanDefinitionRequest.TrialGrants))
             .WithMessage("Trial allowances can only replace periodic meters, not lifetime capacity.")
             .WithErrorCode("subscription_lifetime_meter_trial_grant_invalid");
+
+        RuleFor(request => request)
+            .Must(EveryTrialGrantIsWithinItsMeterScale)
+            .WithName(nameof(PlanDefinitionRequest.TrialGrants))
+            .WithMessage(
+                "A trial grant is finer than its meter's scale. A grant replaces that meter's " +
+                "allowance, so it has to be a quantity that meter can hold.")
+            .WithErrorCode("subscription_trial_grant_quantity_scale_exceeded");
     }
+
+    /// <summary>
+    /// Every quantity a meter carries has to be one that meter can actually hold.
+    /// </summary>
+    /// <remarks>
+    /// The allowance, the carry-forward cap and each rate band's bound, all against the meter's own
+    /// declared scale. A bound the meter cannot represent would put a fractional overage in a band
+    /// whose edge sits between two representable quantities.
+    /// <para>
+    /// Magnitude is checked here too. Decimal128 holds more than a <c>decimal</c> does, so a bound
+    /// large enough to overflow on the way back in is refused at authoring time — the one moment
+    /// there is a person to tell.
+    /// </para>
+    /// </remarks>
+    private static bool HaveQuantitiesWithinScale(PlanMeterRequest meter)
+    {
+        if (!MeterQuantity.IsValidScale(meter.QuantityScale))
+        {
+            // Its own rule reports this; saying it twice would put two messages on one mistake.
+            return true;
+        }
+
+        bool Fits(decimal value) =>
+            MeterQuantity.IsWithinMagnitude(value) &&
+            MeterQuantity.IsWithinScale(value, meter.QuantityScale);
+
+        return Fits(meter.IncludedQuantity) &&
+               (meter.CarryForwardCap is not { } cap || Fits(cap)) &&
+               meter.RateTables.TrueForAll(table =>
+                   table.Tiers.TrueForAll(tier =>
+                       tier.UpToQuantity is not { } bound || Fits(bound)));
+    }
+
+    private static bool EveryTrialGrantIsWithinItsMeterScale(PlanDefinitionRequest request) =>
+        request.TrialGrants.TrueForAll(grant =>
+        {
+            var meter = request.Meters.Find(candidate =>
+                string.Equals(candidate.MeterKey, grant.MeterKey, StringComparison.Ordinal));
+
+            // A grant naming no meter, or a meter with an invalid scale, is already refused by its
+            // own rule.
+            if (meter is null || !MeterQuantity.IsValidScale(meter.QuantityScale))
+            {
+                return true;
+            }
+
+            return MeterQuantity.IsWithinMagnitude(grant.IncludedQuantity) &&
+                   MeterQuantity.IsWithinScale(grant.IncludedQuantity, meter.QuantityScale);
+        });
 
     private static bool BeAJsonObject(string? featuresJson)
     {

--- a/server/Subscription.DomainService/Validators/PreviewUsageOverageRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PreviewUsageOverageRequestValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Validators;
 
@@ -11,6 +12,13 @@ public sealed class PreviewUsageOverageRequestValidator : AbstractValidator<Prev
 
         RuleFor(request => request.AdditionalQuantity)
             .GreaterThan(0)
-            .WithMessage("The additional quantity must be a positive whole number.");
+            .WithMessage("The additional quantity must be positive.");
+
+        // Granularity is checked by the service, which is the only place that knows the meter's
+        // declared scale. Magnitude can be refused here, before anything is read.
+        RuleFor(request => request.AdditionalQuantity)
+            .Must(MeterQuantity.IsWithinMagnitude)
+            .WithMessage("The additional quantity is larger than a quantity may be.")
+            .WithErrorCode("subscription_usage_quantity_scale_invalid");
     }
 }

--- a/server/Subscription.DomainService/Validators/RecordUsageRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/RecordUsageRequestValidator.cs
@@ -27,6 +27,14 @@ public sealed class RecordUsageRequestValidator : AbstractValidator<RecordUsageR
                 "Usage cannot be zero. Negative adjustments are accepted only by never-reset " +
                 "capacity meters, where they release previously consumed capacity.");
 
+        // Granularity is the meter's own business and is checked by UsageRecordingService, which
+        // is the only place the subscription's snapshotted scale is known. Magnitude needs no
+        // meter, so it is refused here before a subscription is even read.
+        RuleFor(request => request.Quantity)
+            .Must(MeterQuantity.IsWithinMagnitude)
+            .WithMessage("The quantity is larger than a quantity may be.")
+            .WithErrorCode("subscription_usage_quantity_scale_invalid");
+
         RuleFor(request => request.Metadata)
             .Must(metadata =>
                 metadata.Count <= options.CurrentValue.MaximumUsageMetadataEntries)

--- a/server/XUnitTest/Integration/FractionalUsageQuantityIntegrationTests.cs
+++ b/server/XUnitTest/Integration/FractionalUsageQuantityIntegrationTests.cs
@@ -1,0 +1,301 @@
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// Fractional quantities against a real MongoDB.
+/// </summary>
+/// <remarks>
+/// Every claim this change rests on is a property of a Mongo write rather than of C#, and none of
+/// them can be observed against a mock:
+/// <list type="bullet">
+/// <item><c>$inc</c> with a <c>Decimal128</c> onto a field that currently holds an <c>Int64</c>
+/// promotes the field in place. This is the whole reason the change needs no data migration — every
+/// counter and ledger row already written holds <c>NumberLong</c>. If it were false, the append-only
+/// usage ledger would have to be rewritten, and that ledger is the authority every past invoice was
+/// computed from;</item>
+/// <item>a fractional balance survives the round trip through the atomic counter exactly, so a
+/// reversal cancels what it compensates;</item>
+/// <item>the projection's <c>$max</c> and <c>$subtract</c> derive fractional balances rather than
+/// truncating them to whole units.</item>
+/// </list>
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class FractionalUsageQuantityIntegrationTests
+{
+    private readonly MongoIntegrationFixture _fixture;
+    private readonly SubscriptionUsageRepository _usage;
+    private readonly SubscriptionUsageCurrentRepository _current;
+
+    public FractionalUsageQuantityIntegrationTests(MongoIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+        _usage = new SubscriptionUsageRepository(fixture.DbContextProvider);
+        _current = new SubscriptionUsageCurrentRepository(fixture.DbContextProvider);
+    }
+
+    /// <summary>
+    /// A counter written before quantities were fractional accepts a fractional increment, and the
+    /// field becomes a decimal in place.
+    /// </summary>
+    /// <remarks>
+    /// The migration guarantee, at the database rather than at the serializer. The document is
+    /// planted as <c>NumberLong</c> by hand, exactly as every counter in every tenant database holds
+    /// it today, and then incremented by a fraction through the ordinary code path.
+    /// </remarks>
+    [Fact]
+    public async Task A_whole_number_balance_accepts_a_fractional_increment()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var counterId = SubscriptionUsageCounter.CreateId(Sub(tenantId), "storage", "M2026-09");
+
+        // Planted the way a build before this change wrote it.
+        await Raw(tenantId).InsertOneAsync(new BsonDocument
+        {
+            ["_id"] = counterId,
+            ["TenantId"] = tenantId,
+            ["OrganizationId"] = "org-1",
+            ["SubscriptionId"] = Sub(tenantId),
+            ["MeterKey"] = "storage",
+            ["PeriodKey"] = "M2026-09",
+            ["Balance"] = new BsonInt64(400),
+            ["AppliedRecordCount"] = new BsonInt64(4),
+            ["LimitSnapshot"] = new BsonInt64(500),
+            ["NotifiedThresholds"] = new BsonArray(),
+            ["PeriodStartUtc"] = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            ["PeriodEndUtc"] = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+            ["ExpiresAtUtc"] = new DateTime(2027, 12, 31, 0, 0, 0, DateTimeKind.Utc),
+            ["LastUpdatedAtUtc"] = DateTime.UtcNow
+        });
+
+        var counter = await _usage.ApplyDeltaAsync(
+            Seed(tenantId, counterId),
+            0.5m,
+            CancellationToken.None);
+
+        counter.Balance.Should().Be(400.5m);
+        counter.AppliedRecordCount.Should().Be(5);
+
+        var stored = await Raw(tenantId)
+            .Find(Builders<BsonDocument>.Filter.Eq("_id", counterId))
+            .SingleAsync();
+
+        stored["Balance"].BsonType.Should().Be(
+            BsonType.Decimal128,
+            "the field has to promote in place, or the next read would truncate it");
+        stored["Balance"].AsDecimal.Should().Be(400.5m);
+        stored["LimitSnapshot"].BsonType.Should().Be(
+            BsonType.Int64,
+            "a field nothing wrote is left exactly as it was, and still reads back as a decimal");
+    }
+
+    /// <summary>
+    /// A run of fractional increments and one reversal of their total leaves nothing behind.
+    /// </summary>
+    /// <remarks>
+    /// The reason quantities are exact decimals rather than doubles. A binary residue here would be
+    /// carried in the counter for the rest of the period and billed as overage — and it would be
+    /// stored, so no later correction could tell it from real usage.
+    /// </remarks>
+    [Fact]
+    public async Task Fractional_increments_and_their_reversal_cancel_exactly()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var counterId = SubscriptionUsageCounter.CreateId(Sub(tenantId), "storage", "M2026-09");
+
+        foreach (var _ in Enumerable.Range(0, 3))
+        {
+            await _usage.ApplyDeltaAsync(
+                Seed(tenantId, counterId), 0.333333m, CancellationToken.None);
+        }
+
+        var reversed = await _usage.ApplyDeltaAsync(
+            Seed(tenantId, counterId), -0.999999m, CancellationToken.None);
+
+        reversed.Balance.Should().Be(0m);
+    }
+
+    /// <summary>
+    /// Rebuilding a counter from the ledger sums fractional deltas exactly.
+    /// </summary>
+    /// <remarks>
+    /// The repair path. The ledger is the authority, so a sum that drifted here would have the
+    /// repair sweep replace a correct counter with a wrong one.
+    /// </remarks>
+    [Fact]
+    public async Task The_ledger_summary_sums_fractional_deltas_exactly()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        foreach (var entry in new (decimal Delta, string Key)[]
+                 {
+                     (0.1m, "a"), (0.2m, "b"), (0.3m, "c"), (-0.6m, "d")
+                 })
+        {
+            (await _usage.TryAppendRecordAsync(
+                new SubscriptionUsageRecord
+                {
+                    TenantId = tenantId,
+                    OrganizationId = "org-1",
+                    SubscriptionId = Sub(tenantId),
+                    MeterKey = "storage",
+                    PeriodKey = "M2026-09",
+                    Delta = entry.Delta,
+                    IdempotencyKey = entry.Key,
+                    OccurredAtUtc = new DateTime(2026, 9, 10, 0, 0, 0, DateTimeKind.Utc)
+                },
+                CancellationToken.None)).Should().BeTrue();
+        }
+
+        var summary = await _usage.SummariseLedgerAsync(
+            tenantId, Sub(tenantId), "storage", "M2026-09", CancellationToken.None);
+
+        summary.RecordCount.Should().Be(4);
+        summary.Balance.Should().Be(0m, "0.1 + 0.2 + 0.3 - 0.6 is exactly zero in base ten");
+    }
+
+    /// <summary>
+    /// A repaired counter may hold a fraction, and the repair still refuses to run backwards.
+    /// </summary>
+    [Fact]
+    public async Task A_repair_writes_a_fractional_balance()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var counterId = SubscriptionUsageCounter.CreateId(Sub(tenantId), "storage", "M2026-09");
+
+        await _usage.ApplyDeltaAsync(Seed(tenantId, counterId), 1m, CancellationToken.None);
+
+        (await _usage.TryRepairCounterAsync(
+            tenantId, counterId, 12.25m, 9, CancellationToken.None)).Should().BeTrue();
+
+        var repaired = await _usage.GetCounterAsync(tenantId, counterId, CancellationToken.None);
+        repaired!.Balance.Should().Be(12.25m);
+
+        (await _usage.TryRepairCounterAsync(
+                tenantId, counterId, 999m, 9, CancellationToken.None))
+            .Should()
+            .BeFalse("a repair at the same record count must not overwrite a later one");
+    }
+
+    /// <summary>
+    /// The projection derives fractional remaining and overage rather than truncating them.
+    /// </summary>
+    /// <remarks>
+    /// <c>Remaining</c> and <c>Overage</c> are computed by a <c>$subtract</c> inside the merge
+    /// pipeline, so they are Mongo's arithmetic and not this service's.
+    /// </remarks>
+    [Fact]
+    public async Task The_projection_derives_a_fractional_remaining_and_overage()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        (await _current.TryPublishAsync(
+            Projection(tenantId, included: 100.5m, used: 40.25m, counterVersion: 1),
+            CancellationToken.None)).Should().BeTrue();
+
+        // A second, later publish so the merge pipeline runs rather than the plain insert.
+        (await _current.TryPublishAsync(
+            Projection(tenantId, included: 100.5m, used: 120.75m, counterVersion: 2),
+            CancellationToken.None)).Should().BeTrue();
+
+        var stored = await _current.GetAsync(
+            tenantId,
+            SubscriptionUsageCurrent.CreateId(Sub(tenantId), "storage", "M2026-09"),
+            CancellationToken.None);
+
+        stored!.Used.Should().Be(120.75m);
+        stored.Remaining.Should().Be(0m);
+        stored.Overage.Should().Be(20.25m);
+    }
+
+    /// <summary>
+    /// The clamped side keeps the field's type rather than turning it into an integer.
+    /// </summary>
+    /// <remarks>
+    /// The floor the derived balances clamp to is a <c>Decimal128</c> zero for exactly this reason:
+    /// a long zero would leave the field holding an integer on precisely the periods that clamped,
+    /// so a consumer reading this collection directly would meet two types in one field.
+    /// </remarks>
+    [Fact]
+    public async Task A_clamped_balance_is_still_stored_as_a_decimal()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        await _current.TryPublishAsync(
+            Projection(tenantId, included: 100.5m, used: 0.5m, counterVersion: 1),
+            CancellationToken.None);
+        await _current.TryPublishAsync(
+            Projection(tenantId, included: 100.5m, used: 1.5m, counterVersion: 2),
+            CancellationToken.None);
+
+        var stored = await _fixture.Database
+            .GetCollection<BsonDocument>("SubscriptionUsageCurrent")
+            .Find(Builders<BsonDocument>.Filter.Eq(
+                "_id",
+                SubscriptionUsageCurrent.CreateId(Sub(tenantId), "storage", "M2026-09")))
+            .SingleAsync();
+
+        stored["Overage"].BsonType.Should().Be(BsonType.Decimal128);
+        stored["Overage"].AsDecimal.Should().Be(0m);
+        stored["Remaining"].AsDecimal.Should().Be(99m);
+    }
+
+    // Named rather than resolved through SubscriptionCollections, which is internal to the domain
+    // service. The fixture maps every tenant to one database, so the collection is the same one the
+    // repository writes to.
+    private IMongoCollection<BsonDocument> Raw(string tenantId) =>
+        _fixture.Database.GetCollection<BsonDocument>("SubscriptionUsageCounters");
+
+    private static SubscriptionUsageCounter Seed(string tenantId, string counterId) => new()
+    {
+        ItemId = counterId,
+        TenantId = tenantId,
+        OrganizationId = "org-1",
+        SubscriptionId = Sub(tenantId),
+        MeterKey = "storage",
+        PeriodKey = "M2026-09",
+        LimitSnapshot = 500m,
+        PeriodStartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+        ExpiresAtUtc = new DateTime(2027, 12, 31, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private static SubscriptionUsageCurrent Projection(
+        string tenantId,
+        decimal included,
+        decimal used,
+        long counterVersion) => new()
+    {
+        ItemId = SubscriptionUsageCurrent.CreateId(Sub(tenantId), "storage", "M2026-09"),
+        TenantId = tenantId,
+        OrganizationId = "org-1",
+        SubscriptionId = Sub(tenantId),
+        SubscriptionStatus = SubscriptionStatus.Active,
+        PlanId = "plan-1",
+        PlanCode = "pro",
+        MeterKey = "storage",
+        UnitLabel = "GB",
+        PeriodKey = "M2026-09",
+        PeriodStartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+        Included = included,
+        Used = used,
+        Remaining = Math.Max(0, included - used),
+        Overage = Math.Max(0, used - included),
+        OverageAllowed = true,
+        CounterVersion = counterVersion,
+        SubscriptionVersion = 1,
+        SchemaVersion = SubscriptionUsageCurrent.CurrentSchemaVersion,
+        UpdatedAtUtc = new DateTime(2026, 9, 15, 11, 0, 0, DateTimeKind.Utc),
+        ExpiresAtUtc = new DateTime(2027, 12, 31, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    // Derived from the tenant id because the fixture maps every tenant to one database, so two
+    // tests sharing a composed id would collide.
+    private static string Sub(string tenantId) => $"sub-{tenantId}";
+}

--- a/server/XUnitTest/Subscription/MeterAllowanceTests.cs
+++ b/server/XUnitTest/Subscription/MeterAllowanceTests.cs
@@ -150,8 +150,81 @@ public sealed class MeterAllowanceTests
         }
     };
 
+    // ------------------------------------------------------------------ fractional quantities
+
+    /// <summary>
+    /// A fractional remainder carries forward exactly, with no residue and no rounding.
+    /// </summary>
+    /// <remarks>
+    /// The subtraction that computes what went unused is the one place a binary residue would
+    /// become a permanent discrepancy: it would be frozen into the next window's allowance
+    /// snapshot and then measured against for the whole period.
+    /// </remarks>
+    [Fact]
+    public void A_fractional_remainder_carries_forward_exactly()
+    {
+        var carried = MeterAllowance.CarriedIn(
+            Subscription(),
+            FractionalMeter(cap: 500m),
+            Previous(),
+            Counter(limit: 1_000m, balance: 999.75m));
+
+        carried.Should().Be(0.25m);
+    }
+
+    /// <summary>
+    /// The cap bounds a fractional carry the same way it bounds a whole one — and it is read from
+    /// the meter, which is the propagation this change also had to repair.
+    /// </summary>
+    [Fact]
+    public void A_fractional_carry_is_still_bounded_by_the_cap()
+    {
+        var carried = MeterAllowance.CarriedIn(
+            Subscription(),
+            FractionalMeter(cap: 0.5m),
+            Previous(),
+            Counter(limit: 1_000m, balance: 100.25m));
+
+        carried.Should().Be(0.5m);
+    }
+
+    /// <summary>
+    /// Thirds carried across three windows do not accumulate a drift.
+    /// </summary>
+    /// <remarks>
+    /// Each window's carry is computed from the previous window's own snapshot, so an inexact
+    /// representation would compound rather than cancel.
+    /// </remarks>
+    [Fact]
+    public void Repeated_fractional_carries_do_not_drift()
+    {
+        var meter = FractionalMeter(cap: 1_000m);
+        var used = 0.333333m;
+        var carried = 0m;
+
+        for (var window = 0; window < 3; window++)
+        {
+            carried = MeterAllowance.CarriedIn(
+                Subscription(),
+                meter,
+                Previous(),
+                Counter(limit: 1_000m, balance: used));
+        }
+
+        carried.Should().Be(1_000m - 0.333333m);
+    }
+
+    private static PlanMeter FractionalMeter(decimal? cap) => new()
+    {
+        MeterKey = "tokens",
+        QuantityScale = 6,
+        IncludedQuantity = 1_000,
+        ResetPolicy = MeterResetPolicy.CarryForward,
+        CarryForwardCap = cap
+    };
+
     private static PlanMeter Meter(
-        long? cap,
+        decimal? cap,
         MeterResetPolicy policy = MeterResetPolicy.CarryForward) => new()
     {
         MeterKey = "tokens",
@@ -164,7 +237,7 @@ public sealed class MeterAllowanceTests
     private static BillingPeriod Previous() =>
         new(1, Anchor.AddMonths(1), Anchor.AddMonths(2), "M20260201T000000Z");
 
-    private static SubscriptionUsageCounter Counter(long limit, long balance) => new()
+    private static SubscriptionUsageCounter Counter(decimal limit, decimal balance) => new()
     {
         MeterKey = "tokens",
         LimitSnapshot = limit,

--- a/server/XUnitTest/Subscription/MeterQuantityTests.cs
+++ b/server/XUnitTest/Subscription/MeterQuantityTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Subscription.DomainService.Utilities;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The rules a fractional metered quantity obeys, and the one place a fractional charge becomes
+/// money.
+/// </summary>
+public sealed class MeterQuantityTests
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(-7, 0)]
+    [InlineData(0.5, 1)]
+    [InlineData(512.5, 1)]
+    [InlineData(0.001, 3)]
+    [InlineData(0.000001, 6)]
+    [InlineData(-0.25, 2)]
+    public void The_scale_is_the_number_of_decimal_places(decimal value, int expected) =>
+        MeterQuantity.ScaleOf(value).Should().Be(expected);
+
+    /// <summary>
+    /// Trailing zeroes do not count.
+    /// </summary>
+    /// <remarks>
+    /// <c>1.50m</c> and <c>1.5m</c> are equal but differently scaled, and a value arriving from
+    /// Decimal128 arithmetic or from JSON can carry places nobody typed. Refusing the first on a
+    /// one-place meter while accepting the second would be arbitrary.
+    /// </remarks>
+    [Fact]
+    public void Trailing_zeroes_do_not_raise_the_scale()
+    {
+        MeterQuantity.ScaleOf(1.50m).Should().Be(1);
+        MeterQuantity.ScaleOf(1.500000m).Should().Be(1);
+        MeterQuantity.ScaleOf(500.000000m).Should().Be(0);
+        MeterQuantity.IsWithinScale(500.000000m, 0).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Zero is whole units only. This is the case every meter authored before fractions existed
+    /// falls into, so it is the one that must not have moved.
+    /// </summary>
+    [Theory]
+    [InlineData(100, true)]
+    [InlineData(0, true)]
+    [InlineData(-3, true)]
+    [InlineData(0.5, false)]
+    [InlineData(100.1, false)]
+    public void Scale_zero_accepts_only_whole_units(decimal value, bool expected) =>
+        MeterQuantity.IsWithinScale(value, 0).Should().Be(expected);
+
+    [Theory]
+    [InlineData(512.5, 3, true)]
+    [InlineData(512.001, 3, true)]
+    [InlineData(512.0001, 3, false)]
+    [InlineData(512, 3, true)]
+    public void A_declared_scale_accepts_that_many_places_and_no_more(
+        decimal value,
+        int scale,
+        bool expected) =>
+        MeterQuantity.IsWithinScale(value, scale).Should().Be(expected);
+
+    /// <summary>A scale above the platform maximum admits nothing, rather than admitting more.</summary>
+    [Fact]
+    public void A_scale_beyond_the_maximum_is_not_a_scale()
+    {
+        MeterQuantity.IsValidScale(MeterQuantity.MaxScale).Should().BeTrue();
+        MeterQuantity.IsValidScale(MeterQuantity.MaxScale + 1).Should().BeFalse();
+        MeterQuantity.IsValidScale(-1).Should().BeFalse();
+        MeterQuantity.IsWithinScale(0.5m, MeterQuantity.MaxScale + 1).Should().BeFalse();
+        MeterQuantity.IsWithinScale(0.5m, -1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Magnitude_is_bounded_in_both_directions()
+    {
+        MeterQuantity.IsWithinMagnitude(MeterQuantity.MaxMagnitude).Should().BeTrue();
+        MeterQuantity.IsWithinMagnitude(-MeterQuantity.MaxMagnitude).Should().BeTrue();
+        MeterQuantity.IsWithinMagnitude(MeterQuantity.MaxMagnitude + 1).Should().BeFalse();
+        MeterQuantity.IsWithinMagnitude(-MeterQuantity.MaxMagnitude - 1).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(0, "1")]
+    [InlineData(1, "0.1")]
+    [InlineData(3, "0.001")]
+    [InlineData(6, "0.000001")]
+    public void The_smallest_step_is_one_at_the_declared_scale(int scale, string expected) =>
+        MeterQuantity.SmallestStep(scale).Should().Be(decimal.Parse(
+            expected, System.Globalization.CultureInfo.InvariantCulture));
+
+    /// <summary>
+    /// Half a minor unit rounds up, and does so symmetrically about zero.
+    /// </summary>
+    /// <remarks>
+    /// Away from zero rather than to even, so a reversal of a charge that rounded up reverses the
+    /// whole of what was charged. Banker's rounding would leave a minor unit behind on half the
+    /// reversals, and the customer would have paid it.
+    /// </remarks>
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(1.4, 1)]
+    [InlineData(1.5, 2)]
+    [InlineData(2.5, 3)]
+    [InlineData(-1.5, -2)]
+    [InlineData(-2.5, -3)]
+    [InlineData(0.0001, 0)]
+    public void A_fractional_charge_rounds_half_away_from_zero(decimal exact, long expected) =>
+        MeterQuantity.ToMinorUnits(exact).Should().Be(expected);
+
+    /// <summary>
+    /// An amount no minor-unit figure can hold is refused rather than wrapped.
+    /// </summary>
+    /// <remarks>
+    /// The narrowing cast is checked for the same reason the tier walk raises: a valid rate and a
+    /// valid quantity can each pass on their own and still multiply past what a long holds.
+    /// Wrapping would misprice the charge instead of refusing it.
+    /// </remarks>
+    [Fact]
+    public void An_unrepresentable_charge_throws_rather_than_wrapping()
+    {
+        var act = () => MeterQuantity.ToMinorUnits(decimal.MaxValue);
+
+        act.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
+    public void A_quantity_is_described_without_trailing_zeroes()
+    {
+        MeterQuantity.Describe(500m).Should().Be("500");
+        MeterQuantity.Describe(512.500m).Should().Be("512.5");
+        MeterQuantity.Describe(0.000001m).Should().Be("0.000001");
+    }
+}

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -1627,6 +1627,57 @@ public sealed class PlanCatalogueServiceTests
         };
     }
 
+    /// <summary>
+    /// A meter's declared scale reaches the stored plan.
+    /// </summary>
+    /// <remarks>
+    /// Without this the catalogue would hold a fractional allowance on a meter that reports itself
+    /// as counting whole units, and every quantity recorded against it would then be refused.
+    /// </remarks>
+    [Fact]
+    public async Task A_meters_quantity_scale_is_persisted()
+    {
+        var request = NewPlan();
+        request.Meters[0].QuantityScale = 3;
+        request.Meters[0].IncludedQuantity = 512.5m;
+
+        await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        _created!.Meters[0].QuantityScale.Should().Be(3);
+        _created!.Meters[0].IncludedQuantity.Should().Be(512.5m);
+    }
+
+    /// <summary>
+    /// A carry-forward meter's cap reaches the stored plan.
+    /// </summary>
+    /// <remarks>
+    /// It did not before. The cap was validated as mandatory, reported as null by three responses,
+    /// and read as "no cap at all" by <c>MeterAllowance.CarriedIn</c> — so a dormant subscription
+    /// banked allowance forever, which is the outcome the validator's own message says requiring
+    /// the cap prevents. Every existing test set the field directly on a snapshot, so nothing
+    /// exercised the path from the request that authored it.
+    /// </remarks>
+    [Fact]
+    public async Task A_carry_forward_cap_is_persisted()
+    {
+        var request = NewPlan();
+        request.Meters[0].ResetPolicy = MeterResetPolicy.CarryForward;
+        request.Meters[0].CarryForwardCap = 250;
+
+        await Service().CreatePlanAsync(request, "corr-1", CancellationToken.None);
+
+        _created!.Meters[0].CarryForwardCap.Should().Be(250);
+    }
+
+    /// <summary>A meter nobody opted in stores zero, which is whole units only.</summary>
+    [Fact]
+    public async Task A_meter_that_declares_no_scale_is_stored_as_whole_units()
+    {
+        await Service().CreatePlanAsync(NewPlan(), "corr-1", CancellationToken.None);
+
+        _created!.Meters[0].QuantityScale.Should().Be(0);
+    }
+
     private static CreatePlanRequest NewPlan() => new()
     {
         Code = "professional",

--- a/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
+++ b/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Utilities;
 using Subscription.DomainService.Validators;
 
 namespace XUnitTest.Subscription;
@@ -150,6 +151,184 @@ public sealed class PlanDefinitionRequestValidatorTests
 
         result.IsValid.Should().BeTrue();
     }
+
+    // ------------------------------------------------------------------ fractional quantities
+
+    /// <summary>
+    /// A meter that declares no scale counts whole units, and a fractional allowance on it is
+    /// refused. This is the state of every plan authored before fractions existed.
+    /// </summary>
+    [Fact]
+    public async Task A_fraction_on_a_whole_unit_meter_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].IncludedQuantity = 512.5m;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_meter_quantity_scale_exceeded");
+    }
+
+    [Fact]
+    public async Task A_fraction_within_the_declared_scale_is_accepted()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 1;
+        request.Meters[0].IncludedQuantity = 512.5m;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task A_quantity_finer_than_the_declared_scale_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 2;
+        request.Meters[0].IncludedQuantity = 512.005m;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_meter_quantity_scale_exceeded");
+    }
+
+    [Fact]
+    public async Task A_scale_beyond_the_platform_maximum_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = MeterQuantity.MaxScale + 1;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_meter_quantity_scale_invalid");
+    }
+
+    /// <summary>
+    /// An invalid scale reports one mistake, not two: the scale rule owns it, and the conformance
+    /// rule stands down rather than also complaining that nothing fits a scale that is not a scale.
+    /// </summary>
+    [Fact]
+    public async Task An_invalid_scale_is_not_reported_twice()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = -1;
+        request.Meters[0].IncludedQuantity = 512.5m;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().NotContain(error =>
+            error.ErrorCode == "subscription_meter_quantity_scale_exceeded");
+    }
+
+    /// <summary>
+    /// A rate band's bound has to be a quantity the meter can hold, or the band's edge would sit
+    /// between two representable quantities.
+    /// </summary>
+    [Fact]
+    public async Task A_tier_bound_finer_than_the_meters_scale_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 1;
+        request.Meters[0].RateTables =
+        [
+            new MeterRateTableRequest
+            {
+                CurrencyCode = "CHF",
+                Tiers = [new MeterTierRequest { UpToQuantity = 400.05m, UnitAmountMinor = 10 }]
+            }
+        ];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_meter_quantity_scale_exceeded");
+    }
+
+    [Fact]
+    public async Task A_carry_forward_cap_finer_than_the_meters_scale_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 1;
+        request.Meters[0].ResetPolicy = MeterResetPolicy.CarryForward;
+        request.Meters[0].CarryForwardCap = 50.05m;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_meter_quantity_scale_exceeded");
+    }
+
+    /// <summary>
+    /// A trial grant replaces its meter's allowance, so it is held to that meter's scale — not to
+    /// the plan's finest, and not to none at all.
+    /// </summary>
+    [Fact]
+    public async Task A_trial_grant_finer_than_its_own_meters_scale_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 1;
+        request.TrialGrants =
+        [
+            new TrialGrantRequest { MeterKey = "screening", IncludedQuantity = 25.25m }
+        ];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_trial_grant_quantity_scale_exceeded");
+    }
+
+    [Fact]
+    public async Task A_trial_grant_within_its_meters_scale_is_accepted()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 2;
+        request.TrialGrants =
+        [
+            new TrialGrantRequest { MeterKey = "screening", IncludedQuantity = 25.25m }
+        ];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A quantity too large to hold is refused at authoring time, which is the only moment there
+    /// is a person to tell. Decimal128 can carry more than a decimal can read back.
+    /// </summary>
+    [Fact]
+    public async Task A_quantity_beyond_the_representable_range_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].IncludedQuantity = MeterQuantity.MaxMagnitude + 1;
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_meter_quantity_scale_exceeded");
+    }
+
+    private static UpdatePlanRequest RequestWithPeriodicMeter() => new()
+    {
+        DisplayName = "Screening plan",
+        Meters =
+        [
+            new PlanMeterRequest
+            {
+                MeterKey = "screening",
+                DisplayName = "Screenings",
+                UnitLabel = "screening",
+                IncludedQuantity = 100,
+                ResetPolicy = MeterResetPolicy.Periodic,
+                OverageAllowed = false
+            }
+        ]
+    };
 
     private static UpdatePlanRequest RequestWithLifetimeMeter() => new()
     {

--- a/server/XUnitTest/Subscription/SubscriptionEntitySerializationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionEntitySerializationTests.cs
@@ -109,6 +109,131 @@ public sealed class SubscriptionEntitySerializationTests
         new BillingAccount().Version.Should().Be(1);
     }
 
+    // ------------------------------------------------------------------ fractional quantities
+
+    /// <summary>
+    /// A quantity is stored as <c>Decimal128</c>, not as a double.
+    /// </summary>
+    /// <remarks>
+    /// The representation the whole design rests on. A double would store 0.1 as a value that is
+    /// not 0.1, and a reversal would leave a residue in the customer's balance that gets billed.
+    /// No serializer is registered for decimal anywhere in this repository, so this pins the
+    /// driver's default rather than a choice made in configuration.
+    /// </remarks>
+    [Fact]
+    public void A_fractional_quantity_is_stored_as_decimal128()
+    {
+        var counter = new SubscriptionUsageCounter
+        {
+            ItemId = "sub-1:storage:M2026-09",
+            Balance = 512.5m,
+            LimitSnapshot = 500m
+        };
+
+        var document = counter.ToBsonDocument();
+
+        document["Balance"].BsonType.Should().Be(BsonType.Decimal128);
+        document["Balance"].AsDecimal.Should().Be(512.5m);
+        document["LimitSnapshot"].BsonType.Should().Be(BsonType.Decimal128);
+    }
+
+    /// <summary>
+    /// A counter written before quantities were fractional still loads.
+    /// </summary>
+    /// <remarks>
+    /// This is what makes the change need no data migration. Every counter and every ledger row in
+    /// every tenant database holds <c>NumberLong</c> today; they are read back as decimals, and the
+    /// next <c>$inc</c> promotes the field in place. If this ever stopped holding, the change would
+    /// require rewriting the append-only usage ledger, which is the authority every past invoice
+    /// was computed from.
+    /// </remarks>
+    [Fact]
+    public void A_counter_stored_as_a_whole_number_still_loads()
+    {
+        var stored = new BsonDocument
+        {
+            ["_id"] = "sub-1:screening:M2026-09",
+            ["TenantId"] = "tenant-1",
+            ["Balance"] = new BsonInt64(400),
+            ["AppliedRecordCount"] = new BsonInt64(7),
+            ["LimitSnapshot"] = new BsonInt64(500)
+        };
+
+        var restored = BsonSerializer.Deserialize<SubscriptionUsageCounter>(stored);
+
+        restored.Balance.Should().Be(400m);
+        restored.LimitSnapshot.Should().Be(500m);
+        restored.AppliedRecordCount.Should().Be(7);
+    }
+
+    /// <summary>A ledger entry written before quantities were fractional still loads.</summary>
+    [Fact]
+    public void A_ledger_entry_stored_as_a_whole_number_still_loads()
+    {
+        var stored = new BsonDocument
+        {
+            ["_id"] = "record-1",
+            ["TenantId"] = "tenant-1",
+            ["Delta"] = new BsonInt64(-3)
+        };
+
+        BsonSerializer.Deserialize<SubscriptionUsageRecord>(stored).Delta.Should().Be(-3m);
+    }
+
+    /// <summary>
+    /// A plan authored before fractions existed has no scale field, reads as zero, and therefore
+    /// counts whole units — which is exactly what it did before.
+    /// </summary>
+    [Fact]
+    public void A_meter_stored_without_a_scale_reads_as_whole_units()
+    {
+        var stored = new BsonDocument
+        {
+            ["MeterKey"] = "screening",
+            ["IncludedQuantity"] = new BsonInt64(500)
+        };
+
+        var restored = BsonSerializer.Deserialize<PlanMeter>(stored);
+
+        restored.QuantityScale.Should().Be(0);
+        restored.IncludedQuantity.Should().Be(500m);
+        restored.CarryForwardCap.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A quantity survives a round trip to the last place it was authored with.
+    /// </summary>
+    /// <remarks>
+    /// Six places is the finest a meter may declare, so this is the tightest case the storage has
+    /// to hold without drift.
+    /// </remarks>
+    [Fact]
+    public void A_six_place_quantity_round_trips_exactly()
+    {
+        var meter = new PlanMeter
+        {
+            MeterKey = "compute",
+            QuantityScale = 6,
+            IncludedQuantity = 1.000001m,
+            CarryForwardCap = 0.000001m,
+            RateTables =
+            [
+                new MeterRateTable
+                {
+                    CurrencyCode = "CHF",
+                    Tiers = [new MeterTier { UpToQuantity = 0.500005m, UnitAmountMinor = 3 }]
+                }
+            ]
+        };
+
+        var restored = BsonSerializer.Deserialize<PlanMeter>(meter.ToBsonDocument());
+
+        restored.QuantityScale.Should().Be(6);
+        restored.IncludedQuantity.Should().Be(1.000001m);
+        restored.CarryForwardCap.Should().Be(0.000001m);
+        restored.RateTables[0].Tiers[0].UpToQuantity.Should().Be(0.500005m);
+    }
+
     private static SubscriptionDetail NewSubscription() => new()
     {
         TenantId = "tenant-1",

--- a/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageOveragePreviewServiceTests.cs
@@ -369,11 +369,11 @@ public sealed class SubscriptionUsageOveragePreviewServiceTests
             Times.Never);
         _usage.Verify(
             repository => repository.ApplyDeltaAsync(
-                It.IsAny<SubscriptionUsageCounter>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+                It.IsAny<SubscriptionUsageCounter>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _usage.Verify(
             repository => repository.TryRepairCounterAsync(
-                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<long>(), It.IsAny<long>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<decimal>(), It.IsAny<long>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
         _usage.Verify(

--- a/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRaterTests.cs
@@ -203,12 +203,163 @@ public sealed class SubscriptionUsageRaterTests
         result.TotalAmountMinor.Should().Be(1_000_000_000_000L * 1_000_000);
     }
 
-    private static MeterTier Tier(long? upTo, long unitAmountMinor) =>
+    // ------------------------------------------------------------------ fractional quantities
+
+    /// <summary>
+    /// Half a unit at a whole-unit rate costs half that rate, and the meter's total is what rounds.
+    /// </summary>
+    [Fact]
+    public void A_fractional_overage_is_priced_exactly_and_rounded_once()
+    {
+        var meter = NewMeter(includedQuantity: 500, tiers: [Tier(null, 3)], scale: 1);
+
+        // 0.5 overage units at 3 minor each = 1.5 minor, which rounds up to 2.
+        SubscriptionUsageRater.OverageAmountMinor(meter, 500.5m, "CHF").Should().Be(2);
+    }
+
+    /// <summary>
+    /// Re-banding a rate table without changing any of its prices cannot change the bill.
+    /// </summary>
+    /// <remarks>
+    /// The property that makes "round once per meter" the right policy. Rounding each band and
+    /// summing would let the arrangement of the table decide the total: three bands at the same
+    /// rate would round three times and one band would round once.
+    /// </remarks>
+    [Fact]
+    public void Splitting_a_band_at_the_same_rate_does_not_change_the_total()
+    {
+        var oneBand = NewMeter(includedQuantity: 0, tiers: [Tier(null, 1)], scale: 6);
+        var threeBands = NewMeter(
+            includedQuantity: 0,
+            tiers: [Tier(0.3m, 1), Tier(0.6m, 1), Tier(null, 1)],
+            scale: 6);
+
+        var overage = 0.9m;
+
+        SubscriptionUsageRater.OverageAmountMinor(threeBands, overage, "CHF")
+            .Should()
+            .Be(SubscriptionUsageRater.OverageAmountMinor(oneBand, overage, "CHF"));
+    }
+
+    /// <summary>
+    /// The band breakdown carries exact amounts, so it sums to the figure that was rounded.
+    /// </summary>
+    /// <remarks>
+    /// Reported exactly rather than rounded per band precisely because only the total is whole. A
+    /// breakdown whose rows had each been rounded would not add up to the charge beside it.
+    /// </remarks>
+    [Fact]
+    public void The_band_breakdown_sums_to_the_amount_that_was_rounded()
+    {
+        var meter = NewMeter(
+            includedQuantity: 0,
+            tiers: [Tier(0.5m, 3), Tier(null, 1)],
+            scale: 1);
+
+        var result = SubscriptionUsageRater.OverageAllocations(meter, 0.8m, "CHF");
+
+        // 0.5 at 3 (=1.5) + 0.3 at 1 (=0.3) = 1.8 exactly, which rounds to 2.
+        result.Allocations.Sum(allocation => allocation.AmountMinor).Should().Be(1.8m);
+        result.TotalAmountMinor.Should().Be(2);
+    }
+
+    /// <summary>
+    /// A band's first quantity is the smallest one its meter can distinguish above the band's
+    /// open lower bound.
+    /// </summary>
+    /// <remarks>
+    /// At scale zero that is the whole unit the band has always started at — the case pinned by
+    /// the whole-unit tests above, which still report 1 and 401. A three-place meter reports
+    /// 400.001, because 401 would leave the quantities between undescribed.
+    /// </remarks>
+    [Fact]
+    public void A_bands_first_quantity_is_one_step_above_its_open_lower_bound()
+    {
+        var meter = NewMeter(
+            includedQuantity: 0,
+            tiers: [Tier(400, 10), Tier(null, 5)],
+            scale: 3);
+
+        var result = SubscriptionUsageRater.OverageAllocations(meter, 500m, "CHF");
+
+        result.Allocations[0].FromOverageQuantity.Should().Be(0.001m);
+        result.Allocations[0].ToOverageQuantity.Should().Be(400m);
+        result.Allocations[1].FromOverageQuantity.Should().Be(400.001m);
+        result.Allocations[1].ToOverageQuantity.Should().Be(500m);
+    }
+
+    /// <summary>
+    /// A fraction sitting exactly on a band edge belongs to the band that closes there, not to the
+    /// next one. Bands are closed above and open below, so no quantity falls into two.
+    /// </summary>
+    [Fact]
+    public void A_quantity_on_a_band_edge_belongs_to_the_band_that_closes_there()
+    {
+        var meter = NewMeter(
+            includedQuantity: 0,
+            tiers: [Tier(0.5m, 100), Tier(null, 1)],
+            scale: 1);
+
+        var result = SubscriptionUsageRater.OverageAllocations(meter, 0.5m, "CHF");
+
+        result.Allocations.Should().HaveCount(1);
+        result.Allocations[0].ToOverageQuantity.Should().Be(0.5m);
+        // 0.5 at 100 = 50 exactly. The second band is never entered.
+        result.TotalAmountMinor.Should().Be(50);
+    }
+
+    /// <summary>
+    /// Pricing only the addition, from a fractional already-billed prefix.
+    /// </summary>
+    /// <remarks>
+    /// The preview's case. The prefix is exclusive, so the units already charged for are not
+    /// charged again, and the reported band still counts from the period's first overage unit.
+    /// </remarks>
+    [Fact]
+    public void A_fractional_prefix_is_excluded_from_the_priced_range()
+    {
+        var meter = NewMeter(includedQuantity: 0, tiers: [Tier(null, 10)], scale: 2);
+
+        var result = SubscriptionUsageRater.OverageAllocations(
+            meter,
+            overageUnits: 2.75m,
+            currencyCode: "CHF",
+            fromOverageUnitsExclusive: 1.25m);
+
+        result.Allocations.Should().HaveCount(1);
+        result.Allocations[0].Units.Should().Be(1.5m);
+        result.Allocations[0].FromOverageQuantity.Should().Be(1.26m);
+        result.TotalAmountMinor.Should().Be(15);
+    }
+
+    /// <summary>
+    /// A third of a unit is held and priced exactly, with no binary residue.
+    /// </summary>
+    /// <remarks>
+    /// The reason quantities are decimal rather than double. Three thirds priced at three minor
+    /// units must come to exactly three, not to 2.9999999999999996.
+    /// </remarks>
+    [Fact]
+    public void Thirds_of_a_unit_sum_without_residue()
+    {
+        var meter = NewMeter(includedQuantity: 0, tiers: [Tier(null, 3)], scale: 6);
+
+        var result = SubscriptionUsageRater.OverageAllocations(meter, 0.333333m * 3, "CHF");
+
+        result.Allocations[0].AmountMinor.Should().Be(2.999997m);
+        result.TotalAmountMinor.Should().Be(3);
+    }
+
+    private static MeterTier Tier(decimal? upTo, long unitAmountMinor) =>
         new() { UpToQuantity = upTo, UnitAmountMinor = unitAmountMinor };
 
-    private static PlanMeter NewMeter(long includedQuantity, List<MeterTier> tiers) => new()
+    private static PlanMeter NewMeter(
+        decimal includedQuantity,
+        List<MeterTier> tiers,
+        int scale = 0) => new()
     {
         MeterKey = "screening",
+        QuantityScale = scale,
         IncludedQuantity = includedQuantity,
         RateTables = [new MeterRateTable { CurrencyCode = "CHF", Tiers = tiers }]
     };

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -516,7 +516,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
                 // The frozen trial-grant-like allowance captured before cancellation — deliberately
                 // different from the plan's plain 500, which is what a live resolve against this
                 // now-Canceled, no-trial subscription would fall back to.
-                MeterAllowances = new Dictionary<string, long>(StringComparer.Ordinal)
+                MeterAllowances = new Dictionary<string, decimal>(StringComparer.Ordinal)
                 {
                     ["screening"] = 300
                 }
@@ -650,7 +650,7 @@ public sealed class SubscriptionUsageRatingProcessorTests
                 Price = subscription.Price,
                 CurrencyCode = "CHF",
                 CorrelationId = "cancel-1",
-                MeterAllowances = new Dictionary<string, long> { ["screening"] = 0 }
+                MeterAllowances = new Dictionary<string, decimal> { ["screening"] = 0 }
             }
         ];
         _due = [subscription];

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -37,7 +37,7 @@ public sealed class UsageRecordingServiceTests
         new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
 
     private SubscriptionDetail _subscription = NewSubscription();
-    private long _balance;
+    private decimal _balance;
     private readonly List<SubscriptionUsageRecord> _ledger = [];
 
     public UsageRecordingServiceTests()
@@ -87,9 +87,9 @@ public sealed class UsageRecordingServiceTests
         _usage
             .Setup(repository => repository.ApplyDeltaAsync(
                 It.IsAny<SubscriptionUsageCounter>(),
-                It.IsAny<long>(),
+                It.IsAny<decimal>(),
                 It.IsAny<CancellationToken>()))
-            .Returns<SubscriptionUsageCounter, long, CancellationToken>((seed, delta, _) =>
+            .Returns<SubscriptionUsageCounter, decimal, CancellationToken>((seed, delta, _) =>
             {
                 _balance += delta;
                 seed.Balance = _balance;
@@ -127,7 +127,7 @@ public sealed class UsageRecordingServiceTests
                 It.IsAny<PlanMeter>(),
                 It.IsAny<BillingPeriod>(),
                 It.IsAny<SubscriptionUsageCounter>(),
-                It.IsAny<long>(),
+                It.IsAny<decimal>(),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(UsageProjectionOutcome.Published);
@@ -154,7 +154,7 @@ public sealed class UsageRecordingServiceTests
         _usage.Verify(
             repository => repository.ApplyDeltaAsync(
                 It.IsAny<SubscriptionUsageCounter>(),
-                It.IsAny<long>(),
+                It.IsAny<decimal>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -291,7 +291,7 @@ public sealed class UsageRecordingServiceTests
             "a rejected claim must never reach the ledger");
         _usage.Verify(
             repository => repository.ApplyDeltaAsync(
-                It.IsAny<SubscriptionUsageCounter>(), It.IsAny<long>(), It.IsAny<CancellationToken>()),
+                It.IsAny<SubscriptionUsageCounter>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()),
             Times.Never,
             "the counter this would have billed against must never be incremented");
         _closures.Verify(
@@ -687,6 +687,137 @@ public sealed class UsageRecordingServiceTests
         new OptionsStub(),
         NullLogger<UsageRecordingService>.Instance,
         _time);
+
+    // ------------------------------------------------------------------ fractional quantities
+
+    /// <summary>
+    /// A meter that declares no scale refuses a fraction, which is how every meter behaved before
+    /// fractional quantities existed. The guard the type widening would otherwise have removed:
+    /// <c>0.5</c> used to be refused for free, because JSON could not bind it to a <c>long</c>.
+    /// </summary>
+    [Fact]
+    public async Task A_whole_unit_meter_refuses_a_fraction()
+    {
+        var request = NewRequest("usage-1");
+        request.Quantity = 0.5m;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_usage_quantity_scale_invalid");
+        _ledger.Should().BeEmpty("nothing may reach the ledger that the meter cannot hold");
+    }
+
+    /// <summary>
+    /// A bad average or a stray division producing 1.3333 on a whole-unit meter is refused rather
+    /// than becoming a billable balance.
+    /// </summary>
+    [Fact]
+    public async Task A_whole_unit_meter_refuses_a_repeating_fraction()
+    {
+        var request = NewRequest("usage-1");
+        request.Quantity = 1.3333m;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_usage_quantity_scale_invalid");
+        _ledger.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task A_meter_that_declares_a_scale_records_a_fraction()
+    {
+        _subscription.Plan.Meters[0].QuantityScale = 3;
+
+        var request = NewRequest("usage-1");
+        request.Quantity = 512.5m;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _ledger.Should().ContainSingle().Which.Delta.Should().Be(512.5m);
+    }
+
+    /// <summary>
+    /// The declared scale is a ceiling, not a licence: a quantity finer than the meter can hold is
+    /// refused even on a meter that accepts fractions.
+    /// </summary>
+    [Fact]
+    public async Task A_quantity_finer_than_the_declared_scale_is_refused()
+    {
+        _subscription.Plan.Meters[0].QuantityScale = 2;
+
+        var request = NewRequest("usage-1");
+        request.Quantity = 1.005m;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.ErrorCode.Should().Be("subscription_usage_quantity_scale_invalid");
+        _ledger.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Measured against the terms this subscription was sold, not the catalogue's current ones.
+    /// </summary>
+    /// <remarks>
+    /// The snapshot is what its allowance and its rating are held to, so it has to be what its
+    /// granularity is held to as well. Reading the live catalogue would let an edit to a plan
+    /// change what an existing subscriber is allowed to report.
+    /// </remarks>
+    [Fact]
+    public async Task The_scale_is_read_from_the_subscriptions_own_snapshot()
+    {
+        _subscription.Plan.Meters[0].QuantityScale = 1;
+
+        var request = NewRequest("usage-1");
+        request.Quantity = 0.5m;
+
+        var result = await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _ledger.Should().ContainSingle().Which.Delta.Should().Be(0.5m);
+    }
+
+    /// <summary>
+    /// A fractional reversal cancels the entry it compensates to the last place.
+    /// </summary>
+    /// <remarks>
+    /// The reason quantities are exact decimals. Three additions of a third and one reversal of
+    /// the whole must leave nothing behind; with binary floating point a residue would sit in the
+    /// balance for the rest of the period and be billed as overage.
+    /// </remarks>
+    [Fact]
+    public async Task A_fractional_release_returns_exactly_what_was_consumed()
+    {
+        AddLifetimeMeter();
+        _subscription.Plan.Meters[1].QuantityScale = 6;
+
+        var add = NewRequest("usage-1");
+        add.MeterKey = "storage";
+        add.Quantity = 0.333333m;
+
+        await Service().RecordAsync(add, "corr-1", CancellationToken.None);
+        await Service().RecordAsync(
+            new RecordUsageRequest
+            {
+                MeterKey = "storage",
+                Quantity = 0.333333m,
+                IdempotencyKey = "usage-2"
+            },
+            "corr-2",
+            CancellationToken.None);
+
+        var release = new RecordUsageRequest
+        {
+            MeterKey = "storage",
+            Quantity = -0.666666m,
+            IdempotencyKey = "usage-3"
+        };
+
+        var result = await Service().RecordAsync(release, "corr-3", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Used.Should().Be(0m, "the release must cancel the consumption exactly");
+    }
 
     private static RecordUsageRequest NewRequest(string idempotencyKey) => new()
     {


### PR DESCRIPTION
## What this does

Lets a meter count in fractions, and only the meters that ask.

`PlanMeter.QuantityScale` is how many decimal places a meter accepts — `0` by default, at most `6`. It governs that meter's allowance, its carry-forward cap, its rate-band bounds, a trial grant naming it, and every quantity recorded against it. Quantities themselves become `decimal`, stored as BSON `Decimal128`, from the plan's allowance through the ledger and the atomic counter to the current-usage projection.

## Why opt-in rather than global

The two kinds of meter live on the same plan. A `storage-gb` meter genuinely holds 512.5; a `screening` meter has no half.

Before this change, `{ "meterKey": "screening", "quantity": 0.5 }` was refused **for free** — JSON cannot bind a fraction to a `long`. Widening the type globally would have spent that guard silently: a stray `1.3333` from a division bug in a calling product would become a recorded, billable balance, with no way to ask for the old strictness back.

With a per-meter scale, a plan already in the database has no such field, so it deserializes to `0`, so it counts whole units. Not "we tested it and nothing moved" — there is no path by which it can differ.

## No data migration, and why that was the deciding factor

The alternative representation was fixed-point scaled integers (store micro-units in a `long`). It was rejected because it would require rewriting every row of the **append-only usage ledger** — the authority every past invoice was computed from.

`Decimal128` needs no rewrite, and this PR verifies both halves of that rather than assuming them:

| Claim | Where it is pinned |
|---|---|
| The driver's default `decimal` serializer reads stored `Int64`/`Int32` back as decimals | `SubscriptionEntitySerializationTests` |
| `$inc` with a `Decimal128` promotes a field holding `NumberLong` **in place** | `FractionalUsageQuantityIntegrationTests`, against a real `mongod` |

The second is a property of a MongoDB write and of nothing else, so it is an integration test. The counter document is planted by hand as `NumberLong` — exactly as every counter in every tenant database holds it today — then incremented by `0.5` through the ordinary code path.

Precedent already existed in this repo: `PaymentCaptureRepository` does an atomic `$inc` with `new Decimal128(...)` onto `decimal` properties carrying no `[BsonRepresentation]`, and no convention is registered anywhere under `server/`.

## Where a fractional charge becomes money

Half a unit at a rate of three minor units costs one and a half of them, and no invoice has a half cent. The policy is **exact through the tiers, rounded once per meter**, half away from zero:

| | |
|---|---|
| Tier arithmetic | exact decimal, no rounding |
| A band's reported amount | exact, so possibly fractional |
| A meter's total | rounded once, whole minor units |
| Aggregate, discount, tax | integral, exactly as before |

Rounding once per meter is what makes **re-banding a rate table without changing any of its prices leave the bill alone**. Rounding each band and summing would let the arrangement of the table decide the total — three bands at one rate would round three times where one band rounds once. It also keeps a band breakdown adding up to the figure that was rounded.

Away from zero rather than to even, so a reversal of a charge that rounded up reverses the whole of what was charged; banker's rounding would leave a minor unit behind on half the reversals and the customer would have paid it.

**The preview needed no rounding rule of its own.** It already defines the additional charge as `Difference(projected, current)` of two fully rated totals, so parity survives rounding by construction. Nothing in the money path changed.

## Bands are closed above and open below

`(previousBound, UpToQuantity]`, so a fractional overage lands in exactly one band. A band reports its first quantity as the smallest one its meter can distinguish above that open bound — **which at scale `0` is the whole unit the band has always started at**. A whole-unit meter still reports units 1–400 and 401 onwards; the pre-existing rater tests asserting exactly that still pass untouched. A three-place meter reports `400.001`, because `401` would leave everything between undescribed.

## An unrelated defect this repairs in passing

`CarryForwardCap` was **never copied** from the request to the stored plan, nor from the plan into the subscription snapshot. It was validated as mandatory, reported as `null` by three responses, and read as "no cap at all" by `MeterAllowance.CarriedIn` — so a carry-forward meter created through the API **banked allowance forever**, which is the precise outcome the validator's own message says requiring a cap prevents.

Invisible to the suite because every existing test set the field directly on an entity or snapshot, never through the path that authors it. Found because these are the two initializers `QuantityScale` had to be added to. Fixed here rather than left, because otherwise this PR would ship a `decimal? CarryForwardCap` that provably cannot hold a value.

Two new tests fail if either propagation is reverted.

## Breaking change

`included`, `used`, `remaining` and `overage` on `UsageResponse`, and the plan and preview quantity fields, **may now be non-integral** for a caller that meets a meter with a scale above zero. A consumer parsing them into an `int` breaks. There is no way to version a number's domain, so this is stated rather than mitigated.

Browsers should treat them as display-only and never sum them: a JavaScript number is a double, and client-side arithmetic on a billing quantity drifts from the exact decimal the server holds. Documented on the endpoint and in the module README.

## Verification

- **Unit:** 3455 passed / 5 failed — 68 new tests. The 4 `SubscriptionSimulation*` failures are the pre-existing permission-guard defect on `dev` (`8d7a4389`, unrelated). The 5th is `PeriodicPingBackgroundServiceTests`, which passes in isolation twice; it and `FinancialDocumentRendererHealthMonitorTests` are timing-sensitive Worker tests unrelated to usage.
- **Integration:** 114 passed / 0 failed against MongoDB 7 (was 108; +6 new). `FractionalUsageQuantityIntegrationTests` is added to the `mongo-integration` filter, with a comment saying why it must run there.
- **Client:** 2428 passed. The one failing *suite* is a worktree artefact — `Cannot find module 'C:\D:\Selise\...'`, a malformed path from the shared `node_modules` junction, in an unrelated IDP auth file.
- **Regression proofs** — each new guard was reverted and the failure count recorded:

| Reverted | Failures |
|---|---|
| The recording-path scale gate | 3 |
| `QuantityScale` propagation to the stored plan | 1 |
| `CarryForwardCap` propagation | 1 |

- `dotnet build` clean on Api, Worker and the domain service; `tsc -b` clean; `eslint` clean on every changed client file.

## Scope notes

- `AppliedRecordCount` stays a `long`. It counts ledger rows, not units.
- `MeterTier.UnitAmountMinor` stays a `long`. It is a rate, not a quantity.
- Money remains `decimal` for amounts and `long` for minor units, untouched.
- `prettier --check` reports 111 files under `client/`, including ones this PR never touches, so it is not treated as a gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
