### PR TITLE
feat(payment): choose a Stripe checkout's payment methods from the portal

### DIFF
--- a/client/app/cross-modules/utilities/payment/components/payment-provider-configuration-fields.tsx
+++ b/client/app/cross-modules/utilities/payment/components/payment-provider-configuration-fields.tsx
@@ -1,4 +1,6 @@
-import { useFormContext } from "react-hook-form";
+import { useFormContext, useWatch } from "react-hook-form";
+import { Badge } from "@/components/ui-kits/badge/badge";
+import { Checkbox } from "@/components/ui-kits/checkbox/checkbox";
 import {
   FormControl,
   FormDescription,
@@ -9,6 +11,10 @@ import {
 } from "@/components/ui-kits/form/form";
 import { Input } from "@/components/ui-kits/input/input";
 import { Switch } from "@/components/ui-kits/switch/switch";
+import {
+  canBeReusedOffSession,
+  PAYMENT_METHOD_OPTIONS,
+} from "../constants/payment.constants";
 
 interface ProviderConfigurationFields {
   frontendResultUrl: string;
@@ -17,16 +23,58 @@ interface ProviderConfigurationFields {
   maxRefundDays: number;
   storeId?: string;
   isEnabled?: boolean;
+  checkoutPaymentMethodTypes: string[];
+  paymentMethodConfigurationId?: string;
 }
 
 interface PaymentProviderConfigurationFieldsProps {
   includeEnabled?: boolean;
+  /**
+   * Which provider is being configured. The payment method selection is Stripe's own concept and
+   * is hidden for anything else; Adyen ignores both fields entirely.
+   */
+  providerName?: string;
+  /**
+   * The methods already stored on this provider. Any that the curated list does not offer are
+   * added to it, so they stay visible and can be kept or removed deliberately.
+   *
+   * These two fields are settable through the API, where nothing constrains them to the list
+   * below. Ticking any box rewrites the whole list from what is offered here, so a method that
+   * was not offered would be dropped by an edit that had nothing to do with it — a silent change
+   * to how a live checkout behaves. Read from the stored provider rather than from form state,
+   * so unticking one does not make its checkbox vanish mid-edit.
+   */
+  additionalPaymentMethods?: readonly string[];
+}
+
+/** One method the form can offer; labelled by its raw value when it is not a curated one. */
+interface PaymentMethodChoice {
+  value: string;
+  label: string;
+  hint?: string | undefined;
 }
 
 export const PaymentProviderConfigurationFields = ({
   includeEnabled = false,
+  providerName,
+  additionalPaymentMethods = [],
 }: PaymentProviderConfigurationFieldsProps) => {
   const form = useFormContext<ProviderConfigurationFields>();
+  const selectedMethods = useWatch({
+    control: form.control,
+    name: "checkoutPaymentMethodTypes",
+  });
+  const hasSelectedMethods = (selectedMethods ?? []).length > 0;
+
+  const offered: PaymentMethodChoice[] = [
+    ...PAYMENT_METHOD_OPTIONS,
+    ...[...new Set(additionalPaymentMethods)]
+      .filter(
+        (method) =>
+          !PAYMENT_METHOD_OPTIONS.some((option) => option.value === method),
+      )
+      .map((method) => ({ value: method, label: method })),
+  ];
 
   return (
     <div className="grid gap-5 sm:grid-cols-2">
@@ -150,6 +198,114 @@ export const PaymentProviderConfigurationFields = ({
           </FormItem>
         )}
       />
+
+      {providerName === "STRIPE" && (
+        <div className="space-y-5 rounded-xl border p-4 sm:col-span-2">
+          <div>
+            <h3 className="font-semibold">Checkout payment methods</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Which methods Stripe Checkout offers a shopper.
+            </p>
+          </div>
+
+          <FormField
+            control={form.control}
+            name="checkoutPaymentMethodTypes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Offer these methods</FormLabel>
+                <div className="space-y-3 rounded-md border p-3">
+                  {offered.map((option) => {
+                    const selected = (field.value ?? []).includes(
+                      option.value,
+                    );
+
+                    return (
+                      <div key={option.value} className="space-y-1">
+                        <div className="flex items-center justify-between gap-2">
+                          {/* The label wraps the control so the method name is its accessible
+                              name. The badge and hint stay outside it, or they would be read as
+                              part of that name. */}
+                          <label className="flex cursor-pointer items-center gap-2 text-sm">
+                            <Checkbox
+                              checked={selected}
+                              onCheckedChange={(checked) => {
+                                const chosen = new Set(field.value ?? []);
+
+                                if (checked) {
+                                  chosen.add(option.value);
+                                } else {
+                                  chosen.delete(option.value);
+                                }
+
+                                // Rebuilt in the order shown rather than in the order ticked:
+                                // Stripe renders the methods in the order they arrive, and a
+                                // checkbox list gives no sign of click order, so ordering by
+                                // what is on screen is the only version an operator can predict.
+                                field.onChange(
+                                  offered
+                                    .map((candidate) => candidate.value)
+                                    .filter((value) => chosen.has(value)),
+                                );
+                              }}
+                            />
+                            {option.label}
+                          </label>
+                          {!canBeReusedOffSession(option.value) && (
+                            <Badge variant="outline">
+                              one-off payments only
+                            </Badge>
+                          )}
+                        </div>
+                        {option.hint && (
+                          <p className="pl-6 text-xs text-muted-foreground">
+                            {option.hint}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                <FormDescription>
+                  Leave every box unchecked to offer whatever the Stripe
+                  Dashboard enables, which is what this provider does today. A
+                  method marked one-off cannot be charged again later, so Stripe
+                  leaves it off a subscription&rsquo;s first payment even when it
+                  is ticked here — it still appears on ordinary payments.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="paymentMethodConfigurationId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Payment method configuration ID</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    maxLength={100}
+                    placeholder="pmc_…"
+                    autoComplete="off"
+                    spellCheck={false}
+                    disabled={hasSelectedMethods}
+                  />
+                </FormControl>
+                <FormDescription>
+                  {hasSelectedMethods
+                    ? "Ignored while methods are ticked above — Stripe rejects a checkout that names both, so the ticked list wins. Untick them all to use this instead."
+                    : "Optional. A configuration assembled in the Stripe Dashboard, used when no method is ticked above."}
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      )}
 
       {includeEnabled && (
         <FormField

--- a/client/app/cross-modules/utilities/payment/constants/payment.constants.ts
+++ b/client/app/cross-modules/utilities/payment/constants/payment.constants.ts
@@ -48,3 +48,58 @@ export const PAYMENT_FLOW_OPTIONS = [
 ] as const;
 
 export const PAYMENT_LIST_REFRESH_INTERVAL_MS = 15_000;
+
+/**
+ * The methods Stripe can charge again later with nobody present.
+ *
+ * Mirrors `StripePaymentMethodSelection.ReusableOffSession` on the server, which is the set that
+ * decides what survives into a checkout that stores the method for renewals. Everything outside it
+ * is dropped from such a session by design — a subscription bought with TWINT could never renew
+ * itself — so this set is what lets the form warn an operator before they wonder why a method they
+ * ticked never appeared on a subscription's first charge.
+ *
+ * Kept as the whole server set rather than only the methods offered below, so a method configured
+ * through the API is badged correctly too.
+ */
+export const REUSABLE_OFF_SESSION_PAYMENT_METHODS = new Set([
+  "card",
+  "link",
+  "paypal",
+  "sepa_debit",
+  "us_bank_account",
+  "bacs_debit",
+  "au_becs_debit",
+]);
+
+/**
+ * The payment methods the provider form offers to tick.
+ *
+ * A fixed list rather than free text: the server validates neither of these two fields, so this is
+ * the only thing standing between a typo and a checkout Stripe refuses to create. It is a curated
+ * subset rather than every method Stripe supports — the ones this product is actually sold with.
+ * A method set through the API that is missing here is still shown and preserved, so curating it
+ * narrows what can be added, never what can be kept.
+ *
+ * Order matters: Stripe renders the methods in the order they arrive, and the form submits them in
+ * the order they appear here so that what an operator sees is what a shopper gets.
+ */
+export const PAYMENT_METHOD_OPTIONS = [
+  {
+    value: "card",
+    label: "Card",
+    hint: "Apple Pay and Google Pay ride on this.",
+  },
+  { value: "twint", label: "TWINT", hint: undefined },
+  {
+    value: "paypal",
+    label: "PayPal",
+    hint: "Subscriptions need Stripe's recurring approval on the account.",
+  },
+  { value: "klarna", label: "Klarna", hint: undefined },
+  { value: "link", label: "Link", hint: undefined },
+  { value: "sepa_debit", label: "SEPA Direct Debit", hint: undefined },
+] as const;
+
+/** Whether a method can back a renewal, so the form can say when one cannot. */
+export const canBeReusedOffSession = (method: string): boolean =>
+  REUSABLE_OFF_SESSION_PAYMENT_METHODS.has(method.trim().toLowerCase());

--- a/client/app/cross-modules/utilities/payment/models/payment-provider.model.ts
+++ b/client/app/cross-modules/utilities/payment/models/payment-provider.model.ts
@@ -20,6 +20,10 @@ export interface PaymentProvider {
   maxRefundDays: number;
   storeId: string | null;
   isEnabled: boolean;
+  /** A Dashboard-built `pmc_…` configuration, ignored while methods are named explicitly. */
+  paymentMethodConfigurationId: string | null;
+  /** The methods checkout offers. Null defers to the provider account's own configuration. */
+  checkoutPaymentMethodTypes: string[] | null;
 }
 
 export interface RegisterPaymentProviderRequest {
@@ -38,6 +42,12 @@ export interface RegisterPaymentProviderRequest {
   manualCapture: boolean;
   maxRefundDays: number;
   storeId?: string;
+  paymentMethodConfigurationId?: string;
+  /**
+   * Omitted rather than sent empty. An empty array is not a checkout offering nothing — the server
+   * reads it as "never set", the same as omitting it, and defers to the account's configuration.
+   */
+  checkoutPaymentMethodTypes?: string[];
   apiKey: string;
   webhookHmacKey: string;
   tokenHmacKey?: string;
@@ -84,6 +94,9 @@ export interface UpdatePaymentProviderRequest {
   maxRefundDays: number;
   storeId?: string;
   isEnabled: boolean;
+  paymentMethodConfigurationId?: string;
+  /** Omitted rather than sent empty; see the note on the register request. */
+  checkoutPaymentMethodTypes?: string[];
 }
 
 export interface RotatePaymentProviderCredentialsRequest {

--- a/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.test.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.test.tsx
@@ -1,7 +1,7 @@
 ﻿import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreatePaymentProviderPage } from "./create-payment-provider-page";
 
 const { registerProvider, useGetOrganizations } = vi.hoisted(() => ({
@@ -340,5 +340,191 @@ describe("CreatePaymentProviderPage organization selection", () => {
     expect(
       screen.queryByText(/adyen\/webhooks/),
     ).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * The payment method selection. Absent unless Stripe is the chosen provider, since it is Stripe's
+ * own concept and Adyen ignores both fields.
+ */
+describe("CreatePaymentProviderPage checkout payment methods", () => {
+  const hex64 = "0123456789abcdef".repeat(4);
+
+  // The blocks above share these mocks without resetting them, so calls accumulate across the
+  // file. Reading the first recorded call would read some earlier test's submission.
+  beforeEach(() => {
+    registerProvider.mockReset();
+    toastMock.mockReset();
+  });
+
+  const renderPage = () => {
+    withOrganizations([]);
+    registerProvider.mockResolvedValue(registered([null]));
+
+    return render(
+      <MemoryRouter>
+        <CreatePaymentProviderPage />
+      </MemoryRouter>,
+    );
+  };
+
+  const chooseProvider = async (
+    user: ReturnType<typeof userEvent.setup>,
+    name: string,
+  ) => {
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByRole("option", { name }));
+  };
+
+  const fillRequiredAdyenFields = async (
+    user: ReturnType<typeof userEvent.setup>,
+  ) => {
+    await user.type(screen.getByLabelText("Merchant ID"), "MyMerchant");
+    await user.type(screen.getByLabelText("API key"), "adyen-key");
+    await user.type(screen.getByLabelText("Standard webhook HMAC"), hex64);
+    await user.type(screen.getByLabelText("Token webhook HMAC"), hex64);
+
+    const resultUrl = screen.getByLabelText("Frontend result URL");
+    await user.clear(resultUrl);
+    await user.type(resultUrl, "https://app.example/payment/result");
+  };
+
+  const create = (user: ReturnType<typeof userEvent.setup>) =>
+    user.click(screen.getByRole("button", { name: /create provider/i }));
+
+  const submitted = () => registerProvider.mock.calls[0][0];
+
+  it("does not offer them for the provider that has no such concept", () => {
+    renderPage();
+
+    // Adyen is the default choice, so this is also the state the page opens in.
+    expect(screen.queryByRole("checkbox", { name: "Card" })).toBeNull();
+    expect(
+      screen.queryByLabelText(/Payment method configuration ID/),
+    ).toBeNull();
+  });
+
+  it("sends the methods that were ticked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await fillRequiredStripeFields(user);
+
+    await user.click(screen.getByRole("checkbox", { name: "Card" }));
+    await user.click(screen.getByRole("checkbox", { name: "TWINT" }));
+    await create(user);
+
+    await waitFor(() => expect(registerProvider).toHaveBeenCalled());
+    expect(submitted().checkoutPaymentMethodTypes).toEqual(["card", "twint"]);
+  });
+
+  /**
+   * Stripe renders the methods in the order they arrive, and a checkbox list shows nothing of the
+   * order they were ticked in — so the order submitted is the order on screen, and clicking the
+   * same two boxes the other way round is the same configuration.
+   */
+  it("submits them in the order shown rather than the order ticked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await fillRequiredStripeFields(user);
+
+    await user.click(screen.getByRole("checkbox", { name: "TWINT" }));
+    await user.click(screen.getByRole("checkbox", { name: "Card" }));
+    await create(user);
+
+    await waitFor(() => expect(registerProvider).toHaveBeenCalled());
+    expect(submitted().checkoutPaymentMethodTypes).toEqual(["card", "twint"]);
+  });
+
+  /**
+   * Omitted rather than empty. An empty list is not a checkout offering nothing — the server reads
+   * it as never having been set, which is what every provider registered before this form did.
+   */
+  it("omits the list when nothing was ticked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await fillRequiredStripeFields(user);
+
+    await create(user);
+
+    await waitFor(() => expect(registerProvider).toHaveBeenCalled());
+    expect(submitted().checkoutPaymentMethodTypes).toBeUndefined();
+    expect(submitted().paymentMethodConfigurationId).toBeUndefined();
+  });
+
+  it("sends a Dashboard configuration id when no method was ticked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await fillRequiredStripeFields(user);
+
+    await user.type(
+      screen.getByLabelText(/Payment method configuration ID/),
+      "pmc_123",
+    );
+    await create(user);
+
+    await waitFor(() => expect(registerProvider).toHaveBeenCalled());
+    expect(submitted().paymentMethodConfigurationId).toBe("pmc_123");
+  });
+
+  it("refuses a configuration id that is not one", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await fillRequiredStripeFields(user);
+
+    await user.type(
+      screen.getByLabelText(/Payment method configuration ID/),
+      "card",
+    );
+    await create(user);
+
+    expect(
+      await screen.findByText(
+        "A Stripe payment method configuration id starts with pmc_.",
+      ),
+    ).toBeTruthy();
+    expect(registerProvider).not.toHaveBeenCalled();
+  });
+
+  /** Switching provider drops the selection, so it cannot be carried into one that ignores it. */
+  it("forgets the selection when the provider changes", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await chooseProvider(user, "Stripe Checkout");
+    await user.click(screen.getByRole("checkbox", { name: "Card" }));
+    expect(screen.getByRole("checkbox", { name: "Card" })).toBeChecked();
+
+    await chooseProvider(user, "Adyen Hosted Checkout");
+    expect(screen.queryByRole("checkbox", { name: "Card" })).toBeNull();
+
+    await chooseProvider(user, "Stripe Checkout");
+    expect(screen.getByRole("checkbox", { name: "Card" })).not.toBeChecked();
+  });
+
+  it("sends neither field for a provider that ignores them", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await chooseProvider(user, "Stripe Checkout");
+    await user.click(screen.getByRole("checkbox", { name: "Card" }));
+    await chooseProvider(user, "Adyen Hosted Checkout");
+
+    await fillRequiredAdyenFields(user);
+    await create(user);
+
+    await waitFor(() => expect(registerProvider).toHaveBeenCalled());
+    expect(submitted().providerName).toBe("ADYEN-ONLINE");
+    expect(submitted().checkoutPaymentMethodTypes).toBeUndefined();
+    expect(submitted().paymentMethodConfigurationId).toBeUndefined();
+  });
+
+  /** Ticking one of these changes nothing about a subscription, so the form says so. */
+  it("marks the methods that cannot back a renewal", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await chooseProvider(user, "Stripe Checkout");
+
+    expect(screen.getAllByText("one-off payments only")).toHaveLength(2);
   });
 });

--- a/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/create-payment-provider-page.tsx
@@ -95,6 +95,8 @@ export const CreatePaymentProviderPage = () => {
       manualCapture: false,
       maxRefundDays: 365,
       storeId: "",
+      checkoutPaymentMethodTypes: [],
+      paymentMethodConfigurationId: "",
       apiKey: "",
       webhookHmacKey: "",
       tokenHmacKey: "",
@@ -143,6 +145,18 @@ export const CreatePaymentProviderPage = () => {
       tokenHmacKey:
         values.providerName === "ADYEN-ONLINE"
           ? normalizeOptional(values.tokenHmacKey)
+          : undefined,
+      // Stripe-only, and omitted when nothing was ticked: the server reads an absent list and an
+      // empty one the same way, as "defer to the account's configuration". Sending [] instead
+      // would be a checkout offering nothing, which Stripe rejects.
+      checkoutPaymentMethodTypes:
+        values.providerName === "STRIPE" &&
+        values.checkoutPaymentMethodTypes.length > 0
+          ? values.checkoutPaymentMethodTypes
+          : undefined,
+      paymentMethodConfigurationId:
+        values.providerName === "STRIPE"
+          ? normalizeOptional(values.paymentMethodConfigurationId)
           : undefined,
     };
 
@@ -233,6 +247,21 @@ export const CreatePaymentProviderPage = () => {
                                 : "",
                             );
                             form.setValue("tokenHmacKey", "");
+
+                            // Stripe's own concept, and the fields are hidden for anything
+                            // else. Cleared rather than left in state so what was ticked for
+                            // one provider cannot be carried into another silently.
+                            if (value !== "STRIPE") {
+                              form.setValue(
+                                "checkoutPaymentMethodTypes",
+                                [],
+                              );
+                              form.setValue(
+                                "paymentMethodConfigurationId",
+                                "",
+                              );
+                            }
+
                             form.clearErrors();
                           }}
                         >
@@ -413,7 +442,9 @@ export const CreatePaymentProviderPage = () => {
                     Runtime behavior that can be edited later.
                   </p>
                 </div>
-                <PaymentProviderConfigurationFields />
+                <PaymentProviderConfigurationFields
+                  providerName={providerName}
+                />
               </section>
 
               <section className="space-y-5 border-t pt-6">

--- a/client/app/cross-modules/utilities/payment/pages/update-payment-provider-page.test.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/update-payment-provider-page.test.tsx
@@ -51,6 +51,8 @@ const provider = (overrides: Partial<PaymentProvider> = {}): PaymentProvider => 
   maxRefundDays: 365,
   storeId: null,
   isEnabled: true,
+  paymentMethodConfigurationId: null,
+  checkoutPaymentMethodTypes: null,
   ...overrides,
 });
 
@@ -223,5 +225,184 @@ describe("UpdatePaymentProviderPage", () => {
     expect(
       screen.getByRole("button", { name: /Saving changes/ }),
     ).toBeDisabled();
+  });
+
+  /**
+   * The payment method selection. Stripe's own concept, so the block is absent for Adyen — which
+   * is what the factory above registers by default.
+   */
+  describe("checkout payment methods", () => {
+    const stripe = (overrides: Partial<PaymentProvider> = {}) =>
+      provider({ providerName: "STRIPE", ...overrides });
+
+    const showStripe = (overrides: Partial<PaymentProvider> = {}) => {
+      providersState = {
+        data: [stripe(overrides)],
+        isLoading: false,
+        isError: false,
+      };
+    };
+
+    const methods = async () => {
+      const [{ request }] = mutateAsyncMock.mock.calls[0];
+      return request.checkoutPaymentMethodTypes;
+    };
+
+    it("should not offer them for a provider that has no such concept", () => {
+      renderPage();
+
+      expect(screen.queryByRole("checkbox", { name: "Card" })).toBeNull();
+      expect(
+        screen.queryByLabelText(/Payment method configuration ID/),
+      ).toBeNull();
+    });
+
+    it("should offer them for Stripe", () => {
+      showStripe();
+      renderPage();
+
+      expect(screen.getByRole("checkbox", { name: "Card" })).toBeTruthy();
+      expect(screen.getByRole("checkbox", { name: "TWINT" })).toBeTruthy();
+    });
+
+    it("should tick the methods the provider already has", () => {
+      showStripe({ checkoutPaymentMethodTypes: ["card", "twint"] });
+      renderPage();
+
+      expect(screen.getByRole("checkbox", { name: "Card" })).toBeChecked();
+      expect(screen.getByRole("checkbox", { name: "TWINT" })).toBeChecked();
+      expect(screen.getByRole("checkbox", { name: "PayPal" })).not.toBeChecked();
+    });
+
+    it("should send the ticked methods", async () => {
+      showStripe({ checkoutPaymentMethodTypes: ["card"] });
+      renderPage();
+
+      fireEvent.click(screen.getByRole("checkbox", { name: "TWINT" }));
+      save();
+
+      await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalled());
+      expect(await methods()).toEqual(["card", "twint"]);
+    });
+
+    /**
+     * Clearing the selection and never having made one are the same instruction to the server —
+     * both mean "offer whatever the account's own configuration enables" — so unticking
+     * everything has to omit the field rather than send an empty array, which Stripe rejects.
+     */
+    it("should omit the list entirely once everything is unticked", async () => {
+      showStripe({ checkoutPaymentMethodTypes: ["card"] });
+      renderPage();
+
+      fireEvent.click(screen.getByRole("checkbox", { name: "Card" }));
+      save();
+
+      await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalled());
+      expect(await methods()).toBeUndefined();
+    });
+
+    /**
+     * Stripe rejects a session naming both, and the server resolves that by letting the ticked
+     * list win. The form says so by disabling the input rather than by implying both apply.
+     */
+    it("should disable the configuration id once a method is ticked", () => {
+      showStripe({ paymentMethodConfigurationId: "pmc_123" });
+      renderPage();
+
+      const configurationId = screen.getByLabelText(
+        /Payment method configuration ID/,
+      );
+      expect(configurationId).toBeEnabled();
+      expect((configurationId as HTMLInputElement).value).toBe("pmc_123");
+
+      fireEvent.click(screen.getByRole("checkbox", { name: "Card" }));
+
+      expect(configurationId).toBeDisabled();
+    });
+
+    it("should refuse a configuration id that is not one", async () => {
+      showStripe();
+      renderPage();
+
+      fireEvent.change(
+        screen.getByLabelText(/Payment method configuration ID/),
+        { target: { value: "card" } },
+      );
+      save();
+
+      expect(
+        await screen.findByText(
+          "A Stripe payment method configuration id starts with pmc_.",
+        ),
+      ).toBeTruthy();
+      expect(mutateAsyncMock).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The case this form could otherwise destroy. Both fields are settable through the API, where
+     * nothing holds them to the list of checkboxes offered here.
+     *
+     * Ticking any box rewrites the whole list from what the form offers, so a stored method the
+     * form did not offer would be dropped by an edit that had nothing to do with it — the
+     * operator ticks PayPal and silently loses us_bank_account from a live checkout. Showing it
+     * is what makes the rewrite lossless. (An untouched Save was never the risk: form state
+     * still holds what it hydrated.)
+     */
+    it("should show a method it does not itself offer, and keep it across an unrelated edit", async () => {
+      showStripe({ checkoutPaymentMethodTypes: ["card", "us_bank_account"] });
+      renderPage();
+
+      expect(
+        screen.getByRole("checkbox", { name: "us_bank_account" }),
+      ).toBeChecked();
+
+      fireEvent.click(screen.getByRole("checkbox", { name: "PayPal" }));
+      save();
+
+      await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalled());
+      expect(await methods()).toEqual(["card", "paypal", "us_bank_account"]);
+    });
+
+    /** Shown, so it can also be removed deliberately. */
+    it("should let an unoffered method be removed", async () => {
+      showStripe({ checkoutPaymentMethodTypes: ["card", "us_bank_account"] });
+      renderPage();
+
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: "us_bank_account" }),
+      );
+      save();
+
+      await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalled());
+      expect(await methods()).toEqual(["card"]);
+    });
+
+    /**
+     * Hidden for Adyen, but still hydrated from the stored provider and sent back — stripping it
+     * would clear a value this form never showed the operator.
+     */
+    it("should preserve methods stored on a provider that does not show them", async () => {
+      providersState = {
+        data: [provider({ checkoutPaymentMethodTypes: ["card"] })],
+        isLoading: false,
+        isError: false,
+      };
+      renderPage();
+
+      expect(screen.queryByRole("checkbox", { name: "Card" })).toBeNull();
+
+      save();
+
+      await waitFor(() => expect(mutateAsyncMock).toHaveBeenCalled());
+      expect(await methods()).toEqual(["card"]);
+    });
+
+    /** A method Stripe cannot charge again is marked, since ticking it changes no renewal. */
+    it("should mark the methods that cannot back a renewal", () => {
+      showStripe();
+      renderPage();
+
+      expect(screen.getAllByText("one-off payments only")).toHaveLength(2);
+    });
   });
 });

--- a/client/app/cross-modules/utilities/payment/pages/update-payment-provider-page.tsx
+++ b/client/app/cross-modules/utilities/payment/pages/update-payment-provider-page.tsx
@@ -60,6 +60,8 @@ export const UpdatePaymentProviderPage = () => {
       maxRefundDays: 0,
       storeId: "",
       isEnabled: true,
+      checkoutPaymentMethodTypes: [],
+      paymentMethodConfigurationId: "",
     },
   });
 
