### PR TITLE
fix(subscription): let a counted entitlement hold its meter's fractional allowance

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
@@ -20,6 +20,7 @@ import {
 import { ENTITLEMENT_LIMIT_KIND_OPTIONS } from "../../constants/subscription.constants";
 import { ENTITLEMENT_LIMIT_KIND_NAMES } from "../../models/subscription-plan.model";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import { stepFor } from "../../utilities/meter-quantity";
 import { describeEntitlementMeterMismatch } from "../../utilities/plan-consistency";
 import { CardListItem, CardListShell } from "./card-list-shell";
 
@@ -200,7 +201,16 @@ export const StepUsageLimits = () => {
                           )}
                         </div>
                         <FormControl>
-                          <Input {...inputField} type="number" min={0} disabled={Boolean(selectedMeter) && !limitIsOverridden} />
+                          {/* Stepped to the granularity of the meter this draws down. Without it
+                              the browser refuses a fractional allowance the meter itself permits —
+                              including the one this form fills in on selecting that meter. */}
+                          <Input
+                            {...inputField}
+                            type="number"
+                            min={0}
+                            step={stepFor(selectedMeter?.quantityScale ?? 0)}
+                            disabled={Boolean(selectedMeter) && !limitIsOverridden}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.test.ts
@@ -730,4 +730,70 @@ describe("quantity discount bands", () => {
     expect(issuePaths(result)).toContainEqual(["meters", 1, "includedQuantity"]);
     expect(issuePaths(result)).not.toContainEqual(["meters", 0, "includedQuantity"]);
   });
+
+  /**
+   * The exact flow that was broken: a meter with a fractional allowance, and the entitlement that
+   * draws it down carrying the same figure.
+   *
+   * The form fills the limit in itself on selecting the meter, and disables the field while it is
+   * inherited — so an integer-only rule here did not merely reject the value, it rejected a value
+   * the form had produced and would not let anyone correct. The plan could not be saved at all.
+   */
+  it("accepts an entitlement limit that matches its meter's fractional allowance", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ meterKey: "tokens", quantityScale: 2, includedQuantity: 550.55 })],
+      entitlements: [
+        { key: "tokens", limitKind: 1, limit: 550.55, meterKey: "tokens" },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an entitlement limit finer than the meter it draws down", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ meterKey: "tokens", quantityScale: 1, includedQuantity: 550.5 })],
+      entitlements: [
+        { key: "tokens", limitKind: 1, limit: 550.55, meterKey: "tokens" },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["entitlements", 0, "limit"]);
+  });
+
+  /** A whole-unit meter still refuses a fractional entitlement limit, as it always has. */
+  it("rejects a fractional entitlement limit on a whole-unit meter", () => {
+    const result = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      meters: [meter({ meterKey: "tokens" })],
+      entitlements: [{ key: "tokens", limitKind: 1, limit: 550.55, meterKey: "tokens" }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(issuePaths(result)).toContainEqual(["entitlements", 0, "limit"]);
+  });
+
+  /**
+   * An entitlement naming no meter is a plain cap on something this module does not count, so no
+   * meter's scale governs it — only the platform maximum.
+   */
+  it("holds a meterless entitlement limit only to the platform maximum", () => {
+    const allowed = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      entitlements: [{ key: "projects", limitKind: 2, limit: 1.5 }],
+    });
+
+    expect(allowed.success).toBe(true);
+
+    const tooFine = createSubscriptionPlanSchema.safeParse({
+      ...validPlan,
+      entitlements: [{ key: "projects", limitKind: 2, limit: 1.00000005 }],
+    });
+
+    expect(tooFine.success).toBe(false);
+    expect(issuePaths(tooFine)).toContainEqual(["entitlements", 0, "limit"]);
+  });
 });

