### PR TITLE
Fix subscription_payment_provider_scope_mismatch on a corrected provider

### DIFF
--- a/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
+++ b/server/Subscription.DomainService/Repositories/BillingAccountRepository.cs
@@ -86,53 +86,88 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
                      ?? account;
         }
 
-        return await BackfillProviderIdentityAsync(account, result, cancellationToken);
+        return await ReconcileProviderIdentityAsync(account, result, cancellationToken);
     }
 
     /// <summary>
-    /// One-time self-healing backfill of <see cref="BillingAccount.ProviderId"/> and
-    /// <see cref="BillingAccount.ProviderOrganizationId"/> onto a legacy account that predates
-    /// this PR's provider-identity work and so was created with both left null.
+    /// Keeps <see cref="BillingAccount.ProviderId"/> and
+    /// <see cref="BillingAccount.ProviderOrganizationId"/> pointed at whatever readiness resolved
+    /// just now, for as long as doing so is still safe -- and freezes them the moment it stops
+    /// being safe.
     /// </summary>
     /// <remarks>
+    /// An account is one per organization and provider and outlives every subscription on it (see
+    /// <see cref="IBillingAccountRepository.GetOrCreateAndReconcileAsync"/>), so the very first
+    /// signup attempt for a given (tenant, organization, provider name) is not necessarily the one
+    /// that ends up paying anything: it can be misconfigured, abandoned, or superseded by a
+    /// corrected <c>PaymentProvider</c> row before a card is ever actually charged or stored. Only
+    /// once <see cref="BillingAccount.ProviderCustomerId"/> is set does that account name a real
+    /// customer at a real provider -- filled in from a confirmed charge, never guessed at (see its
+    /// own remarks) -- and only from that point on would moving <see cref="BillingAccount.ProviderId"/>
+    /// risk stranding a saved card or repointing a live mandate. Before then, re-pinning to the
+    /// current resolution is not merely safe, it is the only way an operator who fixes a
+    /// misconfigured provider between two subscribe attempts is not stuck forever with the first,
+    /// broken one -- see PR #393's <c>subscription_payment_provider_scope_mismatch</c> finding.
+    /// <para>
     /// Deliberately not folded into <see cref="Reconciliation"/>: that single find-and-modify
-    /// cannot express "write this field only if it is currently null" — <c>$set</c> and
-    /// <c>$setOnInsert</c> both act unconditionally on their own side of insert-vs-update — so the
-    /// conditional write here follows this codebase's established compare-and-set convention
+    /// cannot express "write this field only if the account has taken no money yet" — <c>$set</c>
+    /// and <c>$setOnInsert</c> both act unconditionally on their own side of insert-vs-update — so
+    /// the conditional write here follows this codebase's established compare-and-set convention
     /// instead (see <c>PaymentRepository.TryRecordSetupTokenConfirmedAsync</c> in
-    /// Payment.DomainService): a conditional update filtered on the field still being null.
-    /// That filter is what makes
-    /// this strictly additive and one-directional — a billing account's provider identity is
-    /// frozen once set, and this must never be the thing that silently moves it, only the thing
-    /// that fills in a value legacy accounts were never given a chance to record.
+    /// Payment.DomainService): a conditional update filtered on <c>ProviderCustomerId</c> still
+    /// being unset. That filter is what makes this reversible only until real money is on the
+    /// line, and absolute afterwards -- a billing account that has already taken a payment must
+    /// never have its provider identity moved by anything, this method included.
+    /// </para>
     /// <para>
     /// Uses <c>FindOneAndUpdate</c> with <see cref="ReturnDocument.After"/> rather than an
     /// <c>UpdateOneAsync</c> read off its <c>ModifiedCount</c>, so a losing writer in a race
-    /// between two concurrent backfills of the same legacy account still gets back whatever is
+    /// between two concurrent reconciliations of the same account still gets back whatever is
     /// actually on the document now -- the value the winner wrote -- instead of the stale
-    /// pre-update <paramref name="stored"/> it was handed, which would still show
-    /// <c>ProviderId == null</c> and cause its caller to skip the fail-closed
-    /// <c>ExpectedProviderId</c> check even though the database already has a frozen identity.
-    /// See PR #393 review (Finding 2).
+    /// pre-update <paramref name="stored"/> it was handed, which could show a <c>ProviderId</c>
+    /// this call itself just made stale.
     /// </para>
     /// </remarks>
