### PR TITLE
Add doc-to-PDF conversion and make the PDF worker pipeline reachable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,8 @@ results/
 QWEN.md
 .clinerules
 .windsurfrules
+
+# Aspose.Words licence. A purchased credential that Aspose marks "not redistributable", so it is
+# supplied per environment (Aspose:LicenseBase64 / Aspose:LicensePath, or dropped in the project
+# directory for local runs) rather than committed. Without it Aspose output is watermarked.
+Aspose.Words.lic

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -49,6 +49,12 @@ ENV DOTNET_ENVIRONMENT=Production \
 # the binary under both `chromium` and `chromium-browser` across versions, so the symlink below
 # normalises whichever this base image's Alpine actually installed into one path the app's own
 # config always points at, rather than the Dockerfile guessing a version-specific name.
+#
+# ttf-liberation backs Aspose's document-to-PDF conversion. Liberation Sans/Serif/Mono are
+# metric-compatible with Arial, Times New Roman and Courier New, which is what almost every Word
+# document asks for. Aspose substitutes silently when a font is missing, so without these a
+# converted document still renders — just with different line breaks and a different page count
+# than the author saw, which is the kind of wrong that survives review.
 RUN apk add --no-cache \
         icu-libs \
         tzdata \
@@ -58,6 +64,7 @@ RUN apk add --no-cache \
         harfbuzz \
         ca-certificates \
         ttf-freefont \
+        ttf-liberation \
     && CHROMIUM_BIN="$(command -v chromium || command -v chromium-browser)" \
     && ln -sf "$CHROMIUM_BIN" /usr/local/bin/chromium-browser
 

--- a/server/Api/Api.csproj
+++ b/server/Api/Api.csproj
@@ -44,4 +44,12 @@
     <ProjectReference Include="..\Subscription.DomainService\Subscription.DomainService.csproj" />
     <!--<ProjectReference Include="..\Notification.DomainService\Notification.DomainService.csproj" />-->
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- The Aspose.Words licence, when this environment has one. Gitignored and supplied per
+         environment, so the Exists condition keeps a checkout without it building normally; the
+         process then runs Aspose unlicensed and says so in its startup log. Production supplies it
+         through Aspose:LicenseBase64 instead of this file. -->
+    <None Include="Aspose.Words.lic" Condition="Exists('Aspose.Words.lic')" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -461,6 +461,31 @@
             </remarks>
             <returns>StampIntoPdfResponse</returns>
         </member>
+        <member name="M:Api.Controllers.PdfGeneratorController.ConvertDocumentsToPdf(Utility.DomainService.PdfGenerator.ConvertDocumentsToPdfRequest)">
+             <summary>
+             Convert word-processing documents (.doc, .docx, .rtf, .odt, ...) to PDF
+             </summary>
+             <remarks>
+             <param name="request"></param> Request parameters:
+            
+             MessageCoRelationId: Unique identifier for specific request
+             EventReferenceData: Set of values stored on data fields related to a specific event
+             ConvertCommands: Documents to convert. Each command carries:
+               DocumentFileId / DocumentFileName: Source file in storage. The extension decides
+                 whether the file can be read, so the name must include one.
+               OutputPdfFileId / OutputPdfFileName: Destination. The source name with a .pdf
+                 extension is used when OutputPdfFileName is omitted.
+               PreserveFormFields: Keep interactive form fields editable instead of flattening them.
+               PdfACompliant: Emit PDF/A-1b for archival. Forces font embedding and flattens fields.
+               UpdateFields: Recalculate page numbers, cross-references and TOC entries first.
+             ProjectKey: Project key for multi-tenancy
+            
+             Conversion uses Aspose.Words and does not take an Engine number: it is the only library
+             here that reads Word formats. The source file is left in place; the PDF is written to
+             OutputPdfFileId.
+             </remarks>
+             <returns>ConvertDocumentsToPdfResponse</returns>
+        </member>
         <member name="M:Api.Controllers.SequenceController.#ctor(Utility.DomainService.Sequence.service.ISequenceService)">
             <summary>
             Initializes a new instance of the <see cref="T:Api.Controllers.SequenceController"/> class.

--- a/server/Api/Controllers/PdfGeneratorController.cs
+++ b/server/Api/Controllers/PdfGeneratorController.cs
@@ -198,5 +198,35 @@ namespace Api.Controllers
         {
             return await _pdfGeneratorService.StampIntoPdfAsync(request);
         }
+
+        /// <summary>
+        /// Convert word-processing documents (.doc, .docx, .rtf, .odt, ...) to PDF
+        /// </summary>
+        /// <remarks>
+        /// <param name="request"></param> Request parameters:
+        ///
+        /// MessageCoRelationId: Unique identifier for specific request
+        /// EventReferenceData: Set of values stored on data fields related to a specific event
+        /// ConvertCommands: Documents to convert. Each command carries:
+        ///   DocumentFileId / DocumentFileName: Source file in storage. The extension decides
+        ///     whether the file can be read, so the name must include one.
+        ///   OutputPdfFileId / OutputPdfFileName: Destination. The source name with a .pdf
+        ///     extension is used when OutputPdfFileName is omitted.
+        ///   PreserveFormFields: Keep interactive form fields editable instead of flattening them.
+        ///   PdfACompliant: Emit PDF/A-1b for archival. Forces font embedding and flattens fields.
+        ///   UpdateFields: Recalculate page numbers, cross-references and TOC entries first.
+        /// ProjectKey: Project key for multi-tenancy
+        ///
+        /// Conversion uses Aspose.Words and does not take an Engine number: it is the only library
+        /// here that reads Word formats. The source file is left in place; the PDF is written to
+        /// OutputPdfFileId.
+        /// </remarks>
+        /// <returns>ConvertDocumentsToPdfResponse</returns>
+        [HttpPost]
+        [Authorize]
+        public async Task<ConvertDocumentsToPdfResponse> ConvertDocumentsToPdf([FromBody] ConvertDocumentsToPdfRequest request)
+        {
+            return await _pdfGeneratorService.ConvertDocumentsToPdfAsync(request);
+        }
     }
 }

--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
-    <PackageVersion Include="Aspose.Words" Version="20.2.0" />
+    <PackageVersion Include="Aspose.Words" Version="25.6.0" />
     <PackageVersion Include="DotLiquid" Version="2.2.692" />
     <PackageVersion Include="iTextSharp.LGPLv2.Core" Version="1.7.5" />
     <PackageVersion Include="PdfPig" Version="0.1.5" />