--- a/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
+++ b/client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts
@@ -257,7 +257,10 @@ const entitlementSchema = z
   .object({
     key: key("key"),
     limitKind: z.coerce.number().int().min(0).max(2),
-    limit: z.coerce.number().int().min(0).optional(),
+    // Not integer-only: a counted entitlement's limit is the allowance of the meter it draws
+    // down, so it has to be able to hold whatever that meter can. Granularity is checked at plan
+    // level, against that meter's own scale.
+    limit: z.coerce.number().min(0).optional(),
     meterKey: z.string().trim().max(SUBSCRIPTION_KEY_MAX_LENGTH).optional(),
     unitLabel: z.string().trim().max(SUBSCRIPTION_KEY_MAX_LENGTH).optional(),
   })
@@ -475,6 +478,27 @@ export const buildSubscriptionPlanSchema = ({ requirePrice }: { requirePrice: bo
             code: z.ZodIssueCode.custom,
             path: ["entitlements", index, "meterKey"],
             message: "This meter is not defined on this plan.",
+          });
+        }
+
+        if (entitlement.limit === undefined) {
+          return;
+        }
+
+        // Held to the scale of the meter it draws down, because that is the balance it is compared
+        // against. An entitlement naming no meter is a plain cap, so it is held only to the
+        // platform maximum.
+        const meter = plan.meters.find((candidate) => candidate.meterKey === entitlement.meterKey);
+        const scale = meter?.quantityScale ?? METER_QUANTITY_MAX_SCALE;
+
+        if (!isWithinScale(entitlement.limit, scale) || !isWithinMagnitude(entitlement.limit)) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["entitlements", index, "limit"],
+            message:
+              scale === 0
+                ? "This meter takes whole numbers only."
+                : `This meter allows at most ${scale} decimal places.`,
           });
         }
       });

--- a/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
+++ b/server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs
@@ -204,6 +204,15 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
             .WithErrorCode("subscription_lifetime_meter_trial_grant_invalid");
 
         RuleFor(request => request)
+            .Must(EveryEntitlementLimitIsWithinItsMeterScale)
+            .WithName(nameof(PlanDefinitionRequest.Entitlements))
+            .WithMessage(
+                "An entitlement's limit has more decimal places than the meter it draws down " +
+                "allows. The limit is compared against that meter's balance, so it has to be a " +
+                "quantity that meter can hold.")
+            .WithErrorCode("subscription_entitlement_limit_quantity_scale_exceeded");
+
+        RuleFor(request => request)
             .Must(EveryTrialGrantIsWithinItsMeterScale)
             .WithName(nameof(PlanDefinitionRequest.TrialGrants))
             .WithMessage(
@@ -243,6 +252,48 @@ public sealed class PlanDefinitionRequestValidator : AbstractValidator<PlanDefin
                    table.Tiers.TrueForAll(tier =>
                        tier.UpToQuantity is not { } bound || Fits(bound)));
     }
+
+    /// <summary>
+    /// A counted entitlement's limit has to be a quantity its meter can hold.
+    /// </summary>
+    /// <remarks>
+    /// The limit is what <see cref="Services.EntitlementService"/> compares the meter's balance
+    /// against, and what it subtracts that balance from to report what remains. A limit the meter
+    /// cannot represent would advertise an allowance the usage gate could never agree with — the
+    /// disagreement <c>LimitFor</c>'s own remarks warn about.
+    /// <para>
+    /// An entitlement naming no meter is a plain cap on something this module does not count, so it
+    /// is held only to the platform maximum rather than to any meter's scale.
+    /// </para>
+    /// </remarks>
+    private static bool EveryEntitlementLimitIsWithinItsMeterScale(PlanDefinitionRequest request) =>
+        request.Entitlements.TrueForAll(entitlement =>
+        {
+            if (entitlement.Limit is not { } limit)
+            {
+                return true;
+            }
+
+            var meter = request.Meters.Find(candidate =>
+                string.Equals(candidate.MeterKey, entitlement.MeterKey, StringComparison.Ordinal));
+
+            // A meter that does not exist, or whose scale is not a scale, is already refused by its
+            // own rule; saying so twice would put two messages on one mistake.
+            if (entitlement.MeterKey is { Length: > 0 } && meter is null)
+            {
+                return true;
+            }
+
+            var scale = meter is null ? MeterQuantity.MaxScale : meter.QuantityScale;
+
+            if (!MeterQuantity.IsValidScale(scale))
+            {
+                return true;
+            }
+
+            return MeterQuantity.IsWithinMagnitude(limit) &&
+                   MeterQuantity.IsWithinScale(limit, scale);
+        });
 
     private static bool EveryTrialGrantIsWithinItsMeterScale(PlanDefinitionRequest request) =>
         request.TrialGrants.TrueForAll(grant =>

--- a/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
+++ b/server/XUnitTest/Subscription/PlanDefinitionRequestValidatorTests.cs
@@ -313,6 +313,142 @@ public sealed class PlanDefinitionRequestValidatorTests
             error.ErrorCode == "subscription_meter_quantity_scale_exceeded");
     }
 
