### PR TITLE
fix(subscription): let the simulation harness act as the console organization

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.test.tsx
@@ -170,3 +170,45 @@ describe("SubscriptionSimulationPage overage-terms visibility", () => {
     expect(screen.queryByText(/^Usage$/)).not.toBeInTheDocument();
   });
 });
+
+/**
+ * What the default scope is called.
+ *
+ * Selecting no organization does not act tenant-wide. The server reads a blank organization as
+ * the console's own — a real organization, the one a subscription created here is stored under —
+ * so calling it "Tenant-wide" told an operator they had a subscription belonging to no
+ * organization in particular, which nothing in the model can produce. It also read as a
+ * contradiction of the heading right beside it, "Every action below is scoped to this
+ * organization".
+ */
+describe("SubscriptionSimulationPage acting-as scope", () => {
+  const withNoSubscription = () =>
+    useCurrentSimulatedSubscription.mockReturnValue({
+      data: null,
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+  it("names the console organization rather than calling it tenant-wide", () => {
+    withNoSubscription();
+
+    renderPage();
+
+    expect(screen.getByLabelText("Organization")).toHaveTextContent(
+      "Console organization",
+    );
+    expect(screen.queryByText("Tenant-wide only")).not.toBeInTheDocument();
+  });
+
+  it("says what acting with no organization named actually does", () => {
+    withNoSubscription();
+
+    renderPage();
+
+    expect(
+      screen.getByText(/acts as the console's own/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -78,7 +78,13 @@ export const SubscriptionSimulationPage = () => {
 
   const scopeLabel = useMemo(() => {
     if (!organizationScope) {
-      return "Tenant-wide";
+      // Not "Tenant-wide", which is what this said and is not what happens. Naming no
+      // organization does not act tenant-wide: the server reads it as the console's own
+      // organization (Payment:ConsoleOrganizationId, "default" out of the box) and a
+      // subscription created here is stored under it. Calling it tenant-wide left an operator
+      // believing they had a subscription belonging to no organization in particular, which
+      // nothing in the model can produce.
+      return "Console organization";
     }
     return (
       organizationsData?.organizations?.find(
@@ -240,6 +246,8 @@ export const SubscriptionSimulationPage = () => {
             <p className="text-xs text-muted-foreground">
               Every action below is scoped to this organization, exactly as it would be for a
               real integration.
+              {!organizationScope &&
+                " Naming no organization acts as the console's own — a real organization, not a tenant-wide one, and what a subscription created here belongs to."}
             </p>
           </div>
 
@@ -255,7 +263,9 @@ export const SubscriptionSimulationPage = () => {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={TENANT_WIDE_ORGANIZATION}>Tenant-wide only</SelectItem>
+              <SelectItem value={TENANT_WIDE_ORGANIZATION}>
+                Console organization
+              </SelectItem>
               {organizations.map((organization) => (
                 <SelectItem key={organization.itemId} value={organization.itemId}>
                   {organization.name}

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationDataConsoleService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationDataConsoleService.cs
@@ -228,19 +228,9 @@ public sealed class SubscriptionSimulationDataConsoleService : ISubscriptionSimu
                 correlationId));
         }
 
-        if (string.IsNullOrWhiteSpace(organizationId))
-        {
-            return (null, SubscriptionOperationResult<T>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_simulation_organization_required",
-                "organizationId is required: the console has no subscription of its own.",
-                correlationId,
-                new Dictionary<string, string[]>
-                {
-                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
-                }));
-        }
-
+        // A blank organization is left to the resolver, which reads it as the console's own
+        // organization for a console caller — the same answer POST /subscriptions gives. See
+        // SubscriptionSimulationService.ResolveTargetAsync for the whole reasoning.
         var resolution = await _contextResolver.ResolveAsync(correlationId, organizationId, cancellationToken);
 
         if (!resolution.IsSuccess || resolution.Context is null)

--- a/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
+++ b/server/Subscription.DomainService/Simulation/SubscriptionSimulationService.cs
@@ -102,19 +102,6 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
                 correlationId);
         }
 
-        if (string.IsNullOrWhiteSpace(organizationId))
-        {
-            return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_simulation_organization_required",
-                "organizationId is required: the console has no subscription of its own.",
-                correlationId,
-                new Dictionary<string, string[]>
-                {
-                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
-                });
-        }
-
         if (!IsValidLimit(auditLimit) || !IsValidLimit(paymentLimit))
         {
             return SubscriptionOperationResult<SubscriptionSimulationStateResponse>.Failure(
@@ -131,6 +118,8 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
 
         // Resolves and, for the console, verifies the named organization actually exists — the
         // guard above only established who is asking, not that what they asked for is real.
+        // A blank organization is its question too, not one to pre-empt here; see
+        // ResolveTargetAsync for why refusing it outright was wrong.
         var resolution = await _contextResolver.ResolveAsync(
             correlationId, organizationId, cancellationToken);
 
@@ -656,19 +645,16 @@ public sealed class SubscriptionSimulationService : ISubscriptionSimulationServi
                 correlationId));
         }
 
-        if (string.IsNullOrWhiteSpace(organizationId))
-        {
-            return (null, null, SubscriptionOperationResult<T>.Failure(
-                PaymentFailureKind.Validation,
-                "subscription_simulation_organization_required",
-                "organizationId is required: the console has no subscription of its own.",
-                correlationId,
-                new Dictionary<string, string[]>
-                {
-                    ["OrganizationId"] = ["'Organization Id' must not be empty."]
-                }));
-        }
-
+        // Deliberately not refused when blank. The harness is reachable only by the console
+        // (see SubscriptionSimulationGuard), and for a console caller a blank organization is
+        // not "nobody" — the resolver reads it as the console's own organization, exactly as
+        // POST /subscriptions and GET /subscriptions/current already do. Refusing it here made
+        // the harness the only path on the page that disagreed: an operator could subscribe
+        // under the console scope, be shown the subscription, and then be told the console has
+        // no subscription of its own when they tried to renew it.
+        //
+        // A genuinely unresolvable organization still fails, in the resolver, as
+        // subscription_organization_missing.
         var resolution = await _contextResolver.ResolveAsync(
             correlationId, organizationId, cancellationToken);
 

--- a/server/XUnitTest/Subscription/SubscriptionSimulationDataConsoleServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationDataConsoleServiceTests.cs
@@ -2,6 +2,7 @@ using Blocks.Genesis;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Payment.DomainService.Enums;
 using Payment.DomainService.Utilities;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Services;
@@ -104,10 +105,21 @@ public sealed class SubscriptionSimulationDataConsoleServiceTests : IDisposable
         result.ErrorCode.Should().Be("subscription_simulation_limit_invalid");
     }
 
+    /// <summary>
+    /// Naming no organization is resolved as the console's own, not refused. See the matching
+    /// test on <c>SubscriptionSimulationServiceTests</c> for why.
+    /// </summary>
     [Fact]
-    public async Task Find_requires_an_organization_because_the_console_has_none_of_its_own()
+    public async Task Find_resolves_a_blank_organization_rather_than_refusing_it()
     {
         SetAuthorizedCaller();
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                CorrelationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Unavailable,
+                "subscription_organization_missing",
+                "An organization is required to resolve a subscription."));
 
         var result = await CreateService().FindAsync(
             "subscriptions",
@@ -115,8 +127,14 @@ public sealed class SubscriptionSimulationDataConsoleServiceTests : IDisposable
             CorrelationId,
             CancellationToken.None);
 
-        result.IsSuccess.Should().BeFalse();
-        result.ErrorCode.Should().Be("subscription_simulation_organization_required");
+        result.ErrorCode.Should().Be(
+            "subscription_organization_missing",
+            "the resolver's own answer, not a refusal the harness invented first");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                CorrelationId, null, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the blank organization is resolved, not refused before resolving");
     }
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionSimulationServiceTests.cs
@@ -96,15 +96,78 @@ public sealed class SubscriptionSimulationServiceTests : IDisposable
         result.ErrorCode.Should().Be("subscription_simulation_forbidden");
     }
 
+    /// <summary>
+    /// A blank organization is handed to the resolver rather than refused before it runs.
+    /// </summary>
+    /// <remarks>
+    /// The harness used to reject it outright, saying the console has no subscription of its own.
+    /// It does have one: for a console caller the resolver reads a blank organization as the
+    /// console's own, which is exactly what <c>POST /subscriptions</c> and
+    /// <c>GET /subscriptions/current</c> already do with the same input. So an operator working
+    /// in the console scope could create a subscription, be shown it, and then be told the
+    /// console has no subscription of its own the moment they tried to renew it.
+    /// <para>
+    /// Whether a blank organization resolves to anything is now the resolver's question alone,
+    /// and its refusal is the one that surfaces.
+    /// </para>
+    /// </remarks>
     [Fact]
-    public async Task Requires_an_organization_because_the_console_has_none_of_its_own()
+    public async Task A_blank_organization_is_resolved_rather_than_refused()
     {
         SetAuthorizedCaller();
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                CorrelationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Unresolved(
+                PaymentFailureKind.Unavailable,
+                "subscription_organization_missing",
+                "An organization is required to resolve a subscription."));
 
         var result = await GetStateAsync(organizationId: null);
 
         result.IsSuccess.Should().BeFalse();
-        result.ErrorCode.Should().Be("subscription_simulation_organization_required");
+        result.ErrorCode.Should().Be(
+            "subscription_organization_missing",
+            "the resolver's own answer, not a refusal the harness invented first");
+        _contextResolver.Verify(
+            resolver => resolver.ResolveAsync(
+                CorrelationId, null, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// And when it does resolve, the subscription is looked up under the console's own
+    /// organization — the same one subscribing without naming an organization stored it under.
+    /// </summary>
+    /// <remarks>
+    /// Reported as <c>subscription_not_found</c> here only because this test stubs no
+    /// subscription; the point is which organization was searched, which the verification below
+    /// pins exactly.
+    /// </remarks>
+    [Fact]
+    public async Task A_blank_organization_acts_as_the_console_organization()
+    {
+        SetAuthorizedCaller();
+        _contextResolver
+            .Setup(resolver => resolver.ResolveAsync(
+                CorrelationId, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(
+                    TenantId, ConsoleOrganizationId, "user-1", "user-1")));
+
+        var result = await CreateService().AdvanceRenewalAsync(
+            SubscriptionId,
+            new AdvanceRenewalRequest { OrganizationId = null, RunImmediately = true },
+            CorrelationId,
+            CancellationToken.None);
+
+        result.ErrorCode.Should().NotBe("subscription_simulation_organization_required");
+        _subscriptions.Verify(
+            repository => repository.GetAsync(
+                TenantId, ConsoleOrganizationId, SubscriptionId,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the blank organization became the console's own, and that is what was searched");
     }
 
     [Theory]


### PR DESCRIPTION
## The report

Advancing a renewal from the simulation console returned:

```json
{"code":"subscription_simulation_organization_required",
 "message":"organizationId is required: the console has no subscription of its own."}
```

…for a subscription created from that same page moments earlier.

## Why

The harness rejected a blank `organizationId` **before resolving it**. Nothing else does. For a console caller the resolver reads a blank organization as *the console's own*, which is exactly what `POST /subscriptions` and `GET /subscriptions/current` already do — so one page held three paths that disagreed about identical input:

| Path | blank `organizationId` → | Outcome |
|---|---|---|
| Subscribe | console org | ✅ created the subscription |
| Read current | console org | ✅ displayed it |
| **Harness** | **refused** | ❌ could not touch it |

An operator could subscribe under the console scope, be shown the subscription, and then be told the console has no subscription of its own when they tried to renew it. The message was the wrong half of its own contradiction: the console *does* have one, because subscribing had just made it.

I proved the resolution against the real resolver rather than inferring it from types:

```
Console_naming_nothing_resolves_to_the_console_organization
  → IsSuccess: true
  → OrganizationId: "default"
```

`PaymentOptions.cs:149` already says so — the console organization is *"a real identifier, not the tenant-level null"*.

## What changed

Three early checks removed — `GetStateAsync`, `ResolveTargetAsync`, and the data console's `ResolveAsync` — so all three delegate to the resolver like every other path.

**This reaches no wider than before.** `SubscriptionSimulationGuard` already restricts the harness to the console, and the resolver answers with the caller's *own* organization, never another's. A genuinely unresolvable organization still fails, in the resolver, as `subscription_organization_missing` — pinned by a test.

Also relabels the scope selector, which said **"Tenant-wide only"** directly beneath a heading reading *"Every action below is scoped to this organization"*. Naming no organization is not tenant-wide — it is one real organization, the console's. The old label told an operator they had a subscription belonging to no organization in particular, which nothing in the model can produce (`SubscriptionContextResolver` refuses a blank org deliberately: *"a subscription belongs to an organization"*).

Left untouched everywhere "Tenant-wide" describes a **plan's** scope — including the plan-list filter — where it is the correct meaning. Only the "Acting as" selector named an actor.

## Considered and rejected

Forbidding console-owned subscriptions instead — making `POST /subscriptions` refuse when the console names no organization. Closer to the intent the old message asserted, but it changes a live endpoint's behaviour and would orphan subscriptions already created this way, reachable by neither path. Raised with the requester; this direction was chosen deliberately.

## Verification

- **3603 server unit tests pass**; **78 simulation client tests pass** (2 new); type-check and lint clean.
- Each of the three server sites and the label was proved by reverting it and recording the failure — e.g. restoring the `GetStateAsync` check: `Expected result.ErrorCode to be a match … but it differs at index 13`.
- The 4 remaining server failures are the pre-existing `SubscriptionSimulationGuard` permission set (`Refuses_the_console_without_the_permission` and three others). **Its permission check is still commented out with `return true` on `dev`** (commit `8d7a4389`, 24 Aug), so today any console-authenticated caller reaches the harness regardless of `subscription-simulation-administrator`. Untouched here, but it is the guard this PR relies on for scope, so it is worth closing separately.

## For the reporter

Your existing subscription `cb2baaf4…` needs no repair — it belongs to the console organization and will be reachable once this ships. Until then, `?organizationId=default` on the simulation page URL works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)