-    private async Task<BillingAccount> BackfillProviderIdentityAsync(
+    private async Task<BillingAccount> ReconcileProviderIdentityAsync(
         BillingAccount account,
         BillingAccount stored,
         CancellationToken cancellationToken)
     {
-        if (stored.ProviderId is not null || account.ProviderId is null)
+        if (account.ProviderId is null)
         {
-            // Either this account's provider identity is already frozen (nothing to backfill),
-            // or the caller has no provider identity to offer -- e.g. a reconcile call that
+            // The caller has no provider identity to offer -- e.g. a reconcile call that
             // predates this PR's provider-identity work reaching this code path.
             return stored;
         }
 
+        if (!string.IsNullOrWhiteSpace(stored.ProviderCustomerId))
+        {
+            // A real charge already confirmed a customer against this account's provider.
+            // Frozen, permanently: see the type's remarks.
+            return stored;
+        }
+
+        if (string.Equals(stored.ProviderId, account.ProviderId, StringComparison.Ordinal) &&
+            string.Equals(
+                stored.ProviderOrganizationId, account.ProviderOrganizationId, StringComparison.Ordinal))
+        {
+            // Already pinned to exactly what readiness resolved just now. Nothing to reconcile,
+            // and no write to race anyone over.
+            return stored;
+        }
+
+        // Optimistic concurrency on the exact ProviderId this call read, not merely "still
+        // unset": two concurrent reconciles that both read the same stored value and each want to
+        // write a different one must not both succeed -- exactly one may win, or the two calls
+        // converge on different answers, and the whole point of the reload below is that every
+        // caller agrees on a single truth.
         var filter = Builders<BillingAccount>.Filter.And(
             Builders<BillingAccount>.Filter.Eq(x => x.TenantId, stored.TenantId),
             Builders<BillingAccount>.Filter.Eq(x => x.ItemId, stored.ItemId),
-            Builders<BillingAccount>.Filter.Eq(x => x.ProviderId, null));
+            Builders<BillingAccount>.Filter.Eq(x => x.ProviderId, stored.ProviderId),
+            Builders<BillingAccount>.Filter.Or(
+                Builders<BillingAccount>.Filter.Eq(x => x.ProviderCustomerId, null),
+                Builders<BillingAccount>.Filter.Eq(x => x.ProviderCustomerId, string.Empty)));
 
         var update = Builders<BillingAccount>.Update
             .Set(x => x.ProviderId, account.ProviderId)
@@ -152,10 +187,10 @@ public sealed class BillingAccountRepository : IBillingAccountRepository
             return updated;
         }
 
-        // The filter no longer matched: another concurrent call already backfilled this account
-        // between the read that produced `stored` and this attempt. Re-read rather than return
-        // the stale `stored` object, so every concurrent caller ends up agreeing on the same
-        // winning, non-null ProviderId rather than the loser silently reporting none at all.
+        // The filter no longer matched: a concurrent charge confirmed a customer (or another
+        // caller already reconciled this account) between the read that produced `stored` and
+        // this attempt. Re-read rather than return the stale `stored` object, so every concurrent
+        // caller ends up agreeing on whatever is actually on the document now.
         return await FindAsync(
                    stored.TenantId,
                    stored.OrganizationId,

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -532,6 +532,27 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     }
 
     /// <summary>
+    /// The organization scope a checkout session or charge should open under -- the one readiness
+    /// actually resolved the frozen provider from, not the caller's own ambient organization.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="BillingAccount.ProviderOrganizationId"/> can legitimately be <c>null</c> for two
+    /// different reasons that must not be treated alike: an account created before that field was
+    /// recorded at all (nothing to trust it for), and an account correctly pinned to a genuinely
+    /// tenant-wide configuration (a fact worth preserving, not papering over). The two are told
+    /// apart by <see cref="BillingAccount.ProviderId"/>, which started shipping in the same change
+    /// and so is null on exactly the accounts that predate both -- never on one that has a real,
+    /// recorded scope of its own. Falling back to the subscriber's own organization is therefore
+    /// only correct for the first case; doing it for the second would silently reintroduce the
+    /// coercion bug this field exists to avoid one call further downstream.
+    /// </remarks>
+    private static string? ResolveProviderOrganizationId(
+        BillingAccount account, SubscriptionDetail subscription) =>
+        account.ProviderId is null
+            ? account.ProviderOrganizationId ?? subscription.OrganizationId
+            : account.ProviderOrganizationId;
+
+    /// <summary>
     /// What resolving a subscription's frozen provider found: either an account and the provider
     /// to charge through, or the failure to return instead of guessing at one.
     /// </summary>