+    /// <summary>
+    /// A counted entitlement's limit may hold whatever its meter can.
+    /// </summary>
+    /// <remarks>
+    /// The API had the same gap the plan form did: the limit is the allowance of the meter it draws
+    /// down, and the plan builder fills it in from that meter, so refusing a fractional one made a
+    /// fractional meter unusable from the form and inconsistent from the API.
+    /// </remarks>
+    [Fact]
+    public async Task An_entitlement_limit_matching_its_meters_fractional_allowance_is_accepted()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 2;
+        request.Meters[0].IncludedQuantity = 550.55m;
+        request.Entitlements =
+        [
+            new PlanEntitlementRequest
+            {
+                Key = "screening",
+                LimitKind = EntitlementLimitKind.Count,
+                Limit = 550.55m,
+                MeterKey = "screening"
+            }
+        ];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A limit its meter cannot represent would advertise an allowance the usage gate could never
+    /// agree with.
+    /// </summary>
+    [Fact]
+    public async Task An_entitlement_limit_finer_than_its_meter_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Meters[0].QuantityScale = 1;
+        request.Entitlements =
+        [
+            new PlanEntitlementRequest
+            {
+                Key = "screening",
+                LimitKind = EntitlementLimitKind.Count,
+                Limit = 550.55m,
+                MeterKey = "screening"
+            }
+        ];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_entitlement_limit_quantity_scale_exceeded");
+    }
+
+    [Fact]
+    public async Task A_fractional_entitlement_limit_on_a_whole_unit_meter_is_refused()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Entitlements =
+        [
+            new PlanEntitlementRequest
+            {
+                Key = "screening",
+                LimitKind = EntitlementLimitKind.Count,
+                Limit = 550.55m,
+                MeterKey = "screening"
+            }
+        ];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_entitlement_limit_quantity_scale_exceeded");
+    }
+
+    /// <summary>
+    /// An entitlement naming no meter caps something this module does not count, so no meter's
+    /// scale governs it — only the platform maximum.
+    /// </summary>
+    [Fact]
+    public async Task A_meterless_entitlement_limit_is_held_only_to_the_platform_maximum()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Entitlements =
+        [
+            new PlanEntitlementRequest
+            {
+                Key = "projects",
+                LimitKind = EntitlementLimitKind.Count,
+                Limit = 1.5m
+            }
+        ];
+
+        (await new PlanDefinitionRequestValidator().ValidateAsync(request))
+            .Errors
+            .Should()
+            .NotContain(error =>
+                error.ErrorCode == "subscription_entitlement_limit_quantity_scale_exceeded");
+
+        request.Entitlements[0].Limit = 1.00000005m;
+
+        (await new PlanDefinitionRequestValidator().ValidateAsync(request))
+            .Errors
+            .Should()
+            .Contain(error =>
+                error.ErrorCode == "subscription_entitlement_limit_quantity_scale_exceeded");
+    }
+
+    /// <summary>
+    /// An entitlement naming a meter the plan does not define reports that one mistake, not two.
+    /// </summary>
+    [Fact]
+    public async Task An_unknown_meter_does_not_also_report_a_scale_failure()
+    {
+        var request = RequestWithPeriodicMeter();
+        request.Entitlements =
+        [
+            new PlanEntitlementRequest
+            {
+                Key = "screening",
+                LimitKind = EntitlementLimitKind.Count,
+                Limit = 550.55m,
+                MeterKey = "nonexistent"
+            }
+        ];
+
+        var result = await new PlanDefinitionRequestValidator().ValidateAsync(request);
+
+        result.Errors.Should().Contain(error =>
+            error.ErrorCode == "subscription_entitlement_meter_unknown");
+        result.Errors.Should().NotContain(error =>
+            error.ErrorCode == "subscription_entitlement_limit_quantity_scale_exceeded");
+    }
+
     private static UpdatePlanRequest RequestWithPeriodicMeter() => new()
     {
         DisplayName = "Screening plan",


### PR DESCRIPTION
## The bug you hit

A meter with **550.55 tokens included** could not be saved at all. Selecting it under *"what the plan grants"* and entering `550.55` as the limit reported:

> Expected integer, received float

## Why it happened

`entitlementSchema.limit` was still `z.coerce.number().int()`. #397 widened the server's `PlanEntitlement.Limit` to `decimal` and every meter field on the form, and **missed this one**.

What makes it a dead end rather than an annoyance: the form **fills the limit in itself** from the meter it draws down —

```ts
setValue(`entitlements.${index}.limit`, meter?.includedQuantity ?? 0, …)
```

— and **disables the field** while the value is inherited. So the rule rejected a figure the form had produced, on a field nobody could edit. The only escape was Override, and typing `550.55` there was rejected too. **The plan was unsaveable.**

## What the limit actually is

Not incidentally a quantity. It *is* the allowance of the meter it draws down: `EntitlementService` compares that meter's balance against it (`used < limit`) and subtracts to report what remains. A limit the meter cannot represent would advertise an allowance the usage gate could never agree with — the exact disagreement `LimitFor`'s own remarks warn about.

So it is now held to **that meter's own scale**, the way a trial grant already was.

## The fix, in three places

| Where | Change |
|---|---|
[subscription-plan.schema.ts](client/app/cross-modules/utilities/subscription/schemas/subscription-plan.schema.ts) | Drops `.int()`; checks the named meter's scale, reporting against the **limit** field rather than the scale field |
[step-usage-limits.tsx](client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx) | The limit input steps to that meter's granularity |
[PlanDefinitionRequestValidator.cs](server/Subscription.DomainService/Validators/PlanDefinitionRequestValidator.cs) | The matching rule, with `subscription_entitlement_limit_quantity_scale_exceeded` |

The `step` matters independently: without it the browser's own number validation refuses the inherited value **before** the form's validation ever runs, so fixing only the schema would have left the field still unusable.

**The API had the same gap** and would have accepted `550.555` against a one-place meter. Fixed in the same commit rather than left as a second round.

## Two edge cases

- **An entitlement naming no meter** caps something this module does not count (`max projects`), so no meter's scale governs it — only the platform maximum of six places.
- **An entitlement naming a meter the plan does not define** keeps reporting that one mistake. The scale rule stands down rather than adding a second message about a meter that isn't there.

## Verification

Each rule was reverted and the failures recorded:

| Reverted | Failures |
|---|---|
| The form's `.int()` removal | 2 |
| The API validator rule | 3 |

- Server: 3460 passed / 5 failed — the 4 pre-existing `SubscriptionSimulation*` permission-guard failures on `dev` and the known-flaky `FinancialDocumentRendererHealthMonitorTests`.
- Client: **645 passed** across all 51 subscription test files.
- `dotnet build` clean, `tsc -b` clean, `eslint` clean on both changed client files.

## Note

Branched off current `dev` (which has #397). Independent of #398, the copy-only follow-up still open — they touch different parts of the schema file and merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
