### PR TITLE
fix(subscription): link a work attempt to the request that scheduled it

### DIFF
--- a/docs/subscription/tracing/README.md
+++ b/docs/subscription/tracing/README.md
@@ -114,9 +114,34 @@ So worker lines now carry a trace id, and every line of one attempt shares it.
 > no exporter asked for records nothing. No exporter is named at that registration on purpose: the
 > platform's own tracing setup owns where spans go.
 
-**A worker trace id does not yet join the API request that scheduled the work.** The queue item
-carries no trace context to be a child of, so each attempt is a root span. Until that changes,
-`CorrelationId` remains the key that joins the two sides — see the three-step trace above.
+---
+
+## Joining a worker attempt to the request that caused it
+
+Work scheduled from inside a request stores that request's W3C trace context on the queue item. When
+the attempt eventually runs, it reports it three ways:
+
+| Where | What |
+| --- | --- |
+| Span link | `ActivityLink` to the scheduling trace |
+| Span tag | `subscription.scheduled_by.trace_id` |
+| Log scope | `ScheduledByTraceId` on every line of the attempt |
+
+So an operator holding the trace id of the request a customer complained about can find the
+background work it caused — by following the link if the backend renders links, and by grepping the
+trace id if it does not.
+
+**It is a link, not a parent, and that is deliberate.** A renewal is scheduled a month before it
+runs and a cancellation up to a year. A span that made itself a child of the request that scheduled
+it would describe a single trace as lasting a year — past every backend's retention window, and not
+something anybody can open. The link says the same causal thing without lying about duration.
+
+`ScheduledByTraceId="none"` means nothing scheduled it from inside a request. Every sweep-announced
+item reads that way, and so does anything queued at startup.
+
+The parent is whatever activity is ambient at dispatch — nothing in the worker loop, so an attempt
+there is a root span. When due jobs are run on demand from the admin endpoint instead, the attempt
+belongs to that request's trace, which is what somebody watching that request wants to see.
 
 ---
 

--- a/server/Subscription.DomainService/Scheduling/SubscriptionBackgroundWork.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionBackgroundWork.cs
@@ -80,6 +80,29 @@ public sealed class SubscriptionBackgroundWork
     /// <summary>Ties every log line for this work back to whatever asked for it.</summary>
     public string CorrelationId { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The W3C trace context of whatever scheduled this, when it was scheduled inside one.
+    /// </summary>
+    /// <remarks>
+    /// An attempt uses this as a <strong>link</strong> rather than as a parent, deliberately. A
+    /// renewal is scheduled a month before it runs and a cancellation up to a year; a span that made
+    /// itself a child of a request which finished last November would describe a single trace as
+    /// lasting a year — past every backend's retention window, and not a thing anybody can open.
+    /// A link says the same causal thing without lying about duration.
+    /// <para>
+    /// Nullable, and left null by everything that schedules outside a request — the repair sweep
+    /// among them, which mints its own correlation precisely because there is no caller to inherit
+    /// from. Documents written before this field existed keep deserializing and keep meaning what
+    /// they meant.
+    /// </para>
+    /// <para>
+    /// A trace id is not a secret and names no person, so this is safe in the one collection
+    /// operators query across every tenant at once. It is also the only thing here that could be
+    /// mistaken for one, which is why it is spelled out.
+    /// </para>
+    /// </remarks>
+    public string? TraceParent { get; set; }
+
     /// <summary>One attempt's own identity, so two attempts can be told apart in logs.</summary>
     public string? OperationId { get; set; }
 

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkActivity.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkActivity.cs
@@ -33,4 +33,30 @@ public static class SubscriptionWorkActivity
     /// the process.
     /// </summary>
     public static readonly ActivitySource Source = new(SourceName);
+
+    /// <summary>
+    /// The current trace context as a header value to store on scheduled work, or null when there
+    /// is nothing to store.
+    /// </summary>
+    /// <remarks>
+    /// Null outside a request — a sweep, a startup path, a test — which is the ordinary case rather
+    /// than a failure. The format check is not defensiveness about a value we produce: an activity
+    /// in the legacy hierarchical format has an <c>Id</c> that looks like an identifier and does not
+    /// parse as trace context, so storing it would fail silently at the far end a month later.
+    /// </remarks>
+    public static string? CurrentTraceParent() =>
+        Activity.Current is { IdFormat: ActivityIdFormat.W3C } current ? current.Id : null;
+
+    /// <summary>
+    /// The scheduling context to link an attempt to, or null when the work carries none.
+    /// </summary>
+    /// <remarks>
+    /// Remote, because it belongs to a different process and usually to a different month. Anything
+    /// unparseable is treated as absent: a span that refuses to start because a stored header was
+    /// malformed would stop a renewal over a diagnostic.
+    /// </remarks>
+    public static ActivityContext? SchedulingContext(string? traceParent) =>
+        ActivityContext.TryParse(traceParent, traceState: null, isRemote: true, out var context)
+            ? context
+            : null;
 }

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkDispatcher.cs
@@ -127,13 +127,24 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
         // activity from, so without this one every line it wrote carried an empty trace id while
         // the API's were populated.
         //
