### PR TITLE
Accept a batch of files on both conversion endpoints

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -6,7 +6,7 @@
     <members>
         <member name="T:Api.Controllers.DocumentConversionsController">
             <summary>
-            Converting a word-processing document (.doc, .docx, .rtf, .odt, ...) into a PDF.
+            Converting word-processing documents (.doc, .docx, .rtf, .odt, ...) into PDF.
             </summary>
             <remarks>
             Its own controller rather than another action on <c>PdfGeneratorController</c>, because a
@@ -14,45 +14,54 @@
             about afterwards. The PDF generator's other operations are fire-and-forget queue pushes that
             keep no record and have nothing to expose.
             <para>
-            The PDF replaces the source file, so the document's own storage ID is the only thing a caller
-            supplies — its name, extension and directory all come from the file's storage record.
+            Both endpoints take a list of file IDs and answer with one outcome per file, because a caller
+            converting or checking on several documents should not have to make one call per document. Each
+            PDF replaces its own source file, so a file's own storage ID is the only thing supplied for it —
+            its name, extension and directory all come from the file's storage record.
             </para>
             </remarks>
         </member>
         <member name="M:Api.Controllers.DocumentConversionsController.Convert(Utility.DomainService.PdfGenerator.ConvertDocumentToPdfRequest,System.Threading.CancellationToken)">
             <summary>
-            Queues a document for conversion to PDF.
+            Queues one or more documents for conversion to PDF.
             </summary>
             <remarks>
-            Returns 202 as soon as the conversion is recorded and queued — the document is not converted
-            yet. Polling uses the file's own ID, the one just sent in, so no second identifier is issued
-            for the caller to keep track of; the response repeats it as <c>fileId</c> alongside the
-            <c>statusUrl</c>.
+            Returns 202 as soon as the batch is recorded and queued — no document in it is converted yet.
+            Each file in <c>fileIds</c> is accepted or rejected independently: one blank or duplicate ID
+            does not stop the rest of the batch, and the response's <c>results</c> array says which is
+            which. Polling uses a file's own ID, the one just sent in, so no second identifier is issued
+            for the caller to keep track of.
             <para>
-            Supplying <c>messageCoRelationId</c> also gets a completion notification. It is optional, and
-            omitting it changes nothing about the conversion itself.
+            Supplying <c>messageCoRelationId</c> also gets a completion notification per file as each one
+            finishes. It is optional, and omitting it changes nothing about the conversions themselves.
             </para>
             </remarks>
         </member>
-        <member name="M:Api.Controllers.DocumentConversionsController.GetStatus(System.String,System.Threading.CancellationToken)">
+        <member name="M:Api.Controllers.DocumentConversionsController.GetStatus(Utility.DomainService.PdfGenerator.GetDocumentConversionStatusRequest,System.Threading.CancellationToken)">
             <summary>
-            Reads a conversion's outcome, and where to download the PDF once there is one.
+            Reads the conversion outcome of one or more files, and where to download each PDF once there
+            is one.
             </summary>
             <remarks>
-            The fallback for a completion notification that never arrived. A conversion that is still
-            running answers 200 with <c>status</c> of <c>Queued</c> or <c>Processing</c> and
-            <c>isComplete: false</c> — a poller stops when <c>isComplete</c> turns true, whether the
-            conversion succeeded or failed. <c>fileId</c> and <c>fileName</c> describe the file itself:
-            conversion happens in place, so the ID never changes and the name gains its .pdf extension
-            once the conversion succeeds.
+            The fallback for a completion notification that never arrived. A POST rather than a GET, even
+            though this only reads: the query needs to carry a list of file IDs, and a body on a GET is
+            inconsistently supported by clients, proxies and framework model binding.
             <para>
-            A failed conversion is still a 200: the question "what happened to this conversion?" was
-            answered. <c>errorCode</c> carries why it failed. 404 means that file was never submitted for
-            conversion, which is a different sentence entirely.
+            A file that is still running answers with <c>status</c> of <c>Queued</c> or <c>Processing</c>
+            and <c>isComplete: false</c> — a poller stops asking about that file once <c>isComplete</c>
+            turns true, whether the conversion succeeded or failed. A file that was never submitted for
+            conversion answers with <c>found: false</c> rather than dropping out of the response, so the
+            caller can match every ID they asked about against exactly one result.
+            </para>
+            <para>
+            The request as a whole is 400 only when it is structurally invalid — an empty or oversized
+            <c>fileIds</c> list. A per-file outcome such as "never submitted" or "failed" is carried in
+            that file's own result entry, not the HTTP status, because one response can only carry one
+            status code for the whole batch.
             </para>
             <para>
             <c>downloadUrl</c> is resolved on each request because storage URLs expire, and is null until
-            the conversion succeeds.
+            a given file's conversion succeeds.
             </para>
             </remarks>
         </member>

--- a/server/Api/Controllers/DocumentConversionsController.cs
+++ b/server/Api/Controllers/DocumentConversionsController.cs
@@ -1,4 +1,4 @@
-﻿using Api.Utilities;
+using Api.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -9,7 +9,7 @@ using Utility.DomainService.PdfGenerator.service;
 namespace Api.Controllers;
 
 /// <summary>
-/// Converting a word-processing document (.doc, .docx, .rtf, .odt, ...) into a PDF.
+/// Converting word-processing documents (.doc, .docx, .rtf, .odt, ...) into PDF.
 /// </summary>
 /// <remarks>
 /// Its own controller rather than another action on <c>PdfGeneratorController</c>, because a
@@ -17,8 +17,10 @@ namespace Api.Controllers;
 /// about afterwards. The PDF generator's other operations are fire-and-forget queue pushes that
 /// keep no record and have nothing to expose.
 /// <para>
-/// The PDF replaces the source file, so the document's own storage ID is the only thing a caller
-/// supplies — its name, extension and directory all come from the file's storage record.
+/// Both endpoints take a list of file IDs and answer with one outcome per file, because a caller
+/// converting or checking on several documents should not have to make one call per document. Each
+/// PDF replaces its own source file, so a file's own storage ID is the only thing supplied for it —
+/// its name, extension and directory all come from the file's storage record.
 /// </para>
 /// </remarks>
 [ApiController]
@@ -32,76 +34,80 @@ public sealed class DocumentConversionsController : ControllerBase
         _conversions = conversions;
 
     /// <summary>