@@ -670,7 +691,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         // that was validated ready, never one resolved independently from the caller's own
         // ambient context. See BillingAccount.ProviderOrganizationId and
         // ISubscriptionPaymentProviderReadinessService.
-        var providerOrganizationId = account.ProviderOrganizationId ?? subscription.OrganizationId;
+        var providerOrganizationId = ResolveProviderOrganizationId(account, subscription);
 
         var setup = await _paymentMethodSetups.CreateSetupAsync(
             new CreatePaymentMethodSetupRequest
@@ -853,7 +874,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
 
         // Same reason as StartCardSetupAsync: the scope frozen alongside the provider, not the
         // caller's own ambient organization.
-        var providerOrganizationId = account.ProviderOrganizationId ?? subscription.OrganizationId;
+        var providerOrganizationId = ResolveProviderOrganizationId(account, subscription);
 
         var payment = await _payments.MakePaymentAsync(
             new MakePaymentRequest

--- a/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCreationService.cs
@@ -637,7 +637,16 @@ public sealed class SubscriptionCreationService : ISubscriptionCreationService
         // any money moves, so checkout charges through the exact configuration that just passed
         // readiness rather than one resolved independently (and possibly differently) later. See
         // BillingAccount.ProviderOrganizationId.
-        var providerOrganizationId = readinessResult?.Provider?.OrganizationId ?? context.OrganizationId;
+        //
+        // A resolved provider's own OrganizationId is read as-is, null included: null there is
+        // the meaningful fact that the configuration is tenant-wide, not an absent value to
+        // paper over. Falling back to context.OrganizationId only when readiness found no
+        // provider at all (readiness disabled, or _readiness itself not wired up) previously
+        // coerced that tenant-wide null into the subscriber's own organization every time,
+        // silently discarding the one thing this field exists to record.
+        var providerOrganizationId = readinessResult is not null
+            ? readinessResult.Provider?.OrganizationId
+            : context.OrganizationId;
 
         // The exact configuration row readiness resolved -- not merely the organization it
         // happens to be scoped to. Checkout compares a payment's actually-resolved provider

--- a/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionRepositoryIntegrationTests.cs
@@ -766,12 +766,20 @@ public sealed class SubscriptionRepositoryIntegrationTests
     }
 
     /// <summary>
-    /// The other half of Finding 2: a provider identity, once recorded, is frozen. An ordinary
-    /// reconcile must never be the thing that silently moves a billing account onto a different
-    /// provider row, even if a caller somehow supplies a different value.
+    /// The other half of Finding 2, as originally shipped: a provider identity, once recorded, was
+    /// frozen forever, on the theory that reconcile must never be the thing that silently moves a
+    /// billing account onto a different provider row. That theory turned out to be too broad: it
+    /// also permanently stuck an account that never actually took a payment through its first,
+    /// possibly wrong, provider row -- see
+    /// <see cref="A_provider_identity_never_charged_is_repinned_by_reconcile"/> for the real-world
+    /// failure this caused (PR #393's <c>subscription_payment_provider_scope_mismatch</c>).
+    /// The guarantee that still holds, and that this proves: once
+    /// <see cref="BillingAccount.ProviderCustomerId"/> names a real customer -- a charge has
+    /// actually confirmed -- the provider identity is frozen absolutely, because that customer (and
+    /// whatever card it holds) lives at the provider row that took it.
     /// </summary>
     [Fact]
-    public async Task An_already_frozen_provider_identity_is_never_overwritten_by_reconcile()
+    public async Task A_provider_identity_already_charged_is_never_overwritten_by_reconcile()
     {
         var tenantId = MongoIntegrationFixture.NewTenantId();
 
@@ -782,6 +790,13 @@ public sealed class SubscriptionRepositoryIntegrationTests
         var created = await _accounts.GetOrCreateAndReconcileAsync(first, CancellationToken.None);
 
         created.ProviderId.Should().Be("provider-row-original");
+
+        // A real charge confirmed a customer against this account -- the point at which moving
+        // its provider identity would strand a saved card or repoint a live mandate.
+        (await _accounts.TrySetProviderCustomerAsync(
+                tenantId, created.ItemId, "cus_first", "pm_1", "org-legacy-2",
+                CancellationToken.None))
+            .Should().Be(SetProviderCustomerOutcome.Recorded);
 
         var second = NewAccount(tenantId, "org-legacy-2");
         second.ProviderId = "provider-row-different";
@@ -794,14 +809,64 @@ public sealed class SubscriptionRepositoryIntegrationTests
         reconciled.ItemId.Should().Be(created.ItemId);
         reconciled.ProviderId.Should().Be(
             "provider-row-original",
-            "a frozen provider identity must survive unchanged even when a later reconcile call " +
-            "supplies a different one");
+            "a provider identity that already took a payment must survive unchanged even when a " +
+            "later reconcile call supplies a different one");
         reconciled.ProviderOrganizationId.Should().Be("org-legacy-2");
 
         var reloaded = await _accounts.GetAsync(tenantId, created.ItemId, CancellationToken.None);
 
         reloaded!.ProviderId.Should().Be("provider-row-original");
         reloaded.ProviderOrganizationId.Should().Be("org-legacy-2");
+    }
+
+    /// <summary>
+    /// The real-world failure behind PR #393's manual-testing report: an organization's first
+    /// subscribe attempt pins its billing account to whatever <c>PaymentProvider</c> row readiness
+    /// resolved at the time, but that attempt never gets as far as a confirmed charge -- the
+    /// operator notices a mistake in the provider's configuration (wrong merchant id, wrong
+    /// scope, ...), fixes it (which can mean deleting and re-registering the row, minting a new
+    /// <c>ItemId</c>), and subscribes again. Before this fix, the billing account's <c>ProviderId</c>
+    /// stayed frozen to the first, now-defunct row forever, so checkout's fail-closed comparison
+    /// against the provider a real charge actually resolved -- necessarily the corrected, live row
+    /// -- always disagreed with it, and every retry failed closed with
+    /// <c>subscription_payment_provider_scope_mismatch</c> for a merchant that was, in fact,
+    /// configured correctly. Nothing was ever charged through the first row, so re-pinning to the
+    /// corrected one is safe and is exactly what must happen instead.
+    /// </summary>
+    [Fact]
+    public async Task A_provider_identity_never_charged_is_repinned_by_reconcile()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+
+        var first = NewAccount(tenantId, "org-reconfigured");
+        first.ProviderId = "provider-row-misconfigured";
+        first.ProviderOrganizationId = "org-reconfigured";
+
+        var created = await _accounts.GetOrCreateAndReconcileAsync(first, CancellationToken.None);
+
+        created.ProviderId.Should().Be("provider-row-misconfigured");
+
+        // No charge ever confirmed against this account -- the first attempt never reached
+        // checkout, or its session expired unused. The operator has since corrected the Adyen
+        // configuration, which readiness now resolves to a different row entirely.
+        var second = NewAccount(tenantId, "org-reconfigured");
+        second.ProviderId = "provider-row-corrected";
+        second.ProviderOrganizationId = "org-reconfigured";
+
+        var reconciled = await _accounts.GetOrCreateAndReconcileAsync(
+            second,
+            CancellationToken.None);
+
+        reconciled.ItemId.Should().Be(created.ItemId);
+        reconciled.ProviderId.Should().Be(
+            "provider-row-corrected",
+            "an account that has never actually taken a payment must adopt the current, corrected " +
+            "provider configuration rather than stay pinned to a defunct one forever");
+
+        var reloaded = await _accounts.GetAsync(tenantId, created.ItemId, CancellationToken.None);
+
+        reloaded!.ProviderId.Should().Be("provider-row-corrected");
+        reloaded.ProviderOrganizationId.Should().Be("org-reconfigured");
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -198,6 +198,57 @@ public sealed class SubscriptionCheckoutServiceTests
     }
 
     /// <summary>