-        // Consumer, not Internal: this process is taking work another one left for it. The activity
-        // is not linked to the scheduling request's trace yet — the queue item carries no trace
-        // context to be a child of — so this is a root span that stands on its own, and
-        // CorrelationId below remains the key that joins it to whoever scheduled the work.
+        // Consumer, not Internal: this process is taking work another one left for it.
+        //
+        // The stored context is a link, never a parent. Passing it as one would be the obvious move
+        // and would be wrong here: a renewal is scheduled a month before it runs and a cancellation
+        // up to a year, so the trace it joined would be one that started last November and is long
+        // past its backend's retention. A link says the same causal thing and stays openable.
+        //
+        // The parent is whatever is ambient instead — nothing in the worker, which is the case this
+        // exists for, but a real activity when the dispatcher is driven from an admin endpoint that
+        // runs due jobs on demand. Being a child of that request is right, and it is why no parent
+        // is forced here.
+        var scheduledBy = SubscriptionWorkActivity.SchedulingContext(work.TraceParent);
+
         using var activity = SubscriptionWorkActivity.Source.StartActivity(
             $"subscription.work {work.WorkType}",
-            ActivityKind.Consumer);
+            ActivityKind.Consumer,
+            default(ActivityContext),
+            links: scheduledBy is { } origin ? [new ActivityLink(origin)] : null);
 
         // Null whenever no tracer provider subscribed to the source, so every one of these is a
         // no-op rather than a guard somebody has to remember.
@@ -147,6 +158,14 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
             "subscription.subscription_id",
             SubscriptionWorkLogValue.AggregateId(work.AggregateId));
         activity?.SetTag("subscription.correlation_id", PaymentLogValue.Id(work.CorrelationId));
+        // The link above is the proper way to express this and depends on the trace backend
+        // rendering links. This tag does not, and neither does the log-scope field below — an
+        // operator holding the trace id of the request a customer complained about can find this
+        // work by grepping for it, whatever the backend supports.
+        if (scheduledBy is { } linked)
+        {
+            activity?.SetTag("subscription.scheduled_by.trace_id", linked.TraceId.ToString());
+        }
 
         // Everything about this attempt, on every line it writes: the item, who is on it, which
         // attempt, and the correlation the work was created under. One operation has to be
@@ -166,6 +185,12 @@ public sealed class SubscriptionWorkDispatcher : ISubscriptionWorkDispatcher
             ["SubscriptionId"] = SubscriptionWorkLogValue.AggregateId(work.AggregateId),
             ["OrganizationId"] = SubscriptionWorkLogValue.AggregateId(work.OrganizationId),
             ["CorrelationId"] = PaymentLogValue.Id(work.CorrelationId),
+            // The trace the request that scheduled this ran under, so the two sides can be joined
+            // by trace id and not only by correlation id. "none" when nothing scheduled it from
+            // inside a request, which is every sweep.
+            ["ScheduledByTraceId"] = scheduledBy is { } from
+                ? from.TraceId.ToString()
+                : "none",
             ["OperationId"] = work.OperationId,
             ["LeaseId"] = leaseId,
             ["AttemptCount"] = work.AttemptCount

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkScheduler.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkScheduler.cs
@@ -52,7 +52,12 @@ public sealed class SubscriptionWorkScheduler : ISubscriptionWorkScheduler
                 NextAttemptAtUtc = dueAtUtc,
                 Priority = PriorityOf(workType),
                 MaxAttempts = Math.Max(1, _options.CurrentValue.SchedulerMaxAttempts),
-                CorrelationId = correlationId
+                CorrelationId = correlationId,
+                // Read here rather than passed in, for the same reason the correlation id is
+                // ambient: a parameter added to this method reaches only the call sites somebody
+                // remembered to update, and the ones nobody remembers are exactly the ones that are
+                // hard to trace afterwards. Null when nothing is scheduling from inside a request.
+                TraceParent = SubscriptionWorkActivity.CurrentTraceParent()
             },
             cancellationToken);
 

--- a/server/XUnitTest/Subscription/SubscriptionWorkDispatcherTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionWorkDispatcherTests.cs
@@ -534,6 +534,100 @@ public sealed class SubscriptionWorkDispatcherTests
         _handler.ObservedActivity.Should().BeNull();
     }
 
