### PR TITLE
Fix subscription_payment_provider_scope_mismatch on a payment with no recorded provider

### DIFF
--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -739,9 +739,16 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         // The session must actually have opened against the exact configuration row this
         // account was pinned to -- checked here as defense in depth, in addition to (not instead
         // of) CreateSetupAsync's own fail-closed ExpectedProviderId check above, which refuses to
-        // ever contact the provider on a mismatch. This can only still fire for an account with
-        // no frozen ProviderId (created before it was recorded), where CreateSetupAsync had
-        // nothing to compare against and could not fail closed itself.
+        // ever contact the provider on a mismatch.
+        //
+        // Both sides must actually name a row for the comparison to mean anything. A payment
+        // whose ResolvedProviderId is unset is one recorded before that column existed, reached
+        // here by CreateSetupAsync adopting it through the setup's idempotency key rather than
+        // raising a new one -- "not recorded" is not evidence of a different provider, and
+        // refusing on it failed closed against merchants that were correctly configured. The
+        // fail-closed check above already compared ExpectedProviderId against the row it
+        // resolved, so nothing reaches here unverified; this one only catches a payment that
+        // demonstrably names a different row.
         //
         // Compared by provider row id, not by organization: setup.Payment.OrganizationId is the
         // request/operation scope PaymentResponse was mapped from, not which PaymentProvider row
@@ -752,7 +759,8 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         // preserved rather than coerced to this subscriber's own organization. See
         // BillingAccount.ProviderId and PaymentResponse.ResolvedProviderId.
         if (account.ProviderId is { Length: > 0 } expectedProviderId &&
-            !string.Equals(setup.Payment.ResolvedProviderId, expectedProviderId, StringComparison.Ordinal))
+            setup.Payment.ResolvedProviderId is { Length: > 0 } resolvedSetupProviderId &&
+            !string.Equals(resolvedSetupProviderId, expectedProviderId, StringComparison.Ordinal))
         {
             _logger.LogError(
                 "Subscription card setup resolved a different provider configuration than the " +
@@ -934,10 +942,13 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         // Same reason as StartCardSetupAsync: defense in depth alongside MakePaymentAsync's own
         // fail-closed ExpectedProviderId check, compared by provider row id (never by
         // organization, which is the request scope rather than the resolved configuration -- see
-        // PaymentResponse.OrganizationId's remarks). Can only still fire for an account with no
-        // frozen ProviderId, where MakePaymentAsync had nothing to compare against.
+        // PaymentResponse.OrganizationId's remarks), and skipped entirely when the payment names
+        // no row at all. That is the shape a charge recorded before ResolvedProviderId existed
+        // arrives in, adopted here through InitialChargeKeyFor rather than raised fresh; see
+        // StartCardSetupAsync for why an unset value must not be read as a mismatch.
         if (account.ProviderId is { Length: > 0 } expectedProviderId &&
-            !string.Equals(payment.Payment.ResolvedProviderId, expectedProviderId, StringComparison.Ordinal))
+            payment.Payment.ResolvedProviderId is { Length: > 0 } resolvedChargeProviderId &&
+            !string.Equals(resolvedChargeProviderId, expectedProviderId, StringComparison.Ordinal))
         {
             _logger.LogError(
                 "Subscription initial charge resolved a different provider configuration than " +

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -343,6 +343,61 @@ public sealed class SubscriptionCheckoutServiceTests
     }
 
     /// <summary>
+    /// The other half of
+    /// <see cref="A_charge_is_accepted_when_the_billing_account_has_no_frozen_provider_id_to_compare"/>:
+    /// the account names a row but the payment does not.
+    /// </summary>
+    /// <remarks>
+    /// The real-world failure this closes, reported against a live Stripe subscription in the
+    /// default organization: <c>ResolvedProviderId</c> is a column this PR added, so every
+    /// <c>PaymentDetail</c> written before it has none. The initial charge is raised under
+    /// <c>SubscriptionConstants.InitialChargeKeyFor</c> precisely so a retry adopts the payment an
+    /// earlier attempt already made rather than raising a second one -- and that adopted payment
+    /// comes back with the column unset. Comparing it as an ordinary value made "we did not record
+    /// this" indistinguishable from "this resolved a different row", and every retry failed closed
+    /// with <c>subscription_payment_provider_scope_mismatch</c> for a correctly configured
+    /// merchant. <c>MakePaymentAsync</c>'s own fail-closed <c>ExpectedProviderId</c> check has
+    /// already compared the row it resolved by this point, so skipping here waves nothing through.
+    /// </remarks>
+    [Fact]
+    public async Task A_charge_that_records_no_resolved_provider_is_accepted_rather_than_read_as_a_mismatch()
+    {
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, _subscription.BillingAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                ProviderName = PaymentConstants.AdyenOnlineProvider,
+                ProviderOrganizationId = "console-org",
+                ProviderId = "expected-provider-row"
+            });
+
+        // A payment adopted through the initial-charge idempotency key, recorded before
+        // ResolvedProviderId existed: it names no row at all rather than a different one.
+        _payments
+            .Setup(service => service.MakePaymentAsync(
+                It.IsAny<MakePaymentRequest>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PaymentOperationResult.Success(
+                new PaymentResponse
+                {
+                    PaymentDetailId = "pay-1",
+                    RedirectUrl = "https://checkout.example/session",
+                    OrganizationId = "console-org",
+                    ResolvedProviderId = null,
+                    ResolvedProviderOrganizationId = null
+                },
+                "corr-1"));
+
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "a payment that records no resolved provider has not been shown to disagree with " +
+            "the billing account's frozen one");
+    }
+
+    /// <summary>
     /// A missing or corrupted billing account must never silently route the charge through
     /// Stripe -- the fail-open bug this PR exists to close.
     /// </summary>
