### PR TITLE
feat(payment): let a provider choose which methods its checkout offers

### DIFF
--- a/server/Payment.DomainService/Entities/PaymentProvider.cs
+++ b/server/Payment.DomainService/Entities/PaymentProvider.cs
@@ -1,4 +1,4 @@
-using MongoDB.Bson.Serialization.Attributes;
+﻿using MongoDB.Bson.Serialization.Attributes;
 
 namespace Payment.DomainService.Entities;
 
@@ -82,6 +82,27 @@ public sealed class PaymentProvider
     [System.Text.Json.Serialization.JsonIgnore]
     public string? ShopperReferenceHmacKey { get; set; }
     public string[]? PaymentMethods { get; set; }
+
+    /// <summary>
+    /// Stripe's <c>pmc_…</c> payment method configuration, when this provider should offer a
+    /// configuration other than the account's default. Ignored when
+    /// <see cref="CheckoutPaymentMethodTypes"/> names methods explicitly, because Stripe rejects
+    /// a session carrying both.
+    /// </summary>
+    public string? PaymentMethodConfigurationId { get; set; }
+
+    /// <summary>
+    /// The payment methods a hosted checkout should offer, named explicitly. Null or empty — the
+    /// default — leaves the choice to the provider, which resolves it from the account's own
+    /// Dashboard configuration.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately separate from <see cref="PaymentMethods"/>, which predates this and is read
+    /// by nothing: a document written before this field existed may carry provider-specific
+    /// names in it, and reinterpreting those as Stripe method types would silently change what a
+    /// live checkout offers on deploy.
+    /// </remarks>
+    public string[]? CheckoutPaymentMethodTypes { get; set; }
     public bool AllowRecurringFlagFromPayload { get; set; }
     public bool IsRecurring { get; set; }
     public Dictionary<string, object>? Utilities { get; set; }

--- a/server/Payment.DomainService/Providers/Stripe/StripeInitiationRequestFactory.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripeInitiationRequestFactory.cs
@@ -26,6 +26,17 @@ public sealed class StripeInitiationRequestFactory : IProviderInitiationRequestF
     /// </remarks>
     private const string SessionIdTemplate = "sessionId={CHECKOUT_SESSION_ID}";
 
+    /// <summary>
+    /// Methods a configuration named that this session could not offer, for a caller to log.
+    /// Non-empty only when an explicit list contains something unusable off-session.
+    /// </summary>
+    /// <remarks>
+    /// Held on the instance rather than returned because
+    /// <see cref="IProviderInitiationRequestFactory"/> returns the request itself, and widening
+    /// that contract for a diagnostic every other provider would leave empty is a poor trade.
+    /// </remarks>
+    public IReadOnlyCollection<string> DroppedMethods { get; private set; } = [];
+
     public bool Supports(string providerName) =>
         string.Equals(
             providerName,
@@ -72,6 +83,15 @@ public sealed class StripeInitiationRequestFactory : IProviderInitiationRequestF
                         .Add("name", ResolveLineItemName(request, payment)))))
             .AddMetadata(
                 RoutingMetadata(payment, provider, providerReference, shopperReference));