+    [Fact]
+    public async Task An_attempt_links_back_to_the_request_that_scheduled_it()
+    {
+        using var recorder = new ActivityRecorder(SubscriptionWorkActivity.SourceName);
+        using var source = new ActivitySource("test.scheduling");
+        using var listener = new ActivityRecorder(source.Name);
+
+        // The request ends before the work runs, which is the whole point of the feature: the
+        // scheduling call returned to the customer, and a worker picks the item up later — a month
+        // later, for a renewal. Nothing of it survives but the header stored on the item.
+        string traceParent;
+        ActivityTraceId requestTrace;
+
+        using (var request = source.StartActivity("POST /subscriptions", ActivityKind.Server))
+        {
+            traceParent = request!.Id!;
+            requestTrace = request.TraceId;
+        }
+
+        var work = Work();
+        work.TraceParent = traceParent;
+        _claimed.Add(work);
+
+        await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        var span = recorder.Stopped.Should().ContainSingle().Subject;
+
+        // Linked, not parented: a span that made itself a child would put this attempt inside a
+        // trace that started a month ago and has long since aged out of the backend.
+        span.TraceId.Should().NotBe(requestTrace);
+        span.Parent.Should().BeNull();
+        span.Links.Should().ContainSingle().Which.Context.TraceId.Should().Be(requestTrace);
+
+        // Repeated as a tag and on the log scope, so joining the two sides never depends on the
+        // trace backend rendering links.
+        span.GetTagItem("subscription.scheduled_by.trace_id")
+            .Should().Be(requestTrace.ToString());
+    }
+
+    [Fact]
+    public async Task Dispatching_from_inside_a_request_still_joins_that_request_s_trace()
+    {
+        using var recorder = new ActivityRecorder(SubscriptionWorkActivity.SourceName);
+        using var source = new ActivitySource("test.scheduling");
+        using var listener = new ActivityRecorder(source.Name);
+
+        // The admin path: due jobs run on demand from an endpoint rather than by the worker loop.
+        // No parent is forced, so the attempt belongs to the request that asked for it — which is
+        // what somebody watching that request wants to see.
+        using var request = source.StartActivity("POST /background-work/run", ActivityKind.Server);
+
+        _claimed.Add(Work());
+
+        await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        recorder.Stopped.Should().ContainSingle().Which
+            .TraceId.Should().Be(request!.TraceId);
+    }
+
+    [Fact]
+    public async Task An_attempt_nobody_scheduled_from_a_request_carries_no_link()
+    {
+        using var recorder = new ActivityRecorder(SubscriptionWorkActivity.SourceName);
+        // What the sweep produces: no trace context stored, so there is nothing to link to.
+        _claimed.Add(Work());
+
+        await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        var span = recorder.Stopped.Should().ContainSingle().Subject;
+        span.Links.Should().BeEmpty();
+        span.GetTagItem("subscription.scheduled_by.trace_id").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("not-a-traceparent")]
+    [InlineData("00-tooshort-0000000000000001-01")]
+    [InlineData("")]
+    public async Task A_stored_trace_context_that_does_not_parse_is_treated_as_absent(
+        string traceParent)
+    {
+        using var recorder = new ActivityRecorder(SubscriptionWorkActivity.SourceName);
+        var work = Work();
+        work.TraceParent = traceParent;
+        _claimed.Add(work);
+
+        var processed = await Dispatcher().ProcessDueAsync("worker-1", default);
+
+        // The work still runs. A renewal that refused to start because a diagnostic header was
+        // malformed would be money not collected over a trace nobody was looking at.
+        processed.Should().Be(1);
+        _handler.Executions.Should().ContainSingle();
+        recorder.Stopped.Should().ContainSingle().Which.Links.Should().BeEmpty();
+    }
+
     /// <summary>
     /// Collects the spans one source produces while a test runs.
     /// </summary>

--- a/server/XUnitTest/Subscription/SubscriptionWorkSchedulerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionWorkSchedulerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -167,6 +168,58 @@ public sealed class SubscriptionWorkSchedulerTests
                 "corr-1");
 
         _scheduled.Should().ContainSingle().Which.MaxAttempts.Should().Be(9);
