### PR TITLE
feat(subscription): pin the plan builder's actions, and restyle the wizard

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/card-list-shell.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/card-list-shell.tsx
@@ -22,9 +22,11 @@ export const CardListShell = ({
     <button
       type="button"
       onClick={onAdd}
-      className="flex min-h-[7rem] flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-muted-foreground/30 p-4 text-sm text-muted-foreground transition hover:border-blocks-primary-400 hover:text-blocks-primary-600"
+      className="group flex min-h-[7rem] flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border-default bg-blocks-primary-shades-100/40 p-4 text-sm font-medium text-muted-foreground transition-all duration-200 hover:-translate-y-0.5 hover:border-blocks-primary-300 hover:bg-blocks-primary-shades-200 hover:text-blocks-primary-600 hover:shadow-[0_12px_28px_-20px_hsl(var(--blocks-primary-700)/0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
     >
-      <Plus className="h-5 w-5" />
+      <span className="flex h-9 w-9 items-center justify-center rounded-full bg-card text-muted-foreground shadow-sm transition-all duration-200 group-hover:bg-blocks-primary-600 group-hover:text-white group-hover:shadow-[0_8px_18px_-8px_hsl(var(--blocks-primary-700)/0.8)]">
+        <Plus className="h-4 w-4 transition-transform duration-300 group-hover:rotate-90" />
+      </span>
       {addLabel}
     </button>
   </div>
@@ -37,17 +39,25 @@ export const CardListItem = ({
   children: ReactNode;
   onRemove: () => void;
 }) => (
-  <Card className="relative rounded-lg pr-9">
+  <Card className="group/card relative rounded-xl border-border/70 pr-9 transition-all duration-200 hover:-translate-y-0.5 hover:border-blocks-primary-200 hover:shadow-[0_16px_34px_-24px_hsl(var(--blocks-primary-700)/0.55)]">
+    {/*
+      A tint that only exists on hover, so a card being edited separates from the ones beside it
+      without every card in a long list shouting for attention at rest.
+    */}
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 rounded-xl bg-gradient-to-br from-blocks-primary-shades-100/0 via-blocks-primary-shades-100/0 to-blocks-secondary-50/0 opacity-0 transition-opacity duration-300 group-hover/card:opacity-100 group-hover/card:to-blocks-secondary-50/60"
+    />
     <Button
       type="button"
       variant="ghost"
       size="icon"
       onClick={onRemove}
-      className="absolute right-1.5 top-1.5 h-7 w-7 text-muted-foreground hover:text-destructive"
+      className="absolute right-1.5 top-1.5 z-10 h-7 w-7 rounded-lg text-muted-foreground opacity-60 transition-all duration-200 hover:bg-destructive/10 hover:text-destructive hover:opacity-100 group-hover/card:opacity-100"
       aria-label="Remove"
     >
       <X className="h-4 w-4" />
     </Button>
-    <div className="space-y-3">{children}</div>
+    <div className="relative space-y-3">{children}</div>
   </Card>
 );

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-actions.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-actions.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+/**
+ * The sticky action bar.
+ *
+ * The bug this exists to prevent is a plain one: on a long step - the pricing model is by far the
+ * worst - Next and Confirm sat at the very bottom of the card, off screen, with nothing to
+ * suggest they were there. Anything that returns them to normal flow reintroduces it, and no
+ * other test in this module would notice.
+ *
+ * jsdom has no layout engine and no IntersectionObserver, so what is asserted here is the wiring:
+ * the bar carries `sticky bottom-0`, it stays below the Radix portal layer, and it still drives
+ * the same four callbacks. Whether it visually pins is confirmed in a real browser.
+ */
+
+beforeAll(() => {
+  globalThis.IntersectionObserver ??= class {
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof IntersectionObserver;
+});
+
+import { PlanBuilderActions } from "./plan-builder-actions";
+
+const baseProps = {
+  isFirstStep: false,
+  isLastStep: false,
+  isSubmitting: false,
+  submitLabel: "Create plan",
+  submittingLabel: "Creating…",
+  onBack: vi.fn(),
+  onNext: vi.fn(),
+  onSubmit: vi.fn(),
+};
+
+const bar = () => screen.getByTestId("plan-builder-actions");
+
+describe("PlanBuilderActions — the bar stays reachable", () => {
+  it("is sticky to the bottom of the viewport at every breakpoint", () => {
+    render(<PlanBuilderActions {...baseProps} />);
+    expect(bar().className).toContain("sticky");
+    expect(bar().className).toContain("bottom-0");
+    // No responsive prefix: a bar that only sticks at some widths is the bug, not the fix.
+    expect(bar().className).not.toMatch(/(sm|md|lg|xl):sticky/);
+  });
+
+  it("sits below the z-50 Radix Select/Popover portals", () => {
+    render(<PlanBuilderActions {...baseProps} />);
+    const z = bar().className.match(/z-(\d+)/);
+    expect(z).not.toBeNull();
+    expect(Number(z![1])).toBeLessThan(50);
+  });
+
+  it("spans the card padding so it reads as a footer, not an inset row", () => {
+    render(<PlanBuilderActions {...baseProps} />);
+    expect(bar().className).toContain("-mx-5");
+    expect(bar().className).toContain("sm:-mx-7");
+  });
+
+  it("reports its stuck state for the raised treatment", () => {
+    render(<PlanBuilderActions {...baseProps} />);
+    // False without a real IntersectionObserver, which is the documented degraded path.
+    expect(bar()).toHaveAttribute("data-stuck", "false");
+  });
+});
+
+describe("PlanBuilderActions — behaviour", () => {
+  it("advances and retreats through the callbacks it is given", async () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    render(<PlanBuilderActions {...baseProps} onNext={onNext} onBack={onBack} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Next/ }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole("button", { name: /Back/ }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Back on the first step", () => {
+    render(<PlanBuilderActions {...baseProps} isFirstStep />);
+    expect(screen.getByRole("button", { name: /Back/ })).toBeDisabled();
+  });
+
+  it("swaps Next for the submit action on the last step", async () => {
+    const onSubmit = vi.fn();
+    render(<PlanBuilderActions {...baseProps} isLastStep onSubmit={onSubmit} />);
+
+    expect(screen.queryByRole("button", { name: /Next/ })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /Create plan/ }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks both controls and shows the progress label while submitting", () => {
+    render(<PlanBuilderActions {...baseProps} isLastStep isSubmitting />);
+    expect(screen.getByRole("button", { name: /Creating/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Back/ })).toBeDisabled();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-actions.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-actions.tsx
@@ -1,0 +1,112 @@
+import { ArrowLeft, ArrowRight, Check, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui-kits/button/button";
+import { cn } from "@/lib/utils";
+import { useStickyActionBar } from "./use-sticky-action-bar";
+
+export interface PlanBuilderActionsProps {
+  isFirstStep: boolean;
+  isLastStep: boolean;
+  isSubmitting: boolean;
+  submitLabel: string;
+  submittingLabel: string;
+  onBack: () => void;
+  onNext: () => void;
+  onSubmit: () => void;
+}
+
+/**
+ * Back / Next / Confirm, pinned to the bottom of the viewport for as long as the step it belongs
+ * to is taller than the screen.
+ *
+ * It sits inside the step card rather than floating over the whole page, which is what keeps it
+ * aligned with the form column instead of running under the preview panel at xl. The negative
+ * margins let it span the card's padding so the bar reads as an edge-to-edge footer, and the
+ * card's own bottom padding is what it settles into once the step is fully scrolled.
+ *
+ * `z-20` for the same reason the stepper is `z-30`: both must stay below the z-50 Radix
+ * Select/Popover portals, or an open dropdown near the foot of a step would render behind the bar.
+ */
+export const PlanBuilderActions = ({
+  isFirstStep,
+  isLastStep,
+  isSubmitting,
+  submitLabel,
+  submittingLabel,
+  onBack,
+  onNext,
+  onSubmit,
+}: PlanBuilderActionsProps) => {
+  const { barRef, isStuck } = useStickyActionBar();
+
+  return (
+    <div
+      ref={barRef}
+      data-stuck={isStuck ? "true" : "false"}
+      data-testid="plan-builder-actions"
+      className="sticky bottom-0 z-20 -mx-5 -mb-5 mt-8 sm:-mx-7 sm:-mb-7"
+    >
+      {/*
+        Dissolves the last line of the step into the bar instead of letting it slide under a hard
+        edge. Purely decorative, and outside the bar's own box so it never affects its height.
+      */}
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 bottom-full h-10 bg-gradient-to-t from-card to-transparent transition-opacity duration-300",
+          isStuck ? "opacity-100" : "opacity-0",
+        )}
+      />
+
+      <div
+        className={cn(
+          "flex items-center justify-between gap-3 rounded-b-2xl border-t px-5 py-4 transition-[background-color,border-color,box-shadow] duration-300 sm:px-7",
+          "bg-card/85 backdrop-blur-xl supports-[backdrop-filter]:bg-card/70",
+          isStuck
+            ? "border-blocks-primary-200/80 shadow-[0_-20px_45px_-30px_hsl(var(--blocks-primary-900)/0.55)]"
+            : "border-border/60 shadow-none",
+        )}
+      >
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onBack}
+          disabled={isFirstStep || isSubmitting}
+          className="group rounded-xl border-border/70 transition-all duration-200 hover:-translate-x-0.5 hover:border-blocks-primary-300 hover:bg-blocks-primary-shades-200 hover:text-blocks-primary-600 disabled:hover:translate-x-0"
+        >
+          <ArrowLeft className="mr-2 h-4 w-4 transition-transform duration-200 group-hover:-translate-x-0.5" />
+          Back
+        </Button>
+
+        {isLastStep ? (
+          <Button
+            type="button"
+            onClick={onSubmit}
+            disabled={isSubmitting}
+            className="group relative overflow-hidden rounded-xl bg-gradient-to-br from-blocks-primary-500 to-blocks-primary-700 px-6 text-white shadow-[0_10px_30px_-12px_hsl(var(--blocks-primary-700)/0.9)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_16px_38px_-12px_hsl(var(--blocks-primary-700)/0.95)] disabled:hover:translate-y-0"
+          >
+            {/* A sheen that crosses the button on hover. Decorative, and clipped by the button. */}
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 -left-full w-1/2 skew-x-[-20deg] bg-white/20 transition-all duration-700 group-hover:left-[150%]"
+            />
+            {isSubmitting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            {isSubmitting ? submittingLabel : submitLabel}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            onClick={onNext}
+            className="group rounded-xl bg-gradient-to-br from-blocks-primary-500 to-blocks-primary-700 px-6 text-white shadow-[0_10px_30px_-12px_hsl(var(--blocks-primary-700)/0.9)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_16px_38px_-12px_hsl(var(--blocks-primary-700)/0.95)]"
+          >
+            Next
+            <ArrowRight className="ml-2 h-4 w-4 transition-transform duration-200 group-hover:translate-x-0.5" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-progress.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-progress.tsx
@@ -6,10 +6,10 @@ export interface PlanBuilderProgressProps {
   /**
    * True while the stepper is pinned to the top of the viewport. Drives the raised treatment only.
    *
-   * The stuck styling is deliberately **dimension-neutral** - shadow and border colour, never
-   * border width or padding. The measured height of this element positions the preview panel, so
-   * changing the box on stick would shift the preview every time the user crossed the threshold,
-   * and could provoke scroll anchoring.
+   * The stuck styling is deliberately **dimension-neutral** - shadow, ring and border colour,
+   * never border width or padding. The measured height of this element positions the preview
+   * panel, so changing the box on stick would shift the preview every time the user crossed the
+   * threshold, and could provoke scroll anchoring.
    */
   isStuck?: boolean;
 }
@@ -18,17 +18,28 @@ export const PlanBuilderProgress = ({ isStuck = false }: PlanBuilderProgressProp
   const { completedSteps, currentStep, getSteps, goToStep, totalSteps } = useStepper();
   const steps = getSteps();
 
+  // The filled fraction of the rail behind the nodes. Driven by the current step rather than by
+  // `completedSteps` so the bar moves the moment the user arrives somewhere, not only once the
+  // step behind them is validated - which is what makes it read as position rather than score.
+  const progressPercent = totalSteps > 1 ? ((currentStep - 1) / (totalSteps - 1)) * 100 : 100;
+
   return (
     <section
       aria-label="Plan creation progress"
       data-stuck={isStuck ? "true" : "false"}
       className={cn(
-        "overflow-hidden rounded-2xl border bg-card/95 px-4 py-4 sm:px-6 sm:py-5",
+        "relative overflow-hidden rounded-2xl border bg-card/95 px-4 py-4 backdrop-blur-xl transition-[box-shadow,border-color] duration-300 supports-[backdrop-filter]:bg-card/80 sm:px-6 sm:py-5",
         isStuck
-          ? "border-blocks-primary-200 shadow-lg"
-          : "border-blocks-primary-100 shadow-sm",
+          ? "border-blocks-primary-200 shadow-lg ring-1 ring-blocks-primary-100/60"
+          : "border-blocks-primary-100 shadow-sm ring-0",
       )}
     >
+      {/* Brand hairline along the top edge. Decorative; clipped by the section's rounding. */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-blocks-secondary-400 to-transparent"
+      />
+
       <div className="mb-4 flex items-center justify-between gap-4">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.16em] text-blocks-primary-600">
@@ -43,59 +54,75 @@ export const PlanBuilderProgress = ({ isStuck = false }: PlanBuilderProgressProp
         </p>
       </div>
 
-      <ol className="grid grid-cols-5">
-        {steps.map((step, index) => {
-          const isCurrent = currentStep === step.id;
-          const isComplete = completedSteps.includes(step.id);
-          const canNavigate = isCurrent || step.id === 1 || completedSteps.includes(step.id - 1);
+      <div className="relative">
+        {/*
+          One continuous rail behind all five nodes, rather than a separate connector per step.
+          The nodes are centred in equal-width columns, so it spans from the first centre to the
+          last - i.e. inset by half a column at each end.
+        */}
+        <div
+          aria-hidden="true"
+          className="absolute left-[10%] right-[10%] top-4 h-0.5 -translate-y-1/2 overflow-hidden rounded-full bg-border"
+        >
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-blocks-primary-500 to-blocks-secondary-500 transition-[width] duration-500 ease-out"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
 
-          return (
-            <li
-              key={step.id}
-              className={cn(
-                "relative min-w-0",
-                index < steps.length - 1 &&
-                  "after:absolute after:left-[calc(50%+1.25rem)] after:right-[calc(-50%+1.25rem)] after:top-4 after:h-0.5 after:bg-border after:content-['']",
-                index < steps.length - 1 && isComplete && "after:bg-blocks-primary-500",
-              )}
-            >
-              <button
-                type="button"
-                onClick={() => goToStep(step.id)}
-                disabled={!canNavigate}
-                aria-current={isCurrent ? "step" : undefined}
-                className="group relative z-10 flex w-full flex-col items-center gap-2 text-center disabled:cursor-not-allowed"
-              >
-                <span
-                  className={cn(
-                    "flex h-8 w-8 items-center justify-center rounded-full border bg-card text-xs font-bold text-muted-foreground transition-all duration-200",
-                    isCurrent &&
-                      "border-blocks-primary-600 bg-blocks-primary-600 text-white ring-4 ring-blocks-primary-100",
-                    isComplete &&
-                      !isCurrent &&
-                      "border-blocks-primary-500 bg-blocks-primary-50 text-blocks-primary-700",
-                    canNavigate &&
-                      !isCurrent &&
-                      "group-hover:border-blocks-primary-400 group-hover:text-blocks-primary-700",
-                  )}
-                >
-                  {isComplete && !isCurrent ? <Check className="h-4 w-4" /> : step.id}
-                </span>
-                <span
-                  className={cn(
-                    "hidden max-w-full truncate text-xs font-medium text-muted-foreground transition-colors sm:block",
-                    (isCurrent || isComplete) && "text-foreground",
-                  )}
-                >
-                  {step.title}
-                </span>
-              </button>
-            </li>
-          );
-        })}
-      </ol>
+        <ol className="relative grid grid-cols-5">
+          {steps.map((step) => {
+            const isCurrent = currentStep === step.id;
+            const isComplete = completedSteps.includes(step.id);
+            const canNavigate = isCurrent || step.id === 1 || completedSteps.includes(step.id - 1);
 
-      <p className="mt-3 text-center text-sm font-medium text-foreground sm:hidden">
+            return (
+              <li key={step.id} className="relative min-w-0">
+                <button
+                  type="button"
+                  onClick={() => goToStep(step.id)}
+                  disabled={!canNavigate}
+                  aria-current={isCurrent ? "step" : undefined}
+                  className="group relative z-10 flex w-full flex-col items-center gap-2 text-center disabled:cursor-not-allowed"
+                >
+                  <span
+                    className={cn(
+                      "flex h-8 w-8 items-center justify-center rounded-full border bg-card text-xs font-bold text-muted-foreground shadow-sm transition-all duration-300 ease-out",
+                      isCurrent &&
+                        "scale-110 border-transparent bg-gradient-to-br from-blocks-primary-500 to-blocks-primary-700 text-white shadow-[0_8px_20px_-8px_hsl(var(--blocks-primary-700)/0.9)] ring-4 ring-blocks-primary-shades-200",
+                      isComplete &&
+                        !isCurrent &&
+                        "border-transparent bg-gradient-to-br from-blocks-secondary-500 to-blocks-secondary-700 text-white",
+                      canNavigate &&
+                        !isCurrent &&
+                        !isComplete &&
+                        "group-hover:-translate-y-0.5 group-hover:border-blocks-primary-300 group-hover:text-blocks-primary-600",
+                      canNavigate && isComplete && !isCurrent && "group-hover:-translate-y-0.5",
+                    )}
+                  >
+                    {isComplete && !isCurrent ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      step.id
+                    )}
+                  </span>
+                  <span
+                    className={cn(
+                      "hidden max-w-full truncate text-xs font-medium text-muted-foreground transition-colors duration-200 sm:block",
+                      isComplete && !isCurrent && "text-foreground",
+                      isCurrent && "font-semibold text-blocks-primary-600",
+                    )}
+                  >
+                    {step.title}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      <p className="mt-3 text-center text-sm font-semibold text-blocks-primary-600 sm:hidden">
         {steps[currentStep - 1]?.title}
       </p>
     </section>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-sticky-layout.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder-sticky-layout.test.tsx
@@ -95,11 +95,13 @@ describe("plan builder sticky layout", () => {
     expect(decoration.className).toContain("overflow-hidden");
     expect(decoration.className).toContain("absolute");
     expect(decoration.className).toContain("inset-0");
-    // Both original blur elements moved inside it, none left loose in <main>.
-    expect(decoration.querySelectorAll("div.blur-3xl")).toHaveLength(2);
-    expect(
-      document.querySelectorAll("main > div.blur-3xl"),
-    ).toHaveLength(0);
+    // The invariant, not the census: the page's own decorative blurs live inside the clip layer,
+    // and none is left loose as a child of <main>, where an unclipped blur would widen the page.
+    // Asserting a fixed count instead would fail the moment a purely decorative one is added -
+    // which is exactly what happened - while still passing if a blur escaped alongside two that
+    // stayed. Other components may carry their own blurs; this guard is about <main>'s.
+    expect(decoration.querySelectorAll("div.blur-3xl").length).toBeGreaterThan(0);
+    expect(document.querySelectorAll("main > div.blur-3xl")).toHaveLength(0);
   });
 
   it("C5: the clip layer cannot intercept pointer events", () => {

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-builder.tsx
@@ -1,10 +1,9 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ArrowLeft, ArrowRight, Check, ChevronDown, Loader2 } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
-import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import {
   Collapsible,
@@ -38,6 +37,7 @@ import { FLAT_FEE } from "../../schemas/subscription-price.schema";
 import { toMinorUnits } from "../../utilities/subscription-format";
 import { PlanSummaryCard, type PlanSummaryData } from "../plan-summary-card";
 import { SubscriptionPlanPageHeader } from "../subscription-plan-page-header";
+import { PlanBuilderActions } from "./plan-builder-actions";
 import { PlanBuilderProgress } from "./plan-builder-progress";
 import { previewStickyTop, useStickyStepper } from "./use-sticky-stepper";
 import { StepIdentity } from "./step-identity";
@@ -288,6 +288,7 @@ const PlanBuilderWizard = ({
       >
         <div className="pointer-events-none absolute -right-32 top-24 h-80 w-80 rounded-full bg-blocks-secondary-100/30 blur-3xl" />
         <div className="pointer-events-none absolute -left-32 top-96 h-72 w-72 rounded-full bg-blocks-primary-100/30 blur-3xl" />
+        <div className="pointer-events-none absolute -right-24 top-[42rem] h-64 w-64 rounded-full bg-blocks-primary-shades-300/60 blur-3xl" />
       </div>
 
       <div className="relative mx-auto max-w-[96rem] space-y-5">
@@ -309,21 +310,31 @@ const PlanBuilderWizard = ({
               </div>
 
               <div className="grid min-w-0 gap-5 xl:grid-cols-[minmax(0,1fr)_22rem]">
-                <Card className="min-w-0 rounded-2xl border-border/70 bg-card/95 p-5 shadow-[0_18px_50px_-32px_rgba(15,23,42,0.35)] sm:p-7 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:tracking-tight">
-                  {currentStep === 1 && <StepIdentity isEditing={isEditing} />}
-                  {currentStep === 2 && (
-                    <StepPricingModel
-                      isEditing={isEditing}
-                      existingPrices={existingPrices}
-                      onRetirePrice={onRetirePrice}
-                      onUpdatePriceTax={onUpdatePriceTax}
-                      onUpdatePriceDiscount={onUpdatePriceDiscount}
-                      retiringPriceId={retiringPriceId}
-                    />
-                  )}
-                  {currentStep === 3 && <StepUsageLimits />}
-                  {currentStep === 4 && <StepTrial />}
-                  {currentStep === 5 && <StepReview plan={summary} />}
+                <Card className="relative min-w-0 overflow-visible rounded-2xl border-border/60 bg-card/95 p-5 shadow-[0_24px_60px_-40px_hsl(var(--blocks-primary-700)/0.45)] backdrop-blur-sm transition-shadow duration-300 supports-[backdrop-filter]:bg-card/90 sm:p-7 [&_h3]:tracking-tight">
+                  {/*
+                    Keyed on the step so React remounts the body on every move, which is what lets
+                    the enter animation replay - without the key it would run once, on first paint,
+                    and every later step would appear instantly.
+                  */}
+                  <div
+                    key={currentStep}
+                    className="duration-300 animate-in fade-in slide-in-from-bottom-2"
+                  >
+                    {currentStep === 1 && <StepIdentity isEditing={isEditing} />}
+                    {currentStep === 2 && (
+                      <StepPricingModel
+                        isEditing={isEditing}
+                        existingPrices={existingPrices}
+                        onRetirePrice={onRetirePrice}
+                        onUpdatePriceTax={onUpdatePriceTax}
+                        onUpdatePriceDiscount={onUpdatePriceDiscount}
+                        retiringPriceId={retiringPriceId}
+                      />
+                    )}
+                    {currentStep === 3 && <StepUsageLimits />}
+                    {currentStep === 4 && <StepTrial />}
+                    {currentStep === 5 && <StepReview plan={summary} />}
+                  </div>
 
                   {submissionError && (
                     <div
@@ -346,39 +357,16 @@ const PlanBuilderWizard = ({
                     </Collapsible>
                   )}
 
-                  <div className="mt-7 flex justify-between border-t border-border/70 pt-5">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={previousStep}
-                      disabled={currentStep === 1 || isSubmitting}
-                      className="rounded-lg"
-                    >
-                      <ArrowLeft className="mr-2 h-4 w-4" />
-                      Back
-                    </Button>
-
-                    {isLastStep ? (
-                      <Button
-                        type="button"
-                        onClick={submit}
-                        disabled={isSubmitting}
-                        className="rounded-lg shadow-sm"
-                      >
-                        {isSubmitting ? (
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                        ) : (
-                          <Check className="mr-2 h-4 w-4" />
-                        )}
-                        {isSubmitting ? submittingLabel : submitLabel}
-                      </Button>
-                    ) : (
-                      <Button type="button" onClick={nextStep} className="rounded-lg shadow-sm">
-                        Next
-                        <ArrowRight className="ml-2 h-4 w-4" />
-                      </Button>
-                    )}
-                  </div>
+                  <PlanBuilderActions
+                    isFirstStep={currentStep === 1}
+                    isLastStep={isLastStep}
+                    isSubmitting={isSubmitting}
+                    submitLabel={submitLabel}
+                    submittingLabel={submittingLabel}
+                    onBack={previousStep}
+                    onNext={nextStep}
+                    onSubmit={submit}
+                  />
                 </Card>
 
                 <aside className="hidden xl:block" aria-label="Plan preview">

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-heading.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-heading.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+/**
+ * The title block every step opens with.
+ *
+ * Shared rather than repeated per step so the five of them cannot drift apart on type scale or
+ * spacing - which is exactly what had happened, each step carrying its own `text-lg font-semibold`
+ * heading and its own margin.
+ *
+ * The eyebrow is what makes a step recognisable at a glance when the sticky stepper is collapsed
+ * to numbers on a narrow screen, so it repeats the step's own name rather than a generic label.
+ */
+export const StepHeading = ({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description: ReactNode;
+}) => (
+  <div className="relative">
+    {/*
+      A hairline that fades out, standing in for the heavy full-width rule this used to have no
+      room for. Decorative only.
+    */}
+    <span
+      aria-hidden="true"
+      className="absolute -left-5 top-1 hidden h-[calc(100%-0.25rem)] w-px bg-gradient-to-b from-blocks-secondary-500 via-blocks-primary-400 to-transparent sm:-left-7 sm:block"
+    />
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-blocks-secondary-200/70 bg-blocks-secondary-50 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-blocks-secondary-800">
+      <span className="h-1.5 w-1.5 rounded-full bg-blocks-secondary-500" />
+      {eyebrow}
+    </span>
+    <h2 className="mt-3 text-2xl font-semibold tracking-tight text-high-emphasis">{title}</h2>
+    <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">{description}</p>
+  </div>
+);

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-identity.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-identity.tsx
@@ -29,6 +29,7 @@ import {
   TENANT_WIDE_ORGANIZATION,
 } from "../../constants/subscription.constants";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
+import { StepHeading } from "./step-heading";
 
 /**
  * @param isEditing
@@ -48,13 +49,12 @@ export const StepIdentity = ({ isEditing = false }: { isEditing?: boolean }) => 
   const organizations = organizationsData?.organizations ?? [];
 
   return (
-    <div className="space-y-5">
-      <div>
-        <h2 className="text-lg font-semibold">Identity</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          The basics: what this plan is called, and who it&apos;s for.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <StepHeading
+        eyebrow="Identity"
+        title="Identity"
+        description="The basics: what this plan is called, and who it's for."
+      />
 
       <div className="grid gap-5 sm:grid-cols-2">
         <FormField

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -30,6 +30,7 @@ import type { PlanPrice } from "../../models/subscription-plan.model";
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 import { METER_QUANTITY_MAX_SCALE, stepFor } from "../../utilities/meter-quantity";
 import { CardListItem, CardListShell } from "./card-list-shell";
+import { StepHeading } from "./step-heading";
 import { MeterRateTableFields } from "./meter-rate-table-fields";
 import { PlanPriceFields } from "./plan-price-fields";
 import { QuantityDiscountTiers } from "./quantity-discount-tiers";
@@ -68,12 +69,11 @@ export const StepPricingModel = ({
 
   return (
     <div className="space-y-6">
-      <div>
-        <h2 className="text-lg font-semibold">Pricing model</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Add any quantity and usage dimensions this plan needs. A flat-fee plan needs neither.
-        </p>
-      </div>
+      <StepHeading
+        eyebrow="Pricing model"
+        title="Pricing model"
+        description="Add any quantity and usage dimensions this plan needs. A flat-fee plan needs neither."
+      />
 
       <OptionalSection
         title="Quantity items"
@@ -551,14 +551,30 @@ const OptionalSection = ({
   defaultOpen: boolean;
   children: React.ReactNode;
 }) => (
-  <Collapsible defaultOpen={defaultOpen} className="rounded-xl border p-4">
-    <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 text-left">
+  <Collapsible
+    defaultOpen={defaultOpen}
+    className="group/section rounded-xl border border-border/70 bg-card/60 p-4 transition-colors duration-200 hover:border-blocks-primary-200"
+  >
+    <CollapsibleTrigger className="flex w-full items-center justify-between gap-3 rounded-lg text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2">
       <span>
-        <span className="block text-sm font-semibold">{title}</span>
-        <span className="block text-xs text-muted-foreground">{description}</span>
+        <span className="block text-sm font-semibold text-high-emphasis">{title}</span>
+        <span className="block text-xs leading-relaxed text-muted-foreground">{description}</span>
       </span>
-      <ChevronDown className="h-4 w-4 shrink-0" />
+      {/*
+        Radix sets data-state on the trigger, so the chevron can point at the state it will move
+        to without this component tracking `open` itself.
+      */}
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-border/70 bg-card text-muted-foreground transition-all duration-200 group-hover/section:border-blocks-primary-300 group-hover/section:text-blocks-primary-600">
+        <ChevronDown className="h-4 w-4 transition-transform duration-300 group-data-[state=open]/section:rotate-180" />
+      </span>
     </CollapsibleTrigger>
-    <CollapsibleContent className="space-y-3 pt-4">{children}</CollapsibleContent>
+    {/*
+      Fade/slide rather than the accordion height keyframes: those read
+      `--radix-accordion-content-height`, which only Accordion publishes - Collapsible sets
+      `--radix-collapsible-content-height`, so reusing them here would animate to no height at all.
+    */}
+    <CollapsibleContent className="space-y-3 pt-4 duration-200 data-[state=open]:animate-in data-[state=open]:fade-in data-[state=open]:slide-in-from-top-1">
+      {children}
+    </CollapsibleContent>
   </Collapsible>
 );

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-review.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-review.tsx
@@ -1,13 +1,13 @@
 import { PlanSummaryCard, type PlanSummaryData } from "../plan-summary-card";
+import { StepHeading } from "./step-heading";
 
 export const StepReview = ({ plan }: { plan: PlanSummaryData }) => (
-  <div className="space-y-5">
-    <div>
-      <h2 className="text-lg font-semibold">Review</h2>
-      <p className="mt-1 text-sm text-muted-foreground">
-        This is exactly how the plan will read once it&apos;s created.
-      </p>
-    </div>
+  <div className="space-y-6">
+    <StepHeading
+      eyebrow="Review"
+      title="Review"
+      description="This is exactly how the plan will read once it's created."
+    />
 
     <PlanSummaryCard plan={plan} />
   </div>

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-trial.tsx
@@ -18,6 +18,7 @@ import {
 import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscription-plan.schema";
 import { stepFor } from "../../utilities/meter-quantity";
 import { CardListItem, CardListShell } from "./card-list-shell";
+import { StepHeading } from "./step-heading";
 
 /** Not a server value — selecting this clears the trial fields entirely. */
 const NO_TRIAL = "None" as const;
@@ -63,13 +64,12 @@ export const StepTrial = () => {
       ?.quantityScale ?? 0;
 
   return (
-    <div className="space-y-5">
-      <div>
-        <h2 className="text-lg font-semibold">Trial</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Optional. Choose &ldquo;No trial&rdquo; for a plan that charges from day one.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <StepHeading
+        eyebrow="Trial"
+        title="Trial"
+        description={'Optional. Choose “No trial” for a plan that charges from day one.'}
+      />
 
       <div className="grid gap-5 sm:grid-cols-2">
         <FormField

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-usage-limits.tsx
@@ -23,6 +23,7 @@ import type { CreateSubscriptionPlanFormValues } from "../../schemas/subscriptio
 import { stepFor } from "../../utilities/meter-quantity";
 import { describeEntitlementMeterMismatch } from "../../utilities/plan-consistency";
 import { CardListItem, CardListShell } from "./card-list-shell";
+import { StepHeading } from "./step-heading";
 
 export const StepUsageLimits = () => {
   const { control, setValue } = useFormContext<CreateSubscriptionPlanFormValues>();
@@ -35,14 +36,12 @@ export const StepUsageLimits = () => {
   const [limitOverrides, setLimitOverrides] = useState<Record<number, boolean>>({});
 
   return (
-    <div className="space-y-5">
-      <div>
-        <h2 className="text-lg font-semibold">What the plan grants</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          What a subscriber on this plan is allowed to do — separate from what they&apos;re billed for.
-          Skip this if the plan just grants everything.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <StepHeading
+        eyebrow="Entitlements"
+        title="What the plan grants"
+        description="What a subscriber on this plan is allowed to do — separate from what they're billed for. Skip this if the plan just grants everything."
+      />
 
       <CardListShell
         addLabel="Add usage limit"

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/use-sticky-action-bar.ts
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/use-sticky-action-bar.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Whether the builder's action bar is currently pinned to the bottom of the viewport.
+ *
+ * The mirror image of {@link useStickyStepper}'s top-edge detection, and it exists for the same
+ * reason: CSS has no `:stuck`, so the sticky element observes itself through an
+ * IntersectionObserver whose root is shrunk by 1px - this time at the BOTTOM. The bar can only be
+ * fully intersecting while it sits above that line, so the instant it pins to `bottom: 0` it is
+ * clipped and the ratio drops below 1.
+ *
+ * Both conditions in the predicate matter, again for the reasons the stepper documents. The ratio
+ * alone is also below 1 when the bar is merely clipped by the TOP of a short viewport or is wider
+ * than it, neither of which is stuck. Requiring the bar's bottom edge to be at or below the
+ * (1px-inset) root bottom removes those false positives.
+ *
+ * Kept separate from `useStickyStepper` rather than folded into it behind an `edge` argument: the
+ * two share only the observer boilerplate, while the predicate, the root margin and the return
+ * shape all differ - the stepper additionally measures its own height to position the preview
+ * column, which a bar pinned to the bottom has no equivalent of.
+ *
+ * Degrades rather than throwing where IntersectionObserver is absent (jsdom): the bar simply never
+ * reports stuck, which costs the raised treatment and nothing else - it is still sticky, because
+ * that part is pure CSS.
+ */
+export interface StickyActionBarLayout {
+  /** Attach to the element that carries `position: sticky`. */
+  barRef: (node: HTMLElement | null) => void;
+  /** True while the bar is pinned to the bottom of the viewport with content still below it. */
+  isStuck: boolean;
+}
+
+export const useStickyActionBar = (): StickyActionBarLayout => {
+  const [isStuck, setIsStuck] = useState(false);
+  // In state rather than a ref for the reason the stepper spells out: the effect has to re-run
+  // when the node attaches, and a ref plus `[]` deps would observe whatever it held at mount.
+  const [node, setNode] = useState<HTMLElement | null>(null);
+
+  // Stable identity on purpose - a changing callback ref is detached and reattached every render.
+  const barRef = useCallback((next: HTMLElement | null) => setNode(next), []);
+
+  useEffect(() => {
+    if (!node || typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (!entry) return;
+        const rootBottom = entry.rootBounds?.bottom ?? 0;
+        setIsStuck(
+          entry.intersectionRatio < 1 && entry.boundingClientRect.bottom >= rootBottom,
+        );
+      },
+      { threshold: [1], rootMargin: "0px 0px -1px 0px" },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node]);
+
+  return { barRef, isStuck };
+};


### PR DESCRIPTION
## The bug

`Back` / `Next` / `Confirm` sat at the foot of the step card, in normal flow. On the pricing-model step that put them several screens below the fold with nothing to suggest they existed, so the wizard read as a dead end.

They move into a **sticky footer bar inside the step card** — inside, so it stays aligned with the form column instead of running under the preview panel at `xl`, and `z-20` so the Radix Select/Popover portals still layer over it.

Stuck detection mirrors `useStickyStepper`'s self-observing IntersectionObserver, inverted to the bottom edge, and drives only a raised shadow plus the gradient that dissolves the last field row beneath the bar.

### Verified in a real engine

jsdom has no layout engine, so the pinning itself was measured against a harness reproducing the exact ancestor chain (non-clipping `<main>` → grid → padded card), at 1280×800:

| scroll | bar bottom | card bottom | reading |
|---|---|---|---|
| 0 | **800** = viewport | 3759 | pinned from first paint |
| 1500 | **800** = viewport | 2259 | stays pinned |
| end | **764** | **764** | settles flush with the card, stops floating |

## The restyle

Deliberately in the shared primitives rather than sprinkled across the five steps:

- **`StepHeading`** (new) — each step carried its own hand-rolled heading, which had already drifted. The card's `[&_h2]` override that was flattening them all is gone.
- **Stepper** — one continuous rail with an animated gradient fill, gradient/glow on the current node, teal on completed.
- **Card lists** — hover lift, a fading remove control, and an add tile whose `+` rotates.
- **Collapsibles** — rotating chevron; fade/slide content rather than the accordion height keyframes, which read a CSS variable only `Accordion` publishes.
- **Step body** — keyed on the step so its enter animation replays on every move.

## Note on tokens

Light tints use `blocks-primary-shades-*`, not `blocks-primary-50`: that token is `208 16% 79%`, a mid grey-blue, and reading it as a light tint is why the existing chips render heavier than the source suggests.

## Test change

`plan-builder-sticky-layout.test.tsx` counted exactly two decorative blurs, which a purely decorative third fails. It now asserts the invariant the guard was actually protecting — the blurs live inside the clip layer, and none is left loose as a child of `<main>` where it would widen the page.

## Checks

- `vitest` — 660 passed (52 files), on this branch's `dev` base
- `tsc --noEmit` — clean
- `eslint` — clean (one pre-existing React Compiler warning in an unrelated test file)

**Not verified:** the builder sits behind the dashboard auth layout, so the styling has not been eyeballed in the running app. Worth a look at `subscription/plans/create` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
