### PR TITLE
fix(subscription): give worker background work a trace id

### DIFF
--- a/docs/subscription/tracing/README.md
+++ b/docs/subscription/tracing/README.md
@@ -81,21 +81,42 @@ So a message like `Subscription work completed DueAtUtc=… DurationMs=2 LagSeco
 its context — the template just doesn't repeat what the scope already carries. Query the fields, not
 the message text.
 
-> **This requires scope capture to be switched on.** Every `appsettings.json` in `server/Api` and
-> `server/Worker` now sets:
->
-> ```json
-> "Logging": {
->   "Console": {
->     "IncludeScopes": true,
->     "FormatterOptions": { "IncludeScopes": true }
->   }
-> }
-> ```
->
-> Without it those ten fields are computed on every line and then discarded by the sink, and the
-> scopes array renders as `[]`. If your production sink is not the console provider, set
-> `IncludeScopes` on whichever provider you use — the principle is the same.
+---
+
+## The trace id column, and why the worker's used to be empty
+
+The bracketed value beside each line is the **trace id**, not the log scope. The platform's log
+pipeline enriches every record from `Activity.Current`, so a line written outside any activity
+carries an empty one:
+
+```
+utilities         [8ced109d33cc2f17b42e8ae1cfc40e9e]  Executing endpoint '…'
+utilities-worker  []                                  Subscription work completed …
+```
+
+The API is instrumented per HTTP request, which is where its activity comes from. **A worker serves
+no request**, so nothing was creating one and every line it wrote had nothing to be stamped with.
+The enricher was working correctly and had nothing to read.
+
+Background work now runs inside a span of its own — `subscription.work {WorkType}`, kind `Consumer`
+— started by `SubscriptionWorkDispatcher` and carrying:
+
+```
+subscription.work.type   subscription.work.item_id   subscription.work.attempt
+subscription.tenant_id   subscription.subscription_id   subscription.correlation_id
+```
+
+So worker lines now carry a trace id, and every line of one attempt shares it.
+
+> **The source has to be subscribed to.** `Blocks.Subscription.BackgroundWork` — the same name the
+> queue's meter uses — is registered in `server/Worker/Program.cs`. Starting an activity from a
+> source nothing listens to returns null and sets nothing current, exactly as recording to a meter
+> no exporter asked for records nothing. No exporter is named at that registration on purpose: the
+> platform's own tracing setup owns where spans go.
+
+**A worker trace id does not yet join the API request that scheduled the work.** The queue item
+carries no trace context to be a child of, so each attempt is a root span. Until that changes,
+`CorrelationId` remains the key that joins the two sides — see the three-step trace above.
 
 ---
 

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkActivity.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkActivity.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// The span every background work attempt runs inside.
+/// </summary>
+/// <remarks>
+/// A worker serves no HTTP request, so the ASP.NET Core instrumentation that gives every API line a
+/// trace id never runs here and <see cref="Activity.Current"/> was null for the whole of a work
+/// attempt. The log pipeline's trace enricher reads exactly that, which is why the worker's trace id
+/// column was empty while the API's was populated — the enricher was working and had nothing to
+/// read.
+/// <para>
+/// The name matches <see cref="SubscriptionWorkMetrics.MeterName"/> deliberately: the same body of
+/// work described two ways, found under one name in whichever signal an operator reaches for first.
+/// </para>
+/// <para>
+/// It must be registered with a tracer provider to do anything. Starting an activity from a source
+/// nothing listens to returns null and sets no current activity, for the same reason recording to a
+/// meter no exporter subscribed to records nothing — see the worker's composition root, which
+/// subscribes to both.
+/// </para>
+/// </remarks>
+public static class SubscriptionWorkActivity
+{
+    /// <summary>The name a tracer provider subscribes to.</summary>
+    public const string SourceName = SubscriptionWorkMetrics.MeterName;
+
+    /// <summary>
+    /// Shared and never disposed. An <see cref="ActivitySource"/> is a process-wide name rather
+    /// than a resource, and disposing one held by a static field would silence every later span in
+    /// the process.
+    /// </summary>
+    public static readonly ActivitySource Source = new(SourceName);
+}

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -121,6 +122,32 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
         TimeSpan lease,
         CancellationToken cancellationToken)
     {
+        // Started before anything here logs, because the trace enricher stamps each line from
+        // whatever is current when that line is written. A worker has no request to inherit an
+        // activity from, so without this one every line it wrote carried an empty trace id while
+        // the API's were populated.
+        //
+        // Consumer, not Internal: this process is taking work another one left for it. The activity
+        // is not linked to the scheduling request's trace yet — the queue item carries no trace
+        // context to be a child of — so this is a root span that stands on its own, and
+        // CorrelationId below remains the key that joins it to whoever scheduled the work.
+        using var activity = SubscriptionWorkActivity.Source.StartActivity(
+            $"subscription.work {work.WorkType}",
+            ActivityKind.Consumer);
+
+        // Null whenever no tracer provider subscribed to the source, so every one of these is a
+        // no-op rather than a guard somebody has to remember.
+        activity?.SetTag("subscription.work.type", work.WorkType.ToString());
+        activity?.SetTag("subscription.work.item_id", work.ItemId);
+        activity?.SetTag("subscription.work.attempt", work.AttemptCount);
+        // Same rendering as the log scope below, so a span and a log line name the same thing the
+        // same way — including "none" for work that belongs to no one subscription.
+        activity?.SetTag("subscription.tenant_id", PaymentLogValue.Id(work.TenantId));
+        activity?.SetTag(
+            "subscription.subscription_id",
+            SubscriptionWorkLogValue.AggregateId(work.AggregateId));
+        activity?.SetTag("subscription.correlation_id", PaymentLogValue.Id(work.CorrelationId));
+
         // Everything about this attempt, on every line it writes: the item, who is on it, which
         // attempt, and the correlation the work was created under. One operation has to be
         // traceable from the API call that scheduled it to the provider request that finished it.
@@ -213,6 +240,11 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
                     return true;
 
                 default:
+                    // The outcome, not an exception: a retry is an ordinary result here, and a span
+                    // that ended Unset for it would leave a failing queue indistinguishable from a
+                    // healthy one in a trace view.
+                    activity?.SetStatus(ActivityStatusCode.Error, outcome.Result.ToString());
+
                     await FailAsync(work, leaseId, outcome, duration, cancellationToken);
 
                     return false;
@@ -226,6 +258,9 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
         }
         catch (Exception exception)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
+            activity?.AddException(exception);
+
             await renewal.StopAsync();
 
             if (renewal.LeaseWasLost)

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -16,6 +16,8 @@ using Worker.Consumers.Payment;
 using Worker.Consumers.Subscription;
 using Subscription.DomainService.Entities;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using Subscription.DomainService.Scheduling;
 
 const string _serviceName = "blocks-utilities-worker";
 
@@ -79,13 +81,27 @@ IHostBuilder CreateHostBuilder(string[] args) =>
                 context.Configuration, context.HostingEnvironment);
             services.AddOpenTelemetry()
                 .WithMetrics(metrics => metrics
-                    .AddMeter("Blocks.Subscription.BackgroundWork")
+                    // The constant rather than the literal it used to repeat, now that the name is
+                    // shared with the activity source below and a drift between them would be two
+                    // signals for one thing filed under two names.
+                    .AddMeter(SubscriptionWorkMetrics.MeterName)
                     .AddMeter(FinancialDocumentRendererHealthGate.MeterName)
                     // The reconciliation sweep and the backfill run here, so version lag and repair
                     // volume are recorded in this process. Creating the instruments is not enough:
                     // an exporter only observes a meter it has been told to subscribe to.
                     .AddMeter(UsageProjectionMetrics.MeterName)
-                    .AddOtlpExporter());
+                    .AddOtlpExporter())
+                // Subscribing to the source is what makes StartActivity return an activity at all:
+                // one nothing listens to returns null and sets nothing current, exactly as the
+                // meters above record nothing until an exporter asks for them.
+                //
+                // No exporter is named here on purpose. The platform's own tracing registration
+                // owns where spans go, and adding a second destination from this composition root
+                // would send them somewhere nobody configured. What this line is for is the trace
+                // id: the worker serves no request, so until now nothing made an activity current
+                // and every line it logged carried an empty one.
+                .WithTracing(tracing => tracing
+                    .AddSource(SubscriptionWorkActivity.SourceName));
             // First, deliberately: an operator should learn whether the renderer works before
             // anything else in this worker starts moving. It no longer stops the host on failure —
             // see the check's own remarks — only records what it found for

--- a/server/XUnitTest/Subscription/SubscriptionWorkDispatcherTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionWorkDispatcherTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -468,6 +469,101 @@ public sealed class SubscriptionWorkDispatcherTests
         await act.Should().NotThrowAsync();
     }
 
+    [Fact]
+    public async Task An_item_runs_inside_an_activity_so_its_log_lines_carry_a_trace_id()
+    {
+        using var recorder = new ActivityRecorder(SubscriptionWorkActivity.SourceName);
+        _claimed.Add(Work());
+
+        await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        // The whole point: the trace enricher stamps a line from whatever is current when it is
+        // written, and a worker serves no request to inherit one from. Asserted from inside the
+        // handler because that is where a real handler's own logging happens.
+        _handler.ObservedActivity.Should().NotBeNull();
+        _handler.ObservedActivity!.TraceId.Should().NotBe(default(ActivityTraceId));
+
+        var span = recorder.Stopped.Should().ContainSingle().Subject;
+        span.Kind.Should().Be(ActivityKind.Consumer);
+        span.GetTagItem("subscription.work.type").Should().Be(nameof(SubscriptionWorkType.Renewal));
+        span.GetTagItem("subscription.work.item_id").Should().Be("work-1");
+        span.Status.Should().Be(ActivityStatusCode.Unset);
+    }
+
+    [Fact]
+    public async Task Work_that_belongs_to_no_subscription_says_so_on_its_span_too()
+    {
+        using var recorder = new ActivityRecorder(SubscriptionWorkActivity.SourceName);
+        // A tenant-wide sweep carries no aggregate. "none" rather than "missing" on the log scope,
+        // and the span must not disagree with the lines written inside it.
+        _claimed.Add(Work());
+
+        await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        recorder.Stopped.Should().ContainSingle().Which
+            .GetTagItem("subscription.subscription_id").Should().Be("none");
+    }
+
+    [Fact]
+    public async Task A_retried_attempt_ends_its_span_as_an_error()
+    {
+        using var recorder = new ActivityRecorder(SubscriptionWorkActivity.SourceName);
+        _claimed.Add(Work());
+        _handler.Outcome = SubscriptionWorkOutcome.Retry("provider_unreachable", "No answer.");
+
+        await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        // A retry is an ordinary outcome rather than an exception, so nothing else would have
+        // marked the span — and a failing queue that traces as healthy is worse than no trace.
+        recorder.Stopped.Should().ContainSingle().Which
+            .Status.Should().Be(ActivityStatusCode.Error);
+    }
+
+    [Fact]
+    public async Task Nothing_listening_to_the_source_leaves_the_work_untouched()
+    {
+        // No recorder, so StartActivity returns null and every activity call in the dispatcher is a
+        // no-op. Tracing is diagnostics: a process that registered no tracer provider still has to
+        // do the work.
+        _claimed.Add(Work());
+
+        var processed = await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        processed.Should().Be(1);
+        _handler.Executions.Should().ContainSingle();
+        _handler.ObservedActivity.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Collects the spans one source produces while a test runs.
+    /// </summary>
+    /// <remarks>
+    /// A listener is what makes <c>StartActivity</c> return anything at all, so this stands in for
+    /// the tracer provider the worker registers — and its absence stands in for a process that
+    /// registered none.
+    /// </remarks>
+    private sealed class ActivityRecorder : IDisposable
+    {
+        private readonly ActivityListener _listener;
+
+        public ActivityRecorder(string sourceName)
+        {
+            _listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == sourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => Stopped.Add(activity)
+            };
+
+            ActivitySource.AddActivityListener(_listener);
+        }
+
+        public List<Activity> Stopped { get; } = [];
+
+        public void Dispose() => _listener.Dispose();
+    }
+
     private SubscriptionWorkDispatcher Dispatcher(
         int batchSize = 20,
         int leaseSeconds = 120,
@@ -542,10 +638,18 @@ public sealed class SubscriptionWorkDispatcherTests
 
         public bool Cancelled { get; private set; }
 
+        /// <summary>
+        /// Whatever was current when this ran — which is what a real handler's log lines, and the
+        /// provider calls it makes, would be stamped with.
+        /// </summary>
+        public Activity? ObservedActivity { get; private set; }
+
         public async Task<SubscriptionWorkOutcome> ExecuteAsync(
             SubscriptionBackgroundWork work,
             CancellationToken cancellationToken)
         {
+            ObservedActivity = Activity.Current;
+
             if (Throw is not null)
             {
                 throw Throw;


### PR DESCRIPTION
Follow-up to #408. Part A of the plan discussed there.

## The problem

The trace id column is populated for the API and empty for the worker:

```
utilities         [8ced109d33cc2f17b42e8ae1cfc40e9e]  Executing endpoint '…'
utilities-worker  []                                  Subscription work completed …
```

**Correction to #408:** that bracket is the **trace id**, not the log scope. A 32-hex value is a W3C trace id; a scope would render as key/value pairs. The `IncludeScopes` change in #408 addressed a different thing and does not fix this — the other two changes in that PR (the `WorkKey` sanitisation mismatch, `"none"` vs `"missing"`) stand on their own.

## Root cause

Decompiling `Blocks.Genesis.dll` shows the pipeline:

| Type | Meaning |
|---|---|
| `LoggerConfiguration`, `MongoDBDynamicSink` | Logging is Serilog → MongoDB |
| `TraceContextEnricher` | Stamps `TraceId` on each record, read from `Activity.Current` |
| `AddAspNetCoreInstrumentation`, `WithTracing` | Activities are created **per HTTP request** |
| `AddSource` | **absent** — no custom activity sources are registered |

A worker serves no HTTP request, so nothing ever created an Activity and `Activity.Current` was null for the whole of a work attempt. The enricher was working correctly and had nothing to read.

Confirmed against this repo — nothing here starts one:

```
grep -rn "ActivitySource|StartActivity|Activity.Current" server --include=*.cs
→ 3 hits, all in UsageRecordingService, all *reading* Activity.Current
```

## Changes

**`SubscriptionWorkActivity`** — an `ActivitySource` named `Blocks.Subscription.BackgroundWork`, reusing `SubscriptionWorkMetrics.MeterName` rather than inventing a second name for the same body of work.

**`SubscriptionWorkDispatcher.RunAsync`** — each attempt now runs inside a `Consumer` span named `subscription.work {WorkType}`, started before anything in the method logs, tagged with the same identifiers as the log scope and rendered the same way (including `"none"` for tenant-wide work, so a span and a line about the same item don't disagree). A non-`Completed` outcome ends the span as an error — a retry is an ordinary result, not an exception, so nothing else would have marked it.

**`server/Worker/Program.cs`** — `.WithTracing(t => t.AddSource(...))`. Registration is what makes `StartActivity` return anything at all; a source nothing listens to returns null, the same reason the meters beside it record nothing until an exporter asks for them. **No exporter is named** — the platform's own tracing registration owns where spans go, and a second destination configured from here would send them somewhere nobody set up. The neighbouring `AddMeter` literal now uses the constant it was duplicating.

## What this does not do

The span is **not** linked to the API request that scheduled the work. The queue item carries no trace context to be a child of, so each attempt is a root span, and `CorrelationId` remains what joins the two sides. That is Part B — it needs a `traceparent` field on the persisted work entity — and is deliberately not in this PR.

Only the subscription dispatcher is covered. `PaymentBackgroundWorkDispatcher` has the same gap and would take the same shape.

## Verification

- `dotnet build` Worker and Api → **0 errors**
- `dotnet test --filter XUnitTest.Subscription` → **1,602 passed, 4 failed**

The 4 are the pre-existing `SubscriptionSimulation*` permission failures, unrelated and present on clean `dev`.

Four new tests in `SubscriptionWorkDispatcherTests`, asserting from inside the handler because that is where a real handler's own logging happens:

- an item runs inside an activity with a real trace id, kind `Consumer`, tagged
- tenant-wide work reports `"none"` on its span too
- a retried attempt ends its span as an error
- **with no listener registered, `StartActivity` returns null and the work still completes** — tracing is diagnostics; a process that registered no tracer provider still has to do the work

## Risk

Diagnostics only. Every activity call is null-conditional, and the last test above pins that the work is unaffected when nothing is listening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