-    /// Queues a document for conversion to PDF.
+    /// Queues one or more documents for conversion to PDF.
     /// </summary>
     /// <remarks>
-    /// Returns 202 as soon as the conversion is recorded and queued — the document is not converted
-    /// yet. Polling uses the file's own ID, the one just sent in, so no second identifier is issued
-    /// for the caller to keep track of; the response repeats it as <c>fileId</c> alongside the
-    /// <c>statusUrl</c>.
+    /// Returns 202 as soon as the batch is recorded and queued — no document in it is converted yet.
+    /// Each file in <c>fileIds</c> is accepted or rejected independently: one blank or duplicate ID
+    /// does not stop the rest of the batch, and the response's <c>results</c> array says which is
+    /// which. Polling uses a file's own ID, the one just sent in, so no second identifier is issued
+    /// for the caller to keep track of.
     /// <para>
-    /// Supplying <c>messageCoRelationId</c> also gets a completion notification. It is optional, and
-    /// omitting it changes nothing about the conversion itself.
+    /// Supplying <c>messageCoRelationId</c> also gets a completion notification per file as each one
+    /// finishes. It is optional, and omitting it changes nothing about the conversions themselves.
     /// </para>
     /// </remarks>
     [HttpPost]
     [ProducesResponseType(
-        typeof(ApiResponse<ConvertDocumentToPdfAcceptedResponse>),
+        typeof(ApiResponse<ConvertDocumentsToPdfBatchResponse>),
         StatusCodes.Status202Accepted)]
     [ProducesResponseType(
-        typeof(ApiResponse<ConvertDocumentToPdfAcceptedResponse>),
+        typeof(ApiResponse<ConvertDocumentsToPdfBatchResponse>),
         StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(
-        typeof(ApiResponse<ConvertDocumentToPdfAcceptedResponse>),
+        typeof(ApiResponse<ConvertDocumentsToPdfBatchResponse>),
         StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> Convert(
         [FromBody] ConvertDocumentToPdfRequest request,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
-        var result = await _conversions.RequestConversionAsync(request, correlationId, cancellationToken);
+        var result = await _conversions.RequestConversionsAsync(request, correlationId, cancellationToken);
 
         return result.ToActionResult(correlationId, StatusCodes.Status202Accepted);
     }
 
     /// <summary>
-    /// Reads a conversion's outcome, and where to download the PDF once there is one.
+    /// Reads the conversion outcome of one or more files, and where to download each PDF once there
+    /// is one.
     /// </summary>
     /// <remarks>
-    /// The fallback for a completion notification that never arrived. A conversion that is still
-    /// running answers 200 with <c>status</c> of <c>Queued</c> or <c>Processing</c> and
-    /// <c>isComplete: false</c> — a poller stops when <c>isComplete</c> turns true, whether the
-    /// conversion succeeded or failed. <c>fileId</c> and <c>fileName</c> describe the file itself:
-    /// conversion happens in place, so the ID never changes and the name gains its .pdf extension
-    /// once the conversion succeeds.
+    /// The fallback for a completion notification that never arrived. A POST rather than a GET, even
+    /// though this only reads: the query needs to carry a list of file IDs, and a body on a GET is
+    /// inconsistently supported by clients, proxies and framework model binding.
     /// <para>
-    /// A failed conversion is still a 200: the question "what happened to this conversion?" was
-    /// answered. <c>errorCode</c> carries why it failed. 404 means that file was never submitted for
-    /// conversion, which is a different sentence entirely.
+    /// A file that is still running answers with <c>status</c> of <c>Queued</c> or <c>Processing</c>
+    /// and <c>isComplete: false</c> — a poller stops asking about that file once <c>isComplete</c>
+    /// turns true, whether the conversion succeeded or failed. A file that was never submitted for
+    /// conversion answers with <c>found: false</c> rather than dropping out of the response, so the
+    /// caller can match every ID they asked about against exactly one result.
+    /// </para>
+    /// <para>
+    /// The request as a whole is 400 only when it is structurally invalid — an empty or oversized
+    /// <c>fileIds</c> list. A per-file outcome such as "never submitted" or "failed" is carried in
+    /// that file's own result entry, not the HTTP status, because one response can only carry one
+    /// status code for the whole batch.
     /// </para>
     /// <para>
     /// <c>downloadUrl</c> is resolved on each request because storage URLs expire, and is null until
-    /// the conversion succeeds.
+    /// a given file's conversion succeeds.
     /// </para>
     /// </remarks>
-    [HttpGet("{fileId}")]
+    [HttpPost("status")]
     [ProducesResponseType(
-        typeof(ApiResponse<DocumentConversionStatusResponse>),
+        typeof(ApiResponse<DocumentConversionStatusBatchResponse>),
         StatusCodes.Status200OK)]
     [ProducesResponseType(
-        typeof(ApiResponse<DocumentConversionStatusResponse>),
+        typeof(ApiResponse<DocumentConversionStatusBatchResponse>),
         StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType(
-        typeof(ApiResponse<DocumentConversionStatusResponse>),
-        StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetStatus(
-        [FromRoute] string fileId,
+        [FromBody] GetDocumentConversionStatusRequest request,
         CancellationToken cancellationToken)
     {
         var correlationId = HttpContext.TraceIdentifier;
-        var result = await _conversions.GetStatusAsync(fileId, correlationId, cancellationToken);
+        var result = await _conversions.GetStatusAsync(request, correlationId, cancellationToken);
 
         return result.ToActionResult(correlationId);
     }

--- a/server/Utility.DomainService/PdfGenerator/ConvertDocumentToPdfContracts.cs
+++ b/server/Utility.DomainService/PdfGenerator/ConvertDocumentToPdfContracts.cs
@@ -3,64 +3,117 @@ using Utility.DomainService.PdfGenerator.Entities;
 namespace Utility.DomainService.PdfGenerator
 {
     /// <summary>
-    /// Request to convert one word-processing document (.doc, .docx, .rtf, .odt, ...) to PDF.
+    /// Request to convert one or more word-processing documents (.doc, .docx, .rtf, .odt, ...) to
+    /// PDF.
     /// </summary>
     /// <remarks>
-    /// One document per request. The name, extension and directory all come from the file's storage
-    /// record, and the PDF replaces the source file, so the file's own ID is the only thing that has
-    /// to be supplied.
+    /// Each document's name, extension and directory all come from its own storage record, and the
+    /// PDF replaces the source file, so a file's own ID is the only thing that has to be supplied
+    /// for it.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class ConvertDocumentToPdfRequest
     {
         /// <summary>
-        /// Storage file ID of the document. The converted PDF is written back to this same ID under
-        /// a .pdf name, so anything already referencing the ID ends up pointing at the PDF — and the
-        /// same ID is what the status endpoint is polled with.
+        /// Storage file IDs of the documents to convert. Each converted PDF is written back to its
+        /// own ID under a .pdf name, so anything already referencing an ID ends up pointing at the
+        /// PDF — and that same ID is what the status endpoint is queried with. A duplicate ID in the
+        /// list is treated as one request for that file, not two.
         /// </summary>
-        public string InputFileId { get; set; } = string.Empty;
+        public List<string> FileIds { get; set; } = new();
 
         /// <summary>
-        /// Optional. Identifies the request so the caller is notified when the conversion finishes.
-        /// Leaving it empty skips the notification; the conversion still runs and its outcome is
+        /// Optional. Identifies the request so the caller is notified as each conversion finishes.
+        /// Leaving it empty skips the notification; the conversions still run and their outcomes are
         /// still readable from the status endpoint.
         /// </summary>
         public string? MessageCoRelationId { get; set; }
     }
 
     /// <summary>
-    /// The acknowledgement returned when a conversion is accepted.
+    /// Whether one file's conversion was queued, and if not, why.
     /// </summary>
+    /// <remarks>
+    /// A batch request accepts or rejects each file independently — one file with a blank ID does
+    /// not stop the rest of the batch from being queued. This is that per-file outcome, held inside
+    /// <see cref="ConvertDocumentsToPdfBatchResponse"/> rather than surfaced as an HTTP-level
+    /// failure, because a single response can only carry one status code for the batch as a whole.
+    /// </remarks>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class ConvertDocumentToPdfAcceptedResponse
+    public class DocumentConversionAcceptance
     {
         /// <summary>
-        /// The file being converted — the same ID that was sent in, and the one to poll with. No
-        /// second identifier is issued: the caller already has this one.
+        /// The file this outcome is about — the same ID that was sent in, and the one to query
+        /// status with. No second identifier is issued: the caller already has this one.
         /// </summary>
         public string FileId { get; set; } = string.Empty;
 
-        public string? MessageCoRelationId { get; set; }
-
-        public DocumentConversionStatus Status { get; set; } = DocumentConversionStatus.Queued;
-
         /// <summary>
-        /// Where to poll for this conversion's outcome.
+        /// True once the conversion has been recorded and queued. False means it never started —
+        /// <see cref="ErrorCode"/> says why, and there is nothing to poll for this file.
         /// </summary>
-        public string StatusUrl { get; set; } = string.Empty;
+        public bool Accepted { get; set; }
+
+        public DocumentConversionStatus? Status { get; set; }
+
+        public string? ErrorCode { get; set; }
+
+        public string? ErrorMessage { get; set; }
     }
 
     /// <summary>
-    /// A conversion's current state, and how to fetch the result once it has one.
+    /// The acknowledgement returned when a batch of conversions is accepted.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-    public class DocumentConversionStatusResponse
+    public class ConvertDocumentsToPdfBatchResponse
+    {
+        public string? MessageCoRelationId { get; set; }
+
+        /// <summary>
+        /// Where to check on the files in this batch — a POST, because the query needs to name the
+        /// files it is asking about and a URL alone cannot carry a list.
+        /// </summary>
+        public string StatusUrl { get; set; } = "/document-conversions/status";
+
+        public List<DocumentConversionAcceptance> Results { get; set; } = new();
+
+        public int AcceptedCount { get; set; }
+
+        public int RejectedCount { get; set; }
+    }
+
+    /// <summary>
+    /// Request to read the conversion state of one or more files.
+    /// </summary>
+    /// <remarks>
+    /// A POST rather than a GET, even though this only reads: the query needs to carry a list of
+    /// file IDs, and a body on a GET is inconsistently supported by clients, proxies and framework
+    /// model binding. The same trade the batch convert endpoint already makes for its own list.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class GetDocumentConversionStatusRequest
+    {
+        public List<string> FileIds { get; set; } = new();
+    }
+
+    /// <summary>
+    /// One file's conversion state, and how to fetch the result once it has one.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class DocumentConversionStatusResult
     {
         /// <summary>
-        /// The file this is about. Conversion happens in place, so this is both what was sent in and
+        /// The file this is about. Conversion happens in place, so this is both what was queried and
         /// where the PDF now lives.
         /// </summary>
         public string FileId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// False when this file was never submitted for conversion. <see cref="Status"/> and the
+        /// timestamps are meaningless in that case and are left null — there is no conversion for
+        /// them to describe.
+        /// </summary>
+        public bool Found { get; set; }
 
         /// <summary>
         /// The file's name as it currently stands: the document's name while the conversion is
@@ -70,10 +123,11 @@ namespace Utility.DomainService.PdfGenerator
 
         public string? MessageCoRelationId { get; set; }
 
-        public DocumentConversionStatus Status { get; set; }
+        public DocumentConversionStatus? Status { get; set; }
 
         /// <summary>
-        /// True once <see cref="Status"/> can no longer change, so a poller knows to stop.
+        /// True once <see cref="Status"/> can no longer change, so a poller knows to stop asking
+        /// about this file.
         /// </summary>
         public bool IsComplete { get; set; }
 
@@ -88,8 +142,14 @@ namespace Utility.DomainService.PdfGenerator
 
         public string? ErrorMessage { get; set; }
 
-        public DateTime RequestedAtUtc { get; set; }
+        public DateTime? RequestedAtUtc { get; set; }
 
         public DateTime? CompletedAtUtc { get; set; }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class DocumentConversionStatusBatchResponse
+    {
+        public List<DocumentConversionStatusResult> Results { get; set; } = new();
     }
 }

--- a/server/Utility.DomainService/PdfGenerator/service/DocumentConversionService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/DocumentConversionService.cs
@@ -11,6 +11,14 @@ namespace Utility.DomainService.PdfGenerator.service
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class DocumentConversionService : IDocumentConversionService
     {
+        /// <summary>
+        /// The most files one request may name. A caller fanning out an unbounded list in a single
+        /// call turns one HTTP request into an unbounded number of Mongo writes and queue publishes
+        /// before anything is returned; this keeps that work, and the time a caller waits for it,
+        /// bounded to something a single request should reasonably ask for.
+        /// </summary>
+        internal const int MaxBatchSize = 50;
+
         private readonly ILogger<DocumentConversionService> _logger;
         private readonly IMessageClient _messageClient;
         private readonly IPdfGeneratorRepository _repository;
@@ -29,34 +37,97 @@ namespace Utility.DomainService.PdfGenerator.service
         }
 
         /// <inheritdoc />
-        public async Task<DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>> RequestConversionAsync(
+        public async Task<DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>> RequestConversionsAsync(
             ConvertDocumentToPdfRequest request,
             string correlationId,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(request);
 
-            if (string.IsNullOrWhiteSpace(request.InputFileId))
+            // A duplicate ID is one request for that file, not two, so queuing it twice would just
+            // race two workers over the same replacement.
+            var fileIds = (request.FileIds ?? new List<string>())
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            if (fileIds.Count == 0)
             {
-                return DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>.Failure(
+                return DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>.Failure(
                     DocumentConversionFailureKind.Validation,
-                    "input_file_id_required",
-                    "inputFileId is required.",
+                    "file_ids_required",
+                    "fileIds must contain at least one file ID.",
                     correlationId,
                     new Dictionary<string, string[]>(StringComparer.Ordinal)
                     {
-                        ["inputFileId"] = ["inputFileId is required."]
+                        ["fileIds"] = ["fileIds must contain at least one file ID."]
                     });
             }
 
-            var fileId = request.InputFileId;
+            if (fileIds.Count > MaxBatchSize)
+            {
+                return DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>.Failure(
+                    DocumentConversionFailureKind.Validation,
+                    "too_many_files",
+                    $"A single request can convert at most {MaxBatchSize} files; {fileIds.Count} were sent.",
+                    correlationId,
+                    new Dictionary<string, string[]>(StringComparer.Ordinal)
+                    {
+                        ["fileIds"] = [$"A single request can convert at most {MaxBatchSize} files."]
+                    });
+            }
+
             var tenantId = BlocksContext.GetContext()?.TenantId ?? string.Empty;
+            var results = new List<DocumentConversionAcceptance>(fileIds.Count);
+
+            // Sequential rather than fanned out with Task.WhenAll: each file writes to the same
+            // tenant database and publishes to the same queue, so nothing here benefits from
+            // concurrency the way the read side's storage lookups do, and staying sequential keeps
+            // the per-file logging in request order.
+            foreach (var fileId in fileIds)
+            {
+                results.Add(await RequestOneConversion(fileId, request.MessageCoRelationId, tenantId));
+            }
+
+            var accepted = results.Count(r => r.Accepted);
+
+            return DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>.Success(
+                new ConvertDocumentsToPdfBatchResponse
+                {
+                    MessageCoRelationId = request.MessageCoRelationId,
+                    Results = results,
+                    AcceptedCount = accepted,
+                    RejectedCount = results.Count - accepted
+                },
+                correlationId);
+        }
+
+        /// <summary>
+        /// Records and queues the conversion of one file. Never throws — any failure becomes a
+        /// rejected <see cref="DocumentConversionAcceptance"/>, so one bad file cannot abort the rest
+        /// of the batch the caller is waiting on.
+        /// </summary>
+        private async Task<DocumentConversionAcceptance> RequestOneConversion(
+            string fileId,
+            string? messageCoRelationId,
+            string tenantId)
+        {
+            if (string.IsNullOrWhiteSpace(fileId))
+            {
+                return new DocumentConversionAcceptance
+                {
+                    FileId = fileId ?? string.Empty,
+                    Accepted = false,
+                    ErrorCode = "input_file_id_required",
+                    ErrorMessage = "A file ID in the list was blank."
+                };
+            }
+
             var now = DateTime.UtcNow;
 
             var job = new DocumentConversionJob
             {
                 Id = fileId,
-                MessageCoRelationId = request.MessageCoRelationId,
+                MessageCoRelationId = messageCoRelationId,
                 Status = DocumentConversionStatus.Queued,
                 TenantId = tenantId,
                 CreatedBy = BlocksContext.GetContext()?.UserId,
@@ -66,14 +137,17 @@ namespace Utility.DomainService.PdfGenerator.service
 
             // The record is written before the event is published, deliberately. A caller that gets
             // an acknowledgement back must be able to poll immediately; publishing first leaves a
-            // window where the worker has already finished and the status endpoint still 404s.
+            // window where the worker has already finished and the status endpoint still says the
+            // file was never submitted.
             if (!await _repository.SaveDocumentConversionJobAsync(job))
             {
-                return DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>.Failure(
-                    DocumentConversionFailureKind.Unavailable,
-                    "conversion_not_recorded",
-                    "The conversion could not be recorded and was not started.",
-                    correlationId);
+                return new DocumentConversionAcceptance
+                {
+                    FileId = fileId,
+                    Accepted = false,
+                    ErrorCode = "conversion_not_recorded",
+                    ErrorMessage = "The conversion could not be recorded and was not started."
+                };
             }
 
             try
@@ -85,7 +159,7 @@ namespace Utility.DomainService.PdfGenerator.service
                         Payload = new ConvertDocumentToPdfEvent
                         {
                             FileId = fileId,
-                            MessageCoRelationId = job.MessageCoRelationId,
+                            MessageCoRelationId = messageCoRelationId,
                             ProjectKey = tenantId
                         }
                     });
@@ -96,7 +170,7 @@ namespace Utility.DomainService.PdfGenerator.service
                 // than left Queued forever — a poller deserves an answer, not a permanent maybe.
                 _logger.LogError(
                     ex,
-                    "RequestConversionAsync: Failed to queue conversion of file {FileId}",
+                    "RequestConversionsAsync: Failed to queue conversion of file {FileId}",
                     LogSanitizer.Scrub(fileId));
 
                 job.Status = DocumentConversionStatus.Failed;
@@ -105,59 +179,100 @@ namespace Utility.DomainService.PdfGenerator.service
                 job.CompletedDate = DateTime.UtcNow;
                 await _repository.UpdateDocumentConversionJobAsync(job);
 
-                return DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>.Failure(
-                    DocumentConversionFailureKind.Unavailable,
-                    "conversion_not_queued",
-                    "The conversion could not be queued.",
-                    correlationId);
+                return new DocumentConversionAcceptance
+                {
+                    FileId = fileId,
+                    Accepted = false,
+                    ErrorCode = "conversion_not_queued",
+                    ErrorMessage = "The conversion could not be queued."
+                };
             }
 
             _logger.LogInformation(
-                "RequestConversionAsync: Queued conversion of file {FileId}",
+                "RequestConversionsAsync: Queued conversion of file {FileId}",
                 LogSanitizer.Scrub(fileId));
 
-            return DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>.Success(
-                new ConvertDocumentToPdfAcceptedResponse
-                {
-                    FileId = fileId,
-                    MessageCoRelationId = job.MessageCoRelationId,
-                    Status = job.Status,
-                    StatusUrl = $"/document-conversions/{fileId}"
-                },
-                correlationId);
+            return new DocumentConversionAcceptance
+            {
+                FileId = fileId,
+                Accepted = true,
+                Status = job.Status
+            };
         }
 
         /// <inheritdoc />
-        public async Task<DocumentConversionResult<DocumentConversionStatusResponse>> GetStatusAsync(
-            string fileId,
+        public async Task<DocumentConversionResult<DocumentConversionStatusBatchResponse>> GetStatusAsync(
+            GetDocumentConversionStatusRequest request,
             string correlationId,
             CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrWhiteSpace(fileId))
+            ArgumentNullException.ThrowIfNull(request);
+
+            var fileIds = (request.FileIds ?? new List<string>())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            if (fileIds.Count == 0)
             {
-                return DocumentConversionResult<DocumentConversionStatusResponse>.Failure(
+                return DocumentConversionResult<DocumentConversionStatusBatchResponse>.Failure(
                     DocumentConversionFailureKind.Validation,
-                    "file_id_required",
-                    "fileId is required.",
-                    correlationId);
+                    "file_ids_required",
+                    "fileIds must contain at least one file ID.",
+                    correlationId,
+                    new Dictionary<string, string[]>(StringComparer.Ordinal)
+                    {
+                        ["fileIds"] = ["fileIds must contain at least one file ID."]
+                    });
             }
 
-            var job = await _repository.GetDocumentConversionJobAsync(fileId);
-
-            if (job == null)
+            if (fileIds.Count > MaxBatchSize)
             {
-                return DocumentConversionResult<DocumentConversionStatusResponse>.Failure(
-                    DocumentConversionFailureKind.NotFound,
-                    "conversion_not_found",
-                    "That file has not been submitted for conversion.",
-                    correlationId);
+                return DocumentConversionResult<DocumentConversionStatusBatchResponse>.Failure(
+                    DocumentConversionFailureKind.Validation,
+                    "too_many_files",
+                    $"A single request can query at most {MaxBatchSize} files; {fileIds.Count} were sent.",
+                    correlationId,
+                    new Dictionary<string, string[]>(StringComparer.Ordinal)
+                    {
+                        ["fileIds"] = [$"A single request can query at most {MaxBatchSize} files."]
+                    });
+            }
+
+            var jobs = await _repository.GetDocumentConversionJobsAsync(fileIds);
+            var jobsById = jobs.ToDictionary(j => j.Id, StringComparer.Ordinal);
+
+            // Storage is consulted once per succeeded file, and those lookups are independent of one
+            // another, so they run concurrently rather than serially the way the write side does —
+            // there is no shared record any of them is racing to update.
+            var resolutions = await Task.WhenAll(fileIds.Select(fileId => BuildStatus(fileId, jobsById)));
+
+            return DocumentConversionResult<DocumentConversionStatusBatchResponse>.Success(
+                new DocumentConversionStatusBatchResponse { Results = resolutions.ToList() },
+                correlationId);
+        }
+
+        private async Task<DocumentConversionStatusResult> BuildStatus(
+            string fileId,
+            IReadOnlyDictionary<string, DocumentConversionJob> jobsById)
+        {
+            if (!jobsById.TryGetValue(fileId, out var job))
+            {
+                return new DocumentConversionStatusResult
+                {
+                    FileId = fileId,
+                    Found = false,
+                    ErrorCode = "conversion_not_found",
+                    ErrorMessage = "That file has not been submitted for conversion."
+                };
             }
 
             var isComplete = job.Status is DocumentConversionStatus.Succeeded or DocumentConversionStatus.Failed;
 
-            var response = new DocumentConversionStatusResponse
+            var result = new DocumentConversionStatusResult
             {
                 FileId = job.Id,
+                Found = true,
                 FileName = job.FileName,
                 MessageCoRelationId = job.MessageCoRelationId,
                 Status = job.Status,
@@ -182,12 +297,12 @@ namespace Utility.DomainService.PdfGenerator.service
                 }
                 else
                 {
-                    response.DownloadUrl = record.Url;
-                    response.FileName ??= record.Name;
+                    result.DownloadUrl = record.Url;
+                    result.FileName ??= record.Name;
                 }
             }
 
-            return DocumentConversionResult<DocumentConversionStatusResponse>.Success(response, correlationId);
+            return result;
         }
     }
 }

--- a/server/Utility.DomainService/PdfGenerator/service/IDocumentConversionService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/IDocumentConversionService.cs
@@ -1,7 +1,7 @@
-﻿namespace Utility.DomainService.PdfGenerator.service
+namespace Utility.DomainService.PdfGenerator.service
 {
     /// <summary>
-    /// Accepts document-to-PDF conversions and reports what became of them.
+    /// Accepts batches of document-to-PDF conversions and reports what became of them.
     /// </summary>
     /// <remarks>
     /// Separate from <see cref="IPdfGeneratorService"/>, which is a thin queue dispatcher whose
@@ -12,23 +12,21 @@
     public interface IDocumentConversionService
     {
         /// <summary>
-        /// Records and queues a conversion. Returns as soon as the work is accepted, not when it is
-        /// done.
+        /// Records and queues a batch of conversions. Returns as soon as the batch is accepted, not
+        /// when any conversion is done. Each file in the batch succeeds or fails independently — one
+        /// bad ID does not stop the rest of the batch.
         /// </summary>
-        Task<DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>> RequestConversionAsync(
+        Task<DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>> RequestConversionsAsync(
             ConvertDocumentToPdfRequest request,
             string correlationId,
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Reads a file's conversion state, including a download URL once it has succeeded.
+        /// Reads the current state of a batch of files, including a download URL for each one that
+        /// has succeeded.
         /// </summary>
-        /// <remarks>
-        /// Keyed by the file's own ID — the one the caller sent to start the conversion. No separate
-        /// identifier is issued for them to hold on to.
-        /// </remarks>
-        Task<DocumentConversionResult<DocumentConversionStatusResponse>> GetStatusAsync(
-            string fileId,
+        Task<DocumentConversionResult<DocumentConversionStatusBatchResponse>> GetStatusAsync(
+            GetDocumentConversionStatusRequest request,
             string correlationId,
             CancellationToken cancellationToken = default);
     }

--- a/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorRepository.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorRepository.cs
@@ -16,6 +16,13 @@ namespace Utility.DomainService.PdfGenerator.service
         // misses the completion notification can still find out what happened.
         Task<bool> SaveDocumentConversionJobAsync(DocumentConversionJob job, string? tenantId = null);
         Task<DocumentConversionJob?> GetDocumentConversionJobAsync(string fileId, string? tenantId = null);
+
+        /// <summary>
+        /// Reads the conversion state of several files in one round trip, for the batch status
+        /// endpoint. A file with no record simply has no entry in the result — the caller matches
+        /// on <c>Id</c> and treats an absent one as never submitted.
+        /// </summary>
+        Task<List<DocumentConversionJob>> GetDocumentConversionJobsAsync(IEnumerable<string> fileIds, string? tenantId = null);
         Task<bool> UpdateDocumentConversionJobAsync(DocumentConversionJob job, string? tenantId = null);
     }
 }

--- a/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorRepository.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorRepository.cs
@@ -179,6 +179,35 @@ namespace Utility.DomainService.PdfGenerator.service
         }
 
         /// <summary>
+        /// Reads several conversion records in one round trip via an $in filter, rather than the
+        /// batch status endpoint issuing one query per file.
+        /// </summary>
+        public async Task<List<DocumentConversionJob>> GetDocumentConversionJobsAsync(IEnumerable<string> fileIds, string? tenantId = null)
+        {
+            var ids = fileIds.ToList();
+
+            if (ids.Count == 0)
+            {
+                return new List<DocumentConversionJob>();
+            }
+
+            try
+            {
+                var tid = tenantId ?? BlocksContext.GetContext()?.TenantId ?? "";
+                var database = _dbContextProvider.GetDatabase(tid);
+                var collection = database.GetCollection<DocumentConversionJob>(DocumentConversionJobs);
+                var filter = Builders<DocumentConversionJob>.Filter.In(j => j.Id, ids);
+
+                return await collection.Find(filter).ToListAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in GetDocumentConversionJobsAsync for {Count} file(s)", ids.Count);
+                return new List<DocumentConversionJob>();
+            }
+        }
+
+        /// <summary>
         /// Writes a conversion's new state.
         /// </summary>
         /// <remarks>

--- a/server/XUnitTest/PdfGenerator/AsposeDocumentToPdfConverterTests.cs
+++ b/server/XUnitTest/PdfGenerator/AsposeDocumentToPdfConverterTests.cs
@@ -281,23 +281,24 @@ namespace XUnitTest.PdfGenerator
         }
 
         [Fact]
-        public void Request_NeedsNothingButTheInputFileId()
+        public void Request_NeedsNothingButAFileIdList()
         {
-            var request = new ConvertDocumentToPdfRequest { InputFileId = "doc-1" };
+            var request = new ConvertDocumentToPdfRequest { FileIds = new List<string> { "doc-1", "doc-2" } };
 
-            request.InputFileId.Should().Be("doc-1");
+            request.FileIds.Should().Equal("doc-1", "doc-2");
             request.MessageCoRelationId.Should().BeNull();
         }
 
         [Fact]
-        public void StatusResponse_OffersNoDownloadUntilTheConversionSucceeds()
+        public void StatusResult_OffersNoDownloadUntilTheConversionSucceeds()
         {
             // A caller polling a running conversion must not be handed a URL that still points at
-            // the unconverted document. The file ID is always present — it is the key they polled
-            // with — but the download only appears once there is a PDF behind it.
-            var running = new DocumentConversionStatusResponse
+            // the unconverted document. The file ID is always present -- it is the key they queried
+            // with -- but the download only appears once there is a PDF behind it.
+            var running = new DocumentConversionStatusResult
             {
                 FileId = "doc-1",
+                Found = true,
                 FileName = "contract.docx",
                 Status = DocumentConversionStatus.Processing,
                 IsComplete = false
@@ -306,6 +307,23 @@ namespace XUnitTest.PdfGenerator
             running.FileId.Should().Be("doc-1");
             running.DownloadUrl.Should().BeNull();
             running.CompletedAtUtc.Should().BeNull();
+        }
+
+        [Fact]
+        public void StatusResult_NeverSubmitted_IsFoundFalseNotAMissingEntry()
+        {
+            // A batch caller matches every ID they asked about against exactly one result; a file
+            // that was never submitted still gets an entry, just one with Found = false.
+            var neverSubmitted = new DocumentConversionStatusResult
+            {
+                FileId = "doc-9",
+                Found = false,
+                ErrorCode = "conversion_not_found"
+            };
+
+            neverSubmitted.Found.Should().BeFalse();
+            neverSubmitted.Status.Should().BeNull();
+            neverSubmitted.ErrorCode.Should().Be("conversion_not_found");
         }
 
         [Theory]
@@ -323,19 +341,57 @@ namespace XUnitTest.PdfGenerator
         }
 
         [Fact]
-        public void AcceptedResponse_CarriesWhereToPoll()
+        public void Acceptance_AcceptedFile_CarriesItsQueuedStatus()
         {
             // The poll key is the file ID the caller already sent, not a new identifier.
-            var accepted = new ConvertDocumentToPdfAcceptedResponse
+            var accepted = new DocumentConversionAcceptance
             {
                 FileId = "doc-1",
-                Status = DocumentConversionStatus.Queued,
-                StatusUrl = "/document-conversions/doc-1"
+                Accepted = true,
+                Status = DocumentConversionStatus.Queued
             };
 
             accepted.FileId.Should().Be("doc-1");
+            accepted.Accepted.Should().BeTrue();
             accepted.Status.Should().Be(DocumentConversionStatus.Queued);
-            accepted.StatusUrl.Should().Be("/document-conversions/doc-1");
+            accepted.ErrorCode.Should().BeNull();
+        }
+
+        [Fact]
+        public void Acceptance_RejectedFile_CarriesWhyWithNoStatus()
+        {
+            // A rejected file was never queued, so there is nothing to poll for it and no Status to
+            // report -- only the reason it was turned away.
+            var rejected = new DocumentConversionAcceptance
+            {
+                FileId = string.Empty,
+                Accepted = false,
+                ErrorCode = "input_file_id_required"
+            };
+
+            rejected.Accepted.Should().BeFalse();
+            rejected.Status.Should().BeNull();
+            rejected.ErrorCode.Should().Be("input_file_id_required");
+        }
+
+        [Fact]
+        public void BatchResponse_CountsAcceptedAndRejectedSeparately()
+        {
+            var response = new ConvertDocumentsToPdfBatchResponse
+            {
+                Results = new List<DocumentConversionAcceptance>
+                {
+                    new() { FileId = "doc-1", Accepted = true, Status = DocumentConversionStatus.Queued },
+                    new() { FileId = "", Accepted = false, ErrorCode = "input_file_id_required" }
+                },
+                AcceptedCount = 1,
+                RejectedCount = 1
+            };
+
+            response.Results.Should().HaveCount(2);
+            response.AcceptedCount.Should().Be(1);
+            response.RejectedCount.Should().Be(1);
+            response.StatusUrl.Should().Be("/document-conversions/status");
         }
     }
 }

--- a/server/XUnitTest/PdfGenerator/DocumentConversionApiResultsTests.cs
+++ b/server/XUnitTest/PdfGenerator/DocumentConversionApiResultsTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Payment.DomainService.Responses;
 using Utility.DomainService.PdfGenerator;
+using Utility.DomainService.PdfGenerator.Entities;
 using Utility.DomainService.PdfGenerator.service;
 
 namespace XUnitTest.PdfGenerator
@@ -11,11 +12,19 @@ namespace XUnitTest.PdfGenerator
     public class DocumentConversionApiResultsTests
     {
         [Fact]
-        public void AcceptedConversion_Is202NotOk()
+        public void AcceptedBatch_Is202NotOk()
         {
-            // The document is queued, not converted. A 200 would tell a client the work is done.
-            var result = DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>.Success(
-                new ConvertDocumentToPdfAcceptedResponse { FileId = "doc-1" },
+            // The documents are queued, not converted. A 200 would tell a client the work is done.
+            var result = DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>.Success(
+                new ConvertDocumentsToPdfBatchResponse
+                {
+                    Results = new List<DocumentConversionAcceptance>
+                    {
+                        new() { FileId = "doc-1", Accepted = true, Status = DocumentConversionStatus.Queued }
+                    },
+                    AcceptedCount = 1,
+                    RejectedCount = 0
+                },
                 "trace-1");
 
             var action = result.ToActionResult("trace-1", StatusCodes.Status202Accepted) as ObjectResult;
@@ -23,18 +32,47 @@ namespace XUnitTest.PdfGenerator
             action.Should().NotBeNull();
             action!.StatusCode.Should().Be(StatusCodes.Status202Accepted);
 
-            var body = action.Value.Should().BeOfType<ApiResponse<ConvertDocumentToPdfAcceptedResponse>>().Subject;
+            var body = action.Value.Should().BeOfType<ApiResponse<ConvertDocumentsToPdfBatchResponse>>().Subject;
             body.Success.Should().BeTrue();
-            body.Data!.FileId.Should().Be("doc-1");
+            body.Data!.Results.Should().ContainSingle().Which.FileId.Should().Be("doc-1");
+            body.Data.AcceptedCount.Should().Be(1);
             body.Error.Should().BeNull();
             body.Meta.CorrelationId.Should().Be("trace-1");
         }
 
         [Fact]
-        public void StatusRead_Is200()
+        public void StatusBatchRead_Is200()
         {
-            var result = DocumentConversionResult<DocumentConversionStatusResponse>.Success(
-                new DocumentConversionStatusResponse { FileId = "doc-1" },
+            var result = DocumentConversionResult<DocumentConversionStatusBatchResponse>.Success(
+                new DocumentConversionStatusBatchResponse
+                {
+                    Results = new List<DocumentConversionStatusResult>
+                    {
+                        new() { FileId = "doc-1", Found = true, Status = DocumentConversionStatus.Succeeded }
+                    }
+                },
+                "trace-1");
+
+            var action = result.ToActionResult("trace-1") as ObjectResult;
+
+            action!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Fact]
+        public void StatusBatch_PerFileOutcomesDoNotChangeTheOverallStatusCode()
+        {
+            // A file that was never submitted, or one whose conversion failed, is still a
+            // successful read of the batch as a whole -- the question of what happened to each file
+            // was answered. Only a structurally invalid request (an empty fileIds list) is a 4xx.
+            var result = DocumentConversionResult<DocumentConversionStatusBatchResponse>.Success(
+                new DocumentConversionStatusBatchResponse
+                {
+                    Results = new List<DocumentConversionStatusResult>
+                    {
+                        new() { FileId = "doc-1", Found = true, Status = DocumentConversionStatus.Failed, ErrorCode = "conversion_failed" },
+                        new() { FileId = "doc-2", Found = false, ErrorCode = "conversion_not_found" }
+                    }
+                },
                 "trace-1");
 
             var action = result.ToActionResult("trace-1") as ObjectResult;
@@ -52,7 +90,7 @@ namespace XUnitTest.PdfGenerator
             DocumentConversionFailureKind kind,
             int expectedStatusCode)
         {
-            var result = DocumentConversionResult<DocumentConversionStatusResponse>.Failure(
+            var result = DocumentConversionResult<DocumentConversionStatusBatchResponse>.Failure(
                 kind,
                 "some_code",
                 "Something went wrong.",
@@ -66,35 +104,35 @@ namespace XUnitTest.PdfGenerator
         [Fact]
         public void Failure_CarriesCodeMessageAndTraceInTheStandardEnvelope()
         {
-            var result = DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>.Failure(
+            var result = DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>.Failure(
                 DocumentConversionFailureKind.Validation,
-                "input_file_id_required",
-                "inputFileId is required.",
+                "file_ids_required",
+                "fileIds must contain at least one file ID.",
                 "trace-9",
                 new Dictionary<string, string[]>(StringComparer.Ordinal)
                 {
-                    ["inputFileId"] = ["inputFileId is required."]
+                    ["fileIds"] = ["fileIds must contain at least one file ID."]
                 });
 
             var action = result.ToActionResult("trace-9") as ObjectResult;
-            var body = action!.Value.Should().BeOfType<ApiResponse<ConvertDocumentToPdfAcceptedResponse>>().Subject;
+            var body = action!.Value.Should().BeOfType<ApiResponse<ConvertDocumentsToPdfBatchResponse>>().Subject;
 
             body.Success.Should().BeFalse();
             body.Data.Should().BeNull();
-            body.Error!.Code.Should().Be("input_file_id_required");
-            body.Error.Message.Should().Be("inputFileId is required.");
+            body.Error!.Code.Should().Be("file_ids_required");
+            body.Error.Message.Should().Be("fileIds must contain at least one file ID.");
             body.Error.TraceId.Should().Be("trace-9");
-            body.Error.Fields.Should().ContainKey("inputFileId");
+            body.Error.Fields.Should().ContainKey("fileIds");
         }
 
         [Fact]
         public void SuccessStatusCodeOverride_DoesNotLeakIntoFailures()
         {
             // Asking for 202 on success must not turn a validation failure into a 202.
-            var result = DocumentConversionResult<ConvertDocumentToPdfAcceptedResponse>.Failure(
+            var result = DocumentConversionResult<ConvertDocumentsToPdfBatchResponse>.Failure(
                 DocumentConversionFailureKind.Validation,
-                "input_file_id_required",
-                "inputFileId is required.",
+                "file_ids_required",
+                "fileIds must contain at least one file ID.",
                 "trace-1");
 
             var action = result.ToActionResult("trace-1", StatusCodes.Status202Accepted) as ObjectResult;

--- a/server/XUnitTest/PdfGenerator/PdfGeneratorRepositoryTests.cs
+++ b/server/XUnitTest/PdfGenerator/PdfGeneratorRepositoryTests.cs
@@ -153,5 +153,18 @@ namespace XUnitTest.PdfGenerator
             Assert.False(exists);
         }
 
+
+        [Fact]
+        public async Task GetDocumentConversionJobsAsync_EmptyIdList_ReturnsEmptyWithoutQueryingMongo()
+        {
+            // A batch caller that somehow ends up asking about zero files should get an empty
+            // result immediately rather than round-tripping to Mongo for an $in filter with no
+            // values in it.
+            var jobs = await _repository.GetDocumentConversionJobsAsync(Array.Empty<string>(), "tenant1");
+
+            Assert.Empty(jobs);
+            _databaseMock.Verify(db => db.GetCollection<DocumentConversionJob>(It.IsAny<string>(), null), Times.Never);
+        }
+
     }
 }


### PR DESCRIPTION
Follow-up to #422, which merged before this commit was pushed. `dev` currently has the single-file conversion contract; this PR replaces it with batch support on both endpoints, as requested.

## What changes

Both endpoints only ever took one file, which meant a caller converting or checking on several documents had to make one HTTP round trip per document. Both now take a list.

**`POST /document-conversions`** takes `fileIds: string[]` instead of a single `inputFileId`. Each file is recorded and queued independently inside the same request — a blank ID or a file that fails to queue does not stop the rest of the batch — and the `202` response carries one result per file:

```json
{
  "fileIds": ["doc-1", "doc-2", ""]
}
```
```json
{
  "success": true,
  "data": {
    "messageCoRelationId": null,
    "statusUrl": "/document-conversions/status",
    "results": [
      { "fileId": "doc-1", "accepted": true, "status": "Queued" },
      { "fileId": "doc-2", "accepted": true, "status": "Queued" },
      { "fileId": "", "accepted": false, "errorCode": "input_file_id_required", "errorMessage": "A file ID in the list was blank." }
    ],
    "acceptedCount": 2,
    "rejectedCount": 1
  }
}
```

Duplicate IDs in the list are treated as one request for that file, not two — queuing the same replacement twice would just race two workers over it.

**Status moves from `GET /document-conversions/{fileId}` to `POST /document-conversions/status`** with `fileIds: string[]` in the body. A GET cannot carry a list without relying on query-string repetition or a body that clients and proxies handle inconsistently, so this follows the same shape the batch convert endpoint already uses:

```json
{ "fileIds": ["doc-1", "doc-2"] }
```
```json
{
  "success": true,
  "data": {
    "results": [
      { "fileId": "doc-1", "found": true, "status": "Succeeded", "isComplete": true, "fileName": "contract.pdf", "downloadUrl": "https://..." },
      { "fileId": "doc-2", "found": false, "errorCode": "conversion_not_found", "errorMessage": "That file has not been submitted for conversion." }
    ]
  }
}
```

A file with no conversion record still gets a result entry, with `found: false`, rather than being silently dropped — a caller can match every ID they asked about against exactly one result. A per-file outcome (failed, never submitted) never changes the batch's own HTTP status; only a structurally invalid request (empty or oversized `fileIds`) is a `400`.

## Other decisions worth flagging

- **Both endpoints cap a request at 50 files** (`DocumentConversionService.MaxBatchSize`), rejecting an oversized or empty list with `400`. Without this, one call could fan out an unbounded number of Mongo writes and queue publishes before anything is returned to the caller — not something #422's single-file version had to consider, and not something you asked for explicitly, so flagging it as a judgment call rather than something requested.
- **The event, consumer and notification stay keyed by a single file ID.** The service fans a batch out into one `ConvertDocumentToPdfEvent` per file rather than teaching the worker to process a list, so retries, ordering and per-file failure handling on the queue side are unchanged from #422.
- **Status lookups run concurrently within a batch** (`Task.WhenAll` over the per-file storage calls for succeeded files), since each is independent; the write side stays sequential since every file writes to the same tenant database and queue.
- Repository gains `GetDocumentConversionJobsAsync`, an `$in`-filtered bulk read, so status makes one query for a batch instead of one per file.

## Testing

140 PDF tests pass, including new coverage for the batch acceptance/status shapes and the repository's empty-list short-circuit. Full non-integration suite: 3628 passing, same 4 pre-existing `SubscriptionSimulation` permission failures, rebased onto current `dev`. `XUnitTest.Integration.*` needs a live MongoDB and was not run.

Standing caveats from #422 are unchanged: the rename-on-re-upload behaviour is unverified, and nothing in this pipeline has run against a live broker, storage or Mongo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)