+
+        // Which methods the page offers. Applied here, before the save-card branches below, so
+        // the narrowing sees the same save decision they act on: a checkout that stores the
+        // method for later renewals must not offer one Stripe can never charge again, however
+        // the Dashboard is configured.
+        DroppedMethods = StripePaymentMethodSelection.Apply(
+            form,
+            provider,
+            requiresOffSessionReuse: request.ShouldSavePaymentMethod);
 
         if (!string.IsNullOrWhiteSpace(providerPayerReference))
         {

--- a/server/Payment.DomainService/Providers/Stripe/StripePaymentMethodSelection.cs
+++ b/server/Payment.DomainService/Providers/Stripe/StripePaymentMethodSelection.cs
@@ -1,0 +1,146 @@
+using Payment.DomainService.Entities;
+
+namespace Payment.DomainService.Providers.Stripe;
+
+/// <summary>
+/// Decides which payment methods a Checkout Session offers, from the provider's configuration.
+/// </summary>
+/// <remarks>
+/// Stripe offers three ways to answer this, and the first two are mutually exclusive on the
+/// wire: naming <c>payment_method_types</c> explicitly, naming a
+/// <c>payment_method_configuration</c> assembled in the Dashboard, or naming neither and letting
+/// the account's default configuration decide. Sending the first two together is rejected, so
+/// this type picks one.
+/// <para>
+/// Naming neither has always been the behaviour here — no <c>payment_method_types</c> has ever
+/// been sent from this service — which is why a Dashboard change already reaches an ordinary
+/// payment. What it does not reach is a checkout that stores the card, and that is the subtlety
+/// this type exists to hold; see <see cref="ReusableOffSession"/>.
+/// </para>
+/// </remarks>
+public static class StripePaymentMethodSelection
+{
+    /// <summary>
+    /// The methods Stripe can charge again later with nobody present.
+    /// </summary>
+    /// <remarks>
+    /// A renewal is an off-session charge against a stored mandate, and Stripe only establishes
+    /// such a mandate for methods that support one. A checkout carrying
+    /// <c>setup_future_usage=off_session</c> is therefore already narrowed by Stripe to this
+    /// set — which is why a Dashboard that enables TWINT and Klarna still shows neither on a
+    /// subscription's first charge, and why that is correct rather than a defect: a subscription
+    /// bought with TWINT could never renew itself.
+    /// <para>
+    /// Kept here so an explicitly configured list is narrowed the same way, rather than being
+    /// sent whole for Stripe to reject the whole session over. PayPal is present because Stripe
+    /// does support recurring PayPal — once the account is approved for it, which is an account
+    /// question rather than a code one.
+    /// </para>
+    /// </remarks>
+    private static readonly HashSet<string> ReusableOffSession = new(StringComparer.Ordinal)
+    {
+        "card",
+        "link",
+        "paypal",
+        "sepa_debit",
+        "us_bank_account",
+        "bacs_debit",
+        "au_becs_debit"
+    };
+
+    /// <summary>
+    /// Applies the provider's configuration to a Checkout Session form.
+    /// </summary>
+    /// <param name="form">The session form being built.</param>
+    /// <param name="provider">The configuration to read the selection from.</param>
+    /// <param name="requiresOffSessionReuse">
+    /// Whether the session also asks Stripe to store the method for later off-session charges.
+    /// When it does, an explicit list is narrowed to what can actually be charged again.
+    /// </param>
+    /// <returns>
+    /// The methods dropped because they cannot be reused off-session, so a caller can say so in
+    /// a log. Empty when nothing was dropped, which is the ordinary case.
+    /// </returns>
+    public static IReadOnlyCollection<string> Apply(
+        StripeForm form,
+        PaymentProvider provider,
+        bool requiresOffSessionReuse)
+    {
+        ArgumentNullException.ThrowIfNull(form);
+        ArgumentNullException.ThrowIfNull(provider);
+
+        var configured = Normalize(provider.CheckoutPaymentMethodTypes);
+
+        if (configured.Count > 0)
+        {
+            var offered = requiresOffSessionReuse
+                ? configured.Where(ReusableOffSession.Contains).ToList()
+                : configured;
+
+            // Every configured method was unusable here. Sending an empty array is not the same
+            // as sending nothing — Stripe rejects it — and falling back to the configuration id
+            // would answer a question the operator already answered differently. Letting the
+            // account default decide is the one remaining option that still produces a working
+            // checkout rather than no checkout at all.
+            if (offered.Count == 0)
+            {
+                return configured;
+            }
+
+            for (var index = 0; index < offered.Count; index++)
+            {
+                form.Add($"payment_method_types[{index}]", offered[index]);
+            }
+
+            return configured.Except(offered, StringComparer.Ordinal).ToList();
+        }
+
+        // Only when no explicit list was given: Stripe rejects a session carrying both.
+        if (!string.IsNullOrWhiteSpace(provider.PaymentMethodConfigurationId))
+        {
+            form.Add(
+                "payment_method_configuration",
+                provider.PaymentMethodConfigurationId.Trim());
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Trims, lower-cases and de-duplicates a configured list, preserving the order it was
+    /// authored in — Stripe renders the methods in the order they arrive, so that order is a
+    /// presentation decision the operator made.
+    /// </summary>
+    public static List<string> Normalize(IEnumerable<string>? values)
+    {
+        if (values == null)
+        {
+            return [];
+        }
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var normalized = new List<string>();
+
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            var trimmed = value.Trim().ToLowerInvariant();
+
+            if (seen.Add(trimmed))
+            {
+                normalized.Add(trimmed);
+            }
+        }
+
+        return normalized;
+    }
+
+    /// <summary>Whether a method can back a charge raised with nobody present.</summary>
+    public static bool CanBeReusedOffSession(string method) =>
+        !string.IsNullOrWhiteSpace(method) &&
+        ReusableOffSession.Contains(method.Trim().ToLowerInvariant());
+}

--- a/server/Payment.DomainService/Repositories/IPaymentRepository.cs
+++ b/server/Payment.DomainService/Repositories/IPaymentRepository.cs
@@ -1,4 +1,4 @@
-using Payment.DomainService.Entities;
+﻿using Payment.DomainService.Entities;
 using Payment.DomainService.Enums;
 
 namespace Payment.DomainService.Repositories;
@@ -48,6 +48,8 @@ public interface IPaymentRepository
         int maxRefundDays,
         string? storeId,
         bool isEnabled,
+        string? paymentMethodConfigurationId,
+        string[]? checkoutPaymentMethodTypes,
         CancellationToken cancellationToken);
 
     Task<PaymentProvider?> TryRotateProviderCredentialsAsync(

--- a/server/Payment.DomainService/Repositories/PaymentRepository.cs
+++ b/server/Payment.DomainService/Repositories/PaymentRepository.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Blocks.Genesis;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
@@ -806,6 +806,8 @@ public sealed class PaymentRepository : IPaymentRepository
         int maxRefundDays,
         string? storeId,
         bool isEnabled,
+        string? paymentMethodConfigurationId,
+        string[]? checkoutPaymentMethodTypes,
         CancellationToken cancellationToken)
     {
         var filter = ProviderVersionFilter(
@@ -821,6 +823,12 @@ public sealed class PaymentRepository : IPaymentRepository
             .Set(provider => provider.MaxRefundDays, maxRefundDays)
             .Set(provider => provider.StoreId, storeId)
             .Set(provider => provider.IsEnabled, isEnabled)
+            .Set(
+                provider => provider.PaymentMethodConfigurationId,
+                paymentMethodConfigurationId)
+            .Set(
+                provider => provider.CheckoutPaymentMethodTypes,
+                checkoutPaymentMethodTypes)
             .Inc(provider => provider.Version, 1);
 
         return await Providers(tenantId).FindOneAndUpdateAsync(

--- a/server/Payment.DomainService/Requests/RegisterPaymentProviderRequest.cs
+++ b/server/Payment.DomainService/Requests/RegisterPaymentProviderRequest.cs
@@ -1,4 +1,4 @@
-namespace Payment.DomainService.Requests;
+﻿namespace Payment.DomainService.Requests;
 
 /// <summary>
 /// Registers a payment provider for the calling tenant.
@@ -60,6 +60,20 @@ public sealed class RegisterPaymentProviderRequest
     public int MaxRefundDays { get; set; }
 
     public string? StoreId { get; set; }
+
+    /// <summary>
+    /// Stripe's <c>pmc_…</c> payment method configuration, when the checkout should offer one
+    /// other than the account's default. Mutually exclusive with
+    /// <c>CheckoutPaymentMethodTypes</c>.
+    /// </summary>
+    public string? PaymentMethodConfigurationId { get; set; }
+
+    /// <summary>
+    /// The payment methods the hosted checkout should offer, e.g. <c>card</c>, <c>twint</c>,
+    /// <c>paypal</c>, <c>klarna</c>. Omit to let the provider resolve them from its own
+    /// Dashboard configuration, which is the default and what every existing provider does.
+    /// </summary>
+    public string[]? CheckoutPaymentMethodTypes { get; set; }
 
     /// <summary>Provider API key. Stripe's secret key, or Adyen's Checkout API key.</summary>
     public string ApiKey { get; set; } = string.Empty;

--- a/server/Payment.DomainService/Requests/UpdatePaymentProviderRequest.cs
+++ b/server/Payment.DomainService/Requests/UpdatePaymentProviderRequest.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Payment.DomainService.Requests;
@@ -23,6 +23,20 @@ public sealed class UpdatePaymentProviderRequest
     public string? StoreId { get; set; }
 
     public bool IsEnabled { get; set; }
+
+    /// <summary>
+    /// Stripe's <c>pmc_…</c> payment method configuration, when the checkout should offer one
+    /// other than the account's default. Mutually exclusive with
+    /// <c>CheckoutPaymentMethodTypes</c>.
+    /// </summary>
+    public string? PaymentMethodConfigurationId { get; set; }
+
+    /// <summary>
+    /// The payment methods the hosted checkout should offer, e.g. <c>card</c>, <c>twint</c>,
+    /// <c>paypal</c>, <c>klarna</c>. Omit to let the provider resolve them from its own
+    /// Dashboard configuration, which is the default and what every existing provider does.
+    /// </summary>
+    public string[]? CheckoutPaymentMethodTypes { get; set; }
 
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? UnmappedFields { get; set; }

--- a/server/Payment.DomainService/Responses/PaymentProviderResponse.cs
+++ b/server/Payment.DomainService/Responses/PaymentProviderResponse.cs
@@ -1,4 +1,4 @@
-namespace Payment.DomainService.Responses;
+﻿namespace Payment.DomainService.Responses;
 
 /// <summary>
 /// Safe payment-provider configuration. Credential material and tenant
@@ -37,4 +37,8 @@ public sealed class PaymentProviderResponse
     public string? StoreId { get; init; }
 
     public bool IsEnabled { get; init; }
+
+    public string? PaymentMethodConfigurationId { get; init; }
+
+    public string[]? CheckoutPaymentMethodTypes { get; init; }
 }

--- a/server/Payment.DomainService/Services/PaymentProviderConfigurationService.cs
+++ b/server/Payment.DomainService/Services/PaymentProviderConfigurationService.cs
@@ -1,6 +1,7 @@
-using FluentValidation;
+﻿using FluentValidation;
 using Microsoft.Extensions.Logging;
 using Payment.DomainService.Enums;
+using Payment.DomainService.Providers.Stripe;
 using Payment.DomainService.Repositories;
 using Payment.DomainService.Requests;
 using Payment.DomainService.Responses;
@@ -118,6 +119,8 @@ public sealed class PaymentProviderConfigurationService :
                     request.MaxRefundDays,
                     Normalize(request.StoreId),
                     request.IsEnabled,
+                    Normalize(request.PaymentMethodConfigurationId),
+                    NormalizeMethods(request.CheckoutPaymentMethodTypes),
                     cancellationToken);
         }
         catch (OperationCanceledException)
@@ -212,6 +215,19 @@ public sealed class PaymentProviderConfigurationService :
         string.IsNullOrWhiteSpace(value)
             ? null
             : value.Trim();
+
+    /// <summary>
+    /// An empty selection is stored as null rather than an empty array: the two mean opposite
+    /// things downstream, where null defers to the account's own configuration and an empty
+    /// array would be a checkout offering nothing. Clearing the list is therefore expressed the
+    /// same way as never having set one.
+    /// </summary>
+    private static string[]? NormalizeMethods(string[]? values)
+    {
+        var normalized = StripePaymentMethodSelection.Normalize(values);
+
+        return normalized.Count == 0 ? null : [.. normalized];
+    }
 
     private static PaymentProviderMutationResult FromFailure(
         PaymentOperationResult failure,

--- a/server/Payment.DomainService/Services/PaymentProviderRegistrationService.cs
+++ b/server/Payment.DomainService/Services/PaymentProviderRegistrationService.cs
@@ -12,6 +12,8 @@ using Payment.DomainService.Requests;
 using Payment.DomainService.Responses;
 using Payment.DomainService.Utilities;
 
+using Payment.DomainService.Providers.Stripe;
+
 namespace Payment.DomainService.Services;
 
 /// <summary>
@@ -232,6 +234,10 @@ public sealed class PaymentProviderRegistrationService : IPaymentProviderRegistr
             MaxRefundDays = request.MaxRefundDays,
             StoreId = request.StoreId,
             IsEnabled = true,
+            PaymentMethodConfigurationId =
+                Normalize(request.PaymentMethodConfigurationId),
+            CheckoutPaymentMethodTypes =
+                NormalizeMethods(request.CheckoutPaymentMethodTypes),
             ProviderSecretsCiphertext = secrets.ProviderCiphertext,
             TenantSecuritySecretsCiphertext = secrets.TenantCiphertext,
             SecretsEncryptionKeyId = secrets.KeyId
@@ -403,6 +409,21 @@ public sealed class PaymentProviderRegistrationService : IPaymentProviderRegistr
 
     private static string CreateKey() =>
         Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    private static string? Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    /// <summary>
+    /// An empty selection is stored as null rather than an empty array: the two mean opposite
+    /// things downstream, where null defers to the account's own configuration and an empty
+    /// array would be a checkout offering nothing.
+    /// </summary>
+    private static string[]? NormalizeMethods(string[]? values)
+    {
+        var normalized = StripePaymentMethodSelection.Normalize(values);
+
+        return normalized.Count == 0 ? null : [.. normalized];
+    }
 
     private sealed record RegistrationSecrets(
         bool IsProtected,

--- a/server/Payment.DomainService/Services/PaymentProviderResponseMapper.cs
+++ b/server/Payment.DomainService/Services/PaymentProviderResponseMapper.cs
@@ -1,4 +1,4 @@
-using Payment.DomainService.Entities;
+﻿using Payment.DomainService.Entities;
 using Payment.DomainService.Responses;
 
 namespace Payment.DomainService.Services;
@@ -24,7 +24,9 @@ public sealed class PaymentProviderResponseMapper :
             ManualCapture = provider.ManualCapture,
             MaxRefundDays = provider.MaxRefundDays,
             StoreId = provider.StoreId,
-            IsEnabled = provider.IsEnabled
+            IsEnabled = provider.IsEnabled,
+            PaymentMethodConfigurationId = provider.PaymentMethodConfigurationId,
+            CheckoutPaymentMethodTypes = provider.CheckoutPaymentMethodTypes
         };
     }
 }