@@ -1030,6 +1085,45 @@ public sealed class SubscriptionCheckoutServiceTests
         // Not empty string: Stripe's own form-encoding helper only omits a field for a literal
         // null, and an empty customer_email is a value the provider can reject outright.
         _paymentRequest!.CustomerEmail.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The card-setup half of
+    /// <see cref="A_charge_that_records_no_resolved_provider_is_accepted_rather_than_read_as_a_mismatch"/>.
+    /// </summary>
+    /// <remarks>
+    /// Reachable the same way and for the same reason: a setup session adopted through the
+    /// subscription's own setup idempotency key can be one recorded before
+    /// <c>ResolvedProviderId</c> existed. The trial that needs this card is precisely the case
+    /// where an older attempt is most likely to be lying around, so refusing on an unset column
+    /// would strand a subscriber whose provider was never in doubt.
+    /// </remarks>
+    [Fact]
+    public async Task A_card_setup_that_records_no_resolved_provider_is_accepted_rather_than_read_as_a_mismatch()
+    {
+        _subscription.Status = SubscriptionStatus.Trialing;
+        GivenSubscriptionById(_subscription);
+
+        _billingAccounts
+            .Setup(repository => repository.GetAsync(
+                TenantId, _subscription.BillingAccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingAccount
+            {
+                ProviderName = PaymentConstants.StripeProvider,
+                ProviderOrganizationId = OrganizationId,
+                ProviderId = "expected-provider-row"
+            });
+
+        // GivenSetupSessionOpens returns a response with no ResolvedProviderId, which is exactly
+        // the shape a pre-existing setup payment comes back in.
+        GivenSetupSessionOpens();
+
+        var result = await Service().StartPaymentMethodSetupAsync(
+            _subscription.ItemId, OrganizationId, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "a setup session that records no resolved provider has not been shown to disagree " +
+            "with the billing account's frozen one");
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #393, found in manual testing: subscribing against a billing account with a frozen `ProviderId` failed with `subscription_payment_provider_scope_mismatch` for a merchant that was correctly configured. Reported against a live Stripe subscription in the `default` organization.

## Cause

`ResolvedProviderId` is a column #393 added, so every `PaymentDetail` written before it has none.

The initial charge and the card setup are both raised under a subscription-derived idempotency key (`SubscriptionConstants.InitialChargeKeyFor` and the setup equivalent), precisely so a retry adopts the payment an earlier attempt already made rather than raising a second one. That adopted payment comes back with the column unset.

Both defense-in-depth guards in `SubscriptionCheckoutService` compared it as an ordinary value, which made *"we never recorded this"* indistinguishable from *"this resolved a different row"*. The guard failed closed on the absence of a fact rather than on a disagreement, and every retry failed the same way.

This is distinct from the never-charged repin case fixed in `73eb4252`, which lives in `BillingAccountRepository` and does not reach this comparison. Same error code, different cause.

## Fix

Skip the comparison unless the payment actually names a row:

```csharp
payment.Payment.ResolvedProviderId is { Length: > 0 } resolvedChargeProviderId &&
```

Nothing is waved through. `MakePaymentAsync` and `CreateSetupAsync` each run their own fail-closed `ExpectedProviderId` check against the row they resolved, before the provider is ever contacted — so a payment that reaches this point has already been verified. A payment that names a *different* row still fails here, unchanged.

Both guards' comments claimed the check "can only still fire for an account with no frozen ProviderId" — the inverse of their own `account.ProviderId is { Length: > 0 }` condition, and the reason this case was never considered. Corrected.

## Tests

Two regression tests, one per path, asserting a payment with an unset `ResolvedProviderId` is accepted against an account that has a frozen one. Both fail without the fix. They mirror the existing `..._has_no_frozen_provider_id_to_compare` test from the opposite side.

## Verification

- Build: 0 errors
- `SubscriptionCheckoutServiceTests`: 43/43
- Full non-integration suite: 3,418 passed / 4 failed — the pre-existing `SubscriptionSimulation*` permission failures documented as baseline on #393, untouched here

## Note for whoever hits this in data

If a report of this error shows `ResolvedProviderId` holding an *actual different value* rather than null, this fix does not apply and the guard is firing correctly: that means a `PaymentProvider` row changed after a charge confirmed, and renewals on the existing subscription will fail too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