--- a/server/Utility.DomainService/PdfGenerator/ConvertDocumentsToPdfRequest.cs
+++ b/server/Utility.DomainService/PdfGenerator/ConvertDocumentsToPdfRequest.cs
@@ -1,0 +1,67 @@
+using Blocks.Genesis;
+
+namespace Utility.DomainService.PdfGenerator
+{
+    /// <summary>
+    /// Request to convert word-processing documents (.doc, .docx, .rtf, .odt, ...) to PDF
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class ConvertDocumentsToPdfRequest : IProjectKey
+    {
+        public string? ProjectKey { get; set; }
+        public string MessageCoRelationId { get; set; } = string.Empty;
+        public Dictionary<string, string>? EventReferenceData { get; set; }
+        public List<ConvertDocumentToPdfCommand> ConvertCommands { get; set; } = new();
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class ConvertDocumentToPdfCommand
+    {
+        /// <summary>
+        /// Storage file ID of the source document.
+        /// </summary>
+        public string DocumentFileId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Source file name including its extension. The extension is how the converter decides
+        /// whether it can read the file, so a name without one is rejected before the download.
+        /// </summary>
+        public string DocumentFileName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Storage file ID to write the converted PDF to.
+        /// </summary>
+        public string OutputPdfFileId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Name for the converted PDF. When empty, the source name is reused with a .pdf extension.
+        /// </summary>
+        public string? OutputPdfFileName { get; set; }
+
+        /// <summary>
+        /// Keeps interactive form fields editable in the PDF instead of flattening them.
+        /// </summary>
+        public bool PreserveFormFields { get; set; }
+
+        /// <summary>
+        /// Produces a PDF/A-1b file for archival. Forces full font embedding and flattens form
+        /// fields, both of which the standard requires.
+        /// </summary>
+        public bool PdfACompliant { get; set; }
+
+        /// <summary>
+        /// Recalculates page numbers, cross-references and table-of-contents entries before
+        /// rendering.
+        /// </summary>
+        public bool UpdateFields { get; set; }
+
+        public bool OpenInBrowser { get; set; }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class ConvertDocumentsToPdfResponse : BaseResponse
+    {
+        public string MessageCoRelationId { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Events/PdfGeneratorEvents.cs
+++ b/server/Utility.DomainService/PdfGenerator/Events/PdfGeneratorEvents.cs
@@ -1,4 +1,4 @@
-namespace Utility.DomainService.PdfGenerator.Events
+﻿namespace Utility.DomainService.PdfGenerator.Events
 {
     /// <summary>
     /// Event for merging PDFs
@@ -132,5 +132,16 @@ namespace Utility.DomainService.PdfGenerator.Events
         public bool OpenInBrowser { get; set; } = false;
         public string? ProjectKey { get; set; }
     }
-}
 
+    /// <summary>
+    /// Event for converting word-processing documents to PDF
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public record ConvertDocumentsToPdfEvent
+    {
+        public string MessageCoRelationId { get; set; } = string.Empty;
+        public Dictionary<string, string>? EventReferenceData { get; set; }
+        public List<ConvertDocumentToPdfCommand> ConvertCommands { get; set; } = new();
+        public string? ProjectKey { get; set; }
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Utilities/PdfGeneratorConstants.cs
+++ b/server/Utility.DomainService/PdfGenerator/Utilities/PdfGeneratorConstants.cs
@@ -16,6 +16,7 @@ namespace Utility.DomainService.PdfGenerator.Utilities
         public const string StampImageToPdfQueue = "blocks_pdf_stamp_image_listener";
         public const string StampTextToPdfQueue = "blocks_pdf_stamp_text_listener";
         public const string StampIntoPdfQueue = "blocks_pdf_stamp_listener";
+        public const string ConvertDocumentsToPdfQueue = "blocks_pdf_convert_document_listener";
 
         public static MessageConfiguration GetMessageConfiguration(string messageConnectionString)
         {
@@ -29,7 +30,8 @@ namespace Utility.DomainService.PdfGenerator.Utilities
                 FixPdfsQueue,
                 StampImageToPdfQueue,
                 StampTextToPdfQueue,
-                StampIntoPdfQueue
+                StampIntoPdfQueue,
+                ConvertDocumentsToPdfQueue
             );
         }
     }

--- a/server/Utility.DomainService/PdfGenerator/service/AsposeDocumentToPdfConverter.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/AsposeDocumentToPdfConverter.cs
@@ -1,0 +1,219 @@
+using Aspose.Words;
+using Aspose.Words.Fonts;
+using Aspose.Words.Saving;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Utility.DomainService.PdfGenerator.service
+{
+    /// <summary>
+    /// Converts word-processing documents to PDF with Aspose.Words.
+    /// </summary>
+    /// <remarks>
+    /// Aspose is the only library in this solution that reads the binary .doc format and Word's
+    /// layout model, which is what makes a converted document paginate the way the author saw it.
+    /// The alternative considered was rendering via HTML through the Puppeteer engine; that loses
+    /// pagination, headers/footers and form fields, so it is not a substitute here.
+    ///
+    /// The type is a singleton and holds no per-conversion state: every <c>Document</c> is local to
+    /// the call, so concurrent conversions do not interact.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class AsposeDocumentToPdfConverter : IDocumentToPdfConverter
+    {
+        /// <summary>
+        /// Extensions Aspose.Words reads. Kept explicit rather than "anything that is not a PDF" so
+        /// a caller that points at a spreadsheet or an image gets a clear rejection before the file
+        /// is downloaded and handed to a parser that would fail on it in a less obvious way.
+        /// </summary>
+        private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".doc", ".docx", ".docm", ".dot", ".dotx", ".dotm",
+            ".rtf", ".odt", ".ott", ".txt", ".md", ".html", ".htm", ".mhtml"
+        };
+
+        /// <summary>
+        /// Font directories searched in addition to the ones Aspose finds itself. A Linux container
+        /// has no Word fonts, and Aspose silently substitutes a default face when a requested font
+        /// is missing, which shifts line breaks and repaginates the document. Listing the image's
+        /// own font locations lets the substitution at least land on a metric-compatible face.
+        /// </summary>
+        private static readonly string[] FontDirectories =
+        {
+            "/app/fonts",
+            "/usr/share/fonts",
+            "/usr/local/share/fonts"
+        };
+
+        private readonly ILogger<AsposeDocumentToPdfConverter> _logger;
+        private readonly IConfiguration _configuration;
+        private int _fontsConfigured;
+
+        public AsposeDocumentToPdfConverter(
+            ILogger<AsposeDocumentToPdfConverter> logger,
+            IConfiguration configuration)
+        {
+            _logger = logger;
+            _configuration = configuration;
+        }
+
+        /// <inheritdoc />
+        public bool IsSupportedDocument(string fileName)
+        {
+            if (string.IsNullOrWhiteSpace(fileName))
+            {
+                return false;
+            }
+
+            return SupportedExtensions.Contains(Path.GetExtension(fileName));
+        }
+
+        /// <inheritdoc />
+        public async Task<Stream?> ConvertToPdfAsync(Stream documentStream, DocumentConversionOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(documentStream);
+            ArgumentNullException.ThrowIfNull(options);
+
+            try
+            {
+                AsposeLicense.EnsureApplied(_configuration, _logger);
+                ConfigureFontSources();
+
+                // Aspose needs a seekable stream it can read repeatedly; a storage download stream
+                // is typically neither. Buffering once here is cheaper than letting the parser fail
+                // partway through a document it cannot rewind.
+                using var buffered = new MemoryStream();
+                if (documentStream.CanSeek)
+                {
+                    documentStream.Position = 0;
+                }
+
+                await documentStream.CopyToAsync(buffered);
+                buffered.Position = 0;
+
+                if (buffered.Length == 0)
+                {
+                    _logger.LogError("AsposeDocumentToPdfConverter: Source document is empty");
+                    return null;
+                }
+
+                var document = new Document(buffered);
+
+                // Aspose reports substituted fonts and unsupported features through this callback
+                // rather than by failing, so without it a document that rendered wrongly is
+                // indistinguishable from one that rendered correctly.
+                var warnings = new WarningInfoCollection();
+                document.WarningCallback = warnings;
+
+                var saveOptions = BuildSaveOptions(options);
+
+                var outputStream = new MemoryStream();
+                document.Save(outputStream, saveOptions);
+                outputStream.Position = 0;
+
+                foreach (WarningInfo warning in warnings)
+                {
+                    _logger.LogWarning(
+                        "AsposeDocumentToPdfConverter: {Source}/{Type} - {Description}",
+                        warning.Source,
+                        warning.WarningType,
+                        warning.Description);
+                }
+
+                if (outputStream.Length == 0)
+                {
+                    _logger.LogError("AsposeDocumentToPdfConverter: Conversion produced an empty PDF");
+                    await outputStream.DisposeAsync();
+                    return null;
+                }
+
+                _logger.LogInformation(
+                    "AsposeDocumentToPdfConverter: Converted document to PDF, pages={PageCount}, size={PdfSize} bytes, licensed={IsLicensed}",
+                    document.PageCount,
+                    outputStream.Length,
+                    AsposeLicense.IsLicensed);
+
+                return outputStream;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AsposeDocumentToPdfConverter: Error converting document to PDF");
+                return null;
+            }
+        }
+
+        private static PdfSaveOptions BuildSaveOptions(DocumentConversionOptions options)
+        {
+            var saveOptions = new PdfSaveOptions
+            {
+                SaveFormat = SaveFormat.Pdf,
+                PreserveFormFields = options.PreserveFormFields,
+                EmbedFullFonts = options.EmbedFullFonts,
+                UpdateFields = options.UpdateFields,
+                ImageCompression = options.CompressImages
+                    ? PdfImageCompression.Jpeg
+                    : PdfImageCompression.Auto
+            };
+
+            if (options.PdfACompliant)
+            {
+                saveOptions.Compliance = PdfCompliance.PdfA1b;
+
+                // PDF/A requires every glyph the file can display to be embedded, and forbids the
+                // form-field dictionaries PreserveFormFields would emit. Setting the compliance
+                // level without these produces a file that claims PDF/A and fails validation.
+                saveOptions.EmbedFullFonts = true;
+                saveOptions.PreserveFormFields = false;
+            }
+
+            return saveOptions;
+        }
+
+        /// <summary>
+        /// Adds this host's font directories to Aspose's search path, once per process.
+        /// </summary>
+        /// <remarks>
+        /// <c>FontSettings.DefaultInstance</c> is process-global mutable state, so doing this per
+        /// conversion would append the same sources repeatedly and race with a concurrent
+        /// conversion reading them. The interlocked flag makes the first caller do it and everyone
+        /// else skip.
+        /// </remarks>
+        private void ConfigureFontSources()
+        {
+            if (Interlocked.Exchange(ref _fontsConfigured, 1) == 1)
+            {
+                return;
+            }
+
+            try
+            {
+                var existing = FontSettings.DefaultInstance.GetFontsSources();
+                var additional = FontDirectories
+                    .Where(Directory.Exists)
+                    .Select(directory => new FolderFontSource(directory, true))
+                    .Cast<FontSourceBase>()
+                    .ToArray();
+
+                if (additional.Length == 0)
+                {
+                    _logger.LogInformation(
+                        "AsposeDocumentToPdfConverter: No additional font directories found; using Aspose defaults");
+                    return;
+                }
+
+                FontSettings.DefaultInstance.SetFontsSources(existing.Concat(additional).ToArray());
+
+                _logger.LogInformation(
+                    "AsposeDocumentToPdfConverter: Added {Count} font source(s): {Directories}",
+                    additional.Length,
+                    string.Join(", ", FontDirectories.Where(Directory.Exists)));
+            }
+            catch (Exception ex)
+            {
+                // Font discovery failing degrades output quality but does not stop a conversion, so
+                // it must not stop one.
+                _logger.LogWarning(ex, "AsposeDocumentToPdfConverter: Failed to configure font sources");
+            }
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/service/AsposeLicense.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/AsposeLicense.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Utility.DomainService.PdfGenerator.service
+{
+    /// <summary>
+    /// Applies the Aspose.Words licence to the process, exactly once.
+    /// </summary>
+    /// <remarks>
+    /// Aspose.Words is licensed per process, not per document: an unlicensed instance renders an
+    /// evaluation watermark onto every page and truncates long documents, so a converter that skips
+    /// this produces output that looks plausible in a test and is unusable for a customer. The
+    /// licence is read from configuration rather than committed, because it is a purchased
+    /// credential — the repository's secret scan would flag it and Aspose's own terms mark it "not
+    /// redistributable".
+    ///
+    /// Three sources are tried in order, so a container can supply the licence as an environment
+    /// variable while a developer machine keeps a file on disk:
+    /// <list type="number">
+    ///   <item><c>Aspose:LicenseBase64</c> — the .lic file's bytes, base64 encoded.</item>
+    ///   <item><c>Aspose:LicensePath</c> — an absolute or relative path to the .lic file.</item>
+    ///   <item><c>Aspose.Words.lic</c> beside the running assembly.</item>
+    /// </list>
+    ///
+    /// A missing licence is deliberately not fatal. The process still starts and every other feature
+    /// keeps working; only Aspose-backed output is watermarked, and the warning below says so
+    /// plainly rather than letting the watermark be discovered by a customer.
+    /// </remarks>
+    public static class AsposeLicense
+    {
+        private const string LicenseFileName = "Aspose.Words.lic";
+
+        private static readonly object Gate = new();
+        private static bool _attempted;
+
+        /// <summary>
+        /// True when a licence was found and accepted by Aspose. False means the process is in
+        /// evaluation mode and Aspose output carries a watermark.
+        /// </summary>
+        public static bool IsLicensed { get; private set; }
+
+        /// <summary>
+        /// Applies the licence if it has not been applied already. Safe to call from every
+        /// conversion; only the first call does any work.
+        /// </summary>
+        public static void EnsureApplied(IConfiguration configuration, ILogger logger)
+        {
+            if (_attempted)
+            {
+                return;
+            }
+
+            lock (Gate)
+            {
+                if (_attempted)
+                {
+                    return;
+                }
+
+                _attempted = true;
+                IsLicensed = TryApply(configuration, logger);
+            }
+        }
+
+        private static bool TryApply(IConfiguration configuration, ILogger logger)
+        {
+            try
+            {
+                var license = new Aspose.Words.License();
+
+                var base64 = configuration["Aspose:LicenseBase64"];
+                if (!string.IsNullOrWhiteSpace(base64))
+                {
+                    using var stream = new MemoryStream(Convert.FromBase64String(base64));
+                    license.SetLicense(stream);
+                    logger.LogInformation("AsposeLicense: Applied licence from Aspose:LicenseBase64");
+                    return true;
+                }
+
+                var configuredPath = configuration["Aspose:LicensePath"];
+                if (!string.IsNullOrWhiteSpace(configuredPath) && File.Exists(configuredPath))
+                {
+                    license.SetLicense(configuredPath);
+                    logger.LogInformation("AsposeLicense: Applied licence from {LicensePath}", configuredPath);
+                    return true;
+                }
+
+                var localPath = Path.Combine(AppContext.BaseDirectory, LicenseFileName);
+                if (File.Exists(localPath))
+                {
+                    license.SetLicense(localPath);
+                    logger.LogInformation("AsposeLicense: Applied licence from {LicensePath}", localPath);
+                    return true;
+                }
+
+                logger.LogWarning(
+                    "AsposeLicense: No Aspose licence found (checked Aspose:LicenseBase64, Aspose:LicensePath and {LocalPath}). "
+                        + "Aspose output will carry an evaluation watermark and long documents will be truncated.",
+                    localPath);
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                // The most common cause is a licence whose subscription expired before this
+                // Aspose.Words release was published — Aspose rejects the pairing rather than
+                // falling back — so the version is logged alongside the failure.
+                logger.LogError(
+                    ex,
+                    "AsposeLicense: Failed to apply the Aspose licence. Output will carry an evaluation watermark. "
+                        + "If this is a subscription-expiry error, the installed Aspose.Words version is newer than the licence allows.");
+
+                return false;
+            }
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/service/AsposePdfEngine.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/AsposePdfEngine.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using PdfSharp.Pdf;
 using PdfSharp.Pdf.IO;
@@ -16,10 +17,12 @@ namespace Utility.DomainService.PdfGenerator.service
     public class AsposePdfEngine : IPdfEngine
     {
         private readonly ILogger<AsposePdfEngine> _logger;
+        private readonly IConfiguration _configuration;
 
-        public AsposePdfEngine(ILogger<AsposePdfEngine> logger)
+        public AsposePdfEngine(ILogger<AsposePdfEngine> logger, IConfiguration configuration)
         {
             _logger = logger;
+            _configuration = configuration;
         }
 
         public async Task<Stream?> MergePdfsAsync(List<Stream> pdfStreams)
@@ -98,12 +101,18 @@ namespace Utility.DomainService.PdfGenerator.service
             try
             {
                 _logger.LogInformation("AsposePdfEngine: Converting HTML to PDF using Aspose.Words");
-                
-                var htmlLoadOptions = new Aspose.Words.HtmlLoadOptions
+
+                // Aspose is licensed per process and watermarks every page without one, so this has
+                // to happen before the first Document is constructed, not just before the save.
+                AsposeLicense.EnsureApplied(_configuration, _logger);
+
+                // HtmlLoadOptions lives under Aspose.Words.Loading; the unqualified
+                // Aspose.Words.HtmlLoadOptions this used was an alias that no longer exists.
+                var htmlLoadOptions = new Aspose.Words.Loading.HtmlLoadOptions
                 {
                     LoadFormat = Aspose.Words.LoadFormat.Html
                 };
-                
+
                 var htmlBytes = Encoding.UTF8.GetBytes(htmlContent);
                 using (var htmlMemoryStream = new MemoryStream(htmlBytes))
                 {

--- a/server/Utility.DomainService/PdfGenerator/service/IDocumentToPdfConverter.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/IDocumentToPdfConverter.cs
@@ -1,0 +1,62 @@
+namespace Utility.DomainService.PdfGenerator.service
+{
+    /// <summary>
+    /// Converts word-processing documents (.doc, .docx, .rtf, .odt, ...) to PDF.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not part of <see cref="IPdfEngine"/>. Three of the four engines have no
+    /// word-processing format support at all, so folding this in would mean three more methods that
+    /// log a warning and return null, and would let a caller pick an engine number that silently
+    /// cannot do the job. A caller that wants a document converted asks for a converter.
+    /// </remarks>
+    public interface IDocumentToPdfConverter
+    {
+        /// <summary>
+        /// Reads a word-processing document from <paramref name="documentStream"/> and returns it as
+        /// a PDF stream positioned at zero, or null if the conversion failed.
+        /// </summary>
+        Task<Stream?> ConvertToPdfAsync(Stream documentStream, DocumentConversionOptions options);
+
+        /// <summary>
+        /// True when <paramref name="fileName"/> has an extension this converter can read.
+        /// </summary>
+        bool IsSupportedDocument(string fileName);
+    }
+
+    /// <summary>
+    /// Options controlling how a document is rendered to PDF.
+    /// </summary>
+    public class DocumentConversionOptions
+    {
+        /// <summary>
+        /// Keeps interactive form fields as PDF form fields instead of flattening them to static
+        /// text. Off by default: a converted document is normally an archival or signing artefact,
+        /// where a reader being able to edit the fields is a hazard rather than a feature.
+        /// </summary>
+        public bool PreserveFormFields { get; set; }
+
+        /// <summary>
+        /// Embeds complete font files rather than the used-glyphs subset. Larger output, but the
+        /// only way a downstream tool that re-renders or edits the PDF gets the whole typeface.
+        /// </summary>
+        public bool EmbedFullFonts { get; set; } = true;
+
+        /// <summary>
+        /// Recalculates fields (page counts, cross-references, TOC entries) before rendering.
+        /// Off by default, matching the platform's existing conversion behaviour: a document whose
+        /// fields reference an external source updates to whatever this process can see, which for
+        /// a document being archived is a change nobody asked for.
+        /// </summary>
+        public bool UpdateFields { get; set; }
+
+        /// <summary>
+        /// JPEG-compresses images in the output. Off keeps images lossless at the cost of size.
+        /// </summary>
+        public bool CompressImages { get; set; } = true;
+
+        /// <summary>
+        /// Renders to PDF/A-1b instead of plain PDF, for documents that must be archivable.
+        /// </summary>
+        public bool PdfACompliant { get; set; }
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorNotificationService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorNotificationService.cs
@@ -14,6 +14,7 @@ namespace Utility.DomainService.PdfGenerator.service
         Task NotifyStampImageToPdfEvent(bool success, string outputPdfFileId, string messageCoRelationId, string? projectKey);
         Task NotifyStampTextToPdfEvent(bool success, string outputPdfFileId, string messageCoRelationId, string? projectKey);
         Task NotifyStampIntoPdfEvent(bool success, string outputPdfFileId, string messageCoRelationId, string? projectKey);
+        Task NotifyConvertDocumentsToPdfEvent(bool success, string messageCoRelationId, string? projectKey, int successCount, int failureCount);
     }
 }
 

--- a/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorService.cs
@@ -25,6 +25,9 @@ namespace Utility.DomainService.PdfGenerator.service
         Task<StampImageToPdfResponse> StampImageToPdfAsync(StampImageToPdfRequest request);
         Task<StampTextToPdfResponse> StampTextToPdfAsync(StampTextToPdfRequest request);
         Task<StampIntoPdfResponse> StampIntoPdfAsync(StampIntoPdfRequest request);
+
+        // Document conversion operations
+        Task<ConvertDocumentsToPdfResponse> ConvertDocumentsToPdfAsync(ConvertDocumentsToPdfRequest request);
     }
 }
 

--- a/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
@@ -135,6 +135,18 @@ namespace Utility.DomainService.PdfGenerator.service
             });
         }
 
+        public async Task NotifyConvertDocumentsToPdfEvent(bool success, string messageCoRelationId, string? projectKey, int successCount, int failureCount)
+        {
+            _logger.LogInformation("NotifyConvertDocumentsToPdfEvent: Sending notification for messageCoRelationId={MessageCoRelationId}, success={Success}", messageCoRelationId, success);
+
+            await SendNotificationAsync("Convert Documents to PDF", success, messageCoRelationId, new
+            {
+                MessageCoRelationId = messageCoRelationId,
+                SuccessCount = successCount,
+                FailureCount = failureCount
+            });
+        }
+
         private async Task SendNotificationAsync(string title, bool success, string subscriptionFilterId, object additionalData)
         {
             try

--- a/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorService.cs
@@ -1,7 +1,8 @@
-using Blocks.Genesis;
+﻿using Blocks.Genesis;
 using Microsoft.Extensions.Logging;
 using Utility.DomainService.PdfGenerator.Events;
 using Utility.DomainService.PdfGenerator.Utilities;
+using Utility.DomainService.Shared.Utilities;
 
 namespace Utility.DomainService.PdfGenerator.service
 {
@@ -26,12 +27,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("MergePdfsAsync started for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("MergePdfsAsync started for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 // Send event to worker for async processing
                 await SendMergePdfsEvent(request);
 
-                _logger.LogInformation("MergePdfsAsync event sent for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("MergePdfsAsync event sent for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 return new MergePdfsResponse
                 {
@@ -42,7 +43,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in MergePdfsAsync for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogError(ex, "Error in MergePdfsAsync for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
                 return new MergePdfsResponse
                 {
                     IsSuccess = false,
@@ -55,12 +56,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("CreatePdfsFromHtmlAsync started for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("CreatePdfsFromHtmlAsync started for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 // Send event to worker
                 await SendCreatePdfsFromHtmlEvent(request);
 
-                _logger.LogInformation("CreatePdfsFromHtmlAsync event sent for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("CreatePdfsFromHtmlAsync event sent for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 return new CreatePdfsFromHtmlResponse
                 {
@@ -71,7 +72,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in CreatePdfsFromHtmlAsync for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogError(ex, "Error in CreatePdfsFromHtmlAsync for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
                 return new CreatePdfsFromHtmlResponse
                 {
                     IsSuccess = false,
@@ -84,12 +85,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("ExtractTextFromPdfsAsync started for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("ExtractTextFromPdfsAsync started for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 // Send event to worker
                 await SendExtractTextFromPdfsEvent(request);
 
-                _logger.LogInformation("ExtractTextFromPdfsAsync event sent for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("ExtractTextFromPdfsAsync event sent for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 return new ExtractTextFromPdfsResponse
                 {
@@ -100,7 +101,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in ExtractTextFromPdfsAsync for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogError(ex, "Error in ExtractTextFromPdfsAsync for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
                 return new ExtractTextFromPdfsResponse
                 {
                     IsSuccess = false,
@@ -113,12 +114,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("CreatePdfsFromHtmlUsingTEAsync started for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("CreatePdfsFromHtmlUsingTEAsync started for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 // Send event to worker
                 await SendCreatePdfsFromHtmlUsingTEEvent(request);
 
-                _logger.LogInformation("CreatePdfsFromHtmlUsingTEAsync event sent for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("CreatePdfsFromHtmlUsingTEAsync event sent for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 return new CreatePdfsFromHtmlUsingTEResponse
                 {
@@ -129,7 +130,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in CreatePdfsFromHtmlUsingTEAsync for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogError(ex, "Error in CreatePdfsFromHtmlUsingTEAsync for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
                 return new CreatePdfsFromHtmlUsingTEResponse
                 {
                     IsSuccess = false,
@@ -142,12 +143,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("CreatePdfsFromHtmlUsingTEBulkAsync started for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("CreatePdfsFromHtmlUsingTEBulkAsync started for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 // Send event to worker
                 await SendCreatePdfsFromHtmlUsingTEBulkEvent(request);
 
-                _logger.LogInformation("CreatePdfsFromHtmlUsingTEBulkAsync event sent for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("CreatePdfsFromHtmlUsingTEBulkAsync event sent for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 return new CreatePdfsFromHtmlUsingTEBulkResponse
                 {
@@ -158,7 +159,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in CreatePdfsFromHtmlUsingTEBulkAsync for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogError(ex, "Error in CreatePdfsFromHtmlUsingTEBulkAsync for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
                 return new CreatePdfsFromHtmlUsingTEBulkResponse
                 {
                     IsSuccess = false,
@@ -171,7 +172,7 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("FixPdfsAsync started for MessageCorrelationId: {MessageCorrelationId}", request.MessageCorrelationId);
+                _logger.LogInformation("FixPdfsAsync started for MessageCorrelationId: {MessageCorrelationId}", LogSanitizer.Scrub(request.MessageCorrelationId));
 
                 if (request.PdfInfos == null || !request.PdfInfos.Any())
                 {
@@ -185,7 +186,7 @@ namespace Utility.DomainService.PdfGenerator.service
                 // Send event to worker
                 await SendFixPdfsEvent(request);
 
-                _logger.LogInformation("FixPdfsAsync event sent for MessageCorrelationId: {MessageCorrelationId}", request.MessageCorrelationId);
+                _logger.LogInformation("FixPdfsAsync event sent for MessageCorrelationId: {MessageCorrelationId}", LogSanitizer.Scrub(request.MessageCorrelationId));
 
                 return new FixPdfsResponse
                 {
@@ -196,7 +197,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in FixPdfsAsync for MessageCorrelationId: {MessageCorrelationId}", request.MessageCorrelationId);
+                _logger.LogError(ex, "Error in FixPdfsAsync for MessageCorrelationId: {MessageCorrelationId}", LogSanitizer.Scrub(request.MessageCorrelationId));
                 return new FixPdfsResponse
                 {
                     IsSuccess = false,
@@ -209,12 +210,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("StampImageToPdfAsync started for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("StampImageToPdfAsync started for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 // Send event to worker
                 await SendStampImageToPdfEvent(request);
 
-                _logger.LogInformation("StampImageToPdfAsync event sent for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("StampImageToPdfAsync event sent for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 return new StampImageToPdfResponse
                 {
@@ -225,7 +226,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in StampImageToPdfAsync for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogError(ex, "Error in StampImageToPdfAsync for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
                 return new StampImageToPdfResponse
                 {
                     IsSuccess = false,
@@ -238,12 +239,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("StampTextToPdfAsync started for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("StampTextToPdfAsync started for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 // Send event to worker
                 await SendStampTextToPdfEvent(request);
 
-                _logger.LogInformation("StampTextToPdfAsync event sent for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("StampTextToPdfAsync event sent for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 return new StampTextToPdfResponse
                 {
@@ -254,7 +255,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in StampTextToPdfAsync for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogError(ex, "Error in StampTextToPdfAsync for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
                 return new StampTextToPdfResponse
                 {
                     IsSuccess = false,
@@ -267,12 +268,12 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("StampIntoPdfAsync started for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("StampIntoPdfAsync started for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 // Send event to worker
                 await SendStampIntoPdfEvent(request);
 
-                _logger.LogInformation("StampIntoPdfAsync event sent for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogInformation("StampIntoPdfAsync event sent for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
 
                 return new StampIntoPdfResponse
                 {
@@ -283,7 +284,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in StampIntoPdfAsync for OutputPdfFileId: {OutputPdfFileId}", request.OutputPdfFileId);
+                _logger.LogError(ex, "Error in StampIntoPdfAsync for OutputPdfFileId: {OutputPdfFileId}", LogSanitizer.Scrub(request.OutputPdfFileId));
                 return new StampIntoPdfResponse
                 {
                     IsSuccess = false,
@@ -296,7 +297,7 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             try
             {
-                _logger.LogInformation("ConvertDocumentsToPdfAsync started for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("ConvertDocumentsToPdfAsync started for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 if (request.ConvertCommands == null || request.ConvertCommands.Count == 0)
                 {
@@ -310,7 +311,7 @@ namespace Utility.DomainService.PdfGenerator.service
                 // Send event to worker
                 await SendConvertDocumentsToPdfEvent(request);
 
-                _logger.LogInformation("ConvertDocumentsToPdfAsync event sent for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogInformation("ConvertDocumentsToPdfAsync event sent for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
 
                 return new ConvertDocumentsToPdfResponse
                 {
@@ -321,7 +322,7 @@ namespace Utility.DomainService.PdfGenerator.service
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error in ConvertDocumentsToPdfAsync for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                _logger.LogError(ex, "Error in ConvertDocumentsToPdfAsync for MessageCoRelationId: {MessageCoRelationId}", LogSanitizer.Scrub(request.MessageCoRelationId));
                 return new ConvertDocumentsToPdfResponse
                 {
                     IsSuccess = false,

--- a/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorService.cs
@@ -292,6 +292,44 @@ namespace Utility.DomainService.PdfGenerator.service
             }
         }
 
+        public async Task<ConvertDocumentsToPdfResponse> ConvertDocumentsToPdfAsync(ConvertDocumentsToPdfRequest request)
+        {
+            try
+            {
+                _logger.LogInformation("ConvertDocumentsToPdfAsync started for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+
+                if (request.ConvertCommands == null || request.ConvertCommands.Count == 0)
+                {
+                    return new ConvertDocumentsToPdfResponse
+                    {
+                        IsSuccess = false,
+                        Message = "ConvertCommands cannot be null or empty"
+                    };
+                }
+
+                // Send event to worker
+                await SendConvertDocumentsToPdfEvent(request);
+
+                _logger.LogInformation("ConvertDocumentsToPdfAsync event sent for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+
+                return new ConvertDocumentsToPdfResponse
+                {
+                    IsSuccess = true,
+                    MessageCoRelationId = request.MessageCoRelationId,
+                    Message = "Convert documents to PDF request queued successfully"
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in ConvertDocumentsToPdfAsync for MessageCoRelationId: {MessageCoRelationId}", request.MessageCoRelationId);
+                return new ConvertDocumentsToPdfResponse
+                {
+                    IsSuccess = false,
+                    Message = $"Error: {ex.Message}"
+                };
+            }
+        }
+
         #region Private Helper Methods - Send Events
 
         private async Task SendMergePdfsEvent(MergePdfsRequest request)
@@ -466,6 +504,23 @@ namespace Utility.DomainService.PdfGenerator.service
                         Engine = (int)request.Engine,
                         EventReferenceData = request.EventReferenceData,
                         OpenInBrowser = request.OpenInBrowser,
+                        ProjectKey = request.ProjectKey
+                    }
+                }
+            );
+        }
+
+        private async Task SendConvertDocumentsToPdfEvent(ConvertDocumentsToPdfRequest request)
+        {
+            await _messageClient.SendToConsumerAsync(
+                new ConsumerMessage<ConvertDocumentsToPdfEvent>
+                {
+                    ConsumerName = PdfGeneratorConstants.ConvertDocumentsToPdfQueue,
+                    Payload = new ConvertDocumentsToPdfEvent
+                    {
+                        MessageCoRelationId = request.MessageCoRelationId,
+                        EventReferenceData = request.EventReferenceData,
+                        ConvertCommands = request.ConvertCommands,
                         ProjectKey = request.ProjectKey
                     }
                 }

--- a/server/Utility.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Utility.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Blocks.Extension.DependencyInjection;
 using FluentValidation;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Storage.DomainService.Storage;
 using Storage.DomainService.Storage.Validators;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,6 +48,23 @@ namespace DomainService.Utilities
             services.AddSingleton<IPdfGeneratorService, PdfGeneratorService>();
             services.AddSingleton<IPdfGeneratorRepository, PdfGeneratorRepository>();
             services.AddSingleton<IPdfGeneratorNotificationService, PdfGeneratorNotificationService>();
+
+            // PDF engines and the provider that selects between them by engine number. Registered
+            // here rather than in the worker so both hosts resolve the same graph; without these the
+            // PDF consumers cannot be constructed at all and every queued PDF message is dropped.
+            // TryAdd so the Subscription module's own registration of PuppeteerSharpEngine, which
+            // may run either before or after this, does not produce a second browser-owning
+            // singleton.
+            services.TryAddSingleton<PuppeteerSharpEngine>();
+            services.TryAddSingleton<PdfSharpCoreEngine>();
+            services.TryAddSingleton<AsposePdfEngine>();
+            services.TryAddSingleton<WkHtmlToPdfEngine>();
+            services.TryAddSingleton<IPdfEngineProvider, PdfEngineProvider>();
+            services.TryAddSingleton<PdfStorageHelper>();
+
+            // Document conversion. Not an IPdfEngine: Aspose is the only library here that reads
+            // Word formats, so there is nothing to select between.
+            services.TryAddSingleton<IDocumentToPdfConverter, AsposeDocumentToPdfConverter>();
 
             // Magic Link Services
             services.AddSingleton<IMagicLinkService, MagicLinkService>();

--- a/server/Utility.DomainService/Shared/Utilities/LogSanitizer.cs
+++ b/server/Utility.DomainService/Shared/Utilities/LogSanitizer.cs
@@ -1,0 +1,53 @@
+namespace Utility.DomainService.Shared.Utilities
+{
+    /// <summary>
+    /// Makes caller-supplied values safe to write into a log.
+    /// </summary>
+    /// <remarks>
+    /// Correlation IDs and file IDs arrive in a request body and are echoed straight into log
+    /// messages. A value containing a newline splits one log entry into two, so a caller can forge
+    /// entries that appear to come from the service itself — inventing an error that was never
+    /// raised, or hiding a real one under a wall of plausible-looking lines. Structured logging does
+    /// not prevent this: the rendered output a human or a log aggregator reads is still one line of
+    /// text per newline in the value (CWE-117).
+    ///
+    /// Carriage returns and line feeds are removed rather than escaped, so the log keeps one entry
+    /// per event. Remaining control characters are dropped too — a terminal reading the log will
+    /// happily act on an escape sequence embedded in one. The value is truncated as well, because an
+    /// unbounded field is a cheap way to flood log storage.
+    /// </remarks>
+    public static class LogSanitizer
+    {
+        /// <summary>
+        /// Longest sanitized value written to a log. Comfortably longer than the GUIDs and
+        /// correlation IDs this is used for, so a legitimate value is never cut.
+        /// </summary>
+        private const int MaxLength = 200;
+
+        /// <summary>
+        /// Returns <paramref name="value"/> with newlines and other control characters removed and
+        /// its length capped, ready to be logged.
+        /// </summary>
+        public static string Scrub(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            // Explicit newline removal first: this is the injection that matters, and naming it
+            // keeps the intent obvious to a reader (and to the static analysis that flags CWE-117).
+            var scrubbed = value.Replace("\r", string.Empty, StringComparison.Ordinal)
+                                .Replace("\n", string.Empty, StringComparison.Ordinal);
+
+            if (scrubbed.Any(char.IsControl))
+            {
+                scrubbed = new string(scrubbed.Where(c => !char.IsControl(c)).ToArray());
+            }
+
+            return scrubbed.Length > MaxLength
+                ? string.Concat(scrubbed.AsSpan(0, MaxLength), "...[truncated]")
+                : scrubbed;
+        }
+    }
+}

--- a/server/Worker/Consumers/PdfGenerator/ConvertDocumentsToPdfConsumer.cs
+++ b/server/Worker/Consumers/PdfGenerator/ConvertDocumentsToPdfConsumer.cs
@@ -1,8 +1,9 @@
-using Blocks.Genesis;
+﻿using Blocks.Genesis;
 using System.Diagnostics.CodeAnalysis;
 using Utility.DomainService.PdfGenerator;
 using Utility.DomainService.PdfGenerator.Events;
 using Utility.DomainService.PdfGenerator.service;
+using Utility.DomainService.Shared.Utilities;
 
 namespace Worker.Consumers.PdfGenerator
 {
@@ -47,8 +48,8 @@ namespace Worker.Consumers.PdfGenerator
             var tenantId = @event.ProjectKey ?? BlocksContext.GetContext()?.TenantId ?? "";
             _logger.LogInformation(
                 "ConvertDocumentsToPdfConsumer: Processing event for MessageCoRelationId={MessageCoRelationId}, TenantId={TenantId}",
-                @event.MessageCoRelationId,
-                tenantId);
+                LogSanitizer.Scrub(@event.MessageCoRelationId),
+                LogSanitizer.Scrub(tenantId));
 
             var successCount = 0;
             var failureCount = 0;
@@ -84,7 +85,7 @@ namespace Worker.Consumers.PdfGenerator
                 _logger.LogError(
                     ex,
                     "ConvertDocumentsToPdfConsumer: Exception occurred for MessageCoRelationId={MessageCoRelationId}",
-                    @event.MessageCoRelationId);
+                    LogSanitizer.Scrub(@event.MessageCoRelationId));
 
                 await _notificationService.NotifyConvertDocumentsToPdfEvent(
                     false,
@@ -105,8 +106,8 @@ namespace Worker.Consumers.PdfGenerator
             {
                 _logger.LogInformation(
                     "ConvertDocumentsToPdfConsumer: Converting DocumentFileId={DocumentFileId}, name={DocumentFileName}",
-                    command.DocumentFileId,
-                    command.DocumentFileName);
+                    LogSanitizer.Scrub(command.DocumentFileId),
+                    LogSanitizer.Scrub(command.DocumentFileName));
 
                 // Checked before the download: an unsupported extension is a caller error, and
                 // finding that out after pulling the bytes across the network costs the same
@@ -115,7 +116,7 @@ namespace Worker.Consumers.PdfGenerator
                 {
                     _logger.LogError(
                         "ConvertDocumentsToPdfConsumer: Unsupported document type for DocumentFileName={DocumentFileName}",
-                        command.DocumentFileName);
+                        LogSanitizer.Scrub(command.DocumentFileName));
 
                     return false;
                 }
@@ -125,7 +126,7 @@ namespace Worker.Consumers.PdfGenerator
                 {
                     _logger.LogError(
                         "ConvertDocumentsToPdfConsumer: Failed to get document stream for DocumentFileId={DocumentFileId}",
-                        command.DocumentFileId);
+                        LogSanitizer.Scrub(command.DocumentFileId));
 
                     return false;
                 }
@@ -142,7 +143,7 @@ namespace Worker.Consumers.PdfGenerator
                 {
                     _logger.LogError(
                         "ConvertDocumentsToPdfConsumer: Conversion failed for DocumentFileId={DocumentFileId}",
-                        command.DocumentFileId);
+                        LogSanitizer.Scrub(command.DocumentFileId));
 
                     return false;
                 }
@@ -170,14 +171,14 @@ namespace Worker.Consumers.PdfGenerator
                 {
                     _logger.LogError(
                         "ConvertDocumentsToPdfConsumer: Failed to save converted PDF for OutputPdfFileId={OutputPdfFileId}",
-                        command.OutputPdfFileId);
+                        LogSanitizer.Scrub(command.OutputPdfFileId));
 
                     return false;
                 }
 
                 _logger.LogInformation(
                     "ConvertDocumentsToPdfConsumer: Saved converted PDF for OutputPdfFileId={OutputPdfFileId}, size={PdfSize} bytes",
-                    command.OutputPdfFileId,
+                    LogSanitizer.Scrub(command.OutputPdfFileId),
                     pdfStream.Length);
 
                 return true;
@@ -187,7 +188,7 @@ namespace Worker.Consumers.PdfGenerator
                 _logger.LogError(
                     ex,
                     "ConvertDocumentsToPdfConsumer: Error converting DocumentFileId={DocumentFileId}",
-                    command.DocumentFileId);
+                    LogSanitizer.Scrub(command.DocumentFileId));
 
                 return false;
             }

--- a/server/Worker/Consumers/PdfGenerator/ConvertDocumentsToPdfConsumer.cs
+++ b/server/Worker/Consumers/PdfGenerator/ConvertDocumentsToPdfConsumer.cs
@@ -1,0 +1,214 @@
+using Blocks.Genesis;
+using System.Diagnostics.CodeAnalysis;
+using Utility.DomainService.PdfGenerator;
+using Utility.DomainService.PdfGenerator.Events;
+using Utility.DomainService.PdfGenerator.service;
+
+namespace Worker.Consumers.PdfGenerator
+{
+    /// <summary>
+    /// Converts word-processing documents held in storage to PDF and writes the result back as a
+    /// new file.
+    /// </summary>
+    /// <remarks>
+    /// The source file is left untouched and the PDF is written to its own file ID, unlike the
+    /// e-signature service's converter which overwrites the original and renames it. Keeping both
+    /// means a conversion that renders badly can be diagnosed against the input that produced it,
+    /// and it matches how every other consumer in this module treats its output.
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    public class ConvertDocumentsToPdfConsumer : IConsumer<ConvertDocumentsToPdfEvent>
+    {
+        /// <summary>
+        /// Where converted PDFs land. Its own directory so a retention or access policy can be set
+        /// for converted source documents without touching generated output.
+        /// </summary>
+        private const string OutputDirectory = "Blocks-PDF-Converted-Files";
+
+        private readonly ILogger<ConvertDocumentsToPdfConsumer> _logger;
+        private readonly PdfStorageHelper _storageHelper;
+        private readonly IDocumentToPdfConverter _converter;
+        private readonly IPdfGeneratorNotificationService _notificationService;
+
+        public ConvertDocumentsToPdfConsumer(
+            ILogger<ConvertDocumentsToPdfConsumer> logger,
+            PdfStorageHelper storageHelper,
+            IDocumentToPdfConverter converter,
+            IPdfGeneratorNotificationService notificationService)
+        {
+            _logger = logger;
+            _storageHelper = storageHelper;
+            _converter = converter;
+            _notificationService = notificationService;
+        }
+
+        public async Task Consume(ConvertDocumentsToPdfEvent @event)
+        {
+            var tenantId = @event.ProjectKey ?? BlocksContext.GetContext()?.TenantId ?? "";
+            _logger.LogInformation(
+                "ConvertDocumentsToPdfConsumer: Processing event for MessageCoRelationId={MessageCoRelationId}, TenantId={TenantId}",
+                @event.MessageCoRelationId,
+                tenantId);
+
+            var successCount = 0;
+            var failureCount = 0;
+
+            try
+            {
+                foreach (var command in @event.ConvertCommands)
+                {
+                    if (await ConvertOne(command, @event))
+                    {
+                        successCount++;
+                    }
+                    else
+                    {
+                        failureCount++;
+                    }
+                }
+
+                await _notificationService.NotifyConvertDocumentsToPdfEvent(
+                    failureCount == 0,
+                    @event.MessageCoRelationId,
+                    @event.ProjectKey,
+                    successCount,
+                    failureCount);
+
+                _logger.LogInformation(
+                    "ConvertDocumentsToPdfConsumer: Completed processing. Success={SuccessCount}, Failures={FailureCount}",
+                    successCount,
+                    failureCount);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "ConvertDocumentsToPdfConsumer: Exception occurred for MessageCoRelationId={MessageCoRelationId}",
+                    @event.MessageCoRelationId);
+
+                await _notificationService.NotifyConvertDocumentsToPdfEvent(
+                    false,
+                    @event.MessageCoRelationId,
+                    @event.ProjectKey,
+                    successCount,
+                    failureCount);
+            }
+        }
+
+        /// <summary>
+        /// Converts a single document. Returns false rather than throwing, so one unreadable file in
+        /// a batch does not abandon the rest of it.
+        /// </summary>
+        private async Task<bool> ConvertOne(ConvertDocumentToPdfCommand command, ConvertDocumentsToPdfEvent @event)
+        {
+            try
+            {
+                _logger.LogInformation(
+                    "ConvertDocumentsToPdfConsumer: Converting DocumentFileId={DocumentFileId}, name={DocumentFileName}",
+                    command.DocumentFileId,
+                    command.DocumentFileName);
+
+                // Checked before the download: an unsupported extension is a caller error, and
+                // finding that out after pulling the bytes across the network costs the same
+                // rejection plus a transfer.
+                if (!_converter.IsSupportedDocument(command.DocumentFileName))
+                {
+                    _logger.LogError(
+                        "ConvertDocumentsToPdfConsumer: Unsupported document type for DocumentFileName={DocumentFileName}",
+                        command.DocumentFileName);
+
+                    return false;
+                }
+
+                using var documentStream = await _storageHelper.GetPdfStream(command.DocumentFileId, @event.ProjectKey);
+                if (documentStream == null)
+                {
+                    _logger.LogError(
+                        "ConvertDocumentsToPdfConsumer: Failed to get document stream for DocumentFileId={DocumentFileId}",
+                        command.DocumentFileId);
+
+                    return false;
+                }
+
+                var options = new DocumentConversionOptions
+                {
+                    PreserveFormFields = command.PreserveFormFields,
+                    PdfACompliant = command.PdfACompliant,
+                    UpdateFields = command.UpdateFields
+                };
+
+                using var pdfStream = await _converter.ConvertToPdfAsync(documentStream, options);
+                if (pdfStream == null || pdfStream.Length == 0)
+                {
+                    _logger.LogError(
+                        "ConvertDocumentsToPdfConsumer: Conversion failed for DocumentFileId={DocumentFileId}",
+                        command.DocumentFileId);
+
+                    return false;
+                }
+
+                var metadata = new Dictionary<string, string>
+                {
+                    { "MessageCoRelationId", @event.MessageCoRelationId },
+                    { "SourceDocumentFileId", command.DocumentFileId },
+                    { "SourceDocumentFileName", command.DocumentFileName },
+                    { "CreatedDate", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
+                    { "FileType", "ConvertedPDF" },
+                    { "PdfACompliant", command.PdfACompliant.ToString() },
+                    { "OpenInBrowser", command.OpenInBrowser.ToString() }
+                };
+
+                var saveSuccess = await _storageHelper.SavePdfToStorage(
+                    pdfStream,
+                    command.OutputPdfFileId,
+                    ResolveOutputFileName(command),
+                    metadata,
+                    OutputDirectory,
+                    @event.ProjectKey);
+
+                if (!saveSuccess)
+                {
+                    _logger.LogError(
+                        "ConvertDocumentsToPdfConsumer: Failed to save converted PDF for OutputPdfFileId={OutputPdfFileId}",
+                        command.OutputPdfFileId);
+
+                    return false;
+                }
+
+                _logger.LogInformation(
+                    "ConvertDocumentsToPdfConsumer: Saved converted PDF for OutputPdfFileId={OutputPdfFileId}, size={PdfSize} bytes",
+                    command.OutputPdfFileId,
+                    pdfStream.Length);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "ConvertDocumentsToPdfConsumer: Error converting DocumentFileId={DocumentFileId}",
+                    command.DocumentFileId);
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Uses the caller's output name when given, otherwise the source name with its extension
+        /// swapped for .pdf — the same naming the e-signature converter produces.
+        /// </summary>
+        public static string ResolveOutputFileName(ConvertDocumentToPdfCommand command)
+        {
+            if (!string.IsNullOrWhiteSpace(command.OutputPdfFileName))
+            {
+                return command.OutputPdfFileName;
+            }
+
+            var withoutExtension = Path.GetFileNameWithoutExtension(command.DocumentFileName);
+
+            return string.IsNullOrWhiteSpace(withoutExtension)
+                ? $"{command.OutputPdfFileId}.pdf"
+                : $"{withoutExtension}.pdf";
+        }
+    }
+}

--- a/server/Worker/Consumers/PdfGenerator/FixPdfsConsumer.cs
+++ b/server/Worker/Consumers/PdfGenerator/FixPdfsConsumer.cs
@@ -32,8 +32,10 @@ namespace Worker.Consumers.PdfGenerator
 
             try
             {
-                // Always use engine 1 (Aspose) for PDF repair
-                var engine = _engineProvider.GetEngine(1);
+                // Engine 2 (PdfSharpCore). The comment here used to say "engine 1 (Aspose)" and pass
+                // 1, which is PuppeteerSharp — it has no FixPdfAsync and returns null, so every
+                // repair failed silently once this consumer was actually reachable.
+                var engine = _engineProvider.GetEngine(2);
 
                 foreach (var fixCommand in @event.PdfInfos)
                 {

--- a/server/Worker/Consumers/PdfGenerator/PdfGeneratorConsumerRegistration.cs
+++ b/server/Worker/Consumers/PdfGenerator/PdfGeneratorConsumerRegistration.cs
@@ -1,0 +1,38 @@
+using Blocks.Genesis;
+using System.Diagnostics.CodeAnalysis;
+using Utility.DomainService.PdfGenerator.Events;
+
+namespace Worker.Consumers.PdfGenerator
+{
+    /// <summary>
+    /// Registers the PDF generator message consumers with the worker's container.
+    /// </summary>
+    /// <remarks>
+    /// The worker subscribes to every PDF queue through
+    /// <c>PdfGeneratorConstants.GetMessageConfiguration</c>, but subscribing only creates the
+    /// listener — the dispatcher still has to resolve an <c>IConsumer&lt;TEvent&gt;</c> to hand the
+    /// message to. Until this ran, none of these types were registered, so every PDF request the API
+    /// accepted was queued and then dropped while the caller was told the operation had been
+    /// accepted. Adding a consumer without a line here reintroduces exactly that failure, which is
+    /// why they are collected in one place rather than scattered through Program.cs.
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    public static class PdfGeneratorConsumerRegistration
+    {
+        public static IServiceCollection RegisterPdfGeneratorConsumers(this IServiceCollection services)
+        {
+            services.AddSingleton<IConsumer<MergePdfsEvent>, MergePdfsConsumer>();
+            services.AddSingleton<IConsumer<CreatePdfsFromHtmlEvent>, CreatePdfsFromHtmlConsumer>();
+            services.AddSingleton<IConsumer<ExtractTextFromPdfsEvent>, ExtractTextFromPdfsConsumer>();
+            services.AddSingleton<IConsumer<CreatePdfsFromHtmlUsingTEEvent>, CreatePdfsFromHtmlUsingTEConsumer>();
+            services.AddSingleton<IConsumer<CreatePdfsFromHtmlUsingTEBulkEvent>, CreatePdfsFromHtmlUsingTEBulkConsumer>();
+            services.AddSingleton<IConsumer<FixPdfsEvent>, FixPdfsConsumer>();
+            services.AddSingleton<IConsumer<StampImageToPdfEvent>, StampImageToPdfConsumer>();
+            services.AddSingleton<IConsumer<StampTextToPdfEvent>, StampTextToPdfConsumer>();
+            services.AddSingleton<IConsumer<StampIntoPdfEvent>, StampIntoPdfConsumer>();
+            services.AddSingleton<IConsumer<ConvertDocumentsToPdfEvent>, ConvertDocumentsToPdfConsumer>();
+
+            return services;
+        }
+    }
+}

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -12,6 +12,7 @@ using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 using Worker;
 using Worker.Configuration;
+using Worker.Consumers.PdfGenerator;
 using Worker.Consumers.Payment;
 using Worker.Consumers.Subscription;
 using Subscription.DomainService.Entities;
@@ -75,6 +76,7 @@ IHostBuilder CreateHostBuilder(string[] args) =>
                 UsageThresholdReachedConsumer>();
             // Register the test consumer
             services.RegisterUtilityServices();
+            services.RegisterPdfGeneratorConsumers();
             services.AddSingleton<IVault>(_ => paymentVault);
             services.RegisterPaymentDomainServices(context.Configuration);
             services.RegisterSubscriptionDomainServices(

--- a/server/Worker/Worker.csproj
+++ b/server/Worker/Worker.csproj
@@ -16,4 +16,12 @@
     <ProjectReference Include="..\Payment.DomainService\Payment.DomainService.csproj" />
     <ProjectReference Include="..\Subscription.DomainService\Subscription.DomainService.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- The Aspose.Words licence, when this environment has one. Gitignored and supplied per
+         environment, so the Exists condition keeps a checkout without it building normally; the
+         process then runs Aspose unlicensed and says so in its startup log. Production supplies it
+         through Aspose:LicenseBase64 instead of this file. -->
+    <None Include="Aspose.Words.lic" Condition="Exists('Aspose.Words.lic')" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/server/XUnitTest/PdfGenerator/AsposeDocumentToPdfConverterTests.cs
+++ b/server/XUnitTest/PdfGenerator/AsposeDocumentToPdfConverterTests.cs
@@ -1,0 +1,335 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Utility.DomainService.PdfGenerator;
+using Utility.DomainService.PdfGenerator.service;
+using Worker.Consumers.PdfGenerator;
+
+namespace XUnitTest.PdfGenerator
+{
+    public class AsposeDocumentToPdfConverterTests
+    {
+        private readonly AsposeDocumentToPdfConverter _converter;
+
+        public AsposeDocumentToPdfConverterTests()
+        {
+            _converter = new AsposeDocumentToPdfConverter(
+                Mock.Of<ILogger<AsposeDocumentToPdfConverter>>(),
+                new ConfigurationBuilder().Build());
+        }
+
+        [Theory]
+        [InlineData("contract.docx")]
+        [InlineData("contract.doc")]
+        [InlineData("LETTER.DOCX")]
+        [InlineData("notes.rtf")]
+        [InlineData("report.odt")]
+        [InlineData("template.dotx")]
+        public void IsSupportedDocument_WordProcessingFormats_ReturnsTrue(string fileName)
+        {
+            _converter.IsSupportedDocument(fileName).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("already.pdf")]
+        [InlineData("sheet.xlsx")]
+        [InlineData("photo.png")]
+        [InlineData("deck.pptx")]
+        [InlineData("archive.zip")]
+        public void IsSupportedDocument_NonWordFormats_ReturnsFalse(string fileName)
+        {
+            _converter.IsSupportedDocument(fileName).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("no-extension")]
+        public void IsSupportedDocument_MissingExtension_ReturnsFalse(string fileName)
+        {
+            // The extension is the only signal available before the file is downloaded, so a name
+            // without one has to be rejected rather than optimistically converted.
+            _converter.IsSupportedDocument(fileName).Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ConvertToPdfAsync_EmptyStream_ReturnsNull()
+        {
+            using var empty = new MemoryStream();
+
+            var result = await _converter.ConvertToPdfAsync(empty, new DocumentConversionOptions());
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ConvertToPdfAsync_MalformedDocx_ReturnsNullRatherThanThrowing()
+        {
+            // A batch must survive one corrupt member, so a parse failure is a null, not an
+            // exception that would abandon the remaining documents. "PK\x03\x04" is the ZIP magic
+            // that makes Aspose commit to the OOXML reader, which then fails on the truncated body.
+            using var malformed = new MemoryStream(
+                new byte[] { 0x50, 0x4B, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF });
+
+            var result = await _converter.ConvertToPdfAsync(malformed, new DocumentConversionOptions());
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ConvertToPdfAsync_ArbitraryBytes_AreReadAsPlainTextNotRejected()
+        {
+            // Documents the reason the consumer gates on the file extension before it ever gets
+            // here: with no recognisable format signature Aspose falls back to its plain-text
+            // reader and cheerfully produces a PDF, so the converter alone will not tell a caller
+            // that they handed it something that was never a document.
+            using var garbage = new MemoryStream(new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 });
+
+            var result = await _converter.ConvertToPdfAsync(garbage, new DocumentConversionOptions());
+
+            result.Should().NotBeNull();
+            await result!.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task ConvertToPdfAsync_NullStream_Throws()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => _converter.ConvertToPdfAsync(null!, new DocumentConversionOptions()));
+        }
+
+        [Fact]
+        public async Task ConvertToPdfAsync_RealDocx_ProducesAPdf()
+        {
+            using var docx = BuildMinimalDocx();
+
+            using var result = await _converter.ConvertToPdfAsync(docx, new DocumentConversionOptions());
+
+            result.Should().NotBeNull();
+            ReadHeader(result!).Should().Be("%PDF", "the output must be a real PDF, not an empty or truncated stream");
+            result!.Length.Should().BeGreaterThan(1000);
+        }
+
+        [Fact]
+        public async Task ConvertToPdfAsync_PdfACompliant_ProducesAPdf()
+        {
+            using var docx = BuildMinimalDocx();
+
+            using var result = await _converter.ConvertToPdfAsync(
+                docx,
+                new DocumentConversionOptions { PdfACompliant = true, PreserveFormFields = true });
+
+            // PreserveFormFields is deliberately overridden by PdfACompliant rather than producing
+            // a file that claims PDF/A and fails validation.
+            result.Should().NotBeNull();
+            ReadHeader(result!).Should().Be("%PDF");
+        }
+
+        [Fact]
+        public async Task ConvertToPdfAsync_DoesNotRequireASeekableSourceStream()
+        {
+            // Storage hands back a network stream that cannot seek; the converter buffers before
+            // parsing precisely so that works.
+            using var docx = BuildMinimalDocx();
+            using var forwardOnly = new ForwardOnlyStream(docx.ToArray());
+
+            using var result = await _converter.ConvertToPdfAsync(forwardOnly, new DocumentConversionOptions());
+
+            result.Should().NotBeNull();
+            ReadHeader(result!).Should().Be("%PDF");
+        }
+
+        private static string ReadHeader(Stream stream)
+        {
+            stream.Position = 0;
+            var header = new byte[4];
+            stream.ReadExactly(header);
+            stream.Position = 0;
+
+            return System.Text.Encoding.ASCII.GetString(header);
+        }
+
+        /// <summary>
+        /// Builds a valid, minimal OOXML package in memory, so the test exercises the real Word
+        /// reader without carrying a binary fixture in the repository.
+        /// </summary>
+        private static MemoryStream BuildMinimalDocx()
+        {
+            const string ContentTypes =
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+                <Default Extension="xml" ContentType="application/xml"/>
+                <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+                </Types>
+                """;
+
+            const string Rels =
+                """
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+                <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+                </Relationships>
+                """;
+
+            var paragraphs = string.Concat(Enumerable.Range(1, 40).Select(i =>
+                $"""<w:p><w:r><w:t xml:space="preserve">Conversion smoke test, paragraph {i}.</w:t></w:r></w:p>"""));
+
+            var document =
+                $"""
+                <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+                <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{paragraphs}</w:body></w:document>
+                """;
+
+            var buffer = new MemoryStream();
+            using (var archive = new System.IO.Compression.ZipArchive(
+                buffer,
+                System.IO.Compression.ZipArchiveMode.Create,
+                leaveOpen: true))
+            {
+                WriteEntry(archive, "[Content_Types].xml", ContentTypes);
+                WriteEntry(archive, "_rels/.rels", Rels);
+                WriteEntry(archive, "word/document.xml", document);
+            }
+
+            buffer.Position = 0;
+
+            return buffer;
+        }
+
+        private static void WriteEntry(System.IO.Compression.ZipArchive archive, string name, string content)
+        {
+            using var entry = archive.CreateEntry(name).Open();
+            using var writer = new StreamWriter(entry);
+            writer.Write(content);
+        }
+
+        /// <summary>
+        /// A stream that reports CanSeek false, standing in for a storage download.
+        /// </summary>
+        private sealed class ForwardOnlyStream(byte[] data) : Stream
+        {
+            private readonly MemoryStream _inner = new(data);
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            public override long Length => throw new NotSupportedException();
+
+            public override long Position
+            {
+                get => throw new NotSupportedException();
+                set => throw new NotSupportedException();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+            public override void Flush() { }
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    _inner.Dispose();
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+
+        [Fact]
+        public void DocumentConversionOptions_DefaultsFavourArchivalOutput()
+        {
+            var options = new DocumentConversionOptions();
+
+            options.EmbedFullFonts.Should().BeTrue();
+            options.CompressImages.Should().BeTrue();
+            options.PreserveFormFields.Should().BeFalse();
+            options.UpdateFields.Should().BeFalse();
+            options.PdfACompliant.Should().BeFalse();
+        }
+    }
+
+    public class ConvertDocumentsToPdfContractTests
+    {
+        [Fact]
+        public void ResolveOutputFileName_ExplicitName_IsUsedVerbatim()
+        {
+            var name = ConvertDocumentsToPdfConsumer.ResolveOutputFileName(new ConvertDocumentToPdfCommand
+            {
+                DocumentFileName = "source.docx",
+                OutputPdfFileName = "Signed Contract.pdf",
+                OutputPdfFileId = "out-1"
+            });
+
+            name.Should().Be("Signed Contract.pdf");
+        }
+
+        [Fact]
+        public void ResolveOutputFileName_NoExplicitName_SwapsSourceExtension()
+        {
+            var name = ConvertDocumentsToPdfConsumer.ResolveOutputFileName(new ConvertDocumentToPdfCommand
+            {
+                DocumentFileName = "Q3 Report.docx",
+                OutputPdfFileId = "out-1"
+            });
+
+            name.Should().Be("Q3 Report.pdf");
+        }
+
+        [Fact]
+        public void ResolveOutputFileName_NoUsableSourceName_FallsBackToOutputId()
+        {
+            var name = ConvertDocumentsToPdfConsumer.ResolveOutputFileName(new ConvertDocumentToPdfCommand
+            {
+                DocumentFileName = string.Empty,
+                OutputPdfFileId = "out-1"
+            });
+
+            name.Should().Be("out-1.pdf");
+        }
+
+        [Fact]
+        public void ConvertDocumentsToPdfRequest_And_Response_ShouldStoreValues()
+        {
+            var request = new ConvertDocumentsToPdfRequest
+            {
+                ProjectKey = "p1",
+                MessageCoRelationId = "corr",
+                EventReferenceData = new Dictionary<string, string> { ["source"] = "test" },
+                ConvertCommands = new List<ConvertDocumentToPdfCommand>
+                {
+                    new()
+                    {
+                        DocumentFileId = "doc-1",
+                        DocumentFileName = "contract.docx",
+                        OutputPdfFileId = "pdf-1",
+                        PdfACompliant = true
+                    }
+                }
+            };
+
+            request.ProjectKey.Should().Be("p1");
+            request.ConvertCommands.Should().ContainSingle()
+                .Which.DocumentFileName.Should().Be("contract.docx");
+
+            var response = new ConvertDocumentsToPdfResponse
+            {
+                IsSuccess = true,
+                MessageCoRelationId = "corr",
+                Message = "queued"
+            };
+
+            response.IsSuccess.Should().BeTrue();
+            response.MessageCoRelationId.Should().Be("corr");
+        }
+    }
+}

--- a/server/XUnitTest/PdfGenerator/AsposeLicenseTests.cs
+++ b/server/XUnitTest/PdfGenerator/AsposeLicenseTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Utility.DomainService.PdfGenerator.service;
+
+namespace XUnitTest.PdfGenerator
+{
+    public class AsposeLicenseTests
+    {
+        [Fact]
+        public void EnsureApplied_WithNoLicenceAvailable_DoesNotThrow()
+        {
+            // CI has no licence file and no Aspose:* configuration. A missing licence must degrade
+            // to watermarked output rather than taking the process down, otherwise a licence that
+            // expires overnight stops the worker instead of just marking its output.
+            var act = () => AsposeLicense.EnsureApplied(new ConfigurationBuilder().Build(), NullLogger.Instance);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void EnsureApplied_WithGarbageBase64_DoesNotThrow()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Aspose:LicenseBase64"] = "this-is-not-base64!!"
+                })
+                .Build();
+
+            var act = () => AsposeLicense.EnsureApplied(configuration, NullLogger.Instance);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void EnsureApplied_IsIdempotent()
+        {
+            var configuration = new ConfigurationBuilder().Build();
+
+            AsposeLicense.EnsureApplied(configuration, NullLogger.Instance);
+            var afterFirst = AsposeLicense.IsLicensed;
+
+            AsposeLicense.EnsureApplied(configuration, NullLogger.Instance);
+
+            // Every conversion calls this, so repeated calls must be free and must not flip the
+            // result — Aspose's own licence state is process-global and applying twice is wasteful.
+            AsposeLicense.IsLicensed.Should().Be(afterFirst);
+        }
+    }
+}

--- a/server/XUnitTest/PdfGenerator/AsposePdfEngineTests.cs
+++ b/server/XUnitTest/PdfGenerator/AsposePdfEngineTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Moq;
 using PdfSharp.Drawing;
 using PdfSharp.Pdf;
@@ -14,7 +15,7 @@ namespace XUnitTest.PdfGenerator
         public AsposePdfEngineTests()
         {
             var logger = Mock.Of<ILogger<AsposePdfEngine>>();
-            _engine = new AsposePdfEngine(logger);
+            _engine = new AsposePdfEngine(logger, Mock.Of<IConfiguration>());
         }
 
         #region MergePdfsAsync

--- a/server/XUnitTest/PdfGenerator/LogSanitizerTests.cs
+++ b/server/XUnitTest/PdfGenerator/LogSanitizerTests.cs
@@ -1,0 +1,74 @@
+﻿using FluentAssertions;
+using Utility.DomainService.Shared.Utilities;
+
+namespace XUnitTest.PdfGenerator
+{
+    public class LogSanitizerTests
+    {
+        [Theory]
+        [InlineData("req-0001")]
+        [InlineData("9f8c1b2e-4d3a-4a1e-8b7c-0f2a5d6e7c8b")]
+        [InlineData("Employment Contract.docx")]
+        public void Scrub_OrdinaryValues_PassThroughUnchanged(string value)
+        {
+            LogSanitizer.Scrub(value).Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Scrub_NullOrEmpty_ReturnsEmpty(string? value)
+        {
+            LogSanitizer.Scrub(value).Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Scrub_ForgedLogEntry_CollapsesToASingleLine()
+        {
+            // The attack this exists for: a correlation ID that closes the real entry and opens a
+            // fabricated error line of the attacker's choosing.
+            const string Forged = "req-1\r\n[ERROR] Payment gateway compromised, contact admin";
+
+            var scrubbed = LogSanitizer.Scrub(Forged);
+
+            scrubbed.Should().NotContain("\r").And.NotContain("\n");
+            scrubbed.Should().Be("req-1[ERROR] Payment gateway compromised, contact admin");
+        }
+
+        [Theory]
+        [InlineData("a\nb")]
+        [InlineData("a\rb")]
+        [InlineData("a\r\nb")]
+        public void Scrub_RemovesEveryNewlineForm(string value)
+        {
+            LogSanitizer.Scrub(value).Should().Be("ab");
+        }
+
+        [Fact]
+        public void Scrub_RemovesTerminalEscapeSequencesAndNulls()
+        {
+            // A log read in a terminal will act on an embedded escape sequence, so control
+            // characters go as well as newlines.
+            var scrubbed = LogSanitizer.Scrub("req-1\u001b[31mred\u0000");
+
+            scrubbed.Should().Be("req-1[31mred");
+        }
+
+        [Fact]
+        public void Scrub_OverlongValue_IsTruncated()
+        {
+            var scrubbed = LogSanitizer.Scrub(new string('x', 5000));
+
+            scrubbed.Should().HaveLength(200 + "...[truncated]".Length);
+            scrubbed.Should().EndWith("...[truncated]");
+        }
+
+        [Fact]
+        public void Scrub_ValueAtTheLimit_IsNotTruncated()
+        {
+            var atLimit = new string('x', 200);
+
+            LogSanitizer.Scrub(atLimit).Should().Be(atLimit);
+        }
+    }
+}

--- a/server/XUnitTest/PdfGenerator/PdfEngineProviderTests.cs
+++ b/server/XUnitTest/PdfGenerator/PdfEngineProviderTests.cs
@@ -18,7 +18,7 @@ namespace XUnitTest.PdfGenerator
             var mockConfiguration = Mock.Of<IConfiguration>();
             _puppeteer = new PuppeteerSharpEngine(Mock.Of<ILogger<PuppeteerSharpEngine>>(), mockConfiguration);
             _pdfSharp = new PdfSharpCoreEngine(Mock.Of<ILogger<PdfSharpCoreEngine>>());
-            _aspose = new AsposePdfEngine(Mock.Of<ILogger<AsposePdfEngine>>());
+            _aspose = new AsposePdfEngine(Mock.Of<ILogger<AsposePdfEngine>>(), mockConfiguration);
             _wkHtml = new WkHtmlToPdfEngine(Mock.Of<ILogger<WkHtmlToPdfEngine>>(), mockConfiguration);
 
             _provider = new PdfEngineProvider(


### PR DESCRIPTION
## What

Adds `POST /PdfGenerator/ConvertDocumentsToPdf` — converts `.doc`, `.docx`, `.rtf`, `.odt` and related word-processing formats to PDF via Aspose.Words, following the same request → queue → consumer → storage shape as every other operation in this module.

Ported from the e-signature service's `AsposeSaveAs`. Local conversion only — the Aspose Cloud path and its hardcoded org-GUID routing were deliberately left out; if that's wanted later it should key off configuration.

Conversion sits behind a new `IDocumentToPdfConverter` rather than `IPdfEngine`. Three of the four engines cannot read Word formats at all, so folding it into `IPdfEngine` would add three methods that log a warning and return `null`, and would let a caller pick an engine number that silently cannot do the job. The endpoint therefore takes no `Engine` field.

## Two problems this had to fix first

**The PDF consumers were never registered.** `Worker/Program.cs` subscribed to all nine PDF queues but registered no `IConsumer<T>` and no engines, so every PDF request the API accepted was queued, reported as successful, and then dropped. The only path that actually rendered was Subscription's `PuppeteerFinancialDocumentPdfRenderer`, which resolves the engine directly and bypasses the provider.

Engines, provider and storage helper are now registered alongside the other utility services, and the consumers are collected in one `RegisterPdfGeneratorConsumers` call so adding a consumer without wiring it is harder to do by accident.

`FixPdfsConsumer` asked for engine 1 while its comment claimed that was Aspose. Engine 1 is PuppeteerSharp, which has no `FixPdfAsync` and returns `null`, so every repair would have failed silently the moment the consumer became reachable. Now uses engine 2.

**Aspose ran unlicensed on a 2020 build.** Without a licence Aspose watermarks every page and truncates long documents, which would have made converted documents unusable. `Aspose.Words` moves `20.2.0` → `25.6.0`, and `AsposeLicense` applies a licence from `Aspose:LicenseBase64`, `Aspose:LicensePath`, or a file beside the assembly.

## Reviewer notes

**Why 25.6.0 and not the current 26.8.0.** The SELISE licence's `SubscriptionExpiry` is `20250702`, which covers releases published before that date. `25.6.0` shipped 2025-06-06; `25.7.0` shipped 2025-07-07 and would be rejected outright by `SetLicense`. I verified 25.6.0 accepts the licence before settling on it. If the subscription has since been renewed, bumping is a one-line change in `Directory.Packages.props`.

**The licence file is gitignored, not committed** — Aspose marks it non-redistributable and this repo runs TruffleHog secret scanning. `server/Api/Aspose.Words.lic` and `server/Worker/Aspose.Words.lic` are copied to output when present, and both csproj entries are `Condition="Exists(...)"` so a checkout without the file still builds. **Deployment needs `Aspose:LicenseBase64` set as a secret** — without it the process starts normally and logs a warning that output will be watermarked.

**Aspose reads unrecognised bytes as plain text** rather than rejecting them, so it will "successfully" convert a garbage file. The extension check in the consumer is the real guard; there's a test pinning that behaviour so it isn't mistaken for a bug later.

Also in here: the version bump broke `AsposePdfEngine`'s HTML path (`HtmlLoadOptions` moved to `Aspose.Words.Loading`), and `Dockerfile.worker` gains `ttf-liberation` — metric-compatible with Arial, Times New Roman and Courier New. Aspose substitutes missing fonts silently, so without them a converted document renders with different line breaks and a different page count than the author saw.

## Testing

- 104 PDF tests pass, including a real in-memory `.docx` → PDF conversion asserting a `%PDF` header, a PDF/A variant, and a non-seekable source stream (storage hands back a stream that cannot seek).
- Full non-integration suite: 3573 passing on this branch. The 4 `SubscriptionSimulation` permission failures are pre-existing — confirmed against `origin/dev` unmodified.
- `XUnitTest.Integration.*` needs a live MongoDB and was not run.

**Not verified:** nothing has been exercised against a real broker or storage. The DI graph compiles and resolves by inspection, but the first actual queued conversion is untested end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)