--- a/server/XUnitTest/Integration/PaymentRepositoryIntegrationTests.cs
+++ b/server/XUnitTest/Integration/PaymentRepositoryIntegrationTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Payment.DomainService.Models;
 using Payment.DomainService.Utilities;
 using MongoDB.Driver;
@@ -310,6 +310,8 @@ public sealed class PaymentRepositoryIntegrationTests
                 90,
                 null,
                 true,
+                null,
+                null,
                 CancellationToken.None);
         var second = _repository
             .TryUpdateProviderConfigurationAsync(
@@ -322,6 +324,8 @@ public sealed class PaymentRepositoryIntegrationTests
                 90,
                 null,
                 true,
+                null,
+                null,
                 CancellationToken.None);
 
         var results = await Task.WhenAll(first, second);

--- a/server/XUnitTest/Payment/PaymentProviderAdministrationTests.cs
+++ b/server/XUnitTest/Payment/PaymentProviderAdministrationTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -175,6 +175,8 @@ public sealed class PaymentProviderAdministrationTests
                 It.IsAny<int>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
+                It.IsAny<string?>(),
+                It.IsAny<string[]?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(updated);
 
@@ -569,6 +571,8 @@ public sealed class PaymentProviderAdministrationTests
                 30,
                 null,
                 true,