@@ -75,6 +77,9 @@ export const UpdatePaymentProviderPage = () => {
       maxRefundDays: provider.maxRefundDays,
       storeId: provider.storeId ?? "",
       isEnabled: provider.isEnabled,
+      checkoutPaymentMethodTypes: provider.checkoutPaymentMethodTypes ?? [],
+      paymentMethodConfigurationId:
+        provider.paymentMethodConfigurationId ?? "",
     });
   }, [form, provider]);
 
@@ -132,6 +137,20 @@ export const UpdatePaymentProviderPage = () => {
       maxRefundDays: values.maxRefundDays,
       storeId: normalizeOptional(values.storeId),
       isEnabled: values.isEnabled,
+      // Omitted when empty: the server reads an absent list and an empty one the same way, as
+      // "defer to the account's configuration", so unticking everything clears the selection.
+      //
+      // Sent whatever the provider is, rather than only for Stripe. The fields are hidden for
+      // anything else, but they are hydrated from the stored provider either way — so sending
+      // them back preserves what is there, where stripping them would quietly clear a value this
+      // form never showed.
+      checkoutPaymentMethodTypes:
+        values.checkoutPaymentMethodTypes.length > 0
+          ? values.checkoutPaymentMethodTypes
+          : undefined,
+      paymentMethodConfigurationId: normalizeOptional(
+        values.paymentMethodConfigurationId,
+      ),
     };
 
     try {
@@ -199,7 +218,13 @@ export const UpdatePaymentProviderPage = () => {
                     Saving replaces only the fields shown below.
                   </p>
                 </div>
-                <PaymentProviderConfigurationFields includeEnabled />
+                <PaymentProviderConfigurationFields
+                  includeEnabled
+                  providerName={provider.providerName}
+                  additionalPaymentMethods={
+                    provider.checkoutPaymentMethodTypes ?? []
+                  }
+                />
               </section>
 
               {submissionError && (

--- a/client/app/cross-modules/utilities/payment/schemas/payment-provider.schema.test.ts
+++ b/client/app/cross-modules/utilities/payment/schemas/payment-provider.schema.test.ts
@@ -226,4 +226,87 @@ describe("payment provider schemas", () => {
     expect(result.success).toBe(true);
   });
 
+  /**
+   * The two payment method fields. Neither is validated on the server, so the checks here and the
+   * fixed checkbox list in the form are the whole of the guard against a value Stripe will refuse.
+   */
+  describe("checkout payment methods", () => {
+    it("accepts a Dashboard configuration id", () => {
+      const result = registerPaymentProviderSchema.safeParse({
+        ...stripeBase,
+        paymentMethodConfigurationId: "pmc_123",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a configuration id that is not one", () => {
+      const result = registerPaymentProviderSchema.safeParse({
+        ...stripeBase,
+        paymentMethodConfigurationId: "card",
+      });
+
+      expect(messageFor(result, "paymentMethodConfigurationId")).toBe(
+        "A Stripe payment method configuration id starts with pmc_.",
+      );
+    });
+
+    /** Blank is how the form says "not set", the same as every other optional field here. */
+    it("accepts a blank configuration id", () => {
+      const result = registerPaymentProviderSchema.safeParse({
+        ...stripeBase,
+        paymentMethodConfigurationId: "",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("defaults the method list to empty when it is absent", () => {
+      const result = registerPaymentProviderSchema.safeParse(stripeBase);
+
+      expect(result.success && result.data.checkoutPaymentMethodTypes).toEqual(
+        [],
+      );
+    });
+
+    it("keeps the methods it was given, in the order given", () => {
+      const result = registerPaymentProviderSchema.safeParse({
+        ...stripeBase,
+        checkoutPaymentMethodTypes: ["card", "twint"],
+      });
+
+      expect(result.success && result.data.checkoutPaymentMethodTypes).toEqual([
+        "card",
+        "twint",
+      ]);
+    });
+
+    /**
+     * A method this build does not offer as a checkbox, set through the API. Rejecting it would
+     * leave that provider unsaveable from the portal, which is worse than accepting a value the
+     * operator did not choose here and cannot mistype here either.
+     */
+    it("accepts a method the form does not itself offer", () => {
+      const result = updatePaymentProviderSchema.safeParse({
+        frontendResultUrl: "https://app.example/payment/result",
+        countryCode: "CH",
+        manualCapture: false,
+        maxRefundDays: 365,
+        storeId: "",
+        isEnabled: true,
+        checkoutPaymentMethodTypes: ["us_bank_account"],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a blank method rather than sending one to Stripe", () => {
+      const result = registerPaymentProviderSchema.safeParse({
+        ...stripeBase,
+        checkoutPaymentMethodTypes: [""],
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/client/app/cross-modules/utilities/payment/schemas/payment-provider.schema.ts
+++ b/client/app/cross-modules/utilities/payment/schemas/payment-provider.schema.ts
@@ -38,6 +38,27 @@ const providerConfigurationShape = {
     .min(0)
     .max(3650),
   storeId: optionalText(200),
+  // Loose on purpose. The list is authored through a fixed set of checkboxes, so nothing unknown
+  // can be added here — but a provider configured through the API may already hold a method this
+  // form does not offer, and rejecting it would leave that provider unsaveable from the portal.
+  // The cap mirrors the organizationIds convention: comfortably above anything real, so an
+  // oversized list is reported in the form rather than as a request that fails.
+  checkoutPaymentMethodTypes: z
+    .array(z.string().trim().min(1).max(100))
+    .max(50)
+    .default([]),
+  // A typo guard the server does not have: neither of these two fields is validated server-side,
+  // so a mistyped id would otherwise reach Stripe and fail there, at checkout, for a shopper.
+  paymentMethodConfigurationId: z
+    .string()
+    .trim()
+    .max(100)
+    .refine(
+      (value) => value.length === 0 || value.startsWith("pmc_"),
+      "A Stripe payment method configuration id starts with pmc_.",
+    )
+    .optional()
+    .or(z.literal("")),
 };
 
 const isAdyenHmac = (value: string) => /^[0-9A-Fa-f]{64}$/.test(value);


### PR DESCRIPTION
## What this closes

PR #411 put two fields on the provider configuration — `paymentMethodConfigurationId` and `checkoutPaymentMethodTypes` — live on the register request, the update request and the provider response. **Neither was reachable from the portal.** Setting them meant calling `PUT /payments/providers/{id}` by hand, with the current `version` read first. This gives them a control on both provider pages.

Client-only. No server change, no API change.

## The thing the UI has to say out loud

TWINT and Klarna are offered, and marked **`one-off payments only`**.

The reason they never appeared on a subscription's checkout was never a hardcoded `payment_method_types`. A subscription's first charge stores the method for its renewals, and Stripe narrows such a session to methods it can charge again — a subscription bought with TWINT could never renew itself. Without the badge, an operator ticks TWINT, sees nothing change on the subscription page, and files a bug.

The badge is derived from `REUSABLE_OFF_SESSION_PAYMENT_METHODS`, mirroring the server's `StripePaymentMethodSelection.ReusableOffSession` — one set rather than a per-option flag, so a method set through the API is badged correctly too.

## Three decisions, each proved by reverting it

**A stored method this list does not offer is shown anyway**, labelled by its raw value.

This is the case the plan did not cover, and it destroys data. Ticking any box rewrites the whole list from what the form offers, so a provider holding `["card","us_bank_account"]` loses `us_bank_account` the moment an operator ticks PayPal — an edit that had nothing to do with it, silently changing a live checkout. I probed the exact mechanism rather than assuming it: an *untouched* Save was never at risk, since form state still holds what it hydrated. Removing the guard: `expected [ 'card', 'paypal' ] to deeply equal [ 'card', 'us_bank_account' ]`.

**Unticking everything omits the field rather than sending `[]`.** Verified in `PaymentProviderConfigurationService.NormalizeMethods` (empty → null) and in `PaymentRepository`, whose update is an unconditional `.Set` — so absent really does clear, rather than meaning "leave unchanged". Removing it: `expected [] to be undefined`.

**Methods submit in the order shown, not the order ticked.** Stripe renders them in arrival order, and a checkbox list gives no sign of click order. Removing it: `expected [ 'twint', 'card' ] to deeply equal [ 'card', 'twint' ]`.

Also proved: dropping the Stripe-only gate fails 2 tests, one per page.

## Corner cases handled

| Case | Behaviour |
|---|---|
| Both fields set via the API | Configuration id shown but **disabled**, with the reason. Stripe rejects a session naming both; the server lets the ticked list win. |
| Value kept, not cleared, while disabled | Unticking every method restores it — reversible rather than silently destroyed. |
| Adyen provider holding methods | Fields hidden, but hydrated and **sent back**. Stripping them would clear a value this form never showed. |
| Stripe → Adyen mid-create | Cleared on switch, so a selection cannot be carried into a provider that ignores it. |
| A method outside the curated list | Accepted by the schema. Rejecting it would leave that provider unsaveable from the portal. |
| Badge inside the label | Deliberately outside it — inside, the accessible name becomes "TWINT one-off payments only". |

## Verification

- **2557 client tests pass** (338 files), including 28 new ones. Type-check clean; lint clean on all 9 changed files.
- The two `react-hooks/set-state-in-effect` lint errors under `client/.../payment` are in `stored-payment-methods-section.tsx`, which this PR does not touch — pre-existing on `dev`.

Manual, against a real Stripe test account — the point being step 4:

1. Create with provider **Stripe**; confirm switching to Adyen hides the block.
2. Tick Card + TWINT, save, re-open in edit — both still ticked, proving the response round-trips through `reset`.
3. A **one-off** payment offers Card and TWINT.
4. Subscribe to a plan → **Card only.** TWINT is dropped because the session stores the method for renewals. This is what the badge warns about.
5. Untick everything, save, repeat 3 → every Dashboard-enabled method returns.

## Out of scope

- **Server-side validation of these two fields.** The checkbox list constrains the only place they can currently be set from; a free-form API caller stays unvalidated. Worth a separate decision rather than a silent addition here.
- **Documentation.** These fields have no README or API-doc coverage at all — #411 added none, and this PR does not change the API contract. Flagging it as a gap rather than widening scope.
- PayPal on subscriptions still needs Stripe's recurring approval in live mode, and TWINT stays `pending` until the site meets its compliance requirements. Neither is unblocked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)