### PR TITLE
fix(subscription): stop settlement invoices reading as CHF 0.00

### DIFF
--- a/server/Subscription.DomainService/Services/SettlementCharge.cs
+++ b/server/Subscription.DomainService/Services/SettlementCharge.cs
@@ -36,7 +36,15 @@ internal static class SettlementCharge
         Description = Describe(subscription, reservation),
         // From the reservation, which recorded it when the change was quoted — not from the
         // subscription as it stands now, which the settlement is about to change.
-        Settlement = reservation.Settlement
+        Settlement = reservation.Settlement,
+        // Rate and mode only, not net or tax - the breakdown carries the actual figures, and
+        // duplicating them as flat fields would put the charge back into the shape it replaces. The
+        // target price where this is a plan change, since that is what the customer is being taxed
+        // under going forward; a quantity change never moves the price. Where a change crosses tax
+        // modes this states only the target side's rate - a simplification, the two sides' own rates
+        // remain in the settlement table itself.
+        TaxRateBasisPoints = (reservation.PlanChange?.Price ?? subscription.Price).TaxRateBasisPoints,
+        TaxMode = (reservation.PlanChange?.Price ?? subscription.Price).TaxMode
     };
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
+++ b/server/Subscription.DomainService/Services/StripeInvoiceBillingGateway.cs
@@ -477,9 +477,12 @@ public sealed class StripeInvoiceBillingGateway : ISubscriptionBillingGateway
             OrderId = request.OrderId,
             Description = request.Description?.Trim(),
             ProviderInvoiceId = invoiceId,
-            SubscriptionNetAmountMinor = request.NetAmountMinor,
-            SubscriptionTaxAmountMinor = request.TaxAmountMinor,
-            SubscriptionCreditAmountMinor = request.CreditConsumedMinor,
+            // A settlement records its amount as a two-sided breakdown instead - see
+            // SubscriptionSettlementBreakdown. Storing a flat 0 beside it would be indistinguishable
+            // from a renewal that genuinely netted to zero, and would be read back as one.
+            SubscriptionNetAmountMinor = request.Settlement is null ? request.NetAmountMinor : null,
+            SubscriptionTaxAmountMinor = request.Settlement is null ? request.TaxAmountMinor : null,
+            SubscriptionCreditAmountMinor = request.Settlement is null ? request.CreditConsumedMinor : null,
             SubscriptionTaxRateBasisPoints = request.TaxRateBasisPoints,
             SubscriptionTaxMode = request.TaxRateBasisPoints > 0
                 ? (request.TaxMode ?? TaxMode.Exclusive).ToString()

--- a/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
@@ -1328,20 +1328,29 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
         var (outgoingNet, outgoingTax) = ProratedNetAndTax(settlement.Outgoing);
         var (targetNet, targetTax) = ProratedNetAndTax(settlement.Target);
 
-        var netWeight = Math.Max(0, targetNet - outgoingNet);
-        var taxWeight = Math.Max(0, targetTax - outgoingTax);
+        var netDelta = targetNet - outgoingNet;
+        var taxDelta = targetTax - outgoingTax;
 
         // An opening-stub upgrade settles two periods at once - see
         // SubscriptionSettlementBreakdown.Annual. Credit and total are spent once against the
-        // combined figure, so only the nested side weights are added in here.
+        // combined figure, so only the nested side deltas are added in here.
         if (settlement.Annual is { } annual)
         {
             var (annualOutgoingNet, annualOutgoingTax) = ProratedNetAndTax(annual.Outgoing);
             var (annualTargetNet, annualTargetTax) = ProratedNetAndTax(annual.Target);
 
-            netWeight += Math.Max(0, annualTargetNet - annualOutgoingNet);
-            taxWeight += Math.Max(0, annualTargetTax - annualOutgoingTax);
+            netDelta += annualTargetNet - annualOutgoingNet;
+            taxDelta += annualTargetTax - annualOutgoingTax;
         }