+    }
+
+    [Fact]
+    public async Task Work_scheduled_inside_a_request_remembers_the_trace_it_was_asked_for_under()
+    {
+        using var source = new ActivitySource("test.scheduling");
+        using var listener = Listening(source.Name);
+        using var request = source.StartActivity("POST /subscriptions", ActivityKind.Server);
+
+        await Scheduler().ScheduleAsync(
+            SubscriptionWorkType.Renewal,
+            TenantId,
+            "renewal:M20261001T000000Z",
+            _time.GetUtcNow().UtcDateTime,
+            "corr-1");
+
+        // Stored so the attempt can link back to this request a month from now. Parsed rather than
+        // string-compared, because what matters is that it resolves to this request's trace.
+        var stored = _scheduled.Should().ContainSingle().Subject.TraceParent;
+        SubscriptionWorkActivity.SchedulingContext(stored)!.Value.TraceId
+            .Should().Be(request!.TraceId);
+    }
+
+    [Fact]
+    public async Task Work_scheduled_outside_a_request_stores_no_trace_context()
+    {
+        // The sweep's ordinary case: nothing scheduled it from inside a request, so there is no
+        // trace to remember and a fabricated one would link an attempt to nothing.
+        await Scheduler().ScheduleAsync(
+            SubscriptionWorkType.Renewal,
+            TenantId,
+            "renewal:M20261001T000000Z",
+            _time.GetUtcNow().UtcDateTime,
+            "corr-1");
+
+        _scheduled.Should().ContainSingle().Which.TraceParent.Should().BeNull();
+    }
+
+    private static ActivityListener Listening(string sourceName)
+    {
+        // Without one, StartActivity returns null and there is no request to have been scheduled
+        // from — the condition the second test above is about, not the first.
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == sourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        return listener;
     }
 
     private SubscriptionWorkScheduler Scheduler(SubscriptionOptions? options = null) => new(


### PR DESCRIPTION
Part B, following #413 (Part A, merged). `dev` is merged in, so this is verified against what will actually land.

## What Part A left open

Part A gave background work a trace id of its own. It said nothing about where the work came from: an attempt and the checkout that caused it were two unrelated traces, joined only by a correlation id an operator had to know to look for.

## What this does

Work scheduled from inside a request stores that request's W3C trace context on the queue item (`SubscriptionBackgroundWork.TraceParent`). When the attempt eventually runs, it reports it three ways:

| Where | What |
|---|---|
| Span link | `ActivityLink` to the scheduling trace |
| Span tag | `subscription.scheduled_by.trace_id` |
| Log scope | `ScheduledByTraceId` on every line of the attempt |

The link is the correct expression of it. The other two are there because joining the two sides must not depend on the trace backend rendering links — and because a log query is what an operator reaches for first. Given this platform stores logs and spans in separate MongoDB collections, that redundancy is doing real work.

## Link, not parent

Passing the stored context as a parent is the obvious move and is wrong here. **A renewal is scheduled a month before it runs and a cancellation up to a year.** An attempt that made itself a child of the scheduling request would describe one trace as lasting a year — past every backend's retention window, and not something anybody can open. The link says the same causal thing without lying about duration.

## No parent is forced either

This one came out of a failing test rather than a design session, and it changed the design.

`StartActivity(name, kind, default(ActivityContext), links:)` falls back to `Activity.Current` rather than forcing a root — my first test asserted root-ness and failed. That turned out to be the behaviour you want: `SubscriptionBackgroundWorkController` runs due jobs on demand, and an attempt dispatched from that endpoint **should** belong to that request's trace. Forcing a root would have hidden it from whoever asked for it.

So: the worker loop has no ambient activity and its attempts are root spans carrying a link; the admin path joins the request that triggered it. Both are covered by tests.

## Compatibility

`TraceParent` is nullable and left null by everything scheduling outside a request — the repair sweep among them, which mints its own correlation precisely because there is no caller to inherit from. Items queued before the field existed keep deserializing (`[BsonIgnoreExtraElements]`, nullable field).

Anything stored that does not parse is treated as absent. A renewal that refused to start because a diagnostic header was malformed would be money not collected over a trace nobody was looking at.

## Verification

Against `dev` merged in, so this is the code that will land:

- `dotnet build` Subscription.DomainService and Worker → **0 errors**
- `dotnet test --filter "XUnitTest.Subscription|XUnitTest.Payment"` → **3,025 passed, 4 failed**

The 4 are the pre-existing `SubscriptionSimulation*` permission failures, unrelated and present on clean `dev`.

Seven new tests:

**Scheduler** — work scheduled inside a request stores context resolving to that request's trace; work scheduled outside one stores null.

**Dispatcher** — an attempt links back to a request that has already ended (the real flow: request returns, work runs a month later); an attempt nobody scheduled from a request carries no link; dispatching from inside a request joins that request's trace; and a malformed stored header is treated as absent **while the work still runs** — asserted three ways via `[Theory]`.

## Not in this PR

`PaymentBackgroundWorkDispatcher` still has the Part A gap and would need both parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
