### PR TITLE
Fix subscription_payment_provider_scope_mismatch for console-on-behalf-of-org checkout

### DIFF
--- a/server/Payment.DomainService/Services/PaymentMethodSetupService.cs
+++ b/server/Payment.DomainService/Services/PaymentMethodSetupService.cs
@@ -101,11 +101,21 @@ public sealed class PaymentMethodSetupService : IPaymentMethodSetupService
         // and the token it stores -- is opened against, the same rule ReserveAsync's charge
         // counterpart already applies. Without this, a caller naming a scope on the request had
         // it silently ignored: CreateRecord always stamped the caller's own ambient organization.
-        var organization = await _organizationResolver.ResolveAsync(
-            request.OrganizationId,
-            context,
-            correlationId,
-            cancellationToken);
+        //
+        // When the caller already froze an exact provider row (ExpectedProviderId), OrganizationId
+        // is not a naming request to authorize -- it is the scope readiness already resolved and
+        // validated at subscription creation, reproduced verbatim, null included. See
+        // PaymentReservationService.ReserveAsync's matching remark for the full reasoning: routing
+        // a genuinely tenant-wide frozen scope (null) through the general-purpose organization
+        // resolver substitutes the console's own ambient organization for it, which can resolve a
+        // different PaymentProvider row than the one readiness validated.
+        var organization = request.ExpectedProviderId is { Length: > 0 }
+            ? new PaymentOrganizationResolution(request.OrganizationId, null)
+            : await _organizationResolver.ResolveAsync(
+                request.OrganizationId,
+                context,
+                correlationId,
+                cancellationToken);
 
         if (organization.Failure != null)
         {

--- a/server/Payment.DomainService/Services/PaymentReservationService.cs
+++ b/server/Payment.DomainService/Services/PaymentReservationService.cs
@@ -44,11 +44,27 @@ public sealed class PaymentReservationService : IPaymentReservationService
         // Which organization the payment belongs to decides which merchant account takes the
         // money, because provider lookup keys off the payment's organization rather than the
         // caller's context.
-        var organization = await _organizationResolver.ResolveAsync(
-            request.OrganizationId,
-            context,
-            correlationId,
-            cancellationToken);
+        //
+        // When the caller already froze an exact provider row (ExpectedProviderId), OrganizationId
+        // is not a naming request to authorize -- it is the scope readiness already resolved and
+        // validated at subscription creation, reproduced verbatim, null included. Routing it
+        // through the general-purpose organization-naming resolver conflates two different
+        // questions: PaymentOrganizationResolver.ResolveAsync answers "may this caller name an
+        // organization" and, when nothing was named, substitutes the ambient caller's own
+        // organization -- correct for an ordinary caller, but wrong here, because a genuinely
+        // tenant-wide frozen scope (OrganizationId == null) is not "nothing was named"; it is an
+        // explicit fact that must survive unchanged. For a console caller acting on behalf of
+        // another organization, substituting the console's own ambient organization for that null
+        // can resolve a *different* PaymentProvider row than the one readiness validated, which is
+        // exactly the divergence subscription_payment_provider_scope_mismatch exists to catch. See
+        // ExpectedProviderId's own remarks and BillingAccount.ProviderOrganizationId.
+        var organization = request.ExpectedProviderId is { Length: > 0 }
+            ? new PaymentOrganizationResolution(request.OrganizationId, null)
+            : await _organizationResolver.ResolveAsync(
+                request.OrganizationId,
+                context,
+                correlationId,
+                cancellationToken);
 
         if (organization.Failure != null)
         {

--- a/server/XUnitTest/Payment/PaymentReservationServiceTests.cs
+++ b/server/XUnitTest/Payment/PaymentReservationServiceTests.cs
@@ -160,6 +160,90 @@ public sealed class PaymentReservationServiceTests
         Created().Origin.Should().Be(PaymentOrigins.Api);
     }
 
+    /// <summary>
+    /// Reproduces the real-world <c>subscription_payment_provider_scope_mismatch</c> the console
+    /// hit subscribing a brand-new organization to a plain, tenant-wide Stripe provider (a
+    /// <see cref="Payment.DomainService.Entities.PaymentProvider"/> row whose own OrganizationId
+    /// is null).
+    /// </summary>
+    /// <remarks>
+    /// Subscription readiness resolves that provider with the target organization's id, falls
+    /// through the scope chain to the tenant-wide (null) row, and freezes that null verbatim onto
+    /// <c>BillingAccount.ProviderOrganizationId</c> -- see
+    /// <see cref="Subscription.DomainService.Services.SubscriptionCheckoutService.ResolveProviderOrganizationId"/>.
+    /// Checkout then asks the payment module to reproduce that exact scope by passing this same
+    /// null through <see cref="MakePaymentRequest.OrganizationId"/>, alongside
+    /// <see cref="MakePaymentRequest.ExpectedProviderId"/> pinning the exact row.
+    /// <para>
+    /// Before the fix, a null <c>OrganizationId</c> here was indistinguishable from "the caller
+    /// named nothing", so <see cref="PaymentOrganizationResolver.ResolveAsync"/> silently
+    /// substituted the console's own ambient organization for it -- correct for an ordinary
+    /// caller that never named a scope, but wrong here, because the null was not an absence: it
+    /// was the fact, already validated, that this configuration is tenant-wide. Stamping the
+    /// console's own organization onto the payment instead meant a later provider lookup could
+    /// resolve a different <see cref="Entities.PaymentProvider"/> row than the one readiness
+    /// found, which is exactly the divergence <c>subscription_payment_provider_scope_mismatch</c>
+    /// exists to catch.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task ReserveAsync_ConsoleWithFrozenTenantWideScope_PreservesNullOrganization()
+    {
+        SetupConsole();
+        SetupCreate(true);
+        _request.OrganizationId = null;
+        _request.ExpectedProviderId = "tenant-wide-provider-row";
+
+        await RunAsync();
+
+        Created().OrganizationId.Should().BeNull(
+            "a frozen, genuinely tenant-wide provider scope must survive the console's own " +
+            "ambient organization, not be silently coerced onto it");
+        _organizations.Verify(
+            x => x.FindAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a scope the caller already froze needs no fresh naming authorization -- that " +
+            "question was already answered when the subscription was created");
+    }
+
+    /// <summary>
+    /// The same frozen-scope reproduction as above, but for an organization-specific provider
+    /// (not tenant-wide null) -- proving the bypass preserves whatever readiness froze, not only
+    /// null, and does so without re-running IAM verification a second time for the same request.
+    /// </summary>
+    [Fact]
+    public async Task ReserveAsync_ConsoleWithFrozenOrganizationScope_PreservesThatOrganizationVerbatim()
+    {
+        SetupConsole();
+        SetupCreate(true);
+        _request.OrganizationId = "organization-2";
+        _request.ExpectedProviderId = "organization-2-provider-row";
+
+        await RunAsync();
+
+        Created().OrganizationId.Should().Be("organization-2");
+        _organizations.Verify(
+            x => x.FindAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A non-console caller's payment can also carry a frozen scope (its own subscription's
+    /// billing account may still be pinned to a tenant-wide provider) -- the bypass is not
+    /// console-specific, it triggers on <see cref="MakePaymentRequest.ExpectedProviderId"/> alone.
+    /// </summary>
+    [Fact]
+    public async Task ReserveAsync_NonConsoleWithFrozenTenantWideScope_PreservesNullOrganization()
+    {
+        SetupCreate(true);
+        _request.OrganizationId = null;
+        _request.ExpectedProviderId = "tenant-wide-provider-row";
+
+        await RunAsync();
+
+        Created().OrganizationId.Should().BeNull();
+    }
+
     [Fact]
     public async Task ReserveAsync_OrganizationCannotBeVerified_ReservesNothing()
     {


### PR DESCRIPTION
## The real-world scenario

A platform console/admin, subscribing a brand-new organization on its behalf, hit
`subscription_payment_provider_scope_mismatch` on the very first attempt against a
plain, tenant-wide **Stripe** provider ("Stripe is active" on the merchant profile
page) -- no Adyen, no re-registered/stale provider row, nothing that PR #409 (merged at
`73eb4252`/`4b87092b`) was scoped to fix. That PR's diagnosis (a billing account pinned
to a stale/re-registered Adyen `PaymentProvider` row) does not apply here: this is a
first-ever subscribe for a new org, on Stripe, through the console-acting-on-behalf-of
path (reachable both from a normal `/api/subscriptions` subscribe call and from the
subscription-simulation harness's "subscribe" action, which posts to the exact same
endpoint).

## Root cause

Both sides of the mismatch check ultimately call `IPaymentRepository.GetProviderAsync`
with an `organizationId`, so a mismatch can only happen if that argument differs
between the two calls.

1. **Readiness** (`SubscriptionPaymentProviderReadinessService.CheckAsync`, invoked
   from `SubscriptionCreationService`) resolves the provider once, using the *target*
   organization's id, and freezes whatever it finds onto the billing account:
   `BillingAccount.ProviderOrganizationId` and `.ProviderId`. For a genuinely
   tenant-wide Stripe row (`PaymentProvider.OrganizationId == null`), the scope chain
   falls through to `null`, and `null` is frozen -- correctly representing "this
   configuration is tenant-wide," not an absent value.

2. **Checkout** (`SubscriptionCheckoutService.ResolveProviderOrganizationId`)
   reproduces that frozen scope by passing it straight through as
   `MakePaymentRequest.OrganizationId` / `CreatePaymentMethodSetupRequest.OrganizationId`,
   alongside `ExpectedProviderId` pinning the exact provider row. This is where it goes
   wrong: `PaymentReservationService.ReserveAsync` (the charge path) and
   `PaymentMethodSetupService.CreateSetupAsync` (the card-setup path) both route that
   value through `PaymentOrganizationResolver.ResolveAsync`. That resolver's very first
   branch reads:

   ```csharp
   if (string.IsNullOrEmpty(requested))
   {
       return new PaymentOrganizationResolution(context.OrganizationId, null, isConsole);
   }
   ```

   i.e. "the caller named nothing, so use the caller's own ambient organization." That
   is the *correct* rule for an ordinary caller that never named a scope. It is the
   *wrong* rule here: the frozen `null` checkout is reproducing is not "nothing was
   named" -- it is the explicit, already-validated fact that this provider is
   tenant-wide. For a console caller acting on behalf of another organization, this
   resolver substitutes the **console's own ambient organization** for that null. If
   the console's own organization resolves to a *different* `PaymentProvider` row
   (which is exactly the kind of thing multi-provider configuration, from #393/#409,
   makes possible), the two calls diverge -- and `subscription_payment_provider_scope_mismatch`
   correctly refuses to proceed, because the alternative would have been silently
   charging through the wrong merchant configuration.

In short: readiness resolves the frozen scope once, correctly; checkout re-derives it a
second time through a resolver designed to answer a different question ("may this
caller name an organization"), and that second derivation can drift.

## The fix

`ExpectedProviderId` is only ever set internally, by a caller that already froze an
exact provider row from a prior readiness check (`CreatePaymentMethodSetupRequest`'s
doc comment: "never bound from an HTTP body"; `MakePaymentRequest.ExpectedProviderId`
is `[JsonIgnore]`). Its presence is therefore itself the authoritative signal that
`OrganizationId` on the same request is a scope *reproduction*, not a naming request
that needs authorization or IAM re-verification.

`PaymentReservationService.ReserveAsync` and `PaymentMethodSetupService.CreateSetupAsync`
now skip `PaymentOrganizationResolver.ResolveAsync` entirely when `ExpectedProviderId`
is set, using `OrganizationId` verbatim (null included) instead. Every other caller --
anything that never freezes a provider row -- is unaffected; the resolver's existing
behavior (including the console-naming-an-organization path) is untouched.

Considered and rejected: teaching `PaymentOrganizationResolver` a new "explicit
tenant-wide" flag. That would still leave every caller of the resolver reasoning about
a distinction (explicit-null vs. no-override) that only this one frozen-scope
reproduction case needs, for no added safety -- the scope was already validated by
readiness moments earlier in the same operation.

## Test coverage

Added to `PaymentReservationServiceTests` (which already wires up the *real*
`PaymentOrganizationResolver`, not a mock, so it exercises the actual resolution
logic):

- `ReserveAsync_ConsoleWithFrozenTenantWideScope_PreservesNullOrganization` -- the
  exact reported scenario: console caller, frozen `null` (tenant-wide) scope. Confirmed
  failing before the fix (`Created().OrganizationId` came back as the console's own
  organization instead of `null`) and passing after.
- `ReserveAsync_ConsoleWithFrozenOrganizationScope_PreservesThatOrganizationVerbatim` --
  same reproduction for a frozen organization-specific (non-null) scope, and confirms
  no redundant IAM verification call.
- `ReserveAsync_NonConsoleWithFrozenTenantWideScope_PreservesNullOrganization` -- proves
  the bypass triggers on `ExpectedProviderId` alone, not console-specific.

Both the normal subscribe endpoint and the subscription-simulation harness's
"subscribe" action are covered by this fix, since the simulation client posts to the
identical `/api/subscriptions` endpoint and therefore exercises the exact same
`SubscriptionCreationService` / `SubscriptionCheckoutService` /
`PaymentReservationService` / `PaymentMethodSetupService` code path -- there is no
separate simulation-only checkout path to fix.

## Test plan

- [x] `dotnet build server/Api/Api.csproj --no-incremental` -- 0 errors
- [x] `dotnet test --filter "FullyQualifiedName!~Integration"` from `server/` -- 3525
      passed, 4 pre-existing failures (all `SubscriptionSimulation*`/`SubscriptionSimulationGuardTests`,
      confirmed failing identically on `origin/dev` before this change), 1 skipped
- [x] `npm run type-check` from `client/` -- 0 errors
- [x] New regression tests confirmed to fail without the fix and pass with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)