+
+        // Summed before clamping, not clamped per period and then summed. CalculateOpeningStubUpgrade
+        // combines the two periods' raw deltas before it ever clamps - combinedRawDelta = stubDelta +
+        // annualDelta - so that is the sum this has to match for netWeight + taxWeight to land on
+        // exactly total + credit, which is what lets Split return the split unchanged rather than
+        // reallocating. Clamping each period first would drop a negative component and overstate the
+        // weights, quietly trading that exactness for an approximation.
+        var netWeight = Math.Max(0, netDelta);
+        var taxWeight = Math.Max(0, taxDelta);
 
         long net;
         long tax;

--- a/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
@@ -1159,13 +1159,16 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
     /// What the charge was made of, from the strongest source available.
     /// </summary>
     /// <remarks>
-    /// Three sources, in order of how directly they know. A renewal, settlement or overage records
-    /// its own breakdown on the payment as it charges, so that is read verbatim. The initial charge
-    /// goes out through hosted checkout, which composes no invoice and records no breakdown — but
-    /// every input is snapshotted on the subscription and the amount was frozen there, so the same
-    /// calculator that priced it can be asked again and its answer checked against the frozen figure.
-    /// Anything older than either is reported as a single gross line, which is all that can honestly
-    /// be said about it.
+    /// Four sources, in order of how directly they know. A settlement — a plan change or a paid
+    /// quantity increase — records a two-sided breakdown instead of a flat one, because its amount is
+    /// a difference between two prorated periods rather than a single priced charge; that is read
+    /// first, and read ahead of the flat fields below because every settlement payment stores a flat
+    /// net of zero beside its breakdown. A renewal or overage records its own flat breakdown on the
+    /// payment as it charges, so that is read verbatim. The initial charge goes out through hosted
+    /// checkout, which composes no invoice and records no breakdown — but every input is snapshotted
+    /// on the subscription and the amount was frozen there, so the same calculator that priced it can
+    /// be asked again and its answer checked against the frozen figure. Anything older than all three
+    /// is reported as a single gross line, which is all that can honestly be said about it.
     /// </remarks>
     private FinancialDocumentAmounts AmountsFor(
         PaymentDetail payment,
@@ -1173,6 +1176,11 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
         SubscriptionChargeReference charge,
         DocumentTerms terms)
     {
+        if (payment.SubscriptionSettlement is { } settlement)
+        {
+            return SettlementAmounts(payment, settlement);
+        }
+
         if (payment.SubscriptionNetAmountMinor is { } net)
         {
             var (automatic, quantity) = BuiltInDiscountAttribution.Split(
@@ -1291,6 +1299,94 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
             DiscountCombination = SubscriptionDiscountPresentation.Describe(subscription.Price),
             PromotionCode = charge.DiscountApplied ? subscription.Discount?.Code : null
         };
+    }
+
+    /// <summary>
+    /// A settlement's two-sided breakdown, restated as the value/tax/credit split a document renders.
+    /// </summary>
+    /// <remarks>
+    /// A settlement's amount is target-prorated-value less outgoing-prorated-value less credit, not a
+    /// price with a discount, so there is no flat gross or discount to read — see
+    /// <see cref="SubscriptionSettlementBreakdown"/>. <see cref="FinancialDocumentAmounts.TotalMinor"/>
+    /// is taken from what the provider actually took rather than from the breakdown's own arithmetic,
+    /// so it always agrees with the bank; the breakdown only decides how that total splits between
+    /// value and tax. Each side is taxed at its own rate and can straddle a tax-mode change, so the
+    /// split subtracts each side's own tax rather than recomputing one rate for the difference, which
+    /// would restate the charge.
+    /// </remarks>
+    private FinancialDocumentAmounts SettlementAmounts(
+        PaymentDetail payment,
+        SubscriptionSettlementBreakdown settlement)
+    {
+        if (!_currency.TryConvert(payment.PreciseAmount, payment.CurrencyCode, out var total))
+        {
+            total = Math.Max(0, settlement.NetSettlementMinor);
+        }
+
+        var credit = settlement.CreditConsumedMinor;
+
+        var (outgoingNet, outgoingTax) = ProratedNetAndTax(settlement.Outgoing);
+        var (targetNet, targetTax) = ProratedNetAndTax(settlement.Target);
+
+        var netWeight = Math.Max(0, targetNet - outgoingNet);
+        var taxWeight = Math.Max(0, targetTax - outgoingTax);
+
+        // An opening-stub upgrade settles two periods at once - see
+        // SubscriptionSettlementBreakdown.Annual. Credit and total are spent once against the
+        // combined figure, so only the nested side weights are added in here.
+        if (settlement.Annual is { } annual)
+        {
+            var (annualOutgoingNet, annualOutgoingTax) = ProratedNetAndTax(annual.Outgoing);
+            var (annualTargetNet, annualTargetTax) = ProratedNetAndTax(annual.Target);
+
+            netWeight += Math.Max(0, annualTargetNet - annualOutgoingNet);
+            taxWeight += Math.Max(0, annualTargetTax - annualOutgoingTax);
+        }
+
+        long net;
+        long tax;
+        if (netWeight + taxWeight > 0)
+        {
+            var split = ProportionalAllocation.Split(total + credit, [netWeight, taxWeight]);
+            net = split[0];
+            tax = split[1];
+        }
+        else
+        {
+            // Nothing to apportion by - the honest answer is the same one SingleGrossLine gives for
+            // a charge with no breakdown at all: report it as untaxed net rather than inventing a split.
+            net = total + credit;
+            tax = 0;
+        }
+
+        return new FinancialDocumentAmounts
+        {
+            GrossSubtotalMinor = net,
+            NetSubtotalMinor = net,
+            TaxRateBasisPoints = payment.SubscriptionTaxRateBasisPoints,
+            TaxMode = payment.SubscriptionTaxMode,
+            TaxAmountMinor = tax,
+            CreditAppliedMinor = credit,
+            TotalMinor = total
+        };
+    }
+
+    /// <summary>
+    /// One settlement side's prorated value, split into the part that is value and the part that is
+    /// tax, in the same proportion as the side's own full period.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SubscriptionSettlementSide.ProratedValueMinor"/> is tax-inclusive — "the whole
+    /// period, tax included", counted for the part this settlement covers — so the tax share is the
+    /// same proportion of it as the side's own tax is of its own period total.
+    /// </remarks>
+    private static (long Net, long Tax) ProratedNetAndTax(SubscriptionSettlementSide side)
+    {
+        var split = ProportionalAllocation.Split(
+            side.ProratedValueMinor,
+            [side.PeriodTotalMinor - side.TaxAmountMinor, side.TaxAmountMinor]);
+
+        return (split[0], split[1]);
     }
 
     /// <summary>

--- a/server/XUnitTest/Integration/SubscriptionQueueDocumentFlowIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionQueueDocumentFlowIntegrationTests.cs
@@ -442,15 +442,28 @@ public sealed class SubscriptionQueueDocumentFlowIntegrationTests
     /// The charge comes to something payable, by whichever route the issuer would price it.
     /// </summary>
     /// <remarks>
-    /// Two routes, checked in the issuer's own order. A charge this module raised carries its own
-    /// frozen breakdown and the issuer prefers it, totalling net plus tax less credit; anything older
-    /// is reported as a single gross line converted from <c>PreciseAmount</c>. A zero total is not an
-    /// error to the issuer — it is nothing payable, so it consumes the obligation and completes with
-    /// no document. That is correct behaviour and a useless seed, which is why this belongs in the
-    /// preconditions rather than being discovered as an empty collection at the end.
+    /// Three routes, checked in the issuer's own order. A settlement — a plan change or a paid
+    /// quantity increase — carries a two-sided breakdown instead of a flat one and the issuer reads
+    /// that first, ahead of the flat fields below, because a settlement payment stores a flat net of
+    /// zero beside its breakdown. A charge this module raised the ordinary way carries its own frozen
+    /// flat breakdown and the issuer prefers that next, totalling net plus tax less credit; anything
+    /// older is reported as a single gross line converted from <c>PreciseAmount</c>. A zero total is
+    /// not an error to the issuer — it is nothing payable, so it consumes the obligation and completes
+    /// with no document. That is correct behaviour and a useless seed, which is why this belongs in
+    /// the preconditions rather than being discovered as an empty collection at the end.
     /// </remarks>
     private static void AssertIssuerSeesAPositiveTotal(PaymentDetail payment)
     {
+        if (payment.SubscriptionSettlement is { } settlement)
+        {
+            settlement.NetSettlementMinor.Should().NotBe(
+                0,
+                "the issuer reads the settlement's own breakdown ahead of the flat fields, so a " +
+                "seed with nothing settled would reach the total by pure coincidence, if at all");
+
+            return;
+        }
+
         if (payment.SubscriptionNetAmountMinor is { } net)
         {
             var total =

--- a/server/XUnitTest/Integration/SubscriptionQueueDocumentFlowIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionQueueDocumentFlowIntegrationTests.cs
@@ -443,23 +443,27 @@ public sealed class SubscriptionQueueDocumentFlowIntegrationTests
     /// </summary>
     /// <remarks>
     /// Three routes, checked in the issuer's own order. A settlement — a plan change or a paid
-    /// quantity increase — carries a two-sided breakdown instead of a flat one and the issuer reads
+    /// quantity increase — carries a two-sided breakdown instead of a flat one, and the issuer reads
     /// that first, ahead of the flat fields below, because a settlement payment stores a flat net of
-    /// zero beside its breakdown. A charge this module raised the ordinary way carries its own frozen
-    /// flat breakdown and the issuer prefers that next, totalling net plus tax less credit; anything
-    /// older is reported as a single gross line converted from <c>PreciseAmount</c>. A zero total is
-    /// not an error to the issuer — it is nothing payable, so it consumes the obligation and completes
-    /// with no document. That is correct behaviour and a useless seed, which is why this belongs in
-    /// the preconditions rather than being discovered as an empty collection at the end.
+    /// zero beside its breakdown. Its total comes from <c>PreciseAmount</c> — what the provider
+    /// actually took — not from the breakdown's own <c>NetSettlementMinor</c>, which can go negative
+    /// on a downgrade that banks credit instead of charging; that field says nothing about what this
+    /// document will total. A charge this module raised the ordinary way carries its own frozen flat
+    /// breakdown and the issuer prefers that next, totalling net plus tax less credit; anything older
+    /// is reported as a single gross line converted from <c>PreciseAmount</c>. A zero total is not an
+    /// error to the issuer — it is nothing payable, so it consumes the obligation and completes with
+    /// no document. That is correct behaviour and a useless seed, which is why this belongs in the
+    /// preconditions rather than being discovered as an empty collection at the end.
     /// </remarks>
     private static void AssertIssuerSeesAPositiveTotal(PaymentDetail payment)
     {
-        if (payment.SubscriptionSettlement is { } settlement)
+        if (payment.SubscriptionSettlement is not null)
         {
-            settlement.NetSettlementMinor.Should().NotBe(
+            payment.PreciseAmount.Should().BeGreaterThan(
                 0,
-                "the issuer reads the settlement's own breakdown ahead of the flat fields, so a " +
-                "seed with nothing settled would reach the total by pure coincidence, if at all");
+                "a settlement's total comes from PreciseAmount - what the provider actually took - " +
+                "not from the breakdown's own NetSettlementMinor, so a zero or negative amount here " +
+                "reads as nothing payable regardless of what the breakdown says");
 
             return;
         }

--- a/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
+++ b/server/XUnitTest/Subscription/StripeInvoiceBillingGatewayTests.cs
@@ -619,6 +619,35 @@ public sealed class StripeInvoiceBillingGatewayTests
         // The two are alternatives: a settlement is not a discounted price, so the flat fields stay
         // empty rather than describing it badly.
         recorded.SubscriptionGrossAmountMinor.Should().BeNull();
+        recorded.SubscriptionNetAmountMinor.Should().BeNull();
+        recorded.SubscriptionTaxAmountMinor.Should().BeNull();
+        recorded.SubscriptionCreditAmountMinor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_renewal_that_nets_to_zero_still_records_its_zero_rather_than_a_null()
+    {
+        // A 100%-coupon renewal genuinely nets to zero. That must keep reading back as "the
+        // breakdown says zero", not be pushed onto the settlement's null-means-not-applicable path.
+        PaymentDetail? recorded = null;
+        _payments
+            .Setup(repository => repository.TryCreateAsync(
+                It.IsAny<PaymentDetail>(), It.IsAny<CancellationToken>()))
+            .Callback((PaymentDetail payment, CancellationToken _) => recorded = payment)
+            .ReturnsAsync(true);
+
+        var request = Request();
+        request.GrossAmountMinor = 10_000;
+        request.PromotionalDiscountMinor = 10_000;
+        request.NetAmountMinor = 0;
+        request.TaxAmountMinor = 0;
+        request.CreditConsumedMinor = 0;
+
+        await Gateway().ChargeAsync(request, "idem-1", "corr-1", CancellationToken.None);
+
+        recorded!.SubscriptionNetAmountMinor.Should().Be(0);
+        recorded.SubscriptionTaxAmountMinor.Should().Be(0);
+        recorded.SubscriptionCreditAmountMinor.Should().Be(0);
     }
 
     private static SubscriptionChargeRequest Request() => new()

--- a/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
@@ -248,6 +248,17 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
                 SubscriptionId,
                 SettlementReservationKind.PlanChange,
                 "res-9");
+            payment.PreciseAmount = 60.00m;
+            // Production never writes flat fields beside a settlement — see
+            // StripeInvoiceBillingGateway.NewPayment. A test that leaves SettledRenewal's flat 90,000
+            // in place would pass even if the issuer read the wrong branch, because it never has to
+            // fall back to the settlement at all.
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = null;
+            payment.SubscriptionTaxAmountMinor = null;
+            payment.SubscriptionCreditAmountMinor = null;
             payment.SubscriptionSettlement = new SubscriptionSettlementBreakdown
             {
                 Outgoing = new SubscriptionSettlementSide { ProratedValueMinor = 3_000 },
@@ -266,6 +277,245 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
         document.Settlement!.NetSettlementMinor.Should().Be(6_000);
         document.Lines.Should().ContainSingle();
     }
+
+    [Fact]
+    public async Task A_settlement_invoice_totals_what_the_provider_took_not_zero()
+    {
+        Subscribed();
+        SettledRenewal(payment =>
+        {
+            payment.OrderId = SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId,
+                SettlementReservationKind.PlanChange,
+                "res-9");
+            payment.PreciseAmount = 5.17m;
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = null;
+            payment.SubscriptionTaxAmountMinor = null;
+            payment.SubscriptionCreditAmountMinor = null;
+            payment.SubscriptionSettlement = SettlementBreakdown();
+        });
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        document!.Amounts.TotalMinor.Should().Be(517);
+        document.Amounts.NetSubtotalMinor.Should().Be(470);
+        document.Amounts.TaxAmountMinor.Should().Be(47);
+        document.Amounts.GrossSubtotalMinor.Should().Be(470);
+        (document.Amounts.NetSubtotalMinor + document.Amounts.TaxAmountMinor -
+            document.Amounts.CreditAppliedMinor).Should().Be(document.Amounts.TotalMinor);
+    }
+
+    [Fact]
+    public async Task A_settlement_invoice_ignores_a_zero_net_stored_beside_its_breakdown()
+    {
+        // Every settlement payment row written before this fix stores a flat net/tax/credit of 0
+        // beside its breakdown. Without the settlement branch running first, this reproduces the
+        // reported bug exactly: a real charge that reads back as CHF 0.00.
+        Subscribed();
+        SettledRenewal(payment =>
+        {
+            payment.OrderId = SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId,
+                SettlementReservationKind.PlanChange,
+                "res-9");
+            payment.PreciseAmount = 5.17m;
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = 0;
+            payment.SubscriptionTaxAmountMinor = 0;
+            payment.SubscriptionCreditAmountMinor = 0;
+            payment.SubscriptionSettlement = SettlementBreakdown();
+        });
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        document!.Amounts.TotalMinor.Should().Be(517);
+        document.Amounts.NetSubtotalMinor.Should().Be(470);
+        document.Amounts.TaxAmountMinor.Should().Be(47);
+        document.Amounts.GrossSubtotalMinor.Should().Be(470);
+    }
+
+    [Fact]
+    public async Task A_settlement_invoices_line_states_the_net_difference()
+    {
+        Subscribed();
+        SettledRenewal(payment =>
+        {
+            payment.OrderId = SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId,
+                SettlementReservationKind.PlanChange,
+                "res-9");
+            payment.PreciseAmount = 5.17m;
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = null;
+            payment.SubscriptionTaxAmountMinor = null;
+            payment.SubscriptionCreditAmountMinor = null;
+            payment.SubscriptionSettlement = SettlementBreakdown();
+        });
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        document!.Lines.Should().ContainSingle();
+        document.Lines[0].AmountMinor.Should().Be(document.Amounts.NetSubtotalMinor);
+        document.Lines[0].AmountMinor.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task A_settlement_that_spent_credit_shows_it_below_tax()
+    {
+        Subscribed();
+        SettledRenewal(payment =>
+        {
+            payment.OrderId = SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId,
+                SettlementReservationKind.PlanChange,
+                "res-9");
+            payment.PreciseAmount = 3.17m;
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = null;
+            payment.SubscriptionTaxAmountMinor = null;
+            payment.SubscriptionCreditAmountMinor = null;
+
+            var settlement = SettlementBreakdown();
+            settlement.CreditConsumedMinor = 200;
+            settlement.NetSettlementMinor -= 200;
+            payment.SubscriptionSettlement = settlement;
+        });
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        document!.Amounts.CreditAppliedMinor.Should().Be(200);
+        document.Amounts.TotalMinor.Should().Be(317);
+        // Credit pays the bill rather than shrinking what tax is calculated on.
+        (document.Amounts.NetSubtotalMinor + document.Amounts.TaxAmountMinor).Should().Be(517);
+    }
+
+    [Fact]
+    public async Task An_opening_stub_upgrade_counts_both_periods_and_the_credit_once()
+    {
+        Subscribed();
+        SettledRenewal(payment =>
+        {
+            payment.OrderId = SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId,
+                SettlementReservationKind.PlanChange,
+                "res-9");
+            payment.PreciseAmount = 10.34m;
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = null;
+            payment.SubscriptionTaxAmountMinor = null;
+            payment.SubscriptionCreditAmountMinor = null;
+
+            var settlement = SettlementBreakdown();
+            settlement.NetSettlementMinor = 1_034;
+            settlement.Annual = SettlementBreakdown();
+            payment.SubscriptionSettlement = settlement;
+        });
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        document!.Amounts.TotalMinor.Should().Be(1_034);
+        (document.Amounts.NetSubtotalMinor + document.Amounts.TaxAmountMinor -
+            document.Amounts.CreditAppliedMinor).Should().Be(document.Amounts.TotalMinor);
+    }
+
+    [Fact]
+    public async Task A_settlement_with_an_empty_breakdown_reports_the_charge_untaxed()
+    {
+        Subscribed();
+        SettledRenewal(payment =>
+        {
+            payment.OrderId = SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId,
+                SettlementReservationKind.PlanChange,
+                "res-9");
+            payment.PreciseAmount = 5.17m;
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = null;
+            payment.SubscriptionTaxAmountMinor = null;
+            payment.SubscriptionCreditAmountMinor = null;
+            payment.SubscriptionSettlement = new SubscriptionSettlementBreakdown
+            {
+                Outgoing = new SubscriptionSettlementSide(),
+                Target = new SubscriptionSettlementSide(),
+                CreditConsumedMinor = 0,
+                NetSettlementMinor = 517
+            };
+        });
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        document!.Amounts.TotalMinor.Should().Be(517);
+        document.Amounts.NetSubtotalMinor.Should().Be(517);
+        document.Amounts.TaxAmountMinor.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task A_quantity_change_settlement_is_read_the_same_way_as_a_plan_change()
+    {
+        Subscribed();
+        SettledRenewal(payment =>
+        {
+            payment.OrderId = SubscriptionConstants.SettlementOrderIdFor(
+                SubscriptionId,
+                SettlementReservationKind.QuantityIncrease,
+                "res-9");
+            payment.PreciseAmount = 5.17m;
+            payment.SubscriptionGrossAmountMinor = null;
+            payment.SubscriptionBuiltInDiscountMinor = null;
+            payment.SubscriptionPromotionalDiscountMinor = null;
+            payment.SubscriptionNetAmountMinor = null;
+            payment.SubscriptionTaxAmountMinor = null;
+            payment.SubscriptionCreditAmountMinor = null;
+            payment.SubscriptionSettlement = SettlementBreakdown();
+        });
+
+        var document = await Issuer().IssueDocumentForPaymentAsync(
+            TenantId, "pay-1", "corr-1", CancellationToken.None);
+
+        document!.Amounts.TotalMinor.Should().Be(517);
+        document.Amounts.NetSubtotalMinor.Should().Be(470);
+        document.Amounts.TaxAmountMinor.Should().Be(47);
+    }
+
+    /// <summary>The outgoing/target sides used across the settlement tests above: net 517 overall.</summary>
+    private static SubscriptionSettlementBreakdown SettlementBreakdown() => new()
+    {
+        Outgoing = new SubscriptionSettlementSide
+        {
+            GrossAmountMinor = 1_000,
+            TaxAmountMinor = 90,
+            PeriodTotalMinor = 990,
+            ProratedValueMinor = 495
+        },
+        Target = new SubscriptionSettlementSide
+        {
+            GrossAmountMinor = 2_024,
+            TaxAmountMinor = 184,
+            PeriodTotalMinor = 2_024,
+            ProratedValueMinor = 1_012
+        },
+        CreditConsumedMinor = 0,
+        NetSettlementMinor = 517
+    };
 
     [Theory]
     [InlineData(PaymentStatuses.Refused)]

