### PR TITLE
fix(subscription): send the author to the step that failed, not just a message

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder-error-navigation.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder-error-navigation.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A save that cannot proceed takes the author to the step that is wrong.
+ *
+ * Reaching this at all takes some doing, and it is worth being precise about how. `Next` is
+ * disabled while the current step has problems, and stepping back through the progress bar clears
+ * the completed steps behind it — so an author cannot simply break a field and walk forward to
+ * Save. What can happen is the `plans` prop changing underneath a review step that is already
+ * open: a free-opening campaign names the entitlement it caps, and that name is checked against
+ * the plan it applies to. If the plan is edited elsewhere while this builder sits on Review, a step
+ * the author already passed becomes invalid.
+ *
+ * Before this change Save then returned in silence — no message, no movement, nothing — and the
+ * per-step problem list that would have explained it is hidden on the last step, the only step Save
+ * appears on.
+ */
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= vi.fn(() => false) as never;
+  Element.prototype.setPointerCapture ??= vi.fn() as never;
+  Element.prototype.releasePointerCapture ??= vi.fn() as never;
+  Element.prototype.scrollIntoView ??= vi.fn() as never;
+});
+
+const toast = vi.fn();
+
+vi.mock("@/hooks/use-toast", () => ({ toast: (...args: unknown[]) => toast(...args) }));
+
+// Stubbed so this test is about where the author is sent, not about any one control. The stepper
+// shell and the submit path are real.
+vi.mock("./step-identity", () => ({ StepIdentity: () => <div data-testid="step-body" /> }));
+vi.mock("./step-benefit", () => ({ StepBenefit: () => <div data-testid="step-body" /> }));
+vi.mock("./step-eligibility", () => ({ StepEligibility: () => <div data-testid="step-body" /> }));
+vi.mock("./step-review", () => ({ StepReview: () => <div data-testid="step-body" /> }));
+
+import type { SubscriptionPlan } from "../../models/subscription-plan.model";
+import { CampaignBuilder } from "./campaign-builder";
+import { EMPTY_DRAFT, withCampaignKind } from "./campaign-draft";
+import type { CampaignDraft } from "./campaign-draft";
+
+const onSubmit = vi.fn(async () => {});
+
+const planWith = (entitlementKeys: string[]) =>
+  ({
+    planId: "plan-1",
+    code: "pro",
+    displayName: "Pro",
+    prices: [{ priceId: "price-1", currencyCode: "CHF", interval: "Month", intervalCount: 1 }],
+    entitlements: entitlementKeys.map((key) => ({ key, limitKind: "Count" })),
+    meters: [],
+    quantityItems: [],
+  }) as unknown as SubscriptionPlan;
+
+/** A free-opening campaign with nothing wrong with it, given a plan that has its entitlement. */
+const validDraft: CampaignDraft = withCampaignKind(
+  {
+    ...EMPTY_DRAFT,
+    code: "launch-25",
+    displayName: "Launch offer",
+    priceIds: ["price-1"],
+    planCodes: ["pro"],
+    validFromDate: "2026-09-01",
+    timeZoneId: "Europe/Zurich",
+    entitlementKey: "screening",
+    entitlementLimit: "50",
+  },
+  "FreeOpeningCalendarPeriod",
+);
+
+const renderBuilder = (plans: SubscriptionPlan[]) =>
+  render(
+    <CampaignBuilder
+      plans={plans}
+      organizationId={undefined}
+      isSubmitting={false}
+      submissionError={null}
+      onSubmit={onSubmit}
+      onCancel={vi.fn()}
+      initialDraft={validDraft}
+    />,
+  );
+
+const walkToReview = async (user: ReturnType<typeof userEvent.setup>) => {
+  for (let step = 1; step < 4; step++) {
+    await user.click(screen.getByRole("button", { name: /next/i }));
+  }
+};
+
+const save = () => screen.getByRole("button", { name: /create discount/i });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("the campaign builder's review step", () => {
+  it("saves a draft with nothing wrong with it", async () => {
+    const user = userEvent.setup();
+    renderBuilder([planWith(["screening"])]);
+
+    await walkToReview(user);
+    await user.click(save());
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("says something when a step it already passed has gone invalid", async () => {
+    const user = userEvent.setup();
+    const view = renderBuilder([planWith(["screening"])]);
+
+    await walkToReview(user);
+
+    // The plan is edited elsewhere and its entitlement is gone, so eligibility no longer holds.
+    view.rerender(
+      <CampaignBuilder
+        plans={[planWith(["something-else"])]}
+        organizationId={undefined}
+        isSubmitting={false}
+        submissionError={null}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        initialDraft={validDraft}
+      />,
+    );
+
+    await user.click(save());
+
+    await waitFor(() => expect(toast).toHaveBeenCalledTimes(1));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("names the step it sent the author to, and goes there", async () => {
+    const user = userEvent.setup();
+    const view = renderBuilder([planWith(["screening"])]);
+
+    await walkToReview(user);
+
+    view.rerender(
+      <CampaignBuilder
+        plans={[planWith(["something-else"])]}
+        organizationId={undefined}
+        isSubmitting={false}
+        submissionError={null}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        initialDraft={validDraft}
+      />,
+    );
+
+    await user.click(save());
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: expect.stringContaining("Eligibility"),
+        }),
+      ),
+    );
+
+    // Off the review step, so the step's own problem list is on screen to explain it.
+    expect(screen.queryByRole("button", { name: /create discount/i })).toBeNull();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-builder.tsx
@@ -2,12 +2,14 @@ import { ArrowLeft, ArrowRight, Check, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
+import { toast } from "@/hooks/use-toast";
 import StepperProviderComponent, { useStepper } from "@/components/stepper/stepper-provider";
 import type { Steps } from "@/components/stepper/stepper-models";
 import type { SubscriptionPlan } from "../../models/subscription-plan.model";
 import { CampaignBuilderProgress } from "./campaign-builder-progress";
 import {
   EMPTY_DRAFT,
+  firstBlockedStep,
   stepProblems,
   toCreateDiscountRequest,
   withCampaignKind,
@@ -54,7 +56,7 @@ const CampaignBuilderWizard = ({
   initialDraft = EMPTY_DRAFT,
   editing = false,
 }: CampaignBuilderProps) => {
-  const { currentStep, nextStep, previousStep } = useStepper();
+  const { currentStep, nextStep, previousStep, goToStep } = useStepper();
   const [draft, setDraft] = useState<CampaignDraft>(initialDraft);
   const step = currentStep as StepId;
   const isLastStep = currentStep === STEPS.length;
@@ -72,9 +74,28 @@ const CampaignBuilderWizard = ({
   const canAdvance = problems.length === 0;
 
   const submit = async () => {
-    if (stepProblems(1, draft, plans).length > 0 ||
-        stepProblems(2, draft, plans).length > 0 ||
-        stepProblems(3, draft, plans).length > 0) {
+    // This used to return in silence, so Save appeared to do nothing whatever — and the per-step
+    // problem list that would have explained it is hidden on the review step, the only step Save
+    // appears on.
+    //
+    // Getting here takes an unusual route, and it is worth naming so this guard is not mistaken
+    // for dead code: Next is disabled while the current step has problems, and stepping back
+    // through the progress bar clears the completed steps behind it, so an author cannot break a
+    // field and walk forward. What can happen is `plans` changing under an open review step — a
+    // free-opening campaign names the entitlement it caps, and that name is checked against the
+    // plan it applies to, so a plan edited elsewhere can invalidate a step already passed.
+    //
+    // Either way the answer is the same: go to the first step that has something wrong, where its
+    // own problem list is already rendered.
+    const blocked = firstBlockedStep(draft, plans);
+
+    if (blocked !== undefined) {
+      goToStep(blocked);
+      toast({
+        variant: "destructive",
+        title: `Something to fix in ${STEPS[blocked - 1].title}`,
+        description: "Taken to the step that needs attention.",
+      });
       return;
     }
 

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.test.ts
@@ -4,6 +4,7 @@ import {
   EMPTY_DRAFT,
   canSubmit,
   eligiblePrices,
+  firstBlockedStep,
   stepProblems,
   toCreateDiscountRequest,
   withCampaignKind,
@@ -259,6 +260,77 @@ describe("canSubmit", () => {
     };
 
     expect(canSubmit(draft, plans)).toBe(true);
+  });
+});
+
+describe("firstBlockedStep", () => {
+  const plans = [plan()];
+
+  it("names the first step with a problem", () => {
+    expect(firstBlockedStep(EMPTY_DRAFT, plans)).toBe(1);
+  });
+
+  /**
+   * The earliest one, so an author fixing things works forward rather than being sent backwards on
+   * each attempt.
+   */
+  it("names the earliest step when more than one is wrong", () => {
+    const draft = withCampaignKind(
+      { ...EMPTY_DRAFT, code: "", displayName: "", percent: "" },
+      "FreeOpeningCalendarPeriod",
+    );
+
+    expect(firstBlockedStep(draft, plans)).toBe(1);
+  });
+
+  /**
+   * Steps one and two are satisfied here — withCampaignKind sets a free-opening campaign to a full
+   * 100% reduction, so its benefit needs nothing more — and step three is not, because that kind
+   * has to name the entitlement it caps. Asserted alongside the step so the fixture cannot drift
+   * into satisfying step three and quietly stop testing anything.
+   */
+  it("skips the satisfied steps to name a later one", () => {
+    const draft = withCampaignKind(
+      { ...EMPTY_DRAFT, code: "launch-25", displayName: "Launch offer" },
+      "FreeOpeningCalendarPeriod",
+    );
+
+    expect(stepProblems(1, draft, plans)).toEqual([]);
+    expect(stepProblems(2, draft, plans)).toEqual([]);
+    expect(stepProblems(3, draft, plans)).not.toEqual([]);
+    expect(firstBlockedStep(draft, plans)).toBe(3);
+  });
+
+  it("is undefined once nothing blocks the save", () => {
+    const draft: CampaignDraft = {
+      ...EMPTY_DRAFT,
+      code: "launch-25",
+      displayName: "Launch offer",
+    };
+
+    expect(firstBlockedStep(draft, plans)).toBeUndefined();
+  });
+
+  /** Review authors nothing, so it can never be the step an author is sent to. */
+  it("never names the review step", () => {
+    expect(firstBlockedStep(EMPTY_DRAFT, plans)).not.toBe(4);
+  });
+
+  /**
+   * The two answers are one answer. A draft canSubmit says is fine, with a step named to fix,
+   * would be the worst of both.
+   */
+  it("agrees with canSubmit", () => {
+    const drafts: CampaignDraft[] = [
+      EMPTY_DRAFT,
+      { ...EMPTY_DRAFT, code: "launch-25" },
+      { ...EMPTY_DRAFT, code: "launch-25", displayName: "Launch offer" },
+      { ...EMPTY_DRAFT, code: "Launch 25!", displayName: "Launch offer" },
+    ];
+
+    drafts.forEach((draft) => {
+      expect(canSubmit(draft, plans)).toBe(firstBlockedStep(draft, plans) === undefined);
+    });
   });
 });
 

--- a/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
+++ b/client/app/cross-modules/utilities/subscription/components/campaign-builder/campaign-draft.ts
@@ -281,8 +281,29 @@ export const stepProblems = (
   return [];
 };
 
+/**
+ * The first step with something wrong on it, or undefined when the draft is ready to save.
+ *
+ * The review step is excluded because it authors nothing. Pure and exported so the decision can be
+ * tested on its own: reaching it through the builder means completing every step, stepping back
+ * through the progress bar, breaking a field and jumping forward again — a lot of clicks to prove
+ * one comparison.
+ */
+export const firstBlockedStep = (
+  draft: CampaignDraft,
+  plans: SubscriptionPlan[],
+): StepId | undefined =>
+  ([1, 2, 3] as const).find((step) => stepProblems(step, draft, plans).length > 0);
+
+/**
+ * Whether the draft can be saved at all.
+ *
+ * Defined as "nothing blocks it" rather than walking the steps again, so the answer and the step
+ * the author is sent to can never disagree — one saying the draft is fine while the other names a
+ * step to fix would be the worst of both.
+ */
 export const canSubmit = (draft: CampaignDraft, plans: SubscriptionPlan[]): boolean =>
-  ([1, 2, 3] as const).every((step) => stepProblems(step, draft, plans).length === 0);
+  firstBlockedStep(draft, plans) === undefined;
 
 /** The exact request `POST /api/subscription-discounts` expects — units converted here, once. */
 export const toCreateDiscountRequest = (

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-error-navigation.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-error-navigation.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A failed save takes the author to the step that is wrong.
+ *
+ * Saving happens from the review step, so whatever failed validation is on a step that is not
+ * mounted. That has two consequences a test has to hold down: react-hook-form's own
+ * focus-first-error does nothing, because the control does not exist; and a message that merely
+ * says "some steps have something to fix" leaves the author opening each step in turn.
+ */
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= vi.fn(() => false) as never;
+  Element.prototype.setPointerCapture ??= vi.fn() as never;
+  Element.prototype.releasePointerCapture ??= vi.fn() as never;
+  Element.prototype.scrollIntoView ??= vi.fn() as never;
+  globalThis.ResizeObserver ??= class {
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+  } as unknown as typeof ResizeObserver;
+  globalThis.IntersectionObserver ??= class {
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof IntersectionObserver;
+});
+
+const toast = vi.fn();
+
+vi.mock("@seliseblocks/genesis-os", () => ({
+  useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
+}));
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({ data: { data: [], totalCount: 0 } }),
+}));
+vi.mock("@/hooks/use-toast", () => ({ toast: (...args: unknown[]) => toast(...args) }));
+
+// The step bodies are stubbed so this test is about where the builder sends the author, not about
+// any one control. The stepper shell, the form, and the submit path are all real.
+vi.mock("./step-identity", () => ({ StepIdentity: () => <div data-testid="step-body" /> }));
+vi.mock("./step-pricing-model", () => ({
+  StepPricingModel: () => <div data-testid="step-body" />,
+}));
+vi.mock("./step-usage-limits", () => ({
+  StepUsageLimits: () => <div data-testid="step-body" />,
+}));
+vi.mock("./step-trial", () => ({ StepTrial: () => <div data-testid="step-body" /> }));
+vi.mock("./step-review", () => ({ StepReview: () => <div data-testid="step-body" /> }));
+vi.mock("../plan-summary-card", () => ({
+  PlanSummaryCard: () => <div data-testid="plan-summary-card" />,
+}));
+
+import { MemoryRouter } from "react-router";
+import { PlanBuilder } from "./plan-builder";
+import { defaultSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+
+const onSubmit = vi.fn(async () => {});
+
+const renderBuilder = (defaultValues: CreateSubscriptionPlanFormValues) =>
+  render(
+    <MemoryRouter>
+      <PlanBuilder
+        mode="create"
+        defaultValues={defaultValues}
+        title="Create subscription plan"
+        description="desc"
+        backTo="/plans"
+        submitLabel="Create"
+        submittingLabel="Creating"
+        isSubmitting={false}
+        onSubmit={onSubmit}
+      />
+    </MemoryRouter>,
+  );
+
+/** Walks to the review step, where the only way on is Save. */
+const goToReview = async (user: ReturnType<typeof userEvent.setup>) => {
+  for (let step = 1; step < 5; step++) {
+    await user.click(screen.getByRole("button", { name: /next/i }));
+  }
+
+  return screen.getByRole("button", { name: /^create$/i });
+};
+
+/**
+ * Step one is the only step whose Back button is disabled, so this reads the stepper's own state
+ * rather than trusting the message beside it.
+ */
+const isOnFirstStep = () =>
+  (screen.getByRole("button", { name: /back/i }) as HTMLButtonElement).disabled;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("a failed save", () => {
+  it("goes back to the step holding the problem rather than staying on review", async () => {
+    const user = userEvent.setup();
+    // The defaults leave code and displayName empty, both of which live on Identity.
+    renderBuilder(defaultSubscriptionPlanFormValues);
+
+    const save = await goToReview(user);
+    expect(isOnFirstStep()).toBe(false);
+
+    await user.click(save);
+
+    await waitFor(() => expect(isOnFirstStep()).toBe(true));
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("names the step it sent the author to", async () => {
+    const user = userEvent.setup();
+    renderBuilder(defaultSubscriptionPlanFormValues);
+
+    await user.click(await goToReview(user));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: expect.stringContaining("Identity"),
+        }),
+      ),
+    );
+  });
+
+  /**
+   * A problem further in still sends the author forward of step one, so the message and the step
+   * agree — and this is the case the old behaviour was worst at, since Identity happened to be
+   * where an author would look first anyway.
+   */
+  it("sends a pricing problem to the pricing step, not to the first step", async () => {
+    const user = userEvent.setup();
+    renderBuilder({
+      ...defaultSubscriptionPlanFormValues,
+      code: "pro",
+      displayName: "Pro",
+      meters: [
+        {
+          meterKey: "storage-gb",
+          displayName: "Storage",
+          unitLabel: "GB",
+          aggregation: 0,
+          resetPolicy: 0,
+          quantityScale: 0,
+          // Whole units only, so this is refused three steps away from Save.
+          includedQuantity: 512.5,
+          overageAllowed: true,
+          thresholdPercents: [],
+          rateTables: [],
+        },
+      ],
+    } as CreateSubscriptionPlanFormValues);
+
+    await user.click(await goToReview(user));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: expect.stringContaining("Pricing model") }),
+      ),
+    );
+    expect(isOnFirstStep()).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("still saves when nothing is wrong", async () => {
+    const user = userEvent.setup();
+    renderBuilder({
+      ...defaultSubscriptionPlanFormValues,
+      code: "pro",
+      displayName: "Pro",
+    } as CreateSubscriptionPlanFormValues);
+
+    await user.click(await goToReview(user));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(toast).not.toHaveBeenCalled();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ArrowLeft, ArrowRight, Check, ChevronDown, Loader2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
@@ -14,6 +14,12 @@ import {
 import { toast } from "@/hooks/use-toast";
 import StepperProviderComponent, { useStepper } from "@/components/stepper/stepper-provider";
 import type { Steps } from "@/components/stepper/stepper-models";
+import {
+  firstPlanBuilderErrorField,
+  firstPlanBuilderErrorStep,
+  PLAN_BUILDER_STEP_TITLES,
+  type PlanBuilderFieldPath,
+} from "../../utilities/plan-builder-steps";
 import {
   ORGANIZATION_PAGE_SIZE,
   TENANT_WIDE_ORGANIZATION,
@@ -100,7 +106,15 @@ const PlanBuilderWizard = ({
   retiringPriceId = null,
   onSubmit,
 }: PlanBuilderProps) => {
-  const { currentStep, nextStep, previousStep, totalSteps } = useStepper();
+  const { currentStep, nextStep, previousStep, totalSteps, goToStep } = useStepper();
+
+  // The field to focus once the step holding it has mounted. Focusing during the same commit that
+  // changes the step would find nothing: the control does not exist until that step renders.
+  //
+  // A ref rather than state because nothing renders from it — it is a message to the effect below,
+  // consumed once and discarded. Holding it in state would ask for a re-render that changes no
+  // output, and clearing it from inside the effect is the write React lints against.
+  const pendingFocus = useRef<PlanBuilderFieldPath | null>(null);
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const isEditing = mode === "edit";
   const { stepperRef, isStuck, stepperHeight } = useStickyStepper();
@@ -189,26 +203,72 @@ const PlanBuilderWizard = ({
     })),
   };
 
-  const isLastStep = currentStep === totalSteps;
+  useEffect(() => {
+    const field = pendingFocus.current;
 
-  const submit = async () => {
-    setSubmissionError(null);
-
-    if (!(await form.trigger())) {
-      toast({
-        variant: "destructive",
-        title: "Check the highlighted fields",
-        description: "Some steps still have something to fix before this can be saved.",
-      });
+    if (field === null) {
       return;
     }
 
-    try {
-      await onSubmit(form.getValues());
-    } catch (error) {
-      setSubmissionError(error instanceof Error ? error.message : "This plan could not be saved.");
-    }
-  };
+    pendingFocus.current = null;
+
+    // The step is on screen by the time this runs, so the control is registered and focusable.
+    // setFocus is a no-op for a name it cannot resolve — an array-level error whose path is the
+    // array itself, for instance — and the step change has already done the useful half of the
+    // job, so a miss is not worth reporting.
+    form.setFocus(field, { shouldSelect: true });
+  }, [currentStep, form]);
+
+  const isLastStep = currentStep === totalSteps;
+
+  // Assembled when the button is pressed rather than during render, so nothing on the render path
+  // touches the focus target or runs a submit handler.
+  const submit = () =>
+    // handleSubmit rather than trigger, for the errors it hands the second callback. formState is a
+    // render-time snapshot, so reading form.formState.errors straight after awaiting trigger() sees
+    // the state from before validation ran — which reported "nothing is wrong" and sent the author
+    // nowhere, the very thing this is here to fix.
+    form.handleSubmit(
+      async (values) => {
+        setSubmissionError(null);
+
+        try {
+          await onSubmit(values);
+        } catch (error) {
+          setSubmissionError(
+            error instanceof Error ? error.message : "This plan could not be saved.",
+          );
+        }
+      },
+      (errors) => {
+        setSubmissionError(null);
+
+        // Saving happens from the review step, so whatever is wrong is on a step that is not on
+        // screen. Describing that ("some steps still have something to fix") left the author to open
+        // each one and hunt, and react-hook-form's own focus-first-error cannot help either: the
+        // control is unmounted, so there is nothing to focus. So go to the step first, then focus.
+        const step = firstPlanBuilderErrorStep(errors);
+        const field = firstPlanBuilderErrorField(errors);
+
+        if (step !== undefined) {
+          goToStep(step);
+          // Focused once that step has rendered — see the effect above.
+          pendingFocus.current = field ?? null;
+        }
+
+        toast({
+          variant: "destructive",
+          title:
+            step === undefined
+              ? "Check the highlighted fields"
+              : `Something to fix in ${PLAN_BUILDER_STEP_TITLES[step] ?? `step ${step}`}`,
+          description:
+            step === undefined
+              ? "Some steps still have something to fix before this can be saved."
+              : "Taken to the first field that needs attention.",
+        });
+      },
+    )();
 
   // `overflow-hidden` cannot live on <main> any more: an ancestor whose overflow is not `visible`
   // becomes the scrolling box for any sticky descendant, and <main> never scrolls - the page does.

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-builder-steps.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-builder-steps.test.ts
@@ -1,0 +1,226 @@
+import type { FieldErrors } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import {
+  firstPlanBuilderErrorField,
+  firstPlanBuilderErrorStep,
+  PLAN_BUILDER_STEP_OF_FIELD,
+  PLAN_BUILDER_STEP_TITLES,
+} from "./plan-builder-steps";
+import {
+  createSubscriptionPlanSchema,
+  defaultSubscriptionPlanFormValues,
+} from "../schemas/subscription-plan.schema";
+import type { CreateSubscriptionPlanFormValues } from "../schemas/subscription-plan.schema";
+
+const errors = (shape: unknown) => shape as FieldErrors<CreateSubscriptionPlanFormValues>;
+
+/** The shape react-hook-form gives one field's error. */
+const leaf = (message: string) => ({ type: "custom", message, ref: undefined });
+
+describe("the field-to-step map", () => {
+  /**
+   * Every field the form holds is on a step.
+   *
+   * The `Record` type already makes a missing field a compile error, so this guards the other
+   * direction: a mapping that names a field the form no longer has, which would compile forever
+   * and quietly send authors to a step that does not show it.
+   */
+  it("names exactly the fields the form has", () => {
+    const formFields = Object.keys(defaultSubscriptionPlanFormValues).sort();
+    const mappedFields = Object.keys(PLAN_BUILDER_STEP_OF_FIELD).sort();
+
+    expect(mappedFields).toEqual(formFields);
+  });
+
+  it("puts every field on a step the builder actually renders", () => {
+    for (const step of Object.values(PLAN_BUILDER_STEP_OF_FIELD)) {
+      expect(PLAN_BUILDER_STEP_TITLES[step]).toBeDefined();
+    }
+  });
+
+  /** The review step shows no fields, so nothing may be mapped to it. */
+  it("maps nothing to the review step", () => {
+    expect(Object.values(PLAN_BUILDER_STEP_OF_FIELD)).not.toContain(5);
+  });
+});
+
+describe("firstPlanBuilderErrorStep", () => {
+  it("is undefined when nothing is wrong", () => {
+    expect(firstPlanBuilderErrorStep(errors({}))).toBeUndefined();
+  });
+
+  it.each([
+    ["code", 1],
+    ["meters", 2],
+    ["prices", 2],
+    ["entitlements", 3],
+    ["trialGrants", 4],
+  ])("sends %s to step %s", (field, step) => {
+    expect(firstPlanBuilderErrorStep(errors({ [field]: leaf("bad") }))).toBe(step);
+  });
+
+  /**
+   * The earliest step, so an author fixing things walks forward rather than being bounced
+   * backwards on each attempt.
+   */
+  it("picks the earliest step when several have errors", () => {
+    const step = firstPlanBuilderErrorStep(
+      errors({
+        trialGrants: leaf("bad"),
+        entitlements: leaf("bad"),
+        displayName: leaf("bad"),
+      }),
+    );
+
+    expect(step).toBe(1);
+  });
+});
+
+describe("firstPlanBuilderErrorField", () => {
+  it("is undefined when nothing is wrong", () => {
+    expect(firstPlanBuilderErrorField(errors({}))).toBeUndefined();
+  });
+
+  it("names a plain field", () => {
+    expect(firstPlanBuilderErrorField(errors({ displayName: leaf("bad") }))).toBe("displayName");
+  });
+
+  /**
+   * Descends to the control that owns the message. `meters` is not focusable; the input inside it
+   * is, and it is the thing the author has to change.
+   */
+  it("descends into an array to the field that failed", () => {
+    const field = firstPlanBuilderErrorField(
+      errors({ meters: [undefined, { includedQuantity: leaf("whole numbers only") }] }),
+    );
+
+    expect(field).toBe("meters.1.includedQuantity");
+  });
+
+  it("descends through a nested array", () => {
+    const field = firstPlanBuilderErrorField(
+      errors({
+        meters: [
+          {
+            rateTables: [{ tiers: [{ upToQuantity: leaf("too fine") }] }],
+          },
+        ],
+      }),
+    );
+
+    expect(field).toBe("meters.0.rateTables.0.tiers.0.upToQuantity");
+  });
+
+  /**
+   * An error belonging to an array as a whole has no control of its own, so the array's name is
+   * the best available target and focus lands on its first control.
+   */
+  it("stops at the array when the array itself is what failed", () => {
+    expect(firstPlanBuilderErrorField(errors({ prices: leaf("Add at least one price.") }))).toBe(
+      "prices",
+    );
+  });
+
+  it("ignores the bookkeeping react-hook-form files beside real children", () => {
+    const field = firstPlanBuilderErrorField(
+      errors({
+        prices: Object.assign([{ amount: leaf("bad") }], {
+          root: leaf("the list as a whole"),
+        }),
+      }),
+    );
+
+    expect(field).toBe("prices.0.amount");
+  });
+
+  /** Declaration order is the order a step lays its fields out, not react-hook-form's. */
+  it("returns the earliest field on screen rather than the first recorded", () => {
+    const field = firstPlanBuilderErrorField(
+      errors({ familyRank: leaf("bad"), displayName: leaf("bad"), code: leaf("bad") }),
+    );
+
+    expect(field).toBe("code");
+  });
+});
+
+/**
+ * The map is only useful if the paths it is fed are the paths the schema actually produces, so
+ * these drive it from real validation output rather than from hand-built error trees.
+ */
+describe("against real validation output", () => {
+  const invalidPlan = (overrides: Record<string, unknown>) => ({
+    ...defaultSubscriptionPlanFormValues,
+    code: "pro",
+    displayName: "Pro",
+    ...overrides,
+  });
+
+  const errorTree = (values: Record<string, unknown>) => {
+    const result = createSubscriptionPlanSchema.safeParse(values);
+
+    expect(result.success).toBe(false);
+
+    // Mirrors how zodResolver nests issue paths into the shape react-hook-form holds.
+    const tree: Record<string, unknown> = {};
+
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        let node = tree;
+
+        issue.path.slice(0, -1).forEach((segment) => {
+          node[segment] ??= {};
+          node = node[segment] as Record<string, unknown>;
+        });
+
+        node[issue.path[issue.path.length - 1]] = leaf(issue.message);
+      }
+    }
+
+    return errors(tree);
+  };
+
+  it("sends a missing display name to Identity", () => {
+    const tree = errorTree(invalidPlan({ displayName: "" }));
+
+    expect(firstPlanBuilderErrorStep(tree)).toBe(1);
+    expect(firstPlanBuilderErrorField(tree)).toBe("displayName");
+  });
+
+  /**
+   * The case that prompted this: a fractional quantity on a whole-unit meter is reported three
+   * steps away from the review step the author pressed Save on.
+   */
+  it("sends a fractional allowance on a whole-unit meter to Pricing model", () => {
+    const tree = errorTree(
+      invalidPlan({
+        meters: [
+          {
+            meterKey: "storage-gb",
+            displayName: "Storage",
+            unitLabel: "GB",
+            aggregation: 0,
+            resetPolicy: 0,
+            includedQuantity: 512.5,
+            overageAllowed: true,
+            thresholdPercents: [],
+            rateTables: [],
+          },
+        ],
+      }),
+    );
+
+    expect(firstPlanBuilderErrorStep(tree)).toBe(2);
+    expect(firstPlanBuilderErrorField(tree)).toBe("meters.0.includedQuantity");
+  });
+
+  it("sends a counted entitlement with no meter to What the plan grants", () => {
+    const tree = errorTree(
+      invalidPlan({
+        entitlements: [{ key: "usage", limitKind: 1 }],
+      }),
+    );
+
+    expect(firstPlanBuilderErrorStep(tree)).toBe(3);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-builder-steps.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-builder-steps.ts
@@ -1,0 +1,133 @@
+import type { FieldErrors, FieldPath } from "react-hook-form";
+
+import type { CreateSubscriptionPlanFormValues } from "../schemas/subscription-plan.schema";
+
+/**
+ * Which step of the plan builder owns each field, so a failed save can send the author to the
+ * problem instead of describing it.
+ *
+ * A `Record` over every key of the form values rather than a lookup that tolerates a miss: adding
+ * a field to the schema without saying which step shows it stops compiling, which is the only way
+ * this mapping stays true. A field silently unmapped would be worse than no mapping at all — the
+ * author would be told something is wrong and sent nowhere.
+ *
+ * Declared in the order each step lays its fields out. Iteration order of string keys is insertion
+ * order, so the first error found walking this is the first one an author would come to on screen
+ * rather than whichever react-hook-form happened to record first.
+ */
+export const PLAN_BUILDER_STEP_OF_FIELD: Record<
+  keyof CreateSubscriptionPlanFormValues,
+  number
+> = {
+  // 1 — Identity
+  code: 1,
+  displayName: 1,
+  description: 1,
+  organizationId: 1,
+  familyCode: 1,
+  familyRank: 1,
+  featuresJson: 1,
+
+  // 2 — Pricing model
+  quantityItems: 2,
+  prices: 2,
+  quantityDiscountCombinationPolicy: 2,
+  usageInterval: 2,
+  usageIntervalCount: 2,
+  meters: 2,
+  requirePaymentMethodUpfront: 2,
+
+  // 3 — What the plan grants
+  entitlements: 3,
+
+  // 4 — Trial
+  trialDurationKind: 4,
+  trialDurationCount: 4,
+  trialRequiresPaymentMethod: 4,
+  trialGrants: 4,
+};
+
+/** A field path this form can focus. */
+export type PlanBuilderFieldPath = FieldPath<CreateSubscriptionPlanFormValues>;
+
+/** The step titles, so a message can name where the author is being sent. */
+export const PLAN_BUILDER_STEP_TITLES: Record<number, string> = {
+  1: "Identity",
+  2: "Pricing model",
+  3: "What the plan grants",
+  4: "Trial",
+  5: "Review",
+};
+
+/**
+ * The first field carrying an error, as a path react-hook-form can focus.
+ *
+ * Walks down to the leaf that actually holds the message, because that is the control with a DOM
+ * node: `meters` itself is not focusable, `meters.1.includedQuantity` is. An error attached to an
+ * array as a whole — "add at least one price" — has no leaf below it, so the array's own name is
+ * returned and focusing lands on its first control.
+ */
+export const firstPlanBuilderErrorField = (
+  errors: FieldErrors<CreateSubscriptionPlanFormValues>,
+): PlanBuilderFieldPath | undefined => {
+  for (const field of Object.keys(PLAN_BUILDER_STEP_OF_FIELD)) {
+    const error = (errors as Record<string, unknown>)[field];
+
+    if (error) {
+      // Asserted rather than proven. The path is assembled from react-hook-form's own error tree,
+      // whose shape mirrors the form values, so every path this can produce is a path that form
+      // has — but the indices are runtime values and the template type cannot know them. A wrong
+      // path would make setFocus a no-op, not a crash, and the step change has already happened.
+      return `${field}${leafPath(error)}` as PlanBuilderFieldPath;
+    }
+  }
+
+  return undefined;
+};
+
+/** The earliest step holding an error, or undefined when nothing does. */
+export const firstPlanBuilderErrorStep = (
+  errors: FieldErrors<CreateSubscriptionPlanFormValues>,
+): number | undefined => {
+  const steps = Object.entries(PLAN_BUILDER_STEP_OF_FIELD)
+    .filter(([field]) => Boolean((errors as Record<string, unknown>)[field]))
+    .map(([, step]) => step);
+
+  return steps.length > 0 ? Math.min(...steps) : undefined;
+};
+
+/**
+ * Descends an error node to the leaf that owns the message.
+ *
+ * A leaf is recognised by carrying its own `message` or `type` — the shape react-hook-form gives a
+ * single field's error — rather than by depth, because an array error node holds both indexed
+ * children and, when the array itself failed, a `root`-like message beside them.
+ */
+const leafPath = (node: unknown): string => {
+  if (!isRecord(node) || isLeaf(node)) {
+    return "";
+  }
+
+  for (const [key, child] of Object.entries(node)) {
+    // Bookkeeping react-hook-form attaches beside the real children, none of it focusable.
+    // `root` is where it files an error belonging to an array as a whole; skipping it leaves the
+    // array's own name as the path, which focuses that array's first control.
+    if (BOOKKEEPING.has(key)) {
+      continue;
+    }
+
+    if (isRecord(child)) {
+      return `.${key}${leafPath(child)}`;
+    }
+  }
+
+  return "";
+};
+
+const BOOKKEEPING = new Set(["ref", "types", "message", "type", "root"]);
+
+const isLeaf = (node: Record<string, unknown>): boolean =>
+  typeof node.message === "string" || typeof node.type === "string";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;


### PR DESCRIPTION
## The problem

Saving a plan happens on the **review** step, so anything that failed validation is on a step that is not on screen.

- **Plan builder** — toasted *"Some steps still have something to fix"* and stayed on Review. The author had to open each of the four earlier steps and hunt.
- **Campaign builder** — `submit()` returned in silence. No message, no movement. Save appeared to do **nothing whatever**, and the per-step problem list that would have explained it is hidden on the review step, the only step Save appears on.

## What both do now

Go to the **earliest** step with a problem, and say which one in the toast. Earliest rather than last so an author fixing things works forward instead of being bounced backwards on each attempt.

The plan builder also **focuses the offending field**. React-hook-form's own focus-first-error cannot do this: while a step is off screen its controls are unmounted, so there is nothing to focus until after the step changes. Hence a ref-carried target consumed by an effect keyed on `currentStep`.

## The field-to-step map

`PLAN_BUILDER_STEP_OF_FIELD` is a `Record` over **every** key of the form values, so adding a field to the schema without saying which step shows it **does not compile**. That matters more than it looks: a silently unmapped field would be worse than no map at all — the author would be told something is wrong and then sent nowhere, which is exactly today's behaviour.

Declared in the order each step lays its fields out. String keys iterate in insertion order, so the field picked is the first one an author would actually reach on screen, not whichever react-hook-form happened to record first.

Field ownership was read off each step component rather than guessed — `prices` and `meters` both live on step 2, via `PlanPriceFields` inside `StepPricingModel`.

## Two things I got wrong first, and fixed

**`handleSubmit`, not `trigger`.** My first implementation awaited `form.trigger()` then read `form.formState.errors`. That is a render-time snapshot, so it held the state from *before* validation ran — the code concluded nothing was wrong and sent the author nowhere, reproducing the exact bug it was meant to fix. `handleSubmit`'s second callback receives the fresh errors. **The component test caught this; the unit tests could not**, because they feed error trees in directly.

**I overstated the campaign builder.** I first said it was simply worse. In fact its silent return is reachable by a narrower route, and the code comment now names it so the guard is not mistaken for dead code: `Next` is disabled while the current step has problems, and stepping back through the progress bar clears the completed steps behind it — so an author cannot break a field and walk forward. What *can* happen is `plans` changing under an already-open review step, since a free-opening campaign's entitlement name is validated against the plan it applies to. **The test drives that route rather than a hypothetical one.**

`canSubmit` is now defined as "nothing blocks it" (`firstBlockedStep(...) === undefined`) instead of walking the steps a second time, so the two can never disagree — one saying the draft is fine while the other names a step to fix would be the worst of both.

## Verification

| Reverted | Failures |
|---|---|
| Plan builder navigation | 1 |
| Campaign builder navigation | 2 |

- **685 client tests pass** across all 54 subscription files, 34 of them new.
- `plan-builder-steps.test.ts` (20 cases) drives the map from **real validation output** as well as hand-built trees, so the paths it is fed are the paths the schema actually produces.
- `firstBlockedStep` is unit-tested as a pure function, including that it agrees with `canSubmit` and never names the review step.
- `tsc -b` clean; `eslint` clean on every file this touches.

## Scope notes

- **Client only.** No server change, no API change.
- The five lint problems `eslint` reports under `subscription/` are all pre-existing on `dev` — including an unused `toCreateDiscountRequest` import in `campaign-builder.tsx`, which this diff does not touch. Left alone to keep the change about one thing.
- The review step is mapped to nothing, and a test asserts that, since it authors no fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