+                It.IsAny<string?>(),
+                It.IsAny<string[]?>(),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -777,6 +781,8 @@ public sealed class PaymentProviderAdministrationTests
                 It.IsAny<int>(),
                 It.IsAny<string?>(),
                 It.IsAny<bool>(),
+                It.IsAny<string?>(),
+                It.IsAny<string[]?>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new TimeoutException("mongo down"));
 

--- a/server/XUnitTest/Payment/PaymentProviderConfigurationServiceTests.cs
+++ b/server/XUnitTest/Payment/PaymentProviderConfigurationServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -75,6 +75,8 @@ public sealed class PaymentProviderConfigurationServiceTests
                     90,
                     "store-1",
                     false,
+                    It.IsAny<string?>(),
+                    It.IsAny<string[]?>(),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(updated);
 
@@ -130,6 +132,8 @@ public sealed class PaymentProviderConfigurationServiceTests
                     It.IsAny<int>(),
                     It.IsAny<string?>(),
                     It.IsAny<bool>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<string[]?>(),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync((PaymentProvider?)null);
 

--- a/server/XUnitTest/Payment/StripePaymentMethodSelectionTests.cs
+++ b/server/XUnitTest/Payment/StripePaymentMethodSelectionTests.cs
@@ -1,0 +1,185 @@
+using FluentAssertions;
+using Payment.DomainService.Entities;
+using Payment.DomainService.Models;
+using Payment.DomainService.Providers.HostedCheckout;
+using Payment.DomainService.Providers.Stripe;
+using Payment.DomainService.Requests;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+
+namespace XUnitTest.Payment;
+
+/// <summary>
+/// Which payment methods a Checkout Session offers.
+/// </summary>
+/// <remarks>
+/// The behaviour this replaces was widely believed to be a hardcoded
+/// <c>payment_method_types=["card"]</c>. It never was — nothing here has ever sent that field,
+/// which is why <see cref="Nothing_is_sent_when_no_selection_is_configured"/> is the first case
+/// and pins the default rather than a change to it. What actually kept TWINT and Klarna off a
+/// subscription's first charge is the mandate a renewal needs, which
+/// <see cref="A_saving_checkout_drops_methods_that_can_never_be_charged_again"/> covers.
+/// </remarks>
+public sealed class StripePaymentMethodSelectionTests
+{
+    private readonly StripeInitiationRequestFactory _factory = new();
+
+    /// <summary>
+    /// The default, and what every provider registered before this field existed does: name
+    /// nothing and let the account's own Dashboard configuration decide. A Dashboard change
+    /// reaches an ordinary payment precisely because of this.
+    /// </summary>
+    [Fact]
+    public void Nothing_is_sent_when_no_selection_is_configured()
+    {
+        var form = StripeInitiationRequestFactory.ReadForm(Create());
+
+        form.Keys.Should().NotContain(key =>
+            key.StartsWith("payment_method_types", StringComparison.Ordinal));
+        form.Should().NotContainKey("payment_method_configuration");
+    }
+
+    [Fact]
+    public void A_configuration_id_is_sent_when_one_is_named()
+    {
+        var form = StripeInitiationRequestFactory.ReadForm(
+            Create(provider: Provider(configurationId: "pmc_123")));
+
+        form["payment_method_configuration"].Should().Be("pmc_123");
+    }
+
+    /// <summary>
+    /// A one-off payment stores nothing, so there is no mandate to establish and every method
+    /// the operator named survives — TWINT and Klarna included.
+    /// </summary>
+    [Fact]
+    public void An_explicit_list_is_sent_whole_when_nothing_is_being_saved()
+    {
+        var form = StripeInitiationRequestFactory.ReadForm(
+            Create(provider: Provider(methods: ["card", "twint", "paypal", "klarna"])));
+
+        form["payment_method_types[0]"].Should().Be("card");
+        form["payment_method_types[1]"].Should().Be("twint");
+        form["payment_method_types[2]"].Should().Be("paypal");
+        form["payment_method_types[3]"].Should().Be("klarna");
+    }
+
+    /// <summary>
+    /// The heart of it. A subscription's first charge stores the method so renewals can be
+    /// raised against it off-session, and TWINT and Klarna cannot be charged that way — a
+    /// subscription bought with either could never renew itself. They are dropped rather than
+    /// sent for Stripe to reject the whole session over, and the indexes close up behind them
+    /// because Stripe requires a contiguous array.
+    /// </summary>
+    [Fact]
+    public void A_saving_checkout_drops_methods_that_can_never_be_charged_again()
+    {
+        var request = Create(
+            new MakePaymentRequest
+            {
+                Description = "A description",
+                SavePaymentMethod = true
+            },
+            Provider(methods: ["card", "twint", "paypal", "klarna"]));
+
+        var form = StripeInitiationRequestFactory.ReadForm(request);
+
+        form["payment_method_types[0]"].Should().Be("card");
+        form["payment_method_types[1]"].Should().Be("paypal");
+        form.Should().NotContainKey("payment_method_types[2]");
+
+        _factory.DroppedMethods.Should().BeEquivalentTo("twint", "klarna");
+    }
+
+    /// <summary>
+    /// Nothing the operator named survives the narrowing. An empty array is not the same as no
+    /// array — Stripe rejects the first — so the session falls back to the account default and
+    /// still opens, rather than failing the checkout outright.
+    /// </summary>
+    [Fact]
+    public void A_selection_that_narrows_to_nothing_falls_back_rather_than_failing()
+    {
+        var request = Create(
+            new MakePaymentRequest
+            {
+                Description = "A description",
+                SavePaymentMethod = true
+            },
+            Provider(methods: ["twint", "klarna"]));
+
+        var form = StripeInitiationRequestFactory.ReadForm(request);
+
+        form.Keys.Should().NotContain(key =>
+            key.StartsWith("payment_method_types", StringComparison.Ordinal));
+        _factory.DroppedMethods.Should().BeEquivalentTo("twint", "klarna");
+    }
+
+    /// <summary>Stripe rejects a session carrying both, so the explicit list wins.</summary>
+    [Fact]
+    public void An_explicit_list_and_a_configuration_id_are_never_sent_together()
+    {
+        var form = StripeInitiationRequestFactory.ReadForm(
+            Create(provider: Provider(
+                configurationId: "pmc_123",
+                methods: ["card", "twint"])));
+
+        form["payment_method_types[0]"].Should().Be("card");
+        form.Should().NotContainKey("payment_method_configuration");
+    }
+
+    /// <summary>
+    /// Stripe renders methods in the order they arrive, so the authored order is a presentation
+    /// decision and is preserved. Casing and padding are not.
+    /// </summary>
+    [Fact]
+    public void A_selection_is_normalized_without_being_reordered()
+    {
+        StripePaymentMethodSelection
+            .Normalize(["  TWINT ", "card", "twint", "", "  ", "Card"])
+            .Should().Equal("twint", "card");
+    }
+
+    [Theory]
+    [InlineData("card", true)]
+    [InlineData("paypal", true)]
+    [InlineData("link", true)]
+    [InlineData("twint", false)]
+    [InlineData("klarna", false)]
+    public void Only_methods_carrying_a_mandate_can_be_reused(string method, bool reusable) =>
+        StripePaymentMethodSelection.CanBeReusedOffSession(method).Should().Be(reusable);
+
+    private ProviderInitiationRequest Create(
+        MakePaymentRequest? request = null,
+        PaymentProvider? provider = null) =>
+        _factory.Create(
+            request ?? new MakePaymentRequest
+            {
+                Description = "A description",
+                CustomerEmail = "shopper@example.com"
+            },
+            new PaymentExecutionContext("tenant-1", "actor-1", "organization-1"),
+            new PaymentDetail
+            {
+                ItemId = "payment-1",
+                TenantId = "tenant-1",
+                CurrencyCode = "CHF"
+            },
+            provider ?? Provider(),
+            "https://payments.example/return?state=signed",
+            "payment-reference",
+            "shopper-reference",
+            providerPayerReference: null,
+            includeStoredPaymentMethods: true,
+            minorUnits: 29000);
+
+    private static PaymentProvider Provider(
+        string? configurationId = null,
+        string[]? methods = null) => new()
+        {
+            ProviderName = PaymentConstants.StripeProvider,
+            ApiBaseUrl = "https://api.stripe.com",
+            MerchantId = "acct_123",
+            PaymentMethodConfigurationId = configurationId,
+            CheckoutPaymentMethodTypes = methods
+        };
+}