+    /// A billing account pinned to a genuinely tenant-wide configuration -- one that predates the
+    /// null-coercion bug fix and so carries a real, meaningful <c>null</c>
+    /// <see cref="BillingAccount.ProviderOrganizationId"/> -- must not have that null replaced
+    /// with the subscriber's own organization. <see cref="BillingAccount.ProviderId"/> being set
+    /// is what tells this account apart from a legacy one that never recorded a scope at all; only
+    /// the legacy case should fall back to the subscriber's organization.
+    /// </summary>
+    [Fact]
+    public async Task A_charge_against_a_tenant_wide_provider_scope_requests_no_organization()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, _subscription.BillingAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                ProviderName = PaymentConstants.AdyenOnlineProvider,
+                ProviderOrganizationId = null,
+                ProviderId = "tenant-wide-provider-row"
+            });
+
+        _payments
+            .Setup(service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<MakePaymentRequest, string, string, CancellationToken>(
+                (request, key, _, _) =>
+                {
+                    _paymentRequest = request;
+                    _idempotencyKey = key;
+                })
+            .ReturnsAsync(PaymentOperationResult.Success(
+                new PaymentResponse
+                {
+                    PaymentDetailId = "pay-1",
+                    RedirectUrl = "https://checkout.example/session",
+                    OrganizationId = OrganizationId,
+                    ResolvedProviderId = "tenant-wide-provider-row",
+                    ResolvedProviderOrganizationId = null
+                },
+                "corr-1"));
+
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _paymentRequest!.OrganizationId.Should().BeNull(
+            "a recorded provider identity means the account's null scope is a real, meaningful " +
+            "tenant-wide fact, not a gap to fill in with the subscriber's own organization");
+    }
+
+    /// <summary>
     /// A charge that came back resolved against a different PaymentProvider row than the one the
     /// billing account was pinned to must never be adopted, whatever it otherwise reports.
     /// </summary>

--- a/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCreationServiceTests.cs
@@ -1738,6 +1738,63 @@ public sealed class SubscriptionCreationServiceTests
         _account!.ProviderId.Should().Be("provider-row-42");
     }
 
+    /// <summary>
+    /// A genuinely tenant-wide configuration's <c>null</c> organization scope must survive onto
+    /// the billing account as <c>null</c> -- not be coerced into the subscriber's own organization
+    /// just because <c>??</c> cannot tell "nothing to report" apart from "readiness reports
+    /// tenant-wide". Coercing it here defeats <c>BillingAccount.ProviderOrganizationId</c>'s
+    /// whole purpose one call later, at checkout, which then cannot tell "this account was pinned
+    /// to a shared, tenant-wide row" from "this account was pinned to its own organization's row"
+    /// -- the exact distinction the real-world subscription_payment_provider_scope_mismatch
+    /// failure in PR #393 turned on.
+    /// </summary>
+    [Fact]
+    public async Task Null_is_preserved_for_a_genuinely_tenant_wide_provider_scope()
+    {
+        var merchantProfile = new Mock<ISubscriptionMerchantProfileService>();
+        merchantProfile
+            .Setup(service => service.ResolveProviderNameAsync(TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(global::Payment.DomainService.Utilities.PaymentConstants.AdyenOnlineProvider);
+
+        var readinessService = new Mock<ISubscriptionPaymentProviderReadinessService>();
+        readinessService
+            .Setup(service => service.CheckAsync(
+                TenantId, OrganizationId,
+                global::Payment.DomainService.Utilities.PaymentConstants.AdyenOnlineProvider,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionPaymentProviderReadinessResult(
+                global::Subscription.DomainService.Enums.SubscriptionPaymentProviderReadiness.Ready,
+                new global::Payment.DomainService.Entities.PaymentProvider
+                {
+                    ItemId = "provider-row-tenant-wide",
+                    TenantId = TenantId,
+                    ProviderName = global::Payment.DomainService.Utilities.PaymentConstants.AdyenOnlineProvider,
+                    // No organization of its own: this configuration answers for every
+                    // organization in the tenant, including the one subscribing here.
+                    OrganizationId = null
+                }));
+
+        var service = new SubscriptionCreationService(
+            _catalogue.Object,
+            _subscriptions.Object,
+            _discounts.Object,
+            _accounts.Object,
+            new CreateSubscriptionRequestValidator(),
+            NullLogger<SubscriptionCreationService>.Instance,
+            _time,
+            billingProfile: _billingProfile.Object,
+            merchantProfile: merchantProfile.Object,
+            readiness: readinessService.Object);
+
+        var result = await service.CreateAsync(NewRequest(), Context(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _account!.ProviderId.Should().Be("provider-row-tenant-wide");
+        _account!.ProviderOrganizationId.Should().BeNull(
+            "a tenant-wide configuration's null scope is a fact worth keeping, not something to " +
+            "paper over with the subscriber's own organization");
+    }
+
     private static SubscriptionContext Context() =>
         new(TenantId, OrganizationId, "actor-1", "user-1");
 


### PR DESCRIPTION
## Context

PR #393 ("Merchant-selected Stripe/Adyen provider routing for subscriptions") merged into `dev` while this fix was being investigated, so this follow-up lands as its own PR from the same branch rather than as another commit on #393.

## The real-world failure

A user manually testing #393 configured a real Adyen provider under Payment Providers, selected Adyen as the subscription payment provider on the Merchant Profile page, and then tried to subscribe an organization to a plan. It failed with:

> "The payment provider could not be reached under the merchant configuration this subscription was pinned to" (`subscription_payment_provider_scope_mismatch`)

## Root cause

`BillingAccountRepository.GetOrCreateAndReconcileAsync` keys a billing account's identity on `(TenantId, OrganizationId, ProviderName)`. `BillingAccount.ProviderId`/`ProviderOrganizationId` are written under `$setOnInsert`, so they are set only on the **first** reconcile call for that triple and are otherwise permanently frozen (a deliberate PR #393 review finding, meant to stop a live subscription's charge target from silently moving).

That freeze was too broad: it also permanently pinned an account that never got as far as a confirmed charge. A realistic manual-testing sequence — register Adyen, subscribe (this creates/reconciles the billing account and pins `ProviderId` to whatever readiness resolved), notice a mistake in the Adyen configuration, fix it (which can mean deleting and re-registering the `PaymentProvider` row, minting a new `ItemId`), then subscribe again — leaves the billing account permanently pinned to the first, now-defunct row. Checkout always resolves the provider through the corrected, live row, which forever disagrees with the frozen one, so every subsequent attempt fails closed with `subscription_payment_provider_scope_mismatch` for a merchant that is, in fact, configured correctly.

## The fix

`BillingAccountRepository.ReconcileProviderIdentityAsync` (renamed from `BackfillProviderIdentityAsync`) now re-pins `ProviderId`/`ProviderOrganizationId` to the current readiness resolution on every reconcile, for as long as the account has never taken a real payment (`ProviderCustomerId` unset). The moment `TrySetProviderCustomerAsync` records a confirmed customer, the identity freezes absolutely — exactly the original guarantee, just correctly scoped to when it actually matters. The conditional update is a genuine compare-and-set (filtered on the `ProviderId` value just read, not merely "still unset") so two concurrent reconciles still converge on one winner instead of each reporting a different value.

Two related organization-scope bugs found while tracing the report, both fixed alongside it:

- `SubscriptionCreationService` coerced a genuinely tenant-wide provider's `null` `OrganizationId` into the subscriber's own organization via `readinessResult?.Provider?.OrganizationId ?? context.OrganizationId`, discarding the one fact `BillingAccount.ProviderOrganizationId` exists to record. Now only falls back to `context.OrganizationId` when readiness found no provider at all.
- `SubscriptionCheckoutService`'s `account.ProviderOrganizationId ?? subscription.OrganizationId` fallback couldn't distinguish "never recorded" (legacy account) from "recorded, and genuinely null" (tenant-wide). Both call sites now key off `BillingAccount.ProviderId` (null only for accounts that predate this feature) to make that distinction, via a new `ResolveProviderOrganizationId` helper.

## Testing

- New integration test `A_provider_identity_never_charged_is_repinned_by_reconcile` reproduces the exact reported failure against a real MongoDB: fails on the pre-fix code (`provider-row-misconfigured` stays frozen instead of adopting `provider-row-corrected`), passes after the fix. Verified this directly by reverting just the repository change and re-running.
- `An_already_frozen_provider_identity_is_never_overwritten_by_reconcile` (now `A_provider_identity_already_charged_is_never_overwritten_by_reconcile`) updated to set a real `ProviderCustomerId` first, so it now proves the guarantee that actually needs to hold: frozen once money has moved, not from the first attempt regardless.
- New unit tests in `SubscriptionCreationServiceTests` and `SubscriptionCheckoutServiceTests` cover the tenant-wide-null preservation fix end to end.

Build: `dotnet build server/Api/Api.csproj --no-incremental` — 0 errors.

Tests: `dotnet test --filter "FullyQualifiedName!~Integration"` from `server/` — 3416 passed, 4 known pre-existing `SubscriptionSimulation*` failures (unrelated to this change), 1 skipped. Integration suite (`SubscriptionRepositoryIntegrationTests`, 31 tests) run separately against a local MongoDB — all passed.

Client: `npm run type-check` from `client/` — 0 errors (no-op; this change is server-only).

Commit: 73eb425243e3d0f752c5835520e09a0384e0afe7

🤖 Generated with [Claude Code](https://claude.com/claude-code)