### PR TITLE
fix(subscription): make production logs traceable to a subscription

### DIFF
--- a/docs/subscription/README.md
+++ b/docs/subscription/README.md
@@ -8,6 +8,7 @@ means, start here.
 | --- | --- |
 | [plan-authoring/](plan-authoring/) | You are building a plan and need to know what every option means, when to pick each alternative, and how to prove you picked right. |
 | [lifecycle/](lifecycle/) | You need the whole journey — signup, trial, renewal, upgrade, overage, decline, cancellation — and what the subscriber sees at each step. |
+| [tracing/](tracing/) | A customer has reported a problem and you need to find out what actually happened to their subscription. |
 
 For how any of it is *implemented*, the authority is
 [`server/Subscription.DomainService/README.md`](../../server/Subscription.DomainService/README.md).

--- a/docs/subscription/tracing/README.md
+++ b/docs/subscription/tracing/README.md
@@ -1,0 +1,149 @@
+# Tracing a subscription in production
+
+A customer reports a problem. This is how you find out what happened.
+
+---
+
+## The two stores, and what each one answers
+
+| | Answers | Where |
+| --- | --- | --- |
+| **Audit trail** | *Who did what, when, and what state resulted* | `GET /api/subscriptions/{id}/audit` |
+| **Structured logs** | *How the code got there* — stages, attempts, exceptions, timings | Your log sink |
+
+Both are required. Audit records are append-only with no TTL and no update or delete path, but they
+are *intentionally too small to debug execution*. Logs are mutable and retention-bound but carry
+everything the audit trail deliberately leaves out.
+
+**The join key is `CorrelationId`.** Every audit event carries it, and every log line inside a
+correlated flow carries it too.
+
+---
+
+## The three-step trace
+
+### 1. Get a starting key
+
+| You have | Do this |
+| --- | --- |
+| The customer quoted a reference | That is the `X-Correlation-ID` response header — go straight to step 3 |
+| A subscription id | Step 2 |
+| Only an organization | Find the subscription first, then step 2 |
+
+Every API response echoes `X-Correlation-ID`, including endpoints that answer with something other
+than the standard envelope — webhooks and the checkout return among them — *"so a caller reporting
+a problem can quote it."* Surfacing it in your own error UI makes most support calls one step
+shorter.
+
+### 2. Read the audit timeline
+
+```
+GET /api/subscriptions/{subscriptionId}/audit?limit=100
+```
+
+Organization-scoped and sanitised; actor and payment identifiers stay in the database. Each event
+carries:
+
+```
+OperationId   CorrelationId   Operation   Stage   Outcome   Source
+AmountMinor   CurrencyCode    FromStatus  ToStatus
+ErrorCode     FailureKind     Attempt     OccurredAtUtc
+```
+
+Read down the timeline to the step that went wrong and take its **`CorrelationId`**.
+
+### 3. Grep the logs by that correlation id
+
+```
+CorrelationId="<the value from step 2>"
+```
+
+That returns the whole flow — API request, any queued work it produced, and the provider calls that
+finished it.
+
+---
+
+## What the log lines carry
+
+Identifiers are written **in clear, not hashed**. That is deliberate: hashing them *"was the reason
+the logs could not be followed"* — an operator holding an id from the database or the console had no
+way to reach its log lines without recomputing a digest by hand. Personal data (a shopper's email,
+name, phone) still goes through the hash.
+
+Background work runs inside a log scope that stamps **every line it writes**:
+
+```
+WorkItemId  WorkType  WorkKey  TenantId  SubscriptionId
+OrganizationId  CorrelationId  OperationId  LeaseId  AttemptCount
+```
+
+So a message like `Subscription work completed DueAtUtc=… DurationMs=2 LagSeconds=20` is not missing
+its context — the template just doesn't repeat what the scope already carries. Query the fields, not
+the message text.
+
+> **This requires scope capture to be switched on.** Every `appsettings.json` in `server/Api` and
+> `server/Worker` now sets:
+>
+> ```json
+> "Logging": {
+>   "Console": {
+>     "IncludeScopes": true,
+>     "FormatterOptions": { "IncludeScopes": true }
+>   }
+> }
+> ```
+>
+> Without it those ten fields are computed on every line and then discarded by the sink, and the
+> scopes array renders as `[]`. If your production sink is not the console provider, set
+> `IncludeScopes` on whichever provider you use — the principle is the same.
+
+---
+
+## Reading sweep lines
+
+Lines from the repair sweep look like this, and they are **not** about any one customer:
+
+```
+Repair sweep announced subscription work AnnouncedCount=1 WorkKey="sweep20260902T2035Z"
+  CorrelationId="sweep-…" CorrelationOrigin="MintedByRepairSweep" TenantId="…"
+
+Scheduled subscription work WorkType=ActivationRecovery WorkKey="sweep20260902T2035Z"
+  TenantId="…" SubscriptionId="none" DueAtUtc=… CorrelationId="sweep-…"
+```
+
+Two things to know:
+
+- **`SubscriptionId="none"` means the work is tenant-wide**, not that an id was lost. Work about one
+  subscription carries its real id; `missing` would mean something genuinely absent.
+- **`CorrelationOrigin="MintedByRepairSweep"` means the trail stops here going backwards.** The sweep
+  minted this correlation itself, so there is no upstream customer action to find. Anything
+  downstream carries it forward. These lines are the sweep noticing work needs doing — they are
+  normal, and they are not a customer's problem.
+
+---
+
+## Alert on this marker
+
+```
+SUBSCRIPTION_AUDIT_WRITE_FAILED
+```
+
+Audit writes are deliberately **fail-open** after a business operation: an unavailable audit store
+never makes a caller retry money movement. So the money is right and the trail has a hole. Alert on
+the marker; the payment and subscription ledgers remain the reconciliation source.
+
+---
+
+## Common questions, and where the answer lives
+
+| Question | Look at |
+| --- | --- |
+| "Why was I charged this amount?" | Audit event's `AmountMinor` + the settlement breakdown on the payment record |
+| "Why did my card fail?" | Audit `ErrorCode` / `FailureKind` / `Attempt`, then logs by correlation id |
+| "Why did my subscription stop working?" | Audit `FromStatus` → `ToStatus`; `Unpaid` grants nothing |
+| "Where did my allowance go?" | The usage ledger — append-only, never expires, corrections are reversal entries |
+| "My overage bill is wrong" | Usage invoice for that `PeriodKey`; rating is graduated from the first overage unit |
+| "Nothing happened at all" | Check whether the work was ever scheduled — grep `WorkKey` |
+
+The usage ledger is the one to reach for on any billing dispute: it is append-only and never
+expires, so a bill can always be explained even after counters have aged out.