--- a/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
@@ -261,8 +261,18 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
             payment.SubscriptionCreditAmountMinor = null;
             payment.SubscriptionSettlement = new SubscriptionSettlementBreakdown
             {
-                Outgoing = new SubscriptionSettlementSide { ProratedValueMinor = 3_000 },
-                Target = new SubscriptionSettlementSide { ProratedValueMinor = 9_000 },
+                Outgoing = new SubscriptionSettlementSide
+                {
+                    TaxAmountMinor = 540,
+                    PeriodTotalMinor = 6_000,
+                    ProratedValueMinor = 3_000
+                },
+                Target = new SubscriptionSettlementSide
+                {
+                    TaxAmountMinor = 1_620,
+                    PeriodTotalMinor = 18_000,
+                    ProratedValueMinor = 9_000
+                },
                 CreditConsumedMinor = 0,
                 NetSettlementMinor = 6_000
             };
@@ -276,6 +286,11 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
         document!.Settlement.Should().NotBeNull();
         document.Settlement!.NetSettlementMinor.Should().Be(6_000);
         document.Lines.Should().ContainSingle();
+
+        // Both sides carry a real period and tax, so this exercises the main split rather than the
+        // empty-breakdown fallback: net 5,460 and tax 540 out of the 6,000 total.
+        document.Amounts.NetSubtotalMinor.Should().Be(5_460);
+        document.Amounts.TaxAmountMinor.Should().Be(540);
     }
 
     [Fact]