--- a/server/XUnitTest/Subscription/SubscriptionPaymentProviderReadinessServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPaymentProviderReadinessServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Payment.DomainService.Entities;
@@ -399,7 +399,8 @@ public sealed class SubscriptionPaymentProviderReadinessServiceTests
         public Task<PaymentProvider?> TryUpdateProviderConfigurationAsync(
             string tenantId, string providerItemId, long expectedVersion, string frontendResultUrl,
             string? countryCode, bool manualCapture, int maxRefundDays, string? storeId,
-            bool isEnabled, CancellationToken cancellationToken) =>
+            bool isEnabled, string? paymentMethodConfigurationId,
+            string[]? checkoutPaymentMethodTypes, CancellationToken cancellationToken) =>
             throw new NotSupportedException();
 
         public Task<PaymentProvider?> TryRotateProviderCredentialsAsync(


### PR DESCRIPTION
## The premise this started from was wrong, and that matters

The brief was: *"the backend hardcodes `payment_method_types: [\"card\"]`, remove it and every Dashboard-enabled method appears."*

**It has never sent that field.** `payment_method_types` appears nowhere in `server/`. Dynamic payment methods are already in effect, so removing it is a no-op. The supporting evidence actually proves this — a session reporting `["card", "link", "amazon_pay"]` cannot happen if `["card"]` is hardcoded; that is Stripe *echoing back* what it resolved from the Dashboard.

## What actually narrows the list

`SubscriptionCheckoutService` sets `SavePaymentMethod = true`, so the session carries:

```
saved_payment_method_options[payment_method_save] = enabled
payment_intent_data[setup_future_usage]           = off_session
```

Stripe then restricts dynamic methods to those it can charge again **off-session**, which is card plus the wallets wrapping it. That is the reported symptom, and it is **correct rather than a defect**: a renewal is an off-session charge against a stored mandate, and a subscription bought with TWINT could never renew itself.

So the doc's Option B (`["card","twint","paypal","klarna"]`) would not have helped — Stripe either rejects the session or you get subscriptions with nothing to bill at renewal.

## What this PR adds

A provider may now say which methods its checkout offers, in either of Stripe's two mutually-exclusive forms:

| Field | Effect |
|---|---|
| `paymentMethodConfigurationId` | Sends `payment_method_configuration` (a `pmc_…` assembled in the Dashboard) |
| `checkoutPaymentMethodTypes` | Sends `payment_method_types[]` explicitly |
| neither *(default)* | Sends nothing — the account's own configuration decides, exactly as today |

Both are settable at registration and update, and are returned on the provider response.

**The safety property is the point.** When the session also stores the method, an explicit list is narrowed to what can actually be reused, so a configuration written for one-off payments cannot quietly produce unrenewable subscriptions. A list that narrows to nothing falls back to the account default rather than sending the empty array Stripe rejects.

## Where each of the six methods lands

| Method | Subscription checkout | One-off payment |
|---|---|---|
| Card, Apple Pay, Google Pay | works today | works today |
| PayPal | **available** once Stripe grants recurring approval (live mode) | available |
| TWINT, Klarna | not possible — cannot be charged off-session | **available**, configure them explicitly |

## Notes

- Kept deliberately separate from the existing `PaymentMethods` field, which predates this and is read by nothing. Documents may already carry provider-specific names in it; reinterpreting those as Stripe method types would change a live checkout on deploy.
- **No behaviour change for any existing provider** — every one has both fields null and takes the untouched default path.
- Tests: 12 new cases in `StripePaymentMethodSelectionTests`; full `XUnitTest.Payment` suite green at 1412 passed.
- 4 failures exist in `SubscriptionSimulation*` tests — verified pre-existing on `dev` by stashing this branch and re-running. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)