### PR TITLE
fix(subscription): trace the repair sweep, so the work it announces has an origin

### DIFF
--- a/docs/subscription/tracing/README.md
+++ b/docs/subscription/tracing/README.md
@@ -136,8 +136,12 @@ runs and a cancellation up to a year. A span that made itself a child of the req
 it would describe a single trace as lasting a year — past every backend's retention window, and not
 something anybody can open. The link says the same causal thing without lying about duration.
 
-`ScheduledByTraceId="none"` means nothing scheduled it from inside a request. Every sweep-announced
-item reads that way, and so does anything queued at startup.
+`ScheduledByTraceId="none"` means nothing scheduled it from inside a request or a sweep pass —
+anything queued at startup, for instance.
+
+The repair sweep runs each tenant pass inside a `subscription.repair_sweep` span, so its own
+announcement lines carry a trace id and the items it queues link back to the pass that found them.
+That is the answer to "why does this work exist?" when nothing a customer did explains it.
 
 The parent is whatever activity is ambient at dispatch — nothing in the worker loop, so an attempt
 there is a root span. When due jobs are run on demand from the admin endpoint instead, the attempt

--- a/server/Subscription.DomainService/Scheduling/SubscriptionWorkActivity.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionWorkActivity.cs
@@ -1,9 +1,10 @@
 using System.Diagnostics;
+using Payment.DomainService.Utilities;
 
 namespace Subscription.DomainService.Scheduling;
 
 /// <summary>
-/// The span every background work attempt runs inside.
+/// The spans the background work queue produces: one per attempt, and one per repair sweep pass.
 /// </summary>
 /// <remarks>
 /// A worker serves no HTTP request, so the ASP.NET Core instrumentation that gives every API line a
@@ -59,4 +60,31 @@ public static class SubscriptionWorkActivity
         ActivityContext.TryParse(traceParent, traceState: null, isRemote: true, out var context)
             ? context
             : null;
+
+    /// <summary>
+    /// One repair sweep pass over one tenant.
+    /// </summary>
+    /// <remarks>
+    /// The sweep announces work rather than running it, so its lines were the ones still arriving
+    /// with an empty trace id after attempts had theirs: an attempt runs inside a span, and the
+    /// scheduling that produced it did not.
+    /// <para>
+    /// Giving the pass a span closes that, and does a second thing worth more: it is what
+    /// <see cref="CurrentTraceParent"/> reads when the sweep queues an item, so an attempt that
+    /// starts minutes later links back to the pass that found it. Until this existed the sweep
+    /// stored no context and the link was dead weight for every item it announced — which is most
+    /// of them.
+    /// </para>
+    /// <para>
+    /// Internal, not Consumer: nothing handed this work to the sweep. It went looking.
+    /// </para>
+    /// </remarks>
+    public static Activity? StartRepairSweep(string tenantId)
+    {
+        var activity = Source.StartActivity("subscription.repair_sweep", ActivityKind.Internal);
+
+        activity?.SetTag("subscription.tenant_id", PaymentLogValue.Id(tenantId));
+
+        return activity;
+    }
 }

--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -148,6 +148,16 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
             .GetRequiredService<IPaymentTenantContextScopeFactory>()
             .Establish(tenantId);
 
+        // Before the log scope, because the trace enricher stamps a line from whatever is current
+        // when it is written and the announcement lines below were the last ones still arriving
+        // without a trace id — an attempt runs inside a span, and the scheduling that produced it
+        // did not.
+        //
+        // It also gives the items this pass queues something to remember: the scheduler stores
+        // whatever is current as their trace context, so an attempt that starts minutes from now
+        // links back to this pass rather than to nothing.
+        using var activity = SubscriptionWorkActivity.StartRepairSweep(tenantId);
+
         using var logScope = _logger.BeginScope(new Dictionary<string, object?>
         {
             ["TenantHash"] = PaymentLogValue.Hash(tenantId),

--- a/server/XUnitTest/Subscription/SubscriptionWorkSchedulerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionWorkSchedulerTests.cs
@@ -206,6 +206,28 @@ public sealed class SubscriptionWorkSchedulerTests
         _scheduled.Should().ContainSingle().Which.TraceParent.Should().BeNull();
     }
 
+    [Fact]
+    public async Task Work_announced_by_a_sweep_remembers_the_pass_that_found_it()
+    {
+        using var listener = Listening(SubscriptionWorkActivity.SourceName);
+        using var pass = SubscriptionWorkActivity.StartRepairSweep(TenantId);
+
+        await Scheduler().ScheduleAsync(
+            SubscriptionWorkType.UsagePeriodClosure,
+            TenantId,
+            "sweep:20260903T1225Z",
+            _time.GetUtcNow().UtcDateTime,
+            "sweep-20260903T1225Z-e316fb7e");
+
+        // The sweep announces most of the queue, so without a span of its own every one of those
+        // items stored no context and the link on the attempt had nothing to point at.
+        pass.Should().NotBeNull();
+        pass!.Kind.Should().Be(ActivityKind.Internal);
+
+        var stored = _scheduled.Should().ContainSingle().Subject.TraceParent;
+        SubscriptionWorkActivity.SchedulingContext(stored)!.Value.TraceId.Should().Be(pass.TraceId);
+    }
+
     private static ActivityListener Listening(string sourceName)
     {
         // Without one, StartActivity returns null and there is no request to have been scheduled


### PR DESCRIPTION
Completes #413 / #414. This commit was pushed to #414 after its merge commit was cut, so it did not land — same change, re-based on current `dev`.

## What is still missing in production

From a `dev` worker, after #413 and #414:

```
[]                                    Repair sweep announced subscription work AnnouncedCount=1 …
[]                                    Scheduled subscription work WorkType=UsagePeriodClosure …
[cb3d2d8e34c634e6cdcdbb7fcae2324c]    Subscription lifecycle event …
[cb3d2d8e34c634e6cdcdbb7fcae2324c]    Subscription lifecycle event …
[cb3d2d8e34c634e6cdcdbb7fcae2324c]    Subscription work completed …
```

Attempts have trace ids and all three lines of one attempt share it — that is #413 working. The two lines still empty are the **scheduling** side: an attempt runs inside a span, and the sweep that queued it does not. `SweepTenantAsync` opened a log scope and no activity.

## Change

Each tenant sweep pass now runs inside a `subscription.repair_sweep` span. `Internal`, not `Consumer` — nothing handed this work to the sweep, it went looking.

## It also closes a hole in #414

The scheduler stores whatever activity is current as an item's trace context. **The sweep had nothing current, so every item it announced stored null** and the link on the attempt had nothing to point at. Since the sweep announces most of the queue, #414's link was dead weight for most of it — including the `UsagePeriodClosure` items in the log above.

An attempt now leads back to the pass that found it, which is the answer to *"why does this work exist?"* when nothing a customer did explains it.

## What to expect after deploy

The two lines above get trace ids. A sweep pass and the attempt it queues will have **different** trace ids joined by a link, not one shared id — the link-not-parent decision from #414, because attempts can run a month after they are queued.

## Verification

- `dotnet build` Worker → **0 errors**
- `dotnet test --filter XUnitTest.Subscription` → **1,620 passed, 4 failed**

The 4 are the pre-existing `SubscriptionSimulation*` permission failures, unrelated and present on clean `dev`.

One new test — `Work_announced_by_a_sweep_remembers_the_pass_that_found_it` — asserting the stored context resolves to the sweep pass's trace, which is the behaviour that makes #414's link useful for sweep-announced work.

## Not in this PR

`PaymentBackgroundWorkDispatcher` still has no activity of its own and no link back; its worker lines will keep showing `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