@@ -412,7 +427,8 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
                 SubscriptionId,
                 SettlementReservationKind.PlanChange,
                 "res-9");
-            payment.PreciseAmount = 10.34m;
+            // 940 net + 94 tax - 200 credit = 834, the total the provider actually took.
+            payment.PreciseAmount = 8.34m;
             payment.SubscriptionGrossAmountMinor = null;
             payment.SubscriptionBuiltInDiscountMinor = null;
             payment.SubscriptionPromotionalDiscountMinor = null;
@@ -421,15 +437,24 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
             payment.SubscriptionCreditAmountMinor = null;
 
             var settlement = SettlementBreakdown();
-            settlement.NetSettlementMinor = 1_034;
+            settlement.CreditConsumedMinor = 200;
+            settlement.NetSettlementMinor = 834;
+            // A different, larger credit on the nested breakdown. Only the top-level 200 is ever
+            // spent — the nested figure is the annual side's own contribution for the invoice to
+            // explain, not a second deduction — so a bug that summed the two would produce 500 here
+            // instead of 200 and this test would catch it.
             settlement.Annual = SettlementBreakdown();
+            settlement.Annual.CreditConsumedMinor = 300;
             payment.SubscriptionSettlement = settlement;
         });
 
         var document = await Issuer().IssueDocumentForPaymentAsync(
             TenantId, "pay-1", "corr-1", CancellationToken.None);
 
-        document!.Amounts.TotalMinor.Should().Be(1_034);
+        document!.Amounts.CreditAppliedMinor.Should().Be(200);
+        document.Amounts.NetSubtotalMinor.Should().Be(940);
+        document.Amounts.TaxAmountMinor.Should().Be(94);
+        document.Amounts.TotalMinor.Should().Be(834);
         (document.Amounts.NetSubtotalMinor + document.Amounts.TaxAmountMinor -
             document.Amounts.CreditAppliedMinor).Should().Be(document.Amounts.TotalMinor);
     }
@@ -496,19 +521,26 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
         document.Amounts.TaxAmountMinor.Should().Be(47);
     }
 
-    /// <summary>The outgoing/target sides used across the settlement tests above: net 517 overall.</summary>
+    /// <summary>
+    /// The outgoing/target sides used across the settlement tests above: net 517 overall.
+    /// </summary>
+    /// <remarks>
+    /// Gross less discounts (none here) equals period total less tax on each side, the identity a
+    /// real settlement side always satisfies — Gross 900 = PeriodTotal 990 - Tax 90, and Gross 1,840 =
+    /// PeriodTotal 2,024 - Tax 184.
+    /// </remarks>
     private static SubscriptionSettlementBreakdown SettlementBreakdown() => new()
     {
         Outgoing = new SubscriptionSettlementSide
         {
-            GrossAmountMinor = 1_000,
+            GrossAmountMinor = 900,
             TaxAmountMinor = 90,
             PeriodTotalMinor = 990,
             ProratedValueMinor = 495
         },
         Target = new SubscriptionSettlementSide
         {
-            GrossAmountMinor = 2_024,
+            GrossAmountMinor = 1_840,
             TaxAmountMinor = 184,
             PeriodTotalMinor = 2_024,
             ProratedValueMinor = 1_012

--- a/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
@@ -263,12 +263,15 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
             {
                 Outgoing = new SubscriptionSettlementSide
                 {
+                    // Gross less discounts (none here) equals period total less tax: 6,000 - 540.
+                    GrossAmountMinor = 5_460,
                     TaxAmountMinor = 540,
                     PeriodTotalMinor = 6_000,
                     ProratedValueMinor = 3_000
                 },
                 Target = new SubscriptionSettlementSide
                 {
+                    GrossAmountMinor = 16_380,
                     TaxAmountMinor = 1_620,
                     PeriodTotalMinor = 18_000,
                     ProratedValueMinor = 9_000


### PR DESCRIPTION
## Summary
- A plan-change or paid-quantity-increase settlement's amount is a two-sided breakdown, not a flat gross/discount/net — but the flat net field was stored as `0` instead of `null`, so the document totals read it as "the breakdown says zero" while the settlement table beneath them showed the real charge.
- `SubscriptionFinancialDocumentIssuer.AmountsFor` now reads `payment.SubscriptionSettlement` first, ahead of the flat fields, reconstructing value/tax/credit from the breakdown via `ProportionalAllocation.Split`. This is retroactive — it fixes documents for payment rows already stored with the false flat zero, no data migration needed.
- `StripeInvoiceBillingGateway` stops writing that false flat zero for new settlement payments (`null` now correctly reads back as "not applicable", matching the existing gross-amount guard).
- `SettlementCharge` now carries the tax rate/mode the breakdown was taxed under, since the breakdown itself only records tax amounts.

## Test plan
- [x] `dotnet build` on `Subscription.DomainService` and `XUnitTest` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~StripeInvoiceBillingGatewayTests|FullyQualifiedName~SubscriptionFinancialDocumentIssuerTests"` — 68/68 passing, including new regression coverage for: zero-total headline bug, old-data retroactivity (stored flat zero beside a real breakdown), credit applied, opening-stub upgrades, empty breakdowns, and plan-change vs quantity-change parity
- [ ] Manual: subscribe → change to a dearer plan → confirm the settlement invoice total matches the actual charge and agrees with the settlement table

🤖 Generated with [Claude Code](https://claude.com/claude-code)