### PR TITLE
feat(subscription): list plans narrowed to one product family

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -82,6 +82,13 @@ jobs:
       # is the authority every past invoice was computed from. A mocked repository demonstrates
       # none of it.
       #
+      # PlanFamilyListingIntegrationTests is named because narrowing a listing to one product family
+      # has to compose with the organization-over-tenant resolution that listing already performs,
+      # and that resolution is a property of the documents stored rather than of our code: two
+      # plans sharing a code, one owned by an organization and one by the tenant, in different
+      # families. Narrowed in the wrong place it offers a plan subscribing can never select. A
+      # mocked repository would be the thing under test.
+      #
       # Several integration classes are still outside this filter and so run nowhere. Widening it
       # further belongs in its own change, since whatever it turns up would arrive as unrelated
       # failures on whichever pull request happened to widen it.
@@ -89,5 +96,5 @@ jobs:
         run: >-
           dotnet test server/XUnitTest/XUnitTest.csproj
           --no-restore
-          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests|FullyQualifiedName~OpeningStubUpgradeRecoveryIntegrationTests|FullyQualifiedName~SubscriptionUsageCurrentIntegrationTests|FullyQualifiedName~FractionalUsageQuantityIntegrationTests"
+          --filter "FullyQualifiedName~SubscriptionWorkQueueIntegrationTests|FullyQualifiedName~SubscriptionRenewalCrashRecoveryIntegrationTests|FullyQualifiedName~SubscriptionRepositoryIntegrationTests|FullyQualifiedName~SubscriptionQueueDocumentFlowIntegrationTests|FullyQualifiedName~CampaignRedemptionConcurrencyTests|FullyQualifiedName~PlanArchiveIntegrationTests|FullyQualifiedName~SubscriptionCatalogueRepositoryIntegrationTests|FullyQualifiedName~PendingPlanChangeIntegrationTests|FullyQualifiedName~OpeningStubUpgradeRecoveryIntegrationTests|FullyQualifiedName~SubscriptionUsageCurrentIntegrationTests|FullyQualifiedName~FractionalUsageQuantityIntegrationTests|FullyQualifiedName~PlanFamilyListingIntegrationTests"
           --verbosity minimal

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.test.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.test.ts
@@ -42,6 +42,67 @@ describe("subscriptionService", () => {
     expect(getMock).toHaveBeenCalledWith("/api/subscription-plans?organizationId=org-1");
   });
 
+  describe("narrowing to one product family", () => {
+    it("sends the family code when one is given", async () => {
+      getMock.mockResolvedValue(ok([]));
+
+      await subscriptionService.listPlans(undefined, undefined, "growth");
+
+      expect(getMock).toHaveBeenCalledWith("/api/subscription-plans?familyCode=growth");
+    });
+
+    it("combines the family with the organization and the status", async () => {
+      getMock.mockResolvedValue(ok([]));
+
+      await subscriptionService.listPlans("org-1", "All", "growth");
+
+      expect(getMock).toHaveBeenCalledWith(
+        "/api/subscription-plans?organizationId=org-1&status=All&familyCode=growth",
+      );
+    });
+
+    /**
+     * A blank field is not a family. Sending it would be harmless — the server reads blank as
+     * every family — but the request a screen makes should say what it means.
+     */
+    it.each(["", "   "])("omits a blank family code (%s)", async (blank) => {
+      getMock.mockResolvedValue(ok([]));
+
+      await subscriptionService.listPlans(undefined, undefined, blank);
+
+      expect(getMock).toHaveBeenCalledWith("/api/subscription-plans");
+    });
+
+    /**
+     * Byte-identical to the request made before this parameter existed, which is what keeps every
+     * screen that does not care about families untouched.
+     */
+    it("sends nothing extra when no family is named", async () => {
+      getMock.mockResolvedValue(ok([]));
+
+      await subscriptionService.listPlans();
+
+      expect(getMock).toHaveBeenCalledWith("/api/subscription-plans");
+    });
+
+    /** Sent as authored, since the server matches it exactly. */
+    it("does not fold the case of a family code", async () => {
+      getMock.mockResolvedValue(ok([]));
+
+      await subscriptionService.listPlans(undefined, undefined, "Growth");
+
+      expect(getMock).toHaveBeenCalledWith("/api/subscription-plans?familyCode=Growth");
+    });
+
+    it("encodes a family code that needs it", async () => {
+      getMock.mockResolvedValue(ok([]));
+
+      await subscriptionService.listPlans(undefined, undefined, "a/b c");
+
+      expect(getMock).toHaveBeenCalledWith("/api/subscription-plans?familyCode=a%2Fb+c");
+    });
+  });
+
   it("names the organization when reading one scoped plan", async () => {
     getMock.mockResolvedValue(ok({ planId: "plan-1" }));
 

--- a/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
+++ b/client/app/cross-modules/utilities/subscription/services/subscription.service.ts
@@ -32,10 +32,14 @@ class SubscriptionService {
   /**
    * @param status Which plans to ask for. Omitted by every subscriber-facing caller, which is
    * what makes the default — the active catalogue — the thing those screens receive.
+   * @param familyCode Narrows the listing to one product family, ordered by family rank. Omit it
+   * for every family. Matched exactly and case-sensitively by the server, so it must be sent as
+   * the plan authored it.
    */
   async listPlans(
     organizationId?: string,
     status?: PlanCatalogueFilterName,
+    familyCode?: string,
   ): Promise<SubscriptionPlan[]> {
     const parameters = new URLSearchParams();
 
@@ -47,6 +51,13 @@ class SubscriptionService {
     // makes is byte-identical to the one it made before this parameter existed.
     if (status && status !== "Active") {
       parameters.set("status", status);
+    }
+
+    // Trimmed only to decide whether it was supplied at all: a blank field is not a family, and
+    // the server reads blank as "every family" anyway. The value itself is sent untrimmed, because
+    // the server matches it exactly against what the plan was authored with.
+    if (familyCode && familyCode.trim().length > 0) {
+      parameters.set("familyCode", familyCode);
     }
 
     const query = parameters.size > 0 ? `?${parameters.toString()}` : "";

--- a/server/Api/Controllers/SubscriptionPlansController.cs
+++ b/server/Api/Controllers/SubscriptionPlansController.cs
@@ -30,6 +30,7 @@ public sealed class SubscriptionPlansController : ControllerBase
     public async Task<IActionResult> ListPlans(
         [FromQuery] string? organizationId,
         [FromQuery] string? status,
+        [FromQuery] string? familyCode,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
@@ -45,11 +46,16 @@ public sealed class SubscriptionPlansController : ControllerBase
                 correlationId));
         }
 
+        // Passed through as given. Omitting it lists every family, exactly as before; a family
+        // nobody authored is an empty list rather than a refusal, because a listing endpoint
+        // reports what is there and there is nothing malformed about asking after a family that
+        // holds nothing.
         var result = await _catalogue.ListPlansAsync(
             organizationId,
             correlationId,
             cancellationToken,
-            filter);
+            filter,
+            familyCode);
 
         return result.ToActionResult(correlationId);
     }

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -2065,6 +2065,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
           <p>Every plan visible to the caller's organization, each with its prices.</p>
           <h4>Query</h4>
           <p><code>organizationId</code> — console only; ignored otherwise.</p>
+          <p><code>familyCode</code> — narrows the listing to one product family, ordered by <code>familyRank</code>. Omit it for every family. Matched exactly and case-sensitively, like a plan <code>code</code>. A family nobody authored answers <code>200</code> with an empty array, not <code>404</code>.</p>
           <h4>Returns</h4>
           <p><code>200</code> array of plans · <code>503</code> organization could not be resolved.</p>
         </div>
@@ -2390,7 +2391,7 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
       </div>
 
       <div class="endpoint">
-        <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscription-plans?organizationId={organizationId}&amp;status={Active|Archived|All}</span></div>
+        <div class="endpoint-head"><span class="method">GET</span><span class="path">/api/subscription-plans?organizationId={organizationId}&amp;status={Active|Archived|All}&amp;familyCode={familyCode}</span></div>
         <div class="endpoint-body">
           <p><strong>Call when:</strong> listing the catalogue. <code>status</code> is optional and defaults to <code>Active</code>.</p>
           <p class="prose">
@@ -2409,6 +2410,30 @@ Content-Type:  application/json      (on POST and PUT)</code></pre>
           <p class="prose">
             <code>Draft</code> is not accepted and appears in none of the three views. Any other
             value answers <code>400 subscription_plan_status_invalid</code>.
+          </p>
+          <h4>Narrowing to one product family</h4>
+          <p class="prose">
+            <code>familyCode</code> restricts the listing to one family and orders it by
+            <code>familyRank</code> — ascending, so the entry level comes first. Omit it and every
+            family is listed in the code order it always was. It <em>narrows</em> rather than
+            replaces: <code>status</code> still applies, so a family under the default
+            <code>Active</code> view does not surface that family's archived plans.
+          </p>
+          <p class="prose">
+            Matched exactly and case-sensitively, like a plan <code>code</code>. A family code is
+            stored as authored, so <code>Pro</code> and <code>pro</code> are two families that can
+            both exist. A family nobody authored, or one with nothing visible on sale, answers
+            <code>200</code> with an empty array rather than <code>404</code>: a listing reports
+            what is there, and asking after an empty family is a well-formed question.
+          </p>
+          <p class="prose">
+            The narrowing is applied <strong>after</strong> the organization-over-tenant resolution
+            described above, which is observable. If an organization's own <code>pro</code> is in
+            the <code>premium</code> family and the tenant's <code>pro</code> is in
+            <code>basic</code>, then for that organization <code>familyCode=basic</code> returns
+            nothing — the plan it would actually resolve for the code <code>pro</code> is the
+            premium one. Returning the tenant's shadowed record would offer a plan subscribing
+            cannot select.
           </p>
           <h4>New response fields</h4>
           <p><code>status</code> (<code>"Active"</code> or <code>"Archived"</code>), <code>createdAtUtc</code>, and <code>lastUpdatedAtUtc</code> — the last of which changes when a plan is archived, so it can drive a &ldquo;recently updated&rdquo; order.</p>

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -1656,6 +1656,22 @@ spent or whose expiry has passed reduces nothing, so it never blocks a move.
 plan—there is no second tier entity. Prices may carry `DisplayPriceNote` for authored presentation
 such as "$17/month, billed annually".
 
+`GET /api/subscription-plans?familyCode=growth` narrows a listing to one family, ordered by
+`FamilyRank` — the only place that rank means anything. Omitting it lists every family, which is
+what it has always done. Matched exactly and case-sensitively, like `Code`: a family code is stored
+as authored, so `Pro` and `pro` are two families that can both exist and folding case would merge
+them. A family nobody authored is an empty list, not a not-found; a listing reports what is there.
+
+The narrowing is applied **after** the organization-over-tenant resolution, not as part of the
+query, and the distinction changes the answer. The resolution decides which of two plans sharing a
+code is the one subscribing would actually find, and the two need not be in the same family: an
+organization's own `pro` in the premium family shadows the tenant's `pro` in the basic family.
+Narrowing first would leave the tenant's plan as the only candidate in its code group and offer it —
+a plan subscribing can never select, which is the exact misreport the resolution exists to prevent.
+Narrowing afterwards says the basic family has nothing on sale here, which is true.
+`PlanFamilyListingIntegrationTests` pins it; moving the filter into the query fails four of its
+cases.
+
 Discounts are authored at `/api/subscription-discounts`, optionally scoped to an organization and
 optionally restricted to plan codes, price identifiers, or both. Both lists are resolved against the
 catalogue as the discount is authored — an identifier that does not exist in scope, or a price on a

--- a/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionCatalogueRepository.cs
@@ -35,11 +35,19 @@ public interface ISubscriptionCatalogueRepository
     /// archived views deliberately do not collapse: a replacement sharing a code is usually the
     /// reason somebody is reading history.
     /// </param>
+    /// <param name="familyCode">
+    /// Narrows the result to one product family, exactly and case-sensitively. Null or blank lists
+    /// every family, which is what every caller before this asked for. Applied after the
+    /// organization-over-tenant resolution rather than as part of the query — see the
+    /// implementation for why that distinction changes the answer — and orders the result by
+    /// <see cref="Plan.FamilyRank"/>, which is the only place that rank means anything.
+    /// </param>
     Task<IReadOnlyList<Plan>> ListPlansAsync(
         string tenantId,
         string? organizationId,
         PlanCatalogueFilter filter,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken,
+        string? familyCode = null);
 
     /// <summary>
     /// The archived plan a caller would have resolved for <paramref name="code"/>, had it still

--- a/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCatalogueRepository.cs
@@ -104,7 +104,8 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
         string tenantId,
         string? organizationId,
         PlanCatalogueFilter filter,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? familyCode = null)
     {
         await EnsureIndexesAsync(tenantId, cancellationToken);
 
@@ -147,9 +148,43 @@ public sealed class SubscriptionCatalogueRepository : ISubscriptionCatalogueRepo
                 group.First());
 
         var archived = plans.Where(plan => plan.Status == CatalogueStatus.Archived);
+        var listed = resolved.Concat(archived);
 
-        return resolved
-            .Concat(archived)
+        // Narrowed to one family *after* the organization-over-tenant collapse above, deliberately,
+        // and so not as part of the query.
+        //
+        // Filtering in the query would ask the wrong question. The collapse decides which of two
+        // plans sharing a code is the one subscribing would actually resolve, and the two need not
+        // belong to the same family: an organization's own "pro" in the premium family shadows the
+        // tenant's "pro" in the basic family. Narrowing first would leave the tenant's plan as the
+        // only candidate in its group, so a caller asking for the basic family would be shown a
+        // plan that subscribing can never select — the same misreport the collapse itself exists to
+        // prevent. Narrowing afterwards answers truthfully: that family has nothing on sale here.
+        //
+        // No index, and no worse than before: this method already reads every one of the tenant's
+        // plans and resolves them in memory, on the documented assumption that plan counts per
+        // tenant are small.
+        if (!string.IsNullOrWhiteSpace(familyCode))
+        {
+            // Exact and case-sensitive, matching Plan.Code and FindPlanByCodeAsync. A family code
+            // is stored exactly as authored, so "Pro" and "pro" are two families that can both
+            // exist, and folding case here would silently merge them.
+            listed = listed.Where(plan =>
+                string.Equals(plan.FamilyCode, familyCode, StringComparison.Ordinal));
+
+            // Rank first, because ranking a family is what FamilyRank is for and it means nothing
+            // outside one. Authoring requires a rank wherever a family code is set, so the
+            // fallback only covers a plan stored before that rule and keeps it last rather than
+            // first.
+            return listed
+                .OrderBy(plan => plan.FamilyRank ?? int.MaxValue)
+                .ThenBy(plan => plan.Code, StringComparer.Ordinal)
+                .ThenBy(plan => plan.Status == CatalogueStatus.Archived ? 1 : 0)
+                .ThenByDescending(plan => plan.LastUpdatedDateUtc)
+                .ToList();
+        }
+
+        return listed
             .OrderBy(plan => plan.Code, StringComparer.Ordinal)
             .ThenBy(plan => plan.Status == CatalogueStatus.Archived ? 1 : 0)
             .ThenByDescending(plan => plan.LastUpdatedDateUtc)

--- a/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/IPlanCatalogueService.cs
@@ -1,3 +1,4 @@
+using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
@@ -110,11 +111,22 @@ public interface IPlanCatalogueService
     /// keeps archived plans out of subscribe and change-plan selectors without those screens
     /// having to filter anything themselves.
     /// </param>
+    /// <param name="familyCode">
+    /// Narrows the listing to one product family — <see cref="Plan.FamilyCode"/> — matched exactly
+    /// and case-sensitively, and ordered by <see cref="Plan.FamilyRank"/>. Omit it for every
+    /// family, which is what every caller before this asked for and still gets.
+    /// <para>
+    /// A family nobody authored, or one with nothing visible on sale, is an empty list rather than
+    /// a not-found: a listing endpoint reports what is there, and "this family has no plans here"
+    /// is a truthful answer to a well-formed question.
+    /// </para>
+    /// </param>
     Task<SubscriptionOperationResult<IReadOnlyList<PlanResponse>>> ListPlansAsync(
         string? organizationId,
         string correlationId,
         CancellationToken cancellationToken,
-        PlanCatalogueFilter filter = PlanCatalogueFilter.Active);
+        PlanCatalogueFilter filter = PlanCatalogueFilter.Active,
+        string? familyCode = null);
 
     Task<SubscriptionOperationResult<PlanResponse>> GetPlanAsync(
         string planId,

--- a/server/Subscription.DomainService/Services/PlanCatalogueService.cs
+++ b/server/Subscription.DomainService/Services/PlanCatalogueService.cs
@@ -894,7 +894,8 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
         string? organizationId,
         string correlationId,
         CancellationToken cancellationToken,
-        PlanCatalogueFilter filter = PlanCatalogueFilter.Active)
+        PlanCatalogueFilter filter = PlanCatalogueFilter.Active,
+        string? familyCode = null)
     {
         var resolution = await _contextResolver.ResolveAsync(
             correlationId,
@@ -911,7 +912,8 @@ public sealed class PlanCatalogueService : IPlanCatalogueService
             context.TenantId,
             context.OrganizationId,
             filter,
-            cancellationToken);
+            cancellationToken,
+            familyCode);
 
         var responses = new List<PlanResponse>(plans.Count);
 

--- a/server/XUnitTest/Integration/PlanFamilyListingIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PlanFamilyListingIntegrationTests.cs
@@ -1,0 +1,290 @@
+using FluentAssertions;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// Listing a plan catalogue narrowed to one product family.
+/// </summary>
+/// <remarks>
+/// Against a real MongoDB because what is being tested is how the family narrowing composes with
+/// the organization-over-tenant resolution the listing already performs, and that resolution is a
+/// property of the documents actually stored — two plans sharing a code, one owned by an
+/// organization and one by the tenant. A mocked repository would be the thing under test.
+/// <para>
+/// The case that matters most is the one where the two plans sharing a code sit in *different*
+/// families. Narrowing inside the query rather than after the resolution would answer with a plan
+/// that subscribing could never select.
+/// </para>
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class PlanFamilyListingIntegrationTests
+{
+    private const string Organization = "org-1";
+
+    private readonly SubscriptionCatalogueRepository _catalogue;
+
+    public PlanFamilyListingIntegrationTests(MongoIntegrationFixture fixture) =>
+        _catalogue = new SubscriptionCatalogueRepository(fixture.DbContextProvider);
+
+    /// <summary>Omitting the family code lists everything, exactly as it did before.</summary>
+    [Fact]
+    public async Task No_family_code_lists_every_family()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "starter", "growth", 1));
+        await Seed(tenantId, Plan(tenantId, "pro", "growth", 2));
+        await Seed(tenantId, Plan(tenantId, "lab", "research", 1));
+        await Seed(tenantId, Plan(tenantId, "solo", family: null, rank: null));
+
+        var listed = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None);
+
+        listed.Select(plan => plan.Code)
+            .Should()
+            .BeEquivalentTo(["starter", "pro", "lab", "solo"]);
+    }
+
+    [Fact]
+    public async Task A_family_code_lists_only_that_family()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "starter", "growth", 1));
+        await Seed(tenantId, Plan(tenantId, "pro", "growth", 2));
+        await Seed(tenantId, Plan(tenantId, "lab", "research", 1));
+        await Seed(tenantId, Plan(tenantId, "solo", family: null, rank: null));
+
+        var listed = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "growth");
+
+        listed.Select(plan => plan.Code).Should().Equal("starter", "pro");
+    }
+
+    /// <summary>
+    /// Ordered by rank, not by code, because ranking a family is what the rank is for.
+    /// </summary>
+    /// <remarks>
+    /// Seeded so that the two orders disagree: by code "enterprise" would come first, by rank it
+    /// comes last. A test whose codes happened to sort into rank order would pass either way.
+    /// </remarks>
+    [Fact]
+    public async Task A_family_is_ordered_by_rank_rather_than_by_code()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "enterprise", "growth", 3));
+        await Seed(tenantId, Plan(tenantId, "starter", "growth", 1));
+        await Seed(tenantId, Plan(tenantId, "pro", "growth", 2));
+
+        var listed = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "growth");
+
+        listed.Select(plan => plan.Code).Should().Equal("starter", "pro", "enterprise");
+    }
+
+    /// <summary>
+    /// The narrowing happens after the organization-over-tenant collapse, so it can never
+    /// advertise a plan subscribing would not resolve.
+    /// </summary>
+    /// <remarks>
+    /// The organization's own "pro" sits in the premium family and shadows the tenant's "pro",
+    /// which sits in the basic family. Asking for the basic family must report nothing: the plan
+    /// that would resolve for this organization is the premium one, and offering the tenant's
+    /// shadowed record would be a choice subscribing cannot honour.
+    /// <para>
+    /// Filtering inside the query would leave the tenant's plan as the only member of its code
+    /// group and return it — which is the defect this ordering exists to prevent.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task A_shadowed_plans_family_is_not_offered_to_the_organization_that_shadows_it()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "pro", "basic", 1));
+        await Seed(tenantId, Plan(tenantId, "pro", "premium", 1, organizationId: Organization));
+
+        var basic = await _catalogue.ListPlansAsync(
+            tenantId, Organization, PlanCatalogueFilter.Active, CancellationToken.None, "basic");
+
+        basic.Should().BeEmpty(
+            "the plan this organization would resolve for the code 'pro' is not in the basic family");
+
+        var premium = await _catalogue.ListPlansAsync(
+            tenantId, Organization, PlanCatalogueFilter.Active, CancellationToken.None, "premium");
+
+        premium.Should().ContainSingle()
+            .Which.OrganizationId.Should().Be(Organization);
+    }
+
+    /// <summary>
+    /// A tenant-wide reader is unaffected by an organization's shadowing, so it sees the tenant's
+    /// own plan in its own family.
+    /// </summary>
+    [Fact]
+    public async Task A_tenant_wide_reader_still_sees_the_tenants_own_family()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "pro", "basic", 1));
+        await Seed(tenantId, Plan(tenantId, "pro", "premium", 1, organizationId: Organization));
+
+        var listed = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "basic");
+
+        listed.Should().ContainSingle().Which.OrganizationId.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Matched exactly. A family code is stored as authored, so two differing only in case are two
+    /// families, and folding case would merge them.
+    /// </summary>
+    [Fact]
+    public async Task A_family_code_is_matched_case_sensitively()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "starter", "Growth", 1));
+
+        (await _catalogue.ListPlansAsync(
+                tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "growth"))
+            .Should()
+            .BeEmpty();
+
+        (await _catalogue.ListPlansAsync(
+                tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "Growth"))
+            .Should()
+            .ContainSingle();
+    }
+
+    /// <summary>A family nobody authored is an empty list, not an error and not everything.</summary>
+    [Fact]
+    public async Task An_unknown_family_lists_nothing()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "starter", "growth", 1));
+
+        (await _catalogue.ListPlansAsync(
+                tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "nonexistent"))
+            .Should()
+            .BeEmpty();
+    }
+
+    /// <summary>
+    /// A blank family code reads as no family code at all, matching how the other listing
+    /// parameters treat blank, so a caller forwarding an empty form field lists everything rather
+    /// than nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task A_blank_family_code_lists_every_family(string blank)
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "starter", "growth", 1));
+        await Seed(tenantId, Plan(tenantId, "solo", family: null, rank: null));
+
+        var listed = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, blank);
+
+        listed.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// A plan with no family is never in one, so it is absent from every family listing.
+    /// </summary>
+    [Fact]
+    public async Task A_plan_with_no_family_is_in_no_family()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "solo", family: null, rank: null));
+
+        (await _catalogue.ListPlansAsync(
+                tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "growth"))
+            .Should()
+            .BeEmpty();
+    }
+
+    /// <summary>
+    /// The family narrowing composes with the status filter rather than replacing it: asking for a
+    /// family under the default Active view does not surface that family's archived plans.
+    /// </summary>
+    [Fact]
+    public async Task A_family_listing_still_honours_the_status_filter()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(tenantId, Plan(tenantId, "starter", "growth", 1));
+        await Seed(
+            tenantId,
+            Plan(tenantId, "retired", "growth", 2, status: CatalogueStatus.Archived));
+
+        var active = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.Active, CancellationToken.None, "growth");
+
+        active.Select(plan => plan.Code).Should().Equal("starter");
+
+        var all = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.All, CancellationToken.None, "growth");
+
+        all.Select(plan => plan.Code).Should().Equal("starter", "retired");
+
+        var archived = await _catalogue.ListPlansAsync(
+            tenantId, null, PlanCatalogueFilter.Archived, CancellationToken.None, "growth");
+
+        archived.Select(plan => plan.Code).Should().Equal("retired");
+    }
+
+    /// <summary>A draft plan stays out of a family listing, as it stays out of every listing.</summary>
+    [Fact]
+    public async Task A_draft_plan_is_not_in_a_family_listing()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        await Seed(
+            tenantId,
+            Plan(tenantId, "unreleased", "growth", 1, status: CatalogueStatus.Draft));
+
+        (await _catalogue.ListPlansAsync(
+                tenantId, null, PlanCatalogueFilter.All, CancellationToken.None, "growth"))
+            .Should()
+            .BeEmpty();
+    }
+
+    /// <summary>
+    /// Another tenant's family of the same name is not this tenant's.
+    /// </summary>
+    [Fact]
+    public async Task A_family_listing_is_scoped_to_its_tenant()
+    {
+        var mine = MongoIntegrationFixture.NewTenantId();
+        var theirs = MongoIntegrationFixture.NewTenantId();
+        await Seed(mine, Plan(mine, "starter", "growth", 1));
+        await Seed(theirs, Plan(theirs, "starter", "growth", 1));
+
+        var listed = await _catalogue.ListPlansAsync(
+            mine, null, PlanCatalogueFilter.Active, CancellationToken.None, "growth");
+
+        listed.Should().ContainSingle().Which.TenantId.Should().Be(mine);
+    }
+
+    private Task Seed(string tenantId, Plan plan) =>
+        _catalogue.TryCreatePlanAsync(plan, CancellationToken.None);
+
+    private static Plan Plan(
+        string tenantId,
+        string code,
+        string? family,
+        int? rank,
+        string? organizationId = null,
+        CatalogueStatus status = CatalogueStatus.Active) => new()
+    {
+        TenantId = tenantId,
+        // Composed so two tenants, and an organization's plan beside its tenant's, never collide on
+        // the same id in the fixture's single shared database.
+        ItemId = $"{tenantId}:{organizationId ?? "tenant"}:{code}",
+        Code = code,
+        DisplayName = code,
+        FamilyCode = family,
+        FamilyRank = rank,
+        OrganizationId = organizationId,
+        Status = status,
+        Version = 1
+    };
+}

--- a/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
+++ b/server/XUnitTest/Subscription/PlanCatalogueServiceTests.cs
@@ -1592,6 +1592,71 @@ public sealed class PlanCatalogueServiceTests
             Times.Once);
     }
 
+    /// <summary>
+    /// A requested family reaches the repository as given.
+    /// </summary>
+    /// <remarks>
+    /// Verified rather than assumed because the parameter is optional: a service that simply forgot
+    /// to forward it would compile, list every family, and look correct on a tenant that only has
+    /// one.
+    /// </remarks>
+    [Fact]
+    public async Task A_requested_family_reaches_the_repository_unchanged()
+    {
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<PlanCatalogueFilter>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync([]);
+
+        await Service().ListPlansAsync(
+            OrganizationId,
+            "correlation-1",
+            CancellationToken.None,
+            PlanCatalogueFilter.Active,
+            "growth");
+
+        _catalogue.Verify(
+            repository => repository.ListPlansAsync(
+                TenantId,
+                OrganizationId,
+                PlanCatalogueFilter.Active,
+                It.IsAny<CancellationToken>(),
+                "growth"),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Omitting the family asks the repository for every family, which is what every caller before
+    /// this did and still does.
+    /// </summary>
+    [Fact]
+    public async Task Omitting_the_family_asks_for_every_family()
+    {
+        _catalogue
+            .Setup(repository => repository.ListPlansAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<PlanCatalogueFilter>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?>()))
+            .ReturnsAsync([]);
+
+        await Service().ListPlansAsync(OrganizationId, "correlation-1", CancellationToken.None);
+
+        _catalogue.Verify(
+            repository => repository.ListPlansAsync(
+                TenantId,
+                OrganizationId,
+                PlanCatalogueFilter.Active,
+                It.IsAny<CancellationToken>(),
+                null),
+            Times.Once);
+    }
+
     private PlanCatalogueService Service() => new(
         _catalogue.Object,
         _subscriptions.Object,


### PR DESCRIPTION
## What this adds

```
GET /api/subscription-plans?familyCode=growth
```

Returns only that product family, **ordered by `FamilyRank`** — entry level first. Omit the parameter and you get every family in the code order it always had; the request a screen that does not care about families makes is byte-identical to the one it made before.

Also plumbed through `subscriptionService.listPlans(organizationId?, status?, familyCode?)` so it is callable from the client, and it composes with the existing parameters rather than replacing them.

## Ordering by rank, not code

The README already describes the pair as grouping plans into *ordered* product levels, and `FamilyRank` means nothing outside a family — so a family listing is the one place it can be honoured. Seeded in the test so the two orders disagree: by code `enterprise` sorts first, by rank it comes last.

## The part worth reviewing: *where* the narrowing happens

Applied **after** the organization-over-tenant resolution, not as part of the Mongo query. That is not an implementation detail — it changes the answer.

The resolution decides which of two plans sharing a code is the one subscribing would actually find. The two need not be in the same family:

| | code | family | owner |
|---|---|---|---|
| A | `pro` | `premium` | org-1 |
| B | `pro` | `basic` | tenant |

For org-1, A shadows B. So `?familyCode=basic` must return **nothing** — the plan org-1 resolves for `pro` is the premium one.

Narrow inside the query and B becomes the only candidate in its code group, so it survives the collapse and gets returned: a plan subscribing can never select. That is the exact misreport the collapse exists to prevent, and the existing comment in that method already warns about it in the other direction.

**Moving the filter into the query fails 4 of the 13 new integration cases**, including the shadowing one — so this is pinned by tests, not just by a comment.

## Matching is exact and case-sensitive

Like `Plan.Code` and `FindPlanByCodeAsync`. A family code is stored exactly as authored — nothing trims or folds it on write — so `Pro` and `pro` are two families that can genuinely both exist, and folding case here would silently merge them.

A blank value reads as "no family", matching how `organizationId` and `status` already treat blank, so a caller forwarding an empty form field lists everything rather than nothing.

## An unknown family is `200 []`, not `404`

A listing endpoint reports what is there, and asking after a family that holds nothing is a well-formed question with a truthful empty answer. Consistent with how the endpoint already answers when a tenant has no plans at all.

## Composition, not replacement

`status` still applies: asking for a family under the default `Active` view does not surface that family's archived plans. Covered across all three filter values, plus `Draft` staying out as it does everywhere.

## Scope notes

- **No new index.** This method already reads every one of the tenant's plans and resolves them in memory, on the documented assumption that plan counts per tenant are small. Narrowing afterwards adds nothing to that, and `FindSuccessorPlanAsync` set the precedent for following it rather than introducing a new one.
- **The parameter is optional on both repository and service**, so `DiscountCatalogueService`'s own use of the listing is untouched. A test asserts the family actually reaches the repository — a service that forgot to forward an optional argument would compile, list everything, and look correct on a tenant with one family. Removing the forward fails that test.
- **No UI.** This adds the capability and the client call; no screen filters by family yet. The plan list page groups nothing today, and adding that is a separate design question.

## Verification

- **13 new integration tests**, against a real MongoDB, covering: no family lists everything · one family lists only itself · rank ordering where rank and code disagree · the shadowing case both ways · case sensitivity · unknown family · blank family · a plan with no family · all three status filters · Draft exclusion · tenant scoping.
- **Integration suite: 127 passed / 0 failed** (was 114). Added to the `mongo-integration` filter with a comment saying why it must run there.
- **Server unit: 3463 passed / 4 failed** — only the pre-existing `SubscriptionSimulation*` permission-guard failures on `dev`.
- **Client: 652 passed** across all 51 subscription files, including 6 new service cases.
- Regression proofs: filter moved into the query → 4 failures; service forward removed → 1 failure.
- `dotnet build` clean, `tsc -b` clean, `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