--- a/server/Api/appsettings.Development.json
+++ b/server/Api/appsettings.Development.json
@@ -1,4 +1,12 @@
 {
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "GeolocationApiUrl": "https://ipgeolocation.abstractapi.com/v1/?api_key={apiKey}&ip_address={ip}",
   "GeolocationApiKey": "***REMOVED***",
   "RootTenantId": "***REMOVED***",

--- a/server/Api/appsettings.dev.json
+++ b/server/Api/appsettings.dev.json
@@ -1,4 +1,12 @@
 {
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "GeolocationApiUrl": "https://ipgeolocation.abstractapi.com/v1/?api_key={apiKey}&ip_address={ip}",
   "GeolocationApiKey": "***REMOVED***",
   "RootTenantId": "***REMOVED***",

--- a/server/Api/appsettings.json
+++ b/server/Api/appsettings.json
@@ -1,5 +1,11 @@
 ﻿{
   "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    },
     "LogLevel": {
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"

--- a/server/Api/appsettings.prod.json
+++ b/server/Api/appsettings.prod.json
@@ -1,4 +1,12 @@
 ﻿{
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "GeolocationApiUrl": "https://ipgeolocation.abstractapi.com/v1/?api_key={apiKey}&ip_address={ip}",
   "GeolocationApiKey": "***REMOVED***",
   "RootTenantId": "***REMOVED***",

--- a/server/Api/appsettings.stg.json
+++ b/server/Api/appsettings.stg.json
@@ -1,4 +1,12 @@
 ﻿{
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "GeolocationApiUrl": "https://ipgeolocation.abstractapi.com/v1/?api_key={apiKey}&ip_address={ip}",
   "GeolocationApiKey": "***REMOVED***",
   "RootTenantId": "acf19d8d8841400a8999f0a5337fadf5",

--- a/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
@@ -194,8 +194,13 @@ public sealed class SubscriptionRepairAnnouncer
                 "WorkKey={WorkKey} CorrelationId={CorrelationId} CorrelationOrigin={Origin} " +
                 "TenantId={TenantId}",
                 scheduled,
-                workKey,
-                correlationId,
+                // Through the same sanitiser the scheduler uses. Logged raw, this printed
+                // "sweep:20260902T2035Z" while the line the scheduler wrote for the very same item
+                // printed "sweep20260902T2035Z" — the allow-list drops the colon — so an operator
+                // grepping either form found only half the trail. It is also the filter that stops
+                // a key from forging a second log entry.
+                PaymentLogValue.Label(workKey),
+                PaymentLogValue.Id(correlationId),
                 // Says outright that this correlation begins here. Anything downstream carries it,
                 // so the trail leads back to this line and stops — which is the truth.
                 "MintedByRepairSweep",

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
@@ -134,8 +134,10 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
             // scheduler lines without recomputing a digest — which is the reason PaymentLogValue.Id
             // exists at all.
             ["TenantId"] = PaymentLogValue.Id(work.TenantId),
-            ["SubscriptionId"] = PaymentLogValue.Id(work.AggregateId),
-            ["OrganizationId"] = PaymentLogValue.Id(work.OrganizationId ?? string.Empty),
+            // "none" rather than "missing" when the work is tenant-wide, so a sweep is not read as
+            // an item that lost its subscription.
+            ["SubscriptionId"] = SubscriptionWorkLogValue.AggregateId(work.AggregateId),
+            ["OrganizationId"] = SubscriptionWorkLogValue.AggregateId(work.OrganizationId),
             ["CorrelationId"] = PaymentLogValue.Id(work.CorrelationId),
             ["OperationId"] = work.OperationId,
             ["LeaseId"] = leaseId,

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkScheduler.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkScheduler.cs
@@ -65,7 +65,9 @@ public sealed class SubscriptionWorkScheduler : ISubscriptionWorkScheduler
                 workType,
                 PaymentLogValue.Label(workKey),
                 PaymentLogValue.Id(tenantId),
-                PaymentLogValue.Id(aggregateId),
+                // "none" rather than "missing" when the work is tenant-wide: a sweep has no
+                // subscription, and saying so is different from having lost one.
+                SubscriptionWorkLogValue.AggregateId(aggregateId),
                 dueAtUtc,
                 PaymentLogValue.Id(correlationId));
         }

--- a/server/Subscription.DomainService/Utilities/SubscriptionWorkLogValue.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionWorkLogValue.cs
@@ -1,0 +1,27 @@
+using Payment.DomainService.Utilities;
+
+namespace Subscription.DomainService.Utilities;
+
+/// <summary>
+/// Log rendering for the identifiers background work carries.
+/// </summary>
+/// <remarks>
+/// <see cref="PaymentLogValue.Id"/> renders an absent identifier as <c>missing</c>, which reads as
+/// something that should have been there and was lost. Most background work is about one
+/// subscription and that reading is right. A tenant-wide sweep is about none of them, and printing
+/// the same word for both left an operator unable to tell a scope from a defect — the difference
+/// this exists to say out loud.
+/// </remarks>
+public static class SubscriptionWorkLogValue
+{
+    /// <summary>Absent because the work is not about any one aggregate.</summary>
+    private const string NotApplicable = "none";
+
+    /// <summary>
+    /// The aggregate a work item acts on, or <c>none</c> when it acts on the tenant as a whole.
+    /// </summary>
+    public static string AggregateId(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? NotApplicable
+            : PaymentLogValue.Id(value);
+}

--- a/server/Worker/appsettings.Development.json
+++ b/server/Worker/appsettings.Development.json
@@ -1,4 +1,12 @@
 {
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "PdfToolPath": "C:/Program Files/wkhtmltopdf/bin/wkhtmltopdf.exe",
   "RootTenantId": "***REMOVED***",
   "AuthenticationTokenEndpoint": "https://dev-api.blocksdevelopers.com/iam/v1/Authentication/token",

--- a/server/Worker/appsettings.dev.json
+++ b/server/Worker/appsettings.dev.json
@@ -1,4 +1,12 @@
 {
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "PdfToolPath": "/usr/bin/wkhtmltopdf",
   "RootTenantId": "***REMOVED***",
   "AuthenticationTokenEndpoint": "https://dev-api.blocksdevelopers.com/iam/v1/Authentication/token",

--- a/server/Worker/appsettings.json
+++ b/server/Worker/appsettings.json
@@ -1,5 +1,11 @@
 {
   "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    },
     "LogLevel": {
       "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Information"

--- a/server/Worker/appsettings.prod.json
+++ b/server/Worker/appsettings.prod.json
@@ -1,4 +1,12 @@
 {
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "PdfToolPath": "/usr/bin/wkhtmltopdf",
   "RootTenantId": "***REMOVED***",
   "AuthenticationTokenEndpoint": "https://api.seliseblocks.com/iam/v1/Authentication/token",

--- a/server/Worker/appsettings.stg.json
+++ b/server/Worker/appsettings.stg.json
@@ -1,4 +1,12 @@
 {
+  "Logging": {
+    "Console": {
+      "IncludeScopes": true,
+      "FormatterOptions": {
+        "IncludeScopes": true
+      }
+    }
+  },
   "PdfToolPath": "/usr/bin/wkhtmltopdf",
   "RootTenantId": "acf19d8d8841400a8999f0a5337fadf5",
   "AuthenticationTokenEndpoint": "https://stg-api.blocksdevelopers.com/iam/v1/Authentication/token",


### PR DESCRIPTION
## The problem

A customer reports a problem and there is no way to find out what happened to their subscription. Production lines look like this:

```
Scheduled subscription work WorkType=ActivationRecovery WorkKey="sweep20260902T2030Z"
  TenantId="…" SubscriptionId="missing" DueAtUtc=… CorrelationId="sweep-…"
Subscription work completed DueAtUtc=… DurationMs=2 LagSeconds=20
```

The completion line looks like it carries nothing to join on, and `SubscriptionId="missing"` looks like data was lost.

## What was actually wrong

**The instrumentation was already there and correct — the sink was discarding it.**

`SubscriptionWorkDispatcher.RunAsync` opens a log scope stamping ten fields on *every* line a work item writes:

```
WorkItemId  WorkType  WorkKey  TenantId  SubscriptionId
OrganizationId  CorrelationId  OperationId  LeaseId  AttemptCount
```

Its comment states the intent — *"One operation has to be traceable from the API call that scheduled it to the provider request that finished it."* The message templates deliberately don't repeat those fields.

But **no `appsettings` in either service set `IncludeScopes`**, and the default is `false`. So all ten were computed per line and dropped. That empty `[]` in the log viewer is the scopes array.

## Changes

### `IncludeScopes` in all ten appsettings files

```json
"Logging": {
  "Console": {
    "IncludeScopes": true,
    "FormatterOptions": { "IncludeScopes": true }
  }
}
```

All ten rather than only the two base files, because **which overlay actually wins in production is not determinable from this repo**:

- `Dockerfile:52` sets `ASPNETCORE_ENVIRONMENT=Production`; `Dockerfile.worker:38` sets `DOTNET_ENVIRONMENT=Production`
- The overlays are named `.prod.json` / `.stg.json` / `.dev.json` — there is no `appsettings.Production.json`
- `Blocks.Genesis.ApplicationConfigurations.GetEnvironmentAppSettingsFileName` builds the name by concatenating the env var verbatim (`"appsettings." + value + ".json"`); there is no `Production → prod` mapping
- `ci_prod.yml` passes no `ASPNETCORE_ENVIRONMENT` build arg, and neither Dockerfile declares `ARG ASPNETCORE_ENVIRONMENT`, so `ci-dev.yml`'s is inert too

If the GitOps manifests set it to `prod` at runtime the overlays load; otherwise only `appsettings.json` does. Setting it everywhere is correct under either resolution. **Worth confirming separately** — `kubectl exec deploy/<api> -- printenv ASPNETCORE_ENVIRONMENT` — because if it prints `Production`, every `.prod.json` setting in this repo has been dead, which matters well beyond logging.

### `WorkKey` renders consistently

The repair announcer logged it raw while the scheduler logged it through `PaymentLogValue.Label`, so one item printed as both `sweep:20260902T2035Z` and `sweep20260902T2035Z` — grep either form, find half the trail. The raw value was also the one identifier on that line outside the module's log-forging filter.

### `SubscriptionId="none"` for tenant-wide work

`"missing"` said the same word for a sweep that has no subscription and for one genuinely lost. New `SubscriptionWorkLogValue.AggregateId` distinguishes them.

### Runbook

`docs/subscription/tracing/` — the three-step trace (`X-Correlation-ID` → `GET /subscriptions/{id}/audit` → grep by correlation id), how to read sweep lines, the `SUBSCRIPTION_AUDIT_WRITE_FAILED` marker to alert on, and a symptom→source table. Sits beside `plan-authoring/` and `lifecycle/` in the same shape.

## Verification

- `dotnet build Subscription.DomainService` → **0 errors**
- `dotnet test --filter XUnitTest.Subscription` → **1,564 passed, 4 failed**

The 4 failures are pre-existing and unrelated (`SubscriptionSimulation*` permission tests). Confirmed rather than assumed: reverted the changed `.cs` files to HEAD, ran the same tests, got the identical four failures, restored.

## Risk

Config-only behaviour change plus three logging call sites. No business logic, no schema, no money path. The one operational note is that scope capture makes each log line larger — expected, and the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
