### PR TITLE
Add tenant-admin metered-usage analytics reporting

### DIFF
--- a/server/Api/Controllers/SubscriptionUsageReportsController.cs
+++ b/server/Api/Controllers/SubscriptionUsageReportsController.cs
@@ -1,0 +1,104 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// Tenant-admin metered-usage analytics: volume over time, per-organization and per-actor
+/// breakdowns, and allowance/overage history — across every organization on the tenant.
+/// </summary>
+/// <remarks>
+/// Served under <c>/api/subscription-usage/reports</c>, gated by the
+/// <c>SubscriptionUsageReportReader</c> policy — its own claim, not the general authenticated-user
+/// bar every other subscription read clears, because it is the one subscription read that crosses
+/// organizations.
+/// <para>
+/// Follows <c>SubscriptionBackgroundWorkController</c>'s precedent exactly: no organization
+/// resolution step, no <c>PaymentOrganizationScope.RequestMayNameOrganization</c> check. That
+/// method answers "may this caller act as one specific named organization" — a narrower question
+/// than "may this caller read every organization in the tenant", which the policy claim above
+/// already settled. Every query here resolves the caller's own context (their own organization,
+/// which is why this never reaches <c>SubscriptionContextResolver</c>'s fail-closed
+/// <c>subscription_organization_missing</c> path) and then scopes strictly by
+/// <c>TenantId</c>. <c>organizationId</c> on a request is a filter within that tenant, never a
+/// scope escalation.
+/// </para>
+/// <para>
+/// The report returns ids, not names: organization and user display names resolve client-side
+/// through IAM, which is what keeps identity out of the billing module.
+/// </para>
+/// </remarks>
+[ApiController]
+[Authorize(Policy = "SubscriptionUsageReportReader")]
+[Route("subscription-usage/reports")]
+public sealed class SubscriptionUsageReportsController : ControllerBase
+{
+    private readonly ISubscriptionUsageReportService _reports;
+
+    public SubscriptionUsageReportsController(ISubscriptionUsageReportService reports) =>
+        _reports = reports;
+
+    /// <summary>Volume per bucket at the requested granularity.</summary>
+    [HttpGet("timeseries")]
+    [ProducesResponseType(typeof(ApiResponse<UsageTimeseriesResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<UsageTimeseriesResponse>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetTimeseries(
+        [FromQuery] GetUsageReportRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _reports.GetTimeseriesAsync(request, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>Per-organization totals, sortable by consumption.</summary>
+    [HttpGet("organizations")]
+    [ProducesResponseType(
+        typeof(ApiResponse<UsageOrganizationBreakdownResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(
+        typeof(ApiResponse<UsageOrganizationBreakdownResponse>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetOrganizations(
+        [FromQuery] GetUsageReportRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _reports.GetOrganizationsAsync(request, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>Per-user totals within one organization.</summary>
+    [HttpGet("actors")]
+    [ProducesResponseType(typeof(ApiResponse<UsageActorBreakdownResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<UsageActorBreakdownResponse>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetActors(
+        [FromQuery] GetUsageReportRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _reports.GetActorsAsync(request, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>Per-period allowance, plan, footprint and overage.</summary>
+    [HttpGet("allowances")]
+    [ProducesResponseType(typeof(ApiResponse<UsageAllowanceHistoryResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(
+        typeof(ApiResponse<UsageAllowanceHistoryResponse>), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetAllowances(
+        [FromQuery] GetUsageReportRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _reports.GetAllowancesAsync(request, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Program.cs
+++ b/server/Api/Program.cs
@@ -97,6 +97,15 @@ services.AddAuthorization(options =>
             .RequireAuthenticatedUser()
             .RequireClaim("permission", "subscription.background-work.manage"));
 
+    // Tenant-wide metered-usage reporting. Distinct from every other subscription read, which is
+    // scoped to the caller's own organization by construction — this claim is what lets a Tenant
+    // Admin see every organization on the tenant, so it is gated the same explicit way background-
+    // work recovery is rather than granted to anybody merely authenticated.
+    options.AddPolicy(
+        "SubscriptionUsageReportReader",
+        policy => policy
+            .RequireAuthenticatedUser()
+            .RequireClaim("permission", "subscription.usage-report.read"));
 });
 
 builder.Services.Configure<MvcOptions>(options =>

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageActivityRollup.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageActivityRollup.cs
@@ -1,0 +1,83 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One subscription and meter's usage for one UTC day, precomputed so a tenant-wide usage report
+/// never scans the live ledger.
+/// </summary>
+/// <remarks>
+/// Derived and disposable, exactly like <see cref="SubscriptionUsageCurrent"/>: the ledger
+/// (<see cref="SubscriptionUsageRecord"/>) is the only authority, and this document can always be
+/// rebuilt from it. Nothing here may ever be treated as the answer to whether usage is allowed —
+/// only <c>POST /api/subscription-usage</c> with <c>enforce</c> decides that.
+/// <para>
+/// Bucketed by <see cref="DayUtc"/>, which is the day the usage <em>occurred</em>
+/// (<c>OccurredAtUtc</c>), not the day it was recorded. A late-reported record still lands in the
+/// day it happened, which the rollup job achieves by incrementing this bucket regardless of the
+/// order records are read in.
+/// </para>
+/// <para>
+/// <see cref="ConsumedQuantity"/> is a signed sum of every ledger entry's <c>Delta</c> folded into
+/// this bucket, so a reversal nets out of the day and meter it corrected rather than requiring a
+/// second pass.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionUsageActivityRollup
+{
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary><c>{tenantId}:{organizationId}:{subscriptionId}:{meterKey}:{yyyyMMdd}</c>.</summary>
+    [BsonId]
+    public string ItemId { get; set; } = string.Empty;
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    public string MeterKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Denormalized at rollup time rather than joined from the subscription: a plan change
+    /// overwrites the subscription's own current plan fields, so a historical day's bucket would
+    /// otherwise report whatever plan is current now instead of the plan actually in force that
+    /// day.
+    /// </summary>
+    public string PlanId { get; set; } = string.Empty;
+
+    public string PlanCode { get; set; } = string.Empty;
+
+    /// <summary>Midnight UTC of the day this bucket covers.</summary>
+    public DateTime DayUtc { get; set; }
+
+    /// <summary>Signed sum of every ledger entry's <c>Delta</c> folded into this bucket.</summary>
+    public decimal ConsumedQuantity { get; set; }
+
+    /// <summary>How many ledger entries (consumption and reversal both) fed this bucket.</summary>
+    public long EntryCount { get; set; }
+
+    /// <summary>
+    /// Consumption by UTC hour of day, index 0-23, for a peak-hour heatmap. Not decremented by a
+    /// reversal's own hour — a reversal folds into the bucket's signed total but is not expected
+    /// to net out any one hour precisely, since it may be reported at a different hour than the
+    /// entry it corrects.
+    /// </summary>
+    public long[] HourlyQuantity { get; set; } = new long[24];
+
+    /// <summary>
+    /// The highest <c>RecordedAtUtc</c> (and, breaking a tie, the highest <c>ItemId</c>) folded
+    /// into this bucket so far — not for paging, but so a re-run of the rollup job can tell
+    /// whether a given ledger record has already been folded in without re-deriving the whole
+    /// bucket from scratch.
+    /// </summary>
+    public DateTime SourceCursorRecordedAtUtc { get; set; }
+
+    public string SourceCursorItemId { get; set; } = string.Empty;
+
+    public DateTime UpdatedAtUtc { get; set; }
+
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+}

--- a/server/Subscription.DomainService/Entities/SubscriptionUsageActorRollup.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionUsageActorRollup.cs
@@ -1,0 +1,53 @@
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// One user's usage for one organization, meter and UTC day.
+/// </summary>
+/// <remarks>
+/// Kept separate from <see cref="SubscriptionUsageActivityRollup"/> rather than an embedded
+/// per-user map on it: an embedded map grows with organization headcount and would eventually
+/// threaten Mongo's per-document size limit, where a document per user does not.
+/// <para>
+/// <see cref="ConsumedQuantity"/> sums <c>RecordedByUserId</c>-attributed ledger entries,
+/// reversals included — a reversal is written carrying the same <c>RecordedByUserId</c> as the
+/// entry it corrects (see <c>UsageRecordingService.RefuseAsync</c>), so it nets out of the actor
+/// who caused it rather than an unattributed bucket.
+/// </para>
+/// <para>
+/// Only the Blocks user id is stored. Display names resolve client-side through IAM, keeping
+/// identity out of the billing module.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionUsageActorRollup
+{
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary><c>{tenantId}:{organizationId}:{meterKey}:{yyyyMMdd}:{userId}</c>.</summary>
+    [BsonId]
+    public string ItemId { get; set; } = string.Empty;
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string MeterKey { get; set; } = string.Empty;
+
+    public DateTime DayUtc { get; set; }
+
+    public string UserId { get; set; } = string.Empty;
+
+    public decimal ConsumedQuantity { get; set; }
+
+    public long EntryCount { get; set; }
+
+    public DateTime SourceCursorRecordedAtUtc { get; set; }
+
+    public string SourceCursorItemId { get; set; } = string.Empty;
+
+    public DateTime UpdatedAtUtc { get; set; }
+
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+}

--- a/server/Subscription.DomainService/Entities/UsageInvoiceLine.cs
+++ b/server/Subscription.DomainService/Entities/UsageInvoiceLine.cs
@@ -15,6 +15,16 @@ public sealed class UsageInvoiceLine
 {
     public string MeterKey { get; set; } = string.Empty;
 
+    /// <summary>
+    /// The window's own frozen allowance for this meter — a trial grant or a carried-forward
+    /// allowance included, never the plan's bare IncludedQuantity. See
+    /// <see cref="Subscription.DomainService.Services.IMeterAllowanceResolver"/>.
+    /// </summary>
+    public decimal IncludedQuantity { get; set; }
+
+    /// <summary>The meter's total consumption this window, before allowance is applied.</summary>
+    public decimal UsedQuantity { get; set; }
+
     public decimal OverageQuantity { get; set; }
 
     public long AmountMinor { get; set; }

--- a/server/Subscription.DomainService/Enums/SubscriptionWorkType.cs
+++ b/server/Subscription.DomainService/Enums/SubscriptionWorkType.cs
@@ -66,5 +66,15 @@ public enum SubscriptionWorkType
     /// Bookkeeping, not money. Priority sits below every work type that can charge a customer.
     /// </para>
     /// </remarks>
-    UsageProjectionRefresh = 10
+    UsageProjectionRefresh = 10,
+
+    /// <summary>
+    /// Fold newly-recorded ledger entries into the tenant-usage-analytics rollup collections.
+    /// </summary>
+    /// <remarks>
+    /// Scheduled by the repair sweep whenever the ledger holds records past the rollup's own
+    /// persisted cursor. Bookkeeping for a read-only report, not money: it writes to two derived
+    /// collections nothing in the enforcement or billing path ever reads.
+    /// </remarks>
+    UsageActivityRollup = 11
 }

--- a/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionUsageRatingProcessor.cs
@@ -453,6 +453,11 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 ? ledger.Balance
                 : counter?.Balance ?? 0;
 
+            // Whether this meter saw any activity this window at all — distinct from whether it
+            // priced to a positive overage. A meter with entries that net to a zero balance (all
+            // consumption reversed) was still rated; a meter nothing ever touched was not.
+            var wasRated = ledger.RecordCount > 0 || counter is not null;
+
             // The window's own frozen allowance — a trial grant or a carried-forward allowance
             // included — never the plan's bare IncludedQuantity. The same resolver the overage
             // preview uses, so the two can never disagree about what "overage" means for this
@@ -500,7 +505,12 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
                 return InvoiceReadiness.Deferred;
             }
 
-            if (allocations.TotalAmountMinor <= 0)
+            // Only a meter with no activity this window at all is skipped. A meter that was rated
+            // but priced to zero (fully within allowance) still gets a line — at AmountMinor = 0
+            // — so the invoice records what it included and used, not just what it charged for.
+            // This must never change the charge itself: a zero-amount line contributes nothing to
+            // the aggregate total summed below.
+            if (!wasRated)
             {
                 continue;
             }
@@ -508,6 +518,8 @@ public sealed class SubscriptionUsageRatingProcessor : ISubscriptionUsageRatingP
             lines.Add(new UsageInvoiceLine
             {
                 MeterKey = meter.MeterKey,
+                IncludedQuantity = allowance,
+                UsedQuantity = balance,
                 OverageQuantity = overageQuantity,
                 AmountMinor = allocations.TotalAmountMinor
             });

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageActivityRollupRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageActivityRollupRepository.cs
@@ -1,0 +1,109 @@
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// Reads and writes the precomputed per-subscription, per-meter, per-day usage buckets behind
+/// the tenant-admin usage report.
+/// </summary>
+public interface ISubscriptionUsageActivityRollupRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Folds one ledger entry into its day's bucket, creating the bucket if this is its first
+    /// entry.
+    /// </summary>
+    /// <remarks>
+    /// An upsert with <c>$inc</c>, not a read-modify-write: two rollup passes (or a pass and a
+    /// concurrent backfill) folding the same tenant's records at once must not lose either one's
+    /// contribution. Idempotent by the caller's own bookkeeping — see <c>UsageRollupService</c> —
+    /// rather than by this method refusing an entry it has already applied, since the ledger keeps
+    /// no per-bucket record of which entries fed it.
+    /// </remarks>
+    Task ApplyAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        string meterKey,
+        string planId,
+        string planCode,
+        DateTime dayUtc,
+        int hourUtc,
+        decimal delta,
+        DateTime recordedAtUtc,
+        string sourceRecordId,
+        DateTime updatedAtUtc,
+        CancellationToken cancellationToken);
+
+    Task<UsageActivityRollupPage> ListAsync(
+        string tenantId,
+        string? organizationId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageRollupCursor? after,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sums consumption across every matching bucket, grouped by the requested granularity —
+    /// the volume-over-time report. A Mongo-side aggregation ($dateTrunc + $sum) rather than a
+    /// read-and-group in application code, so a tenant with a long history is summed by the
+    /// database instead of being paged entirely into this process first.
+    /// </summary>
+    Task<UsageTimeseriesPage> SumByPeriodAsync(
+        string tenantId,
+        string? organizationId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        BillingInterval granularity,
+        int pageSize,
+        DateTime? afterPeriodStartUtc,
+        CancellationToken cancellationToken);
+
+    /// <summary>Per-organization totals across the matching window — the organization breakdown.</summary>
+    Task<UsageOrganizationTotalsPage> SumByOrganizationAsync(
+        string tenantId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageOrganizationTotalsCursor? after,
+        CancellationToken cancellationToken);
+}
+
+public sealed record UsageTimeseriesBucket(
+    DateTime PeriodStartUtc,
+    decimal ConsumedQuantity,
+    long EntryCount);
+
+public sealed record UsageTimeseriesPage(IReadOnlyList<UsageTimeseriesBucket> Items, bool HasMore);
+
+public sealed record UsageOrganizationTotal(
+    string OrganizationId,
+    decimal ConsumedQuantity,
+    long EntryCount);
+
+public sealed record UsageOrganizationTotalsPage(
+    IReadOnlyList<UsageOrganizationTotal> Items,
+    bool HasMore);
+
+/// <summary>
+/// A keyset boundary over totals ordered by descending consumption, then organization id — the
+/// tie-break needed because two organizations can consume exactly the same amount.
+/// </summary>
+public sealed record UsageOrganizationTotalsCursor(decimal ConsumedQuantity, string OrganizationId);
+
+/// <summary>One page of activity-rollup buckets, newest day first.</summary>
+public sealed record UsageActivityRollupPage(
+    IReadOnlyList<SubscriptionUsageActivityRollup> Items,
+    bool HasMore);
+
+/// <summary>A keyset page boundary shared by the rollup listings: the day, then the id.</summary>
+public sealed record UsageRollupCursor(DateTime DayUtc, string ItemId);

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageActorRollupRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageActorRollupRepository.cs
@@ -1,0 +1,46 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// Reads and writes the precomputed per-user, per-meter, per-day usage buckets behind the
+/// tenant-admin usage report's actor breakdown.
+/// </summary>
+public interface ISubscriptionUsageActorRollupRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Folds one ledger entry into its actor's day bucket. See
+    /// <see cref="ISubscriptionUsageActivityRollupRepository.ApplyAsync"/> for why this is an
+    /// idempotent upsert rather than a read-modify-write.
+    /// </summary>
+    Task ApplyAsync(
+        string tenantId,
+        string organizationId,
+        string meterKey,
+        DateTime dayUtc,
+        string userId,
+        decimal delta,
+        DateTime recordedAtUtc,
+        string sourceRecordId,
+        DateTime updatedAtUtc,
+        CancellationToken cancellationToken);
+
+    Task<UsageActorRollupPage> ListAsync(
+        string tenantId,
+        string organizationId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageActorRollupCursor? after,
+        CancellationToken cancellationToken);
+}
+
+public sealed record UsageActorRollupPage(
+    IReadOnlyList<SubscriptionUsageActorRollup> Items,
+    bool HasMore);
+
+/// <summary>A keyset page boundary for the actor listing: the day, then the user id.</summary>
+public sealed record UsageActorRollupCursor(DateTime DayUtc, string UserId);

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
@@ -85,4 +85,19 @@ public interface ISubscriptionUsageCurrentRepository
         string tenantId,
         string documentId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// The current windows across an organization, optionally narrowed to one subscription or
+    /// meter — the open-period half of the tenant-usage-report's allowance history. Unlike
+    /// <see cref="ListCurrentAsync"/> this does not require a subscription id, since the report
+    /// may ask for every open window an organization has.
+    /// </summary>
+    Task<IReadOnlyList<SubscriptionUsageCurrent>> ListByOrganizationAsync(
+        string tenantId,
+        string organizationId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageInvoiceRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageInvoiceRepository.cs
@@ -58,4 +58,26 @@ public interface ISubscriptionUsageInvoiceRepository
         DateTime nextAttemptAtUtc,
         string? failureReason,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Closed usage periods across the tenant, optionally narrowed to one organization or
+    /// subscription and a creation-date window — the closed-period half of the allowance-history
+    /// report. Newest first, keyset-paged the same way
+    /// <see cref="ISubscriptionFinancialDocumentRepository.ListAsync"/> is.
+    /// </summary>
+    Task<UsageInvoicePage> ListAsync(
+        string tenantId,
+        string? organizationId,
+        string? subscriptionId,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageInvoiceCursor? after,
+        CancellationToken cancellationToken);
 }
+
+public sealed record UsageInvoicePage(
+    IReadOnlyList<SubscriptionUsageInvoice> Items,
+    bool HasMore);
+
+public sealed record UsageInvoiceCursor(DateTime CreatedAtUtc, string InvoiceId);

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
@@ -100,4 +100,21 @@ public interface ISubscriptionUsageRepository
         string? periodKey,
         int limit,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Every ledger record across the tenant, walked forward from a stored mark on
+    /// <c>RecordedAtUtc</c>. What the usage-rollup job reads instead of scanning the ledger.
+    /// </summary>
+    /// <remarks>
+    /// Ordered by <c>RecordedAtUtc</c> then <c>ItemId</c> so a page can resume exactly, even
+    /// across records that share one recorded instant. Deliberately not ordered by
+    /// <c>OccurredAtUtc</c> — a late-reported record's <c>OccurredAtUtc</c> can be arbitrarily far
+    /// in the past, so paging on it could never reach a stable "caught up" position.
+    /// </remarks>
+    Task<IReadOnlyList<SubscriptionUsageRecord>> ListRecordedSinceAsync(
+        string tenantId,
+        DateTime afterRecordedAtUtc,
+        string? afterId,
+        int limit,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -52,6 +52,21 @@ internal static class SubscriptionCollections
     public const string CampaignRedemptions = "SubscriptionCampaignRedemptions";
 
     /// <summary>
+    /// One document per subscription, meter and day — the precomputed volume-over-time and
+    /// per-organization view behind the tenant-admin usage report. Derived from
+    /// <see cref="UsageRecords"/> and disposable; never authoritative.
+    /// </summary>
+    public const string UsageActivityRollups = "SubscriptionUsageActivityRollups";
+
+    /// <summary>
+    /// One document per organization, meter, day and user — the per-actor breakdown behind the
+    /// tenant-admin usage report. Its own collection rather than a map embedded on
+    /// <see cref="UsageActivityRollups"/>, so a busy organization's headcount cannot grow one
+    /// document past Mongo's size limit.
+    /// </summary>
+    public const string UsageActorRollups = "SubscriptionUsageActorRollups";
+
+    /// <summary>
     /// Append-only record of every mail handed to the listener, payload included. Separate from the
     /// documents it reports on, because it also covers mail that has no document behind it.
     /// </summary>

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -84,6 +84,14 @@ public static class SubscriptionIndexDefinitions
     public const string UsagePeriodIndexName =
         "ix_subscription_usage_tenant_subscription_meter_period";
 
+    /// <summary>
+    /// What the usage-rollup job walks forward on. Additive and load-bearing: without it, the
+    /// rollup's incremental pass over <c>RecordedAtUtc</c> is the exact collection scan this
+    /// report exists to avoid.
+    /// </summary>
+    public const string UsageRecordRolloverScanIndexName =
+        "ix_subscription_usage_tenant_recorded_at";
+
     public const string UsageCounterExpiryIndexName =
         "ttl_subscription_usage_counter_expires";
 
@@ -98,6 +106,14 @@ public static class SubscriptionIndexDefinitions
 
     public const string UsageInvoiceSweepIndexName =
         "ix_subscription_usageinvoice_tenant_state_next_attempt";
+
+    /// <summary>
+    /// What the allowance-history report's closed-period half queries: every invoice for a
+    /// tenant, optionally an organization, newest first. The id tie-break lets a page resume
+    /// exactly across invoices created in the same instant.
+    /// </summary>
+    public const string UsageInvoiceOrganizationIndexName =
+        "ix_subscription_usageinvoice_tenant_org_created";
 
     /// <summary>
     /// One open subscription attempt per organization, enforced before checkout by the database
@@ -351,7 +367,15 @@ public static class SubscriptionIndexDefinitions
                 .Ascending(record => record.SubscriptionId)
                 .Ascending(record => record.MeterKey)
                 .Ascending(record => record.PeriodKey),
-            new CreateIndexOptions { Name = UsagePeriodIndexName })
+            new CreateIndexOptions { Name = UsagePeriodIndexName }),
+        // Tie-broken on the id so a page of records sharing one RecordedAtUtc instant — ordinary
+        // under concurrent writers — can still be resumed exactly rather than re-read or skipped.
+        new(
+            Builders<SubscriptionUsageRecord>.IndexKeys
+                .Ascending(record => record.TenantId)
+                .Ascending(record => record.RecordedAtUtc)
+                .Ascending(record => record.ItemId),
+            new CreateIndexOptions { Name = UsageRecordRolloverScanIndexName })
     ];
 
     /// <summary>
@@ -520,6 +544,86 @@ public static class SubscriptionIndexDefinitions
                 .Ascending(invoice => invoice.TenantId)
                 .Ascending(invoice => invoice.State)
                 .Ascending(invoice => invoice.NextAttemptAtUtc),
-            new CreateIndexOptions { Name = UsageInvoiceSweepIndexName })
+            new CreateIndexOptions { Name = UsageInvoiceSweepIndexName }),
+        new(
+            Builders<SubscriptionUsageInvoice>.IndexKeys
+                .Ascending(invoice => invoice.TenantId)
+                .Ascending(invoice => invoice.OrganizationId)
+                .Descending(invoice => invoice.CreatedAtUtc)
+                .Descending(invoice => invoice.ItemId),
+            new CreateIndexOptions { Name = UsageInvoiceOrganizationIndexName })
+    ];
+
+    public const string UsageActivityRollupUniqueIndexName =
+        "ux_usage_activity_rollup_identity";
+    public const string UsageActivityRollupTenantIndexName =
+        "ix_usage_activity_rollup_tenant_meter_day";
+    public const string UsageActivityRollupOrganizationIndexName =
+        "ix_usage_activity_rollup_tenant_org_meter_day";
+
+    /// <summary>
+    /// The tenant-usage-report's read indexes. The first is a restatement of the composed
+    /// <c>ItemId</c>, declared anyway so a consumer reading this collection directly sees the
+    /// guarantee in the index list; the other two serve the unfiltered and organization-filtered
+    /// listings respectively, both newest-day-first with the id as tie-break so a page of buckets
+    /// sharing one day can be resumed without a blocking sort.
+    /// </summary>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionUsageActivityRollup>>
+        CreateUsageActivityRollupIndexes() =>
+    [
+        new(
+            Builders<SubscriptionUsageActivityRollup>.IndexKeys
+                .Ascending(rollup => rollup.TenantId)
+                .Ascending(rollup => rollup.OrganizationId)
+                .Ascending(rollup => rollup.SubscriptionId)
+                .Ascending(rollup => rollup.MeterKey)
+                .Ascending(rollup => rollup.DayUtc),
+            new CreateIndexOptions { Name = UsageActivityRollupUniqueIndexName, Unique = true }),
+        new(
+            Builders<SubscriptionUsageActivityRollup>.IndexKeys
+                .Ascending(rollup => rollup.TenantId)
+                .Ascending(rollup => rollup.MeterKey)
+                .Descending(rollup => rollup.DayUtc)
+                .Descending(rollup => rollup.ItemId),
+            new CreateIndexOptions { Name = UsageActivityRollupTenantIndexName }),
+        new(
+            Builders<SubscriptionUsageActivityRollup>.IndexKeys
+                .Ascending(rollup => rollup.TenantId)
+                .Ascending(rollup => rollup.OrganizationId)
+                .Ascending(rollup => rollup.MeterKey)
+                .Descending(rollup => rollup.DayUtc)
+                .Descending(rollup => rollup.ItemId),
+            new CreateIndexOptions { Name = UsageActivityRollupOrganizationIndexName })
+    ];
+
+    public const string UsageActorRollupUniqueIndexName = "ux_usage_actor_rollup_identity";
+    public const string UsageActorRollupReadIndexName =
+        "ix_usage_actor_rollup_tenant_org_meter_day_user";
+
+    /// <summary>
+    /// The per-actor breakdown's read indexes. The unique index restates the composed
+    /// <c>ItemId</c> the same way the activity rollup's does; the read index serves the actor
+    /// listing itself, sorted by descending consumption client-side since totals here are per
+    /// bucket rather than a running sum an index could order by.
+    /// </summary>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionUsageActorRollup>>
+        CreateUsageActorRollupIndexes() =>
+    [
+        new(
+            Builders<SubscriptionUsageActorRollup>.IndexKeys
+                .Ascending(rollup => rollup.TenantId)
+                .Ascending(rollup => rollup.OrganizationId)
+                .Ascending(rollup => rollup.MeterKey)
+                .Ascending(rollup => rollup.DayUtc)
+                .Ascending(rollup => rollup.UserId),
+            new CreateIndexOptions { Name = UsageActorRollupUniqueIndexName, Unique = true }),
+        new(
+            Builders<SubscriptionUsageActorRollup>.IndexKeys
+                .Ascending(rollup => rollup.TenantId)
+                .Ascending(rollup => rollup.OrganizationId)
+                .Ascending(rollup => rollup.MeterKey)
+                .Descending(rollup => rollup.DayUtc)
+                .Ascending(rollup => rollup.UserId),
+            new CreateIndexOptions { Name = UsageActorRollupReadIndexName })
     ];
 }

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageActivityRollupRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageActivityRollupRepository.cs
@@ -1,0 +1,362 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionUsageActivityRollupRepository :
+    ISubscriptionUsageActivityRollupRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionUsageActivityRollupRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Rollups(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateUsageActivityRollupIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task ApplyAsync(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        string meterKey,
+        string planId,
+        string planCode,
+        DateTime dayUtc,
+        int hourUtc,
+        decimal delta,
+        DateTime recordedAtUtc,
+        string sourceRecordId,
+        DateTime updatedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var itemId = BucketId(tenantId, organizationId, subscriptionId, meterKey, dayUtc);
+        var builder = Builders<SubscriptionUsageActivityRollup>.Filter;
+
+        // Matches an existing bucket only when this ledger entry is strictly newer than the last
+        // one folded into it — the guard that makes a re-run of the same page idempotent. A
+        // record already accounted for fails this filter, the upsert then collides on _id, and
+        // that collision is the "already applied, nothing to do" signal caught below. A bucket
+        // that does not exist yet fails the whole filter (there is no document to compare
+        // against) and the upsert inserts it fresh instead.
+        var filter = builder.And(
+            builder.Eq(rollup => rollup.ItemId, itemId),
+            builder.Or(
+                builder.Lt(rollup => rollup.SourceCursorRecordedAtUtc, recordedAtUtc),
+                builder.And(
+                    builder.Eq(rollup => rollup.SourceCursorRecordedAtUtc, recordedAtUtc),
+                    builder.Lt(rollup => rollup.SourceCursorItemId, sourceRecordId))));
+
+        var update = Builders<SubscriptionUsageActivityRollup>.Update
+            .SetOnInsert(rollup => rollup.ItemId, itemId)
+            .SetOnInsert(rollup => rollup.TenantId, tenantId)
+            .SetOnInsert(rollup => rollup.OrganizationId, organizationId)
+            .SetOnInsert(rollup => rollup.SubscriptionId, subscriptionId)
+            .SetOnInsert(rollup => rollup.MeterKey, meterKey)
+            .SetOnInsert(rollup => rollup.DayUtc, dayUtc)
+            .SetOnInsert(rollup => rollup.HourlyQuantity, new long[24])
+            .Set(rollup => rollup.PlanId, planId)
+            .Set(rollup => rollup.PlanCode, planCode)
+            .Set(rollup => rollup.SourceCursorRecordedAtUtc, recordedAtUtc)
+            .Set(rollup => rollup.SourceCursorItemId, sourceRecordId)
+            .Set(rollup => rollup.UpdatedAtUtc, updatedAtUtc)
+            .Set(rollup => rollup.SchemaVersion, SubscriptionUsageActivityRollup.CurrentSchemaVersion)
+            .Inc(rollup => rollup.ConsumedQuantity, delta)
+            .Inc(rollup => rollup.EntryCount, 1L)
+            .Inc($"{nameof(SubscriptionUsageActivityRollup.HourlyQuantity)}.{hourUtc}", 1L);
+
+        try
+        {
+            await Rollups(tenantId).UpdateOneAsync(
+                filter,
+                update,
+                new UpdateOptions { IsUpsert = true },
+                cancellationToken);
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // The bucket already exists and this entry did not advance its cursor: it was already
+            // folded in by an earlier pass over the same page. Nothing to do — applying it again
+            // would double-count.
+        }
+    }
+
+    public async Task<UsageActivityRollupPage> ListAsync(
+        string tenantId,
+        string? organizationId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageRollupCursor? after,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var builder = Builders<SubscriptionUsageActivityRollup>.Filter;
+        var filters = new List<FilterDefinition<SubscriptionUsageActivityRollup>>
+        {
+            builder.Eq(rollup => rollup.TenantId, tenantId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            filters.Add(builder.Eq(rollup => rollup.OrganizationId, organizationId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            filters.Add(builder.Eq(rollup => rollup.SubscriptionId, subscriptionId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(meterKey))
+        {
+            filters.Add(builder.Eq(rollup => rollup.MeterKey, meterKey));
+        }
+
+        if (fromUtc is { } from)
+        {
+            filters.Add(builder.Gte(rollup => rollup.DayUtc, from));
+        }
+
+        if (toUtc is { } to)
+        {
+            filters.Add(builder.Lte(rollup => rollup.DayUtc, to));
+        }
+
+        if (after is not null)
+        {
+            filters.Add(builder.Or(
+                builder.Lt(rollup => rollup.DayUtc, after.DayUtc),
+                builder.And(
+                    builder.Eq(rollup => rollup.DayUtc, after.DayUtc),
+                    builder.Lt(rollup => rollup.ItemId, after.ItemId))));
+        }
+
+        var items = await Rollups(tenantId)
+            .Find(builder.And(filters))
+            .Sort(Builders<SubscriptionUsageActivityRollup>.Sort
+                .Descending(rollup => rollup.DayUtc)
+                .Descending(rollup => rollup.ItemId))
+            .Limit(pageSize + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = items.Count > pageSize;
+
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        return new UsageActivityRollupPage(items, hasMore);
+    }
+
+    public async Task<UsageTimeseriesPage> SumByPeriodAsync(
+        string tenantId,
+        string? organizationId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        BillingInterval granularity,
+        int pageSize,
+        DateTime? afterPeriodStartUtc,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var matchFilter = BuildFilter(
+            tenantId, organizationId, subscriptionId, meterKey, fromUtc, toUtc);
+
+        var aggregate = Rollups(tenantId).Aggregate().Match(matchFilter)
+            .AppendStage<BsonDocument>(new BsonDocument("$group", new BsonDocument
+            {
+                {
+                    "_id", new BsonDocument("$dateTrunc", new BsonDocument
+                    {
+                        { "date", "$DayUtc" },
+                        { "unit", MongoUnitFor(granularity) },
+                        { "timezone", "UTC" },
+                        { "startOfWeek", "monday" }
+                    })
+                },
+                { "ConsumedQuantity", new BsonDocument("$sum", "$ConsumedQuantity") },
+                { "EntryCount", new BsonDocument("$sum", "$EntryCount") }
+            }));
+
+        if (afterPeriodStartUtc is { } after)
+        {
+            aggregate = aggregate.AppendStage<BsonDocument>(
+                new BsonDocument("$match", new BsonDocument("_id", new BsonDocument("$lt", after))));
+        }
+
+        aggregate = aggregate
+            .AppendStage<BsonDocument>(new BsonDocument("$sort", new BsonDocument("_id", -1)))
+            .AppendStage<BsonDocument>(new BsonDocument("$limit", pageSize + 1));
+
+        var documents = await aggregate.ToListAsync(cancellationToken);
+        var hasMore = documents.Count > pageSize;
+
+        if (hasMore)
+        {
+            documents.RemoveAt(documents.Count - 1);
+        }
+
+        var items = documents
+            .Select(document => new UsageTimeseriesBucket(
+                document["_id"].ToUniversalTime(),
+                document["ConsumedQuantity"].ToDecimal(),
+                document["EntryCount"].ToInt64()))
+            .ToList();
+
+        return new UsageTimeseriesPage(items, hasMore);
+    }
+
+    public async Task<UsageOrganizationTotalsPage> SumByOrganizationAsync(
+        string tenantId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageOrganizationTotalsCursor? after,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var matchFilter = BuildFilter(
+            tenantId, organizationId: null, subscriptionId, meterKey, fromUtc, toUtc);
+
+        var aggregate = Rollups(tenantId).Aggregate().Match(matchFilter)
+            .AppendStage<BsonDocument>(new BsonDocument("$group", new BsonDocument
+            {
+                { "_id", "$OrganizationId" },
+                { "ConsumedQuantity", new BsonDocument("$sum", "$ConsumedQuantity") },
+                { "EntryCount", new BsonDocument("$sum", "$EntryCount") }
+            }));
+
+        if (after is { } cursor)
+        {
+            aggregate = aggregate.AppendStage<BsonDocument>(new BsonDocument("$match", new BsonDocument(
+                "$or",
+                new BsonArray
+                {
+                    new BsonDocument("ConsumedQuantity", new BsonDocument("$lt", cursor.ConsumedQuantity)),
+                    new BsonDocument("$and", new BsonArray
+                    {
+                        new BsonDocument("ConsumedQuantity", cursor.ConsumedQuantity),
+                        new BsonDocument("_id", new BsonDocument("$gt", cursor.OrganizationId))
+                    })
+                })));
+        }
+
+        aggregate = aggregate
+            .AppendStage<BsonDocument>(new BsonDocument("$sort", new BsonDocument
+            {
+                { "ConsumedQuantity", -1 },
+                { "_id", 1 }
+            }))
+            .AppendStage<BsonDocument>(new BsonDocument("$limit", pageSize + 1));
+
+        var documents = await aggregate.ToListAsync(cancellationToken);
+        var hasMore = documents.Count > pageSize;
+
+        if (hasMore)
+        {
+            documents.RemoveAt(documents.Count - 1);
+        }
+
+        var items = documents
+            .Select(document => new UsageOrganizationTotal(
+                document["_id"].AsString,
+                document["ConsumedQuantity"].ToDecimal(),
+                document["EntryCount"].ToInt64()))
+            .ToList();
+
+        return new UsageOrganizationTotalsPage(items, hasMore);
+    }
+
+    private static FilterDefinition<SubscriptionUsageActivityRollup> BuildFilter(
+        string tenantId,
+        string? organizationId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc)
+    {
+        var builder = Builders<SubscriptionUsageActivityRollup>.Filter;
+        var filters = new List<FilterDefinition<SubscriptionUsageActivityRollup>>
+        {
+            builder.Eq(rollup => rollup.TenantId, tenantId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            filters.Add(builder.Eq(rollup => rollup.OrganizationId, organizationId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            filters.Add(builder.Eq(rollup => rollup.SubscriptionId, subscriptionId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(meterKey))
+        {
+            filters.Add(builder.Eq(rollup => rollup.MeterKey, meterKey));
+        }
+
+        if (fromUtc is { } from)
+        {
+            filters.Add(builder.Gte(rollup => rollup.DayUtc, from));
+        }
+
+        if (toUtc is { } to)
+        {
+            filters.Add(builder.Lte(rollup => rollup.DayUtc, to));
+        }
+
+        return builder.And(filters);
+    }
+
+    private static string MongoUnitFor(BillingInterval granularity) => granularity switch
+    {
+        BillingInterval.Day => "day",
+        BillingInterval.Week => "week",
+        BillingInterval.Month => "month",
+        BillingInterval.Year => "year",
+        _ => "month"
+    };
+
+    internal static string BucketId(
+        string tenantId,
+        string organizationId,
+        string subscriptionId,
+        string meterKey,
+        DateTime dayUtc) =>
+        $"{tenantId}:{organizationId}:{subscriptionId}:{meterKey}:{dayUtc:yyyyMMdd}";
+
+    private IMongoCollection<SubscriptionUsageActivityRollup> Rollups(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionUsageActivityRollup>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.UsageActivityRollups);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageActorRollupRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageActorRollupRepository.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionUsageActorRollupRepository : ISubscriptionUsageActorRollupRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionUsageActorRollupRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Rollups(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateUsageActorRollupIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task ApplyAsync(
+        string tenantId,
+        string organizationId,
+        string meterKey,
+        DateTime dayUtc,
+        string userId,
+        decimal delta,
+        DateTime recordedAtUtc,
+        string sourceRecordId,
+        DateTime updatedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var itemId = BucketId(tenantId, organizationId, meterKey, dayUtc, userId);
+        var builder = Builders<SubscriptionUsageActorRollup>.Filter;
+
+        // Same idempotency guard as the activity rollup: matches an existing bucket only when
+        // this entry is newer than the last one folded in, so a re-run over an already-applied
+        // page collides on _id instead of double-counting.
+        var filter = builder.And(
+            builder.Eq(rollup => rollup.ItemId, itemId),
+            builder.Or(
+                builder.Lt(rollup => rollup.SourceCursorRecordedAtUtc, recordedAtUtc),
+                builder.And(
+                    builder.Eq(rollup => rollup.SourceCursorRecordedAtUtc, recordedAtUtc),
+                    builder.Lt(rollup => rollup.SourceCursorItemId, sourceRecordId))));
+
+        var update = Builders<SubscriptionUsageActorRollup>.Update
+            .SetOnInsert(rollup => rollup.ItemId, itemId)
+            .SetOnInsert(rollup => rollup.TenantId, tenantId)
+            .SetOnInsert(rollup => rollup.OrganizationId, organizationId)
+            .SetOnInsert(rollup => rollup.MeterKey, meterKey)
+            .SetOnInsert(rollup => rollup.DayUtc, dayUtc)
+            .SetOnInsert(rollup => rollup.UserId, userId)
+            .Set(rollup => rollup.SourceCursorRecordedAtUtc, recordedAtUtc)
+            .Set(rollup => rollup.SourceCursorItemId, sourceRecordId)
+            .Set(rollup => rollup.UpdatedAtUtc, updatedAtUtc)
+            .Set(rollup => rollup.SchemaVersion, SubscriptionUsageActorRollup.CurrentSchemaVersion)
+            .Inc(rollup => rollup.ConsumedQuantity, delta)
+            .Inc(rollup => rollup.EntryCount, 1L);
+
+        try
+        {
+            await Rollups(tenantId).UpdateOneAsync(
+                filter,
+                update,
+                new UpdateOptions { IsUpsert = true },
+                cancellationToken);
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Already accounted for by an earlier pass over the same page. See the activity
+            // rollup's own remarks.
+        }
+    }
+
+    public async Task<UsageActorRollupPage> ListAsync(
+        string tenantId,
+        string organizationId,
+        string? meterKey,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageActorRollupCursor? after,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var builder = Builders<SubscriptionUsageActorRollup>.Filter;
+        var filters = new List<FilterDefinition<SubscriptionUsageActorRollup>>
+        {
+            builder.Eq(rollup => rollup.TenantId, tenantId),
+            builder.Eq(rollup => rollup.OrganizationId, organizationId)
+        };
+
+        if (!string.IsNullOrWhiteSpace(meterKey))
+        {
+            filters.Add(builder.Eq(rollup => rollup.MeterKey, meterKey));
+        }
+
+        if (fromUtc is { } from)
+        {
+            filters.Add(builder.Gte(rollup => rollup.DayUtc, from));
+        }
+
+        if (toUtc is { } to)
+        {
+            filters.Add(builder.Lte(rollup => rollup.DayUtc, to));
+        }
+
+        if (after is not null)
+        {
+            filters.Add(builder.Or(
+                builder.Lt(rollup => rollup.DayUtc, after.DayUtc),
+                builder.And(
+                    builder.Eq(rollup => rollup.DayUtc, after.DayUtc),
+                    builder.Gt(rollup => rollup.UserId, after.UserId))));
+        }
+
+        var items = await Rollups(tenantId)
+            .Find(builder.And(filters))
+            .Sort(Builders<SubscriptionUsageActorRollup>.Sort
+                .Descending(rollup => rollup.DayUtc)
+                .Ascending(rollup => rollup.UserId))
+            .Limit(pageSize + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = items.Count > pageSize;
+
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        return new UsageActorRollupPage(items, hasMore);
+    }
+
+    internal static string BucketId(
+        string tenantId,
+        string organizationId,
+        string meterKey,
+        DateTime dayUtc,
+        string userId) =>
+        $"{tenantId}:{organizationId}:{meterKey}:{dayUtc:yyyyMMdd}:{userId}";
+
+    private IMongoCollection<SubscriptionUsageActorRollup> Rollups(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionUsageActorRollup>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.UsageActorRollups);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -343,6 +343,41 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
             .Limit(limit)
             .ToListAsync(cancellationToken);
 
+    public async Task<IReadOnlyList<SubscriptionUsageCurrent>> ListByOrganizationAsync(
+        string tenantId,
+        string organizationId,
+        string? subscriptionId,
+        string? meterKey,
+        DateTime asOfUtc,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        var builder = Builders<SubscriptionUsageCurrent>.Filter;
+        var filters = new List<FilterDefinition<SubscriptionUsageCurrent>>
+        {
+            builder.Eq(current => current.OrganizationId, organizationId),
+            builder.Lte(current => current.PeriodStartUtc, asOfUtc),
+            // Strictly after, matching ListCurrentAsync's own boundary: a period ends the instant
+            // its successor begins.
+            builder.Gt(current => current.PeriodEndUtc, asOfUtc)
+        };
+
+        if (!string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            filters.Add(builder.Eq(current => current.SubscriptionId, subscriptionId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(meterKey))
+        {
+            filters.Add(builder.Eq(current => current.MeterKey, meterKey));
+        }
+
+        return await Current(tenantId)
+            .Find(builder.And(filters))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<SubscriptionUsageCurrent?> GetAsync(
         string tenantId,
         string documentId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageInvoiceRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageInvoiceRepository.cs
@@ -170,6 +170,68 @@ public sealed class SubscriptionUsageInvoiceRepository : ISubscriptionUsageInvoi
                 .Set(invoice => invoice.LastUpdatedDateUtc, DateTime.UtcNow),
             cancellationToken: cancellationToken);
 
+    public async Task<UsageInvoicePage> ListAsync(
+        string tenantId,
+        string? organizationId,
+        string? subscriptionId,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        int pageSize,
+        UsageInvoiceCursor? after,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var builder = Builders<SubscriptionUsageInvoice>.Filter;
+        var filters = new List<FilterDefinition<SubscriptionUsageInvoice>> { TenantFilter(tenantId) };
+
+        if (!string.IsNullOrWhiteSpace(organizationId))
+        {
+            filters.Add(builder.Eq(invoice => invoice.OrganizationId, organizationId));
+        }
+
+        if (!string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            filters.Add(builder.Eq(invoice => invoice.SubscriptionId, subscriptionId));
+        }
+
+        if (fromUtc is { } from)
+        {
+            filters.Add(builder.Gte(invoice => invoice.CreatedAtUtc, from));
+        }
+
+        if (toUtc is { } to)
+        {
+            filters.Add(builder.Lte(invoice => invoice.CreatedAtUtc, to));
+        }
+
+        if (after is not null)
+        {
+            filters.Add(builder.Or(
+                builder.Lt(invoice => invoice.CreatedAtUtc, after.CreatedAtUtc),
+                builder.And(
+                    builder.Eq(invoice => invoice.CreatedAtUtc, after.CreatedAtUtc),
+                    builder.Lt(invoice => invoice.ItemId, after.InvoiceId))));
+        }
+
+        var items = await Invoices(tenantId)
+            .Find(builder.And(filters))
+            .Sort(Builders<SubscriptionUsageInvoice>.Sort
+                .Descending(invoice => invoice.CreatedAtUtc)
+                .Descending(invoice => invoice.ItemId))
+            .Limit(pageSize + 1)
+            .ToListAsync(cancellationToken);
+
+        var hasMore = items.Count > pageSize;
+
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        return new UsageInvoicePage(items, hasMore);
+    }
+
     private static FilterDefinition<SubscriptionUsageInvoice> PendingFilter(
         string tenantId,
         string invoiceId) =>

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
@@ -287,6 +287,35 @@ public sealed class SubscriptionUsageRepository : ISubscriptionUsageRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IReadOnlyList<SubscriptionUsageRecord>> ListRecordedSinceAsync(
+        string tenantId,
+        DateTime afterRecordedAtUtc,
+        string? afterId,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        await EnsureIndexesAsync(tenantId, cancellationToken);
+
+        var builder = Builders<SubscriptionUsageRecord>.Filter;
+        var filter = builder.And(
+            builder.Eq(record => record.TenantId, tenantId),
+            string.IsNullOrWhiteSpace(afterId)
+                ? builder.Gte(record => record.RecordedAtUtc, afterRecordedAtUtc)
+                : builder.Or(
+                    builder.Gt(record => record.RecordedAtUtc, afterRecordedAtUtc),
+                    builder.And(
+                        builder.Eq(record => record.RecordedAtUtc, afterRecordedAtUtc),
+                        builder.Gt(record => record.ItemId, afterId))));
+
+        return await Records(tenantId)
+            .Find(filter)
+            .Sort(Builders<SubscriptionUsageRecord>.Sort
+                .Ascending(record => record.RecordedAtUtc)
+                .Ascending(record => record.ItemId))
+            .Limit(limit)
+            .ToListAsync(cancellationToken);
+    }
+
     private IMongoCollection<SubscriptionUsageRecord> Records(string tenantId) =>
         SubscriptionCollections.Of<SubscriptionUsageRecord>(
             _dbContextProvider,

--- a/server/Subscription.DomainService/Requests/GetUsageReportRequest.cs
+++ b/server/Subscription.DomainService/Requests/GetUsageReportRequest.cs
@@ -1,0 +1,37 @@
+namespace Subscription.DomainService.Requests;
+
+/// <summary>
+/// The query shared by every tenant-usage-analytics report endpoint.
+/// </summary>
+/// <remarks>
+/// Tenant-scoped-with-optional-organization-filter, not organization-scoped like every other
+/// subscription read: <see cref="OrganizationId"/> narrows within the caller's tenant rather than
+/// naming which organization the caller acts as. See
+/// <c>SubscriptionUsageReportsController</c>'s own remarks for why that is a materially different
+/// question from <c>PaymentOrganizationScope.RequestMayNameOrganization</c>.
+/// </remarks>
+public sealed class GetUsageReportRequest
+{
+    /// <summary>
+    /// "Day", "Week", "Month" or "Year", case-insensitive. Unrecognised is a domain error rather
+    /// than a silent fallback — see <c>SubscriptionUsageReportService.TryParseGranularity</c>.
+    /// </summary>
+    public string? Granularity { get; set; }
+
+    /// <summary>Inclusive lower bound on when usage occurred. Null means "from the beginning".</summary>
+    public DateTime? FromUtc { get; set; }
+
+    /// <summary>Inclusive upper bound on when usage occurred. Null means "through now".</summary>
+    public DateTime? ToUtc { get; set; }
+
+    /// <summary>A filter within the tenant, never a scope escalation. Null lists every organization.</summary>
+    public string? OrganizationId { get; set; }
+
+    public string? MeterKey { get; set; }
+
+    public string? SubscriptionId { get; set; }
+
+    public int PageSize { get; set; } = 25;
+
+    public string? After { get; set; }
+}

--- a/server/Subscription.DomainService/Responses/SubscriptionUsageReportResponses.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionUsageReportResponses.cs
@@ -1,0 +1,122 @@
+namespace Subscription.DomainService.Responses;
+
+/// <summary>Shared page info, matching <c>SubscriptionFinancialDocumentPageInfoResponse</c>'s shape.</summary>
+public sealed class UsageReportPageInfoResponse
+{
+    public int PageSize { get; init; }
+
+    public bool HasNextPage { get; init; }
+
+    public string? NextCursor { get; init; }
+}
+
+/// <summary>Volume per bucket at the requested granularity — answers "how much, over time".</summary>
+public sealed class UsageTimeseriesResponse
+{
+    public IReadOnlyList<UsageTimeseriesPointResponse> Items { get; init; } = [];
+
+    public UsageReportPageInfoResponse PageInfo { get; init; } = new();
+}
+
+public sealed class UsageTimeseriesPointResponse
+{
+    public string PeriodKey { get; init; } = string.Empty;
+
+    public DateTime PeriodStartUtc { get; init; }
+
+    public decimal ConsumedQuantity { get; init; }
+
+    public long EntryCount { get; init; }
+}
+
+/// <summary>Per-organization totals — answers "which organizations, how much".</summary>
+public sealed class UsageOrganizationBreakdownResponse
+{
+    public IReadOnlyList<UsageOrganizationTotalResponse> Items { get; init; } = [];
+
+    public UsageReportPageInfoResponse PageInfo { get; init; } = new();
+}
+
+public sealed class UsageOrganizationTotalResponse
+{
+    /// <summary>The Blocks organization id. Display name resolves client-side through IAM.</summary>
+    public string OrganizationId { get; init; } = string.Empty;
+
+    public decimal ConsumedQuantity { get; init; }
+
+    public long EntryCount { get; init; }
+}
+
+/// <summary>Per-user totals — answers "who, how much".</summary>
+public sealed class UsageActorBreakdownResponse
+{
+    public IReadOnlyList<UsageActorTotalResponse> Items { get; init; } = [];
+
+    public UsageReportPageInfoResponse PageInfo { get; init; } = new();
+}
+
+public sealed class UsageActorTotalResponse
+{
+    public string OrganizationId { get; init; } = string.Empty;
+
+    public string MeterKey { get; init; } = string.Empty;
+
+    public DateTime DayUtc { get; init; }
+
+    /// <summary>The Blocks user id. Display name resolves client-side through IAM.</summary>
+    public string UserId { get; init; } = string.Empty;
+
+    public decimal ConsumedQuantity { get; init; }
+
+    public long EntryCount { get; init; }
+}
+
+/// <summary>
+/// Per-period allowance, plan, footprint and overage — answers "how much was included, used and
+/// charged for".
+/// </summary>
+public sealed class UsageAllowanceHistoryResponse
+{
+    public IReadOnlyList<UsageAllowancePeriodResponse> Items { get; init; } = [];
+
+    public UsageReportPageInfoResponse PageInfo { get; init; } = new();
+}
+
+public sealed class UsageAllowancePeriodResponse
+{
+    public string OrganizationId { get; init; } = string.Empty;
+
+    public string SubscriptionId { get; init; } = string.Empty;
+
+    public string PeriodKey { get; init; } = string.Empty;
+
+    /// <summary><c>true</c> for the subscription's still-open window, <c>false</c> for a closed one.</summary>
+    public bool IsOpenPeriod { get; init; }
+
+    public IReadOnlyList<UsageAllowanceMeterResponse> Meters { get; init; } = [];
+}
+
+public sealed class UsageAllowanceMeterResponse
+{
+    public string MeterKey { get; init; } = string.Empty;
+
+    public string PlanId { get; init; } = string.Empty;
+
+    public string PlanCode { get; init; } = string.Empty;
+
+    public decimal IncludedQuantity { get; init; }
+
+    public decimal UsedQuantity { get; init; }
+
+    public decimal OverageQuantity { get; init; }
+
+    public long? OverageAmountMinor { get; init; }
+
+    /// <summary>
+    /// <c>true</c> for a closed period rated before the invoice line carried
+    /// <c>IncludedQuantity</c>/<c>UsedQuantity</c>. Its allowance and usage footprint cannot be
+    /// reconstructed retroactively, so only the overage it was actually charged for is reported —
+    /// see the module's own remarks on why no backfill invents a number here.
+    /// </summary>
+    public bool IsHistoricalOverageOnly { get; init; }
+}

--- a/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
@@ -42,6 +42,7 @@ public sealed class SubscriptionRepairAnnouncer
     private readonly TimeProvider _time;
     private readonly CampaignRedemptionReconciler? _campaignRedemptions;
     private readonly IUsageProjectionReconciler? _usageProjections;
+    private readonly ISubscriptionUsageRepository? _usage;
 
     public SubscriptionRepairAnnouncer(
         ISubscriptionWorkScheduler scheduler,
@@ -61,7 +62,10 @@ public sealed class SubscriptionRepairAnnouncer
         CampaignRedemptionReconciler? campaignRedemptions = null,
         // Optional for the same reason: a caller or test that constructs this class by hand,
         // unaware the usage projection exists, must keep compiling and keep behaving as before.
-        IUsageProjectionReconciler? usageProjections = null)
+        IUsageProjectionReconciler? usageProjections = null,
+        // Optional for the same reason: this is what the usage-rollup due-check reads, and a
+        // caller unaware of it must keep compiling.
+        ISubscriptionUsageRepository? usage = null)
     {
         _scheduler = scheduler;
         _subscriptions = subscriptions;
@@ -76,6 +80,7 @@ public sealed class SubscriptionRepairAnnouncer
         _time = time ?? TimeProvider.System;
         _campaignRedemptions = campaignRedemptions;
         _usageProjections = usageProjections;
+        _usage = usage;
     }
 
     /// <summary>
@@ -326,6 +331,29 @@ public sealed class SubscriptionRepairAnnouncer
                 cancellationToken)).Count > 0)
         {
             due.Add(SubscriptionWorkType.FinancialDocumentDelivery);
+        }
+
+        // Asked from the rollup job's own stored mark, the same way the document sweep above asks
+        // from its two — so this answers "does the ledger hold anything past what the rollup has
+        // accounted for" rather than guessing at a fixed lookback window.
+        if (_usage is not null)
+        {
+            var rolledUpTo = await _cursors.GetAsync(
+                tenantId,
+                Services.UsageRollupService.RollupCursorName,
+                cancellationToken);
+
+            var pending = await _usage.ListRecordedSinceAsync(
+                tenantId,
+                rolledUpTo?.ReadUpToUtc ?? DateTime.MinValue.ToUniversalTime(),
+                rolledUpTo?.AfterId,
+                1,
+                cancellationToken);
+
+            if (pending.Count > 0)
+            {
+                due.Add(SubscriptionWorkType.UsageActivityRollup);
+            }
         }
 
         return due;

--- a/server/Subscription.DomainService/Scheduling/UsageActivityRollupWorkHandler.cs
+++ b/server/Subscription.DomainService/Scheduling/UsageActivityRollupWorkHandler.cs
@@ -1,0 +1,38 @@
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Services;
+
+namespace Subscription.DomainService.Scheduling;
+
+/// <summary>
+/// Folds the tenant's newly-recorded usage ledger entries into the analytics rollup collections.
+/// </summary>
+/// <remarks>
+/// Always tenant-wide — this work type names no aggregate, since the rollup walks the ledger by
+/// its own persisted cursor rather than by subscription. One batch per attempt: if the ledger
+/// still holds more behind the cursor after this batch, the repair sweep's own due-check finds
+/// that on its next pass and schedules another occurrence, the same way every other
+/// cursor-driven recovery pass in this module works.
+/// </remarks>
+public sealed class UsageActivityRollupWorkHandler : ISubscriptionWorkHandler
+{
+    private readonly IUsageRollupService _rollups;
+
+    public UsageActivityRollupWorkHandler(IUsageRollupService rollups) => _rollups = rollups;
+
+    public SubscriptionWorkType WorkType => SubscriptionWorkType.UsageActivityRollup;
+
+    public async Task<SubscriptionWorkOutcome> ExecuteAsync(
+        SubscriptionBackgroundWork work,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+
+        var correlationId = string.IsNullOrWhiteSpace(work.CorrelationId)
+            ? work.ItemId
+            : work.CorrelationId;
+
+        await _rollups.RunBatchAsync(work.TenantId, correlationId, cancellationToken);
+
+        return SubscriptionWorkOutcome.Completed();
+    }
+}

--- a/server/Subscription.DomainService/Services/ISubscriptionUsageReportService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionUsageReportService.cs
@@ -1,0 +1,37 @@
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// The tenant-admin metered-usage analytics report: volume over time, per-organization and
+/// per-actor breakdowns, and allowance/overage history — every one of them read from the
+/// precomputed rollup collections rather than the live usage ledger.
+/// </summary>
+/// <remarks>
+/// Every query here is scoped by the caller's <c>TenantId</c> alone. <c>OrganizationId</c> on a
+/// request is a filter within that tenant, never a scope escalation — see
+/// <c>SubscriptionUsageReportsController</c>'s own remarks.
+/// </remarks>
+public interface ISubscriptionUsageReportService
+{
+    Task<SubscriptionOperationResult<UsageTimeseriesResponse>> GetTimeseriesAsync(
+        GetUsageReportRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<UsageOrganizationBreakdownResponse>> GetOrganizationsAsync(
+        GetUsageReportRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<UsageActorBreakdownResponse>> GetActorsAsync(
+        GetUsageReportRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionOperationResult<UsageAllowanceHistoryResponse>> GetAllowancesAsync(
+        GetUsageReportRequest request,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/IUsageRollupService.cs
+++ b/server/Subscription.DomainService/Services/IUsageRollupService.cs
@@ -1,0 +1,39 @@
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Precomputes the tenant-wide usage-analytics rollups from the append-only usage ledger.
+/// </summary>
+/// <remarks>
+/// The ledger is the only authority. This reads it forward from a persisted, named cursor —
+/// never re-scans it from the beginning — and folds each entry into the day bucket it belongs to,
+/// so the tenant-admin usage report never touches the live ledger itself. See
+/// <see cref="Entities.SubscriptionUsageActivityRollup"/> and
+/// <see cref="Entities.SubscriptionUsageActorRollup"/> for what it writes.
+/// </remarks>
+public interface IUsageRollupService
+{
+    /// <summary>
+    /// Processes one bounded batch of ledger records and advances the tenant's rollup cursor
+    /// past them. Returns how many records were read, which is also the caller's signal for
+    /// whether there is more work behind this batch.
+    /// </summary>
+    Task<int> RunBatchAsync(
+        string tenantId,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Rebuilds every rollup bucket for one subscription from the ledger, from scratch.
+    /// </summary>
+    /// <remarks>
+    /// For repairing a rollup that has drifted, or backfilling history recorded before this
+    /// feature existed. Safe to run beside the incremental pass: it reads the same authoritative
+    /// ledger and applies through the same idempotent upsert, so it can only converge a bucket
+    /// toward the ledger's own truth, never away from it.
+    /// </remarks>
+    Task<int> BackfillSubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        string correlationId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Services/SubscriptionUsageReportService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionUsageReportService.cs
@@ -1,0 +1,571 @@
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Responses;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <inheritdoc cref="ISubscriptionUsageReportService" />
+public sealed class SubscriptionUsageReportService : ISubscriptionUsageReportService
+{
+    private const int MaximumPageSize = 100;
+    private const int DefaultPageSize = 25;
+
+    private readonly ISubscriptionContextResolver _context;
+    private readonly ISubscriptionUsageActivityRollupRepository _activity;
+    private readonly ISubscriptionUsageActorRollupRepository _actors;
+    private readonly ISubscriptionUsageInvoiceRepository _invoices;
+    private readonly ISubscriptionUsageCurrentRepository _current;
+    private readonly TimeProvider _time;
+
+    public SubscriptionUsageReportService(
+        ISubscriptionContextResolver context,
+        ISubscriptionUsageActivityRollupRepository activity,
+        ISubscriptionUsageActorRollupRepository actors,
+        ISubscriptionUsageInvoiceRepository invoices,
+        ISubscriptionUsageCurrentRepository current,
+        TimeProvider? time = null)
+    {
+        _context = context;
+        _activity = activity;
+        _actors = actors;
+        _invoices = invoices;
+        _current = current;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<SubscriptionOperationResult<UsageTimeseriesResponse>> GetTimeseriesAsync(
+        GetUsageReportRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryValidateCommon<UsageTimeseriesResponse>(
+                request, correlationId, out var pageSize, out var failure))
+        {
+            return failure!;
+        }
+
+        if (!TryParseGranularity(request.Granularity, out var granularity))
+        {
+            return Invalid<UsageTimeseriesResponse>(
+                correlationId, nameof(request.Granularity),
+                "Granularity must be Day, Week, Month or Year.");
+        }
+
+        var resolution = await _context.ResolveAsync(correlationId, null, cancellationToken);
+
+        if (resolution.Context is not { } context)
+        {
+            return resolution.ToFailure<UsageTimeseriesResponse>(correlationId);
+        }
+
+        var scope = ScopeFor(context.TenantId, request, granularity.ToString());
+
+        DateTime? after = null;
+        if (request.After is not null)
+        {
+            if (!UsageReportCursorCodec.TryDecode(request.After, scope, out var boundary) ||
+                !DateTime.TryParse(
+                    boundary,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind,
+                    out var parsed))
+            {
+                return Invalid<UsageTimeseriesResponse>(
+                    correlationId, nameof(request.After), "After is not a valid cursor.");
+            }
+
+            after = parsed;
+        }
+
+        var page = await _activity.SumByPeriodAsync(
+            context.TenantId,
+            request.OrganizationId,
+            request.SubscriptionId,
+            request.MeterKey,
+            request.FromUtc?.ToUniversalTime(),
+            request.ToUtc?.ToUniversalTime(),
+            granularity,
+            pageSize,
+            after,
+            cancellationToken);
+
+        var last = page.Items.LastOrDefault();
+
+        return SubscriptionOperationResult<UsageTimeseriesResponse>.Success(
+            new UsageTimeseriesResponse
+            {
+                Items = [.. page.Items.Select(item => new UsageTimeseriesPointResponse
+                {
+                    PeriodKey = PeriodKey.Create(granularity, item.PeriodStartUtc),
+                    PeriodStartUtc = item.PeriodStartUtc,
+                    ConsumedQuantity = item.ConsumedQuantity,
+                    EntryCount = item.EntryCount
+                })],
+                PageInfo = PageInfo(
+                    pageSize,
+                    page.HasMore,
+                    last is not null
+                        ? UsageReportCursorCodec.Encode(scope, last.PeriodStartUtc.ToString("O"))
+                        : null)
+            },
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<UsageOrganizationBreakdownResponse>>
+        GetOrganizationsAsync(
+            GetUsageReportRequest request,
+            string correlationId,
+            CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryValidateCommon<UsageOrganizationBreakdownResponse>(
+                request, correlationId, out var pageSize, out var failure))
+        {
+            return failure!;
+        }
+
+        var resolution = await _context.ResolveAsync(correlationId, null, cancellationToken);
+
+        if (resolution.Context is not { } context)
+        {
+            return resolution.ToFailure<UsageOrganizationBreakdownResponse>(correlationId);
+        }
+
+        var scope = ScopeFor(context.TenantId, request, granularity: null);
+
+        UsageOrganizationTotalsCursor? after = null;
+        if (request.After is not null)
+        {
+            if (!UsageReportCursorCodec.TryDecode(request.After, scope, out var boundary) ||
+                !TryDecodeOrganizationCursor(boundary, out after))
+            {
+                return Invalid<UsageOrganizationBreakdownResponse>(
+                    correlationId, nameof(request.After), "After is not a valid cursor.");
+            }
+        }
+
+        var page = await _activity.SumByOrganizationAsync(
+            context.TenantId,
+            request.SubscriptionId,
+            request.MeterKey,
+            request.FromUtc?.ToUniversalTime(),
+            request.ToUtc?.ToUniversalTime(),
+            pageSize,
+            after,
+            cancellationToken);
+
+        var last = page.Items.LastOrDefault();
+
+        return SubscriptionOperationResult<UsageOrganizationBreakdownResponse>.Success(
+            new UsageOrganizationBreakdownResponse
+            {
+                Items = [.. page.Items.Select(item => new UsageOrganizationTotalResponse
+                {
+                    OrganizationId = item.OrganizationId,
+                    ConsumedQuantity = item.ConsumedQuantity,
+                    EntryCount = item.EntryCount
+                })],
+                PageInfo = PageInfo(
+                    pageSize,
+                    page.HasMore,
+                    last is not null
+                        ? UsageReportCursorCodec.Encode(
+                            scope, $"{last.ConsumedQuantity:G29}|{last.OrganizationId}")
+                        : null)
+            },
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<UsageActorBreakdownResponse>> GetActorsAsync(
+        GetUsageReportRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryValidateCommon<UsageActorBreakdownResponse>(
+                request, correlationId, out var pageSize, out var failure))
+        {
+            return failure!;
+        }
+
+        // Per-actor totals are asked within one organization: a user is a member of an
+        // organization, not of a tenant at large, so "every user on the tenant" is not a
+        // meaningful single list the way "every organization" or "every day" is.
+        if (string.IsNullOrWhiteSpace(request.OrganizationId))
+        {
+            return Invalid<UsageActorBreakdownResponse>(
+                correlationId, nameof(request.OrganizationId),
+                "OrganizationId is required for the actor breakdown.");
+        }
+
+        var resolution = await _context.ResolveAsync(correlationId, null, cancellationToken);
+
+        if (resolution.Context is not { } context)
+        {
+            return resolution.ToFailure<UsageActorBreakdownResponse>(correlationId);
+        }
+
+        var scope = ScopeFor(context.TenantId, request, granularity: null);
+
+        UsageActorRollupCursor? after = null;
+        if (request.After is not null)
+        {
+            if (!UsageReportCursorCodec.TryDecode(request.After, scope, out var boundary) ||
+                !TryDecodeActorCursor(boundary, out after))
+            {
+                return Invalid<UsageActorBreakdownResponse>(
+                    correlationId, nameof(request.After), "After is not a valid cursor.");
+            }
+        }
+
+        var page = await _actors.ListAsync(
+            context.TenantId,
+            request.OrganizationId!,
+            request.MeterKey,
+            request.FromUtc?.ToUniversalTime(),
+            request.ToUtc?.ToUniversalTime(),
+            pageSize,
+            after,
+            cancellationToken);
+
+        var last = page.Items.LastOrDefault();
+
+        return SubscriptionOperationResult<UsageActorBreakdownResponse>.Success(
+            new UsageActorBreakdownResponse
+            {
+                Items = [.. page.Items.Select(item => new UsageActorTotalResponse
+                {
+                    OrganizationId = item.OrganizationId,
+                    MeterKey = item.MeterKey,
+                    DayUtc = item.DayUtc,
+                    UserId = item.UserId,
+                    ConsumedQuantity = item.ConsumedQuantity,
+                    EntryCount = item.EntryCount
+                })],
+                PageInfo = PageInfo(
+                    pageSize,
+                    page.HasMore,
+                    last is not null
+                        ? UsageReportCursorCodec.Encode(
+                            scope, $"{last.DayUtc:O}|{last.UserId}")
+                        : null)
+            },
+            correlationId);
+    }
+
+    public async Task<SubscriptionOperationResult<UsageAllowanceHistoryResponse>> GetAllowancesAsync(
+        GetUsageReportRequest request,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!TryValidateCommon<UsageAllowanceHistoryResponse>(
+                request, correlationId, out var pageSize, out var failure))
+        {
+            return failure!;
+        }
+
+        if (string.IsNullOrWhiteSpace(request.OrganizationId))
+        {
+            return Invalid<UsageAllowanceHistoryResponse>(
+                correlationId, nameof(request.OrganizationId),
+                "OrganizationId is required for the allowance history.");
+        }
+
+        var resolution = await _context.ResolveAsync(correlationId, null, cancellationToken);
+
+        if (resolution.Context is not { } context)
+        {
+            return resolution.ToFailure<UsageAllowanceHistoryResponse>(correlationId);
+        }
+
+        var scope = ScopeFor(context.TenantId, request, granularity: null);
+
+        UsageInvoiceCursor? after = null;
+        if (request.After is not null)
+        {
+            if (!UsageReportCursorCodec.TryDecode(request.After, scope, out var boundary) ||
+                !TryDecodeInvoiceCursor(boundary, out after))
+            {
+                return Invalid<UsageAllowanceHistoryResponse>(
+                    correlationId, nameof(request.After), "After is not a valid cursor.");
+            }
+        }
+
+        var closedPage = await _invoices.ListAsync(
+            context.TenantId,
+            request.OrganizationId,
+            request.SubscriptionId,
+            request.FromUtc?.ToUniversalTime(),
+            request.ToUtc?.ToUniversalTime(),
+            pageSize,
+            after,
+            cancellationToken);
+
+        var items = new List<UsageAllowancePeriodResponse>();
+
+        foreach (var invoice in closedPage.Items)
+        {
+            var meters = invoice.Lines
+                .Where(line => request.MeterKey is null ||
+                               string.Equals(line.MeterKey, request.MeterKey, StringComparison.Ordinal))
+                .Select(line => MapClosedMeter(line))
+                .ToList();
+
+            if (meters.Count == 0)
+            {
+                continue;
+            }
+
+            items.Add(new UsageAllowancePeriodResponse
+            {
+                OrganizationId = invoice.OrganizationId,
+                SubscriptionId = invoice.SubscriptionId,
+                PeriodKey = invoice.PeriodKey,
+                IsOpenPeriod = false,
+                Meters = meters
+            });
+        }
+
+        // The open period is appended only on the first page: it has no place in a keyset walk
+        // over closed invoices, and repeating it on every page would misrepresent it as recurring
+        // history rather than the one window still in progress.
+        if (after is null)
+        {
+            var open = await _current.ListByOrganizationAsync(
+                context.TenantId,
+                request.OrganizationId,
+                request.SubscriptionId,
+                request.MeterKey,
+                _time.GetUtcNow().UtcDateTime,
+                limit: 200,
+                cancellationToken);
+
+            foreach (var bySubscription in open.GroupBy(
+                         document => document.SubscriptionId, StringComparer.Ordinal))
+            {
+                items.Add(new UsageAllowancePeriodResponse
+                {
+                    OrganizationId = request.OrganizationId,
+                    SubscriptionId = bySubscription.Key,
+                    PeriodKey = bySubscription.First().PeriodKey,
+                    IsOpenPeriod = true,
+                    Meters = [.. bySubscription.Select(document => new UsageAllowanceMeterResponse
+                    {
+                        MeterKey = document.MeterKey,
+                        PlanId = document.PlanId,
+                        PlanCode = document.PlanCode,
+                        IncludedQuantity = document.Included,
+                        UsedQuantity = document.Used,
+                        OverageQuantity = document.Overage,
+                        OverageAmountMinor = null,
+                        IsHistoricalOverageOnly = false
+                    })]
+                });
+            }
+        }
+
+        var lastClosed = closedPage.Items.LastOrDefault();
+
+        return SubscriptionOperationResult<UsageAllowanceHistoryResponse>.Success(
+            new UsageAllowanceHistoryResponse
+            {
+                Items = items,
+                PageInfo = PageInfo(
+                    pageSize,
+                    closedPage.HasMore,
+                    lastClosed is not null
+                        ? UsageReportCursorCodec.Encode(
+                            scope, $"{lastClosed.CreatedAtUtc:O}|{lastClosed.ItemId}")
+                        : null)
+            },
+            correlationId);
+    }
+
+    private static UsageAllowanceMeterResponse MapClosedMeter(UsageInvoiceLine line)
+    {
+        // A period rated before this feature's rating fix shipped carries only OverageQuantity —
+        // IncludedQuantity and UsedQuantity deserialize as zero because the field did not exist
+        // yet. The combination of "overage present" with "nothing used" is otherwise impossible
+        // (overage can never exceed usage), so it is the signal that this line predates the fix
+        // rather than a real zero-allowance, zero-usage period.
+        var isHistorical = line.UsedQuantity == 0 && line.OverageQuantity > 0;
+
+        return new UsageAllowanceMeterResponse
+        {
+            MeterKey = line.MeterKey,
+            IncludedQuantity = line.IncludedQuantity,
+            UsedQuantity = line.UsedQuantity,
+            OverageQuantity = line.OverageQuantity,
+            OverageAmountMinor = line.AmountMinor,
+            IsHistoricalOverageOnly = isHistorical
+        };
+    }
+
+    private static UsageReportCursorScope ScopeFor(
+        string tenantId, GetUsageReportRequest request, string? granularity) =>
+        new(
+            tenantId,
+            request.OrganizationId,
+            request.SubscriptionId,
+            request.MeterKey,
+            granularity,
+            request.FromUtc?.ToUniversalTime(),
+            request.ToUtc?.ToUniversalTime());
+
+    private static bool TryValidateCommon<TValue>(
+        GetUsageReportRequest request,
+        string correlationId,
+        out int pageSize,
+        out SubscriptionOperationResult<TValue>? failure)
+    {
+        pageSize = request.PageSize <= 0 ? DefaultPageSize : request.PageSize;
+        failure = null;
+
+        if (pageSize is < 1 or > MaximumPageSize)
+        {
+            failure = Invalid<TValue>(
+                correlationId, nameof(request.PageSize),
+                $"PageSize must be between 1 and {MaximumPageSize}.");
+
+            return false;
+        }
+
+        if (request.FromUtc is { } from && request.ToUtc is { } to && from > to)
+        {
+            failure = Invalid<TValue>(
+                correlationId, nameof(request.FromUtc),
+                "FromUtc must not be later than ToUtc.");
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Parsed by hand so an unrecognised value is a domain error rather than a silent fallback to
+    /// the default — mirroring <c>SubscriptionPlansController.TryParseCatalogueFilter</c>.
+    /// </summary>
+    private static bool TryParseGranularity(string? value, out BillingInterval granularity)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            granularity = BillingInterval.Month;
+
+            return true;
+        }
+
+        switch (value.Trim())
+        {
+            case var day when day.Equals(nameof(BillingInterval.Day), StringComparison.OrdinalIgnoreCase):
+                granularity = BillingInterval.Day;
+
+                return true;
+            case var week when week.Equals(
+                nameof(BillingInterval.Week), StringComparison.OrdinalIgnoreCase):
+                granularity = BillingInterval.Week;
+
+                return true;
+            case var month when month.Equals(
+                nameof(BillingInterval.Month), StringComparison.OrdinalIgnoreCase):
+                granularity = BillingInterval.Month;
+
+                return true;
+            case var year when year.Equals(
+                nameof(BillingInterval.Year), StringComparison.OrdinalIgnoreCase):
+                granularity = BillingInterval.Year;
+
+                return true;
+            default:
+                granularity = default;
+
+                return false;
+        }
+    }
+
+    private static bool TryDecodeOrganizationCursor(
+        string boundary, out UsageOrganizationTotalsCursor? cursor)
+    {
+        cursor = null;
+        var parts = boundary.Split('|', 2);
+
+        if (parts.Length != 2 ||
+            !decimal.TryParse(
+                parts[0], System.Globalization.NumberStyles.Number,
+                System.Globalization.CultureInfo.InvariantCulture, out var quantity) ||
+            string.IsNullOrWhiteSpace(parts[1]))
+        {
+            return false;
+        }
+
+        cursor = new UsageOrganizationTotalsCursor(quantity, parts[1]);
+
+        return true;
+    }
+
+    private static bool TryDecodeActorCursor(string boundary, out UsageActorRollupCursor? cursor)
+    {
+        cursor = null;
+        var parts = boundary.Split('|', 2);
+
+        if (parts.Length != 2 ||
+            !DateTime.TryParse(
+                parts[0], System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind, out var day) ||
+            string.IsNullOrWhiteSpace(parts[1]))
+        {
+            return false;
+        }
+
+        cursor = new UsageActorRollupCursor(day, parts[1]);
+
+        return true;
+    }
+
+    private static bool TryDecodeInvoiceCursor(string boundary, out UsageInvoiceCursor? cursor)
+    {
+        cursor = null;
+        var parts = boundary.Split('|', 2);
+
+        if (parts.Length != 2 ||
+            !DateTime.TryParse(
+                parts[0], System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.RoundtripKind, out var createdAt) ||
+            string.IsNullOrWhiteSpace(parts[1]))
+        {
+            return false;
+        }
+
+        cursor = new UsageInvoiceCursor(createdAt, parts[1]);
+
+        return true;
+    }
+
+    private static UsageReportPageInfoResponse PageInfo(
+        int pageSize, bool hasMore, string? nextCursor) =>
+        new()
+        {
+            PageSize = pageSize,
+            HasNextPage = hasMore,
+            NextCursor = hasMore ? nextCursor : null
+        };
+
+    private static SubscriptionOperationResult<TValue> Invalid<TValue>(
+        string correlationId, string field, string message) =>
+        SubscriptionOperationResult<TValue>.Failure(
+            PaymentFailureKind.Validation,
+            "subscription_usage_report_query_invalid",
+            "The usage report query is invalid.",
+            correlationId,
+            new Dictionary<string, string[]> { [field] = [message] });
+}

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -834,6 +834,10 @@ public sealed class UsageRecordingService : IUsageRecordingService
                 IdempotencyKey = $"{record.IdempotencyKey}:reversal",
                 CompensatesRecordId = record.ItemId,
                 OccurredAtUtc = record.OccurredAtUtc,
+                // Copied from the record being reversed so a reversal nets out of the actor who
+                // caused it, not an unattributed bucket. See the per-actor rollup, which sums this
+                // field directly rather than following CompensatesRecordId back at rollup time.
+                RecordedByUserId = record.RecordedByUserId,
                 CorrelationId = correlationId
             },
             cancellationToken);

--- a/server/Subscription.DomainService/Services/UsageReportCursorCodec.cs
+++ b/server/Subscription.DomainService/Services/UsageReportCursorCodec.cs
@@ -1,0 +1,138 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Subscription.DomainService.Services;
+
+/// <summary>
+/// Encodes a usage-report page boundary as an opaque cursor, bound to the tenant and the whole
+/// filter set the page was issued under.
+/// </summary>
+/// <remarks>
+/// Modelled on <see cref="FinancialDocumentCursorCodec"/> — see its own remarks on why an
+/// unchecked cursor is "an access-control bypass with a base64 costume" — but bound to more than
+/// an organization. These endpoints are tenant-scoped-with-optional-organization-filter rather
+/// than purely organization-scoped, so a cursor also has to be refused if presented against a
+/// different organization filter, meter, subscription, granularity or date range than the one it
+/// was issued under: any of those changes what "the next page" means, and honouring a stale
+/// cursor against a new filter would silently splice two different result sets together.
+/// </remarks>
+public static class UsageReportCursorCodec
+{
+    private const int Version = 1;
+    private const int MaximumCursorLength = 4_096;
+
+    public static string Encode(UsageReportCursorScope scope, string boundary)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+
+        var json = JsonSerializer.Serialize(new CursorPayload
+        {
+            Version = Version,
+            TenantId = scope.TenantId,
+            OrganizationId = scope.OrganizationId,
+            SubscriptionId = scope.SubscriptionId,
+            MeterKey = scope.MeterKey,
+            Granularity = scope.Granularity,
+            FromUtc = scope.FromUtc,
+            ToUtc = scope.ToUtc,
+            Boundary = boundary
+        });
+
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    public static bool TryDecode(
+        string? cursor,
+        UsageReportCursorScope scope,
+        out string boundary)
+    {
+        boundary = string.Empty;
+
+        ArgumentNullException.ThrowIfNull(scope);
+
+        if (string.IsNullOrWhiteSpace(cursor) || cursor.Length > MaximumCursorLength)
+        {
+            return false;
+        }
+
+        try
+        {
+            var normalized = cursor.Replace('-', '+').Replace('_', '/');
+            var padded = normalized.PadRight(
+                normalized.Length + ((4 - (normalized.Length % 4)) % 4),
+                '=');
+
+            var payload = JsonSerializer.Deserialize<CursorPayload>(
+                Convert.FromBase64String(padded));
+
+            if (payload is null ||
+                payload.Version != Version ||
+                string.IsNullOrWhiteSpace(payload.Boundary) ||
+                !string.Equals(payload.TenantId, scope.TenantId, StringComparison.Ordinal) ||
+                !string.Equals(
+                    payload.OrganizationId ?? string.Empty,
+                    scope.OrganizationId ?? string.Empty,
+                    StringComparison.Ordinal) ||
+                !string.Equals(
+                    payload.SubscriptionId ?? string.Empty,
+                    scope.SubscriptionId ?? string.Empty,
+                    StringComparison.Ordinal) ||
+                !string.Equals(
+                    payload.MeterKey ?? string.Empty,
+                    scope.MeterKey ?? string.Empty,
+                    StringComparison.Ordinal) ||
+                !string.Equals(
+                    payload.Granularity ?? string.Empty,
+                    scope.Granularity ?? string.Empty,
+                    StringComparison.OrdinalIgnoreCase) ||
+                payload.FromUtc != scope.FromUtc ||
+                payload.ToUtc != scope.ToUtc)
+            {
+                return false;
+            }
+
+            boundary = payload.Boundary;
+
+            return true;
+        }
+        catch (Exception exception) when (
+            exception is FormatException or JsonException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private sealed class CursorPayload
+    {
+        public int Version { get; set; }
+
+        public string TenantId { get; set; } = string.Empty;
+
+        public string? OrganizationId { get; set; }
+
+        public string? SubscriptionId { get; set; }
+
+        public string? MeterKey { get; set; }
+
+        public string? Granularity { get; set; }
+
+        public DateTime? FromUtc { get; set; }
+
+        public DateTime? ToUtc { get; set; }
+
+        public string Boundary { get; set; } = string.Empty;
+    }
+}
+
+/// <summary>The filter set a usage-report cursor is bound to.</summary>
+public sealed record UsageReportCursorScope(
+    string TenantId,
+    string? OrganizationId,
+    string? SubscriptionId,
+    string? MeterKey,
+    string? Granularity,
+    DateTime? FromUtc,
+    DateTime? ToUtc);

--- a/server/Subscription.DomainService/Services/UsageRollupService.cs
+++ b/server/Subscription.DomainService/Services/UsageRollupService.cs
@@ -1,0 +1,200 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Payment.DomainService.Utilities;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Utilities;
+
+namespace Subscription.DomainService.Services;
+
+/// <inheritdoc cref="IUsageRollupService" />
+public sealed class UsageRollupService : IUsageRollupService
+{
+    /// <summary>
+    /// The named, persisted cursor this job walks the ledger forward on. Reuses
+    /// <see cref="ISubscriptionDocumentCursorRepository"/> — the same mechanism the financial
+    /// document recovery sweep already uses for its settled-charge and refund cursors — rather
+    /// than the in-memory <c>UsageProjectionBackfillCursors</c>, which is deliberately
+    /// non-persisted and appropriate only for a pass that is always safe to redo from the start.
+    /// A tenant with a large ledger should not redo a full scan on every process restart.
+    /// </summary>
+    public const string RollupCursorName = "usage-activity-rollup";
+
+    /// <summary>Bound on one backfill pass, so a runaway subscription cannot hold the ledger open.</summary>
+    private const int BackfillRecordLimit = 50_000;
+
+    private readonly ISubscriptionUsageRepository _usage;
+    private readonly ISubscriptionUsageActivityRollupRepository _activity;
+    private readonly ISubscriptionUsageActorRollupRepository _actors;
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly ISubscriptionDocumentCursorRepository _cursors;
+    private readonly IOptionsMonitor<SubscriptionOptions> _options;
+    private readonly ILogger<UsageRollupService> _logger;
+    private readonly TimeProvider _time;
+
+    public UsageRollupService(
+        ISubscriptionUsageRepository usage,
+        ISubscriptionUsageActivityRollupRepository activity,
+        ISubscriptionUsageActorRollupRepository actors,
+        ISubscriptionRepository subscriptions,
+        ISubscriptionDocumentCursorRepository cursors,
+        IOptionsMonitor<SubscriptionOptions> options,
+        ILogger<UsageRollupService> logger,
+        TimeProvider? time = null)
+    {
+        _usage = usage;
+        _activity = activity;
+        _actors = actors;
+        _subscriptions = subscriptions;
+        _cursors = cursors;
+        _options = options;
+        _logger = logger;
+        _time = time ?? TimeProvider.System;
+    }
+
+    public async Task<int> RunBatchAsync(
+        string tenantId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var options = _options.CurrentValue;
+        var batch = Math.Max(1, options.UsageRollupBatchSize);
+
+        var mark = await _cursors.GetAsync(tenantId, RollupCursorName, cancellationToken)
+            ?? new FinancialDocumentSweepMark(
+                _time.GetUtcNow().UtcDateTime.AddDays(
+                    -Math.Max(1, options.UsageRollupFirstPassReachDays)),
+                null);
+
+        var records = await _usage.ListRecordedSinceAsync(
+            tenantId,
+            mark.ReadUpToUtc,
+            mark.AfterId,
+            batch,
+            cancellationToken);
+
+        if (records.Count == 0)
+        {
+            return 0;
+        }
+
+        // One subscription lookup per distinct subscription in the batch, not per record: a
+        // batch of five hundred ledger entries ordinarily belongs to far fewer subscriptions than
+        // that.
+        var subscriptions = new Dictionary<string, SubscriptionDetail?>(StringComparer.Ordinal);
+
+        foreach (var record in records)
+        {
+            await ApplyRecordAsync(tenantId, record, subscriptions, cancellationToken);
+        }
+
+        var last = records[^1];
+
+        await _cursors.SetAsync(
+            tenantId,
+            RollupCursorName,
+            new FinancialDocumentSweepMark(last.RecordedAtUtc, last.ItemId),
+            cancellationToken);
+
+        _logger.LogInformation(
+            "Usage rollup folded a batch of ledger records TenantHash={TenantHash} " +
+            "RecordCount={RecordCount} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(tenantId),
+            records.Count,
+            correlationId);
+
+        return records.Count;
+    }
+
+    public async Task<int> BackfillSubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var subscription = await _subscriptions.GetByIdAsync(
+            tenantId, subscriptionId, cancellationToken);
+
+        var records = await _usage.ListRecordsAsync(
+            tenantId,
+            subscriptionId,
+            meterKey: null,
+            periodKey: null,
+            BackfillRecordLimit,
+            cancellationToken);
+
+        var subscriptions = new Dictionary<string, SubscriptionDetail?>(StringComparer.Ordinal)
+        {
+            [subscriptionId] = subscription
+        };
+
+        foreach (var record in records)
+        {
+            await ApplyRecordAsync(tenantId, record, subscriptions, cancellationToken);
+        }
+
+        _logger.LogInformation(
+            "Usage rollup backfilled one subscription from the ledger TenantHash={TenantHash} " +
+            "SubscriptionHash={SubscriptionHash} RecordCount={RecordCount} " +
+            "CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(tenantId),
+            PaymentLogValue.Hash(subscriptionId),
+            records.Count,
+            correlationId);
+
+        return records.Count;
+    }
+
+    private async Task ApplyRecordAsync(
+        string tenantId,
+        SubscriptionUsageRecord record,
+        Dictionary<string, SubscriptionDetail?> subscriptionCache,
+        CancellationToken cancellationToken)
+    {
+        if (!subscriptionCache.TryGetValue(record.SubscriptionId, out var subscription))
+        {
+            subscription = await _subscriptions.GetByIdAsync(
+                tenantId, record.SubscriptionId, cancellationToken);
+            subscriptionCache[record.SubscriptionId] = subscription;
+        }
+
+        // Bucketed by the day (and hour) the usage actually occurred, never by when it was
+        // recorded: a record reported late must still land in the day it happened, which is why
+        // the cursor above walks RecordedAtUtc while the bucket key below uses OccurredAtUtc.
+        var occurred = DateTime.SpecifyKind(record.OccurredAtUtc, DateTimeKind.Utc);
+        var dayUtc = occurred.Date;
+        var updatedAtUtc = _time.GetUtcNow().UtcDateTime;
+
+        await _activity.ApplyAsync(
+            tenantId,
+            record.OrganizationId,
+            record.SubscriptionId,
+            record.MeterKey,
+            subscription?.Plan.PlanId ?? string.Empty,
+            subscription?.Plan.Code ?? string.Empty,
+            dayUtc,
+            occurred.Hour,
+            record.Delta,
+            record.RecordedAtUtc,
+            record.ItemId,
+            updatedAtUtc,
+            cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(record.RecordedByUserId))
+        {
+            return;
+        }
+
+        await _actors.ApplyAsync(
+            tenantId,
+            record.OrganizationId,
+            record.MeterKey,
+            dayUtc,
+            record.RecordedByUserId,
+            record.Delta,
+            record.RecordedAtUtc,
+            record.ItemId,
+            updatedAtUtc,
+            cancellationToken);
+    }
+}

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -77,6 +77,12 @@ public static class ApplicationServiceCollectionExtensions
             ISubscriptionUsageCurrentRepository,
             SubscriptionUsageCurrentRepository>();
         services.AddSingleton<
+            ISubscriptionUsageActivityRollupRepository,
+            SubscriptionUsageActivityRollupRepository>();
+        services.AddSingleton<
+            ISubscriptionUsageActorRollupRepository,
+            SubscriptionUsageActorRollupRepository>();
+        services.AddSingleton<
             ISubscriptionPaymentLinkRepository,
             SubscriptionPaymentLinkRepository>();
         services.AddSingleton<
@@ -179,6 +185,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<ISubscriptionWorkHandler, FinancialDocumentIssueWorkHandler>();
         services.AddScoped<ISubscriptionWorkHandler, FinancialDocumentDeliveryWorkHandler>();
         services.AddScoped<ISubscriptionWorkHandler, UsageProjectionRefreshWorkHandler>();
+        services.AddScoped<ISubscriptionWorkHandler, UsageActivityRollupWorkHandler>();
 
         services.AddSingleton<IEntitlementSnapshotCache, EntitlementSnapshotCache>();
         services.AddSingleton<IPlanResponseMapper, PlanResponseMapper>();
@@ -255,6 +262,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<
             ISubscriptionFinancialDocumentHistoryService,
             SubscriptionFinancialDocumentHistoryService>();
+        services.AddScoped<
+            ISubscriptionUsageReportService,
+            SubscriptionUsageReportService>();
 
         // The two adapters that reach into the platform's PDF and storage modules, and the pieces of
         // those modules they need. Registered here with TryAdd rather than assumed: the PDF module
@@ -301,6 +311,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddScoped<IUsageRecordingService, UsageRecordingService>();
         services.AddScoped<IUsageProjectionPublisher, UsageProjectionPublisher>();
         services.AddScoped<IUsageProjectionReconciler, UsageProjectionReconciler>();
+        services.AddScoped<IUsageRollupService, UsageRollupService>();
         // Singleton on purpose: the reconciler is scoped and the reconciliation service opens a
         // fresh scope per tenant sweep, so a cursor living on the reconciler was reset on every
         // pass and the backfill never got past its first page.

--- a/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionOptions.cs
@@ -58,6 +58,21 @@ public sealed class SubscriptionOptions
     public int UsageProjectionBackfillBatchSize { get; set; } = 50;
 
     /// <summary>
+    /// How many ledger records one tenant-usage-analytics rollup pass reads per tenant, walked
+    /// forward from a persisted cursor. Bounded the same way the projection backfill is: the pass
+    /// costs the same whatever the backlog, and a tenant larger than one page is caught up by
+    /// successive sweep passes rather than one long pass holding the ledger.
+    /// </summary>
+    public int UsageRollupBatchSize { get; set; } = 500;
+
+    /// <summary>
+    /// How far back a tenant's first-ever rollup pass reaches into ledger history that predates
+    /// this feature. Every pass after it resumes from its own cursor, so this bounds only the
+    /// one-time catch-up.
+    /// </summary>
+    public int UsageRollupFirstPassReachDays { get; set; } = 400;
+
+    /// <summary>
     /// How long a subscription may sit unpaid before the initial charge is considered
     /// abandoned. Covers the shopper who opens checkout and closes the tab.
     /// </summary>

--- a/server/XUnitTest/Integration/SubscriptionUsageActivityRollupIntegrationTests.cs
+++ b/server/XUnitTest/Integration/SubscriptionUsageActivityRollupIntegrationTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Subscription.DomainService.Repositories;
+
+namespace XUnitTest.Integration;
+
+/// <summary>
+/// The tenant-usage-analytics rollup collections, against a real MongoDB.
+/// </summary>
+/// <remarks>
+/// What matters here is a property of the Mongo write itself, not of C#: the idempotent upsert
+/// that lets a re-run over an already-applied page fold nothing twice. A mocked repository cannot
+/// observe that — it would have to reimplement the same conditional-filter logic to fake it, which
+/// proves nothing about whether the real filter and the real duplicate-key race actually behave
+/// this way against a server. Mirrors <see cref="SubscriptionUsageCurrentIntegrationTests"/>'s own
+/// conventions.
+/// </remarks>
+[Collection(MongoIntegrationCollection.Name)]
+public sealed class SubscriptionUsageActivityRollupIntegrationTests
+{
+    private readonly SubscriptionUsageActivityRollupRepository _activity;
+    private readonly SubscriptionUsageActorRollupRepository _actors;
+
+    public SubscriptionUsageActivityRollupIntegrationTests(MongoIntegrationFixture fixture)
+    {
+        _activity = new SubscriptionUsageActivityRollupRepository(fixture.DbContextProvider);
+        _actors = new SubscriptionUsageActorRollupRepository(fixture.DbContextProvider);
+    }
+
+    [Fact]
+    public async Task Applying_one_entry_creates_a_bucket_with_its_figures()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var day = new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Utc);
+
+        await _activity.ApplyAsync(
+            tenantId, "org-1", "sub-1", "screening", "plan-1", "pro",
+            day, hourUtc: 14, delta: 5m,
+            recordedAtUtc: day.AddHours(14).AddMinutes(1), sourceRecordId: "rec-1",
+            updatedAtUtc: DateTime.UtcNow, CancellationToken.None);
+
+        var page = await _activity.ListAsync(
+            tenantId, "org-1", "sub-1", "screening", null, null, 10, null, CancellationToken.None);
+
+        page.Items.Should().ContainSingle();
+        var bucket = page.Items[0];
+        bucket.ConsumedQuantity.Should().Be(5m);
+        bucket.EntryCount.Should().Be(1);
+        bucket.HourlyQuantity[14].Should().Be(1);
+        bucket.PlanId.Should().Be("plan-1");
+        bucket.PlanCode.Should().Be("pro");
+    }
+
+    [Fact]
+    public async Task Two_entries_the_same_day_accumulate_into_one_bucket()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var day = new DateTime(2026, 3, 11, 0, 0, 0, DateTimeKind.Utc);
+
+        await _activity.ApplyAsync(
+            tenantId, "org-1", "sub-1", "screening", "plan-1", "pro",
+            day, hourUtc: 8, delta: 3m,
+            recordedAtUtc: day.AddHours(8), sourceRecordId: "rec-1",
+            updatedAtUtc: DateTime.UtcNow, CancellationToken.None);
+        await _activity.ApplyAsync(
+            tenantId, "org-1", "sub-1", "screening", "plan-1", "pro",
+            day, hourUtc: 20, delta: 4m,
+            recordedAtUtc: day.AddHours(20), sourceRecordId: "rec-2",
+            updatedAtUtc: DateTime.UtcNow, CancellationToken.None);
+
+        var page = await _activity.ListAsync(
+            tenantId, "org-1", "sub-1", "screening", null, null, 10, null, CancellationToken.None);
+
+        var bucket = page.Items.Should().ContainSingle().Subject;
+        bucket.ConsumedQuantity.Should().Be(7m);
+        bucket.EntryCount.Should().Be(2);
+        bucket.HourlyQuantity[8].Should().Be(1);
+        bucket.HourlyQuantity[20].Should().Be(1);
+    }
+
+    /// <summary>
+    /// Re-running the same entry must not double-count it — the guarantee the per-bucket
+    /// <c>SourceCursor</c> comparison exists for, proven here against a real duplicate-key race
+    /// rather than a mock that would just do whatever the test told it to.
+    /// </summary>
+    [Fact]
+    public async Task Re_applying_the_same_entry_does_not_double_count()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var day = new DateTime(2026, 3, 12, 0, 0, 0, DateTimeKind.Utc);
+        var recordedAt = day.AddHours(9);
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            await _activity.ApplyAsync(
+                tenantId, "org-1", "sub-1", "screening", "plan-1", "pro",
+                day, hourUtc: 9, delta: 10m,
+                recordedAtUtc: recordedAt, sourceRecordId: "rec-1",
+                updatedAtUtc: DateTime.UtcNow, CancellationToken.None);
+        }
+
+        var page = await _activity.ListAsync(
+            tenantId, "org-1", "sub-1", "screening", null, null, 10, null, CancellationToken.None);
+
+        var bucket = page.Items.Should().ContainSingle().Subject;
+        bucket.ConsumedQuantity.Should().Be(10m, "the second application repeats a record already folded in");
+        bucket.EntryCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_reversal_nets_the_actor_bucket_back_to_zero()
+    {
+        var tenantId = MongoIntegrationFixture.NewTenantId();
+        var day = new DateTime(2026, 3, 13, 0, 0, 0, DateTimeKind.Utc);
+
+        await _actors.ApplyAsync(
+            tenantId, "org-1", "screening", day, "user-a", delta: 8m,
+            recordedAtUtc: day.AddHours(1), sourceRecordId: "rec-1",
+            updatedAtUtc: DateTime.UtcNow, CancellationToken.None);
+        await _actors.ApplyAsync(
+            tenantId, "org-1", "screening", day, "user-a", delta: -8m,
+            recordedAtUtc: day.AddHours(2), sourceRecordId: "rec-1:reversal",
+            updatedAtUtc: DateTime.UtcNow, CancellationToken.None);
+
+        var page = await _actors.ListAsync(
+            tenantId, "org-1", "screening", null, null, 10, null, CancellationToken.None);
+
+        var bucket = page.Items.Should().ContainSingle().Subject;
+        bucket.ConsumedQuantity.Should().Be(0m);
+        bucket.EntryCount.Should().Be(2);
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionIndexDefinitionsTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionIndexDefinitionsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
@@ -40,5 +41,57 @@ public sealed class SubscriptionIndexDefinitionsTests
         reservedStatuses.Should().NotContain((int)SubscriptionStatus.IncompleteExpired);
         reservedStatuses.Should().NotContain((int)SubscriptionStatus.Unpaid);
         reservedStatuses.Should().NotContain((int)SubscriptionStatus.Canceled);
+    }
+
+    [Fact]
+    public void Usage_record_indexes_include_the_rollup_scan_index()
+    {
+        var index = SubscriptionIndexDefinitions.CreateUsageRecordIndexes()
+            .Single(candidate =>
+                candidate.Options.Name ==
+                SubscriptionIndexDefinitions.UsageRecordRolloverScanIndexName);
+
+        var keys = index.Keys.Render(
+            new RenderArgs<SubscriptionUsageRecord>(
+                BsonSerializer.SerializerRegistry.GetSerializer<SubscriptionUsageRecord>(),
+                BsonSerializer.SerializerRegistry));
+
+        keys.Should().BeEquivalentTo(new BsonDocument
+        {
+            { nameof(SubscriptionUsageRecord.TenantId), 1 },
+            { nameof(SubscriptionUsageRecord.RecordedAtUtc), 1 },
+            { "_id", 1 }
+        });
+    }
+
+    [Fact]
+    public void Usage_activity_rollup_identity_index_is_unique()
+    {
+        var index = SubscriptionIndexDefinitions.CreateUsageActivityRollupIndexes()
+            .Single(candidate =>
+                candidate.Options.Name ==
+                SubscriptionIndexDefinitions.UsageActivityRollupUniqueIndexName);
+
+        index.Options.Unique.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Usage_actor_rollup_identity_index_is_unique()
+    {
+        var index = SubscriptionIndexDefinitions.CreateUsageActorRollupIndexes()
+            .Single(candidate =>
+                candidate.Options.Name ==
+                SubscriptionIndexDefinitions.UsageActorRollupUniqueIndexName);
+
+        index.Options.Unique.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Usage_invoice_organization_index_exists_for_the_allowance_report()
+    {
+        SubscriptionIndexDefinitions.CreateUsageInvoiceIndexes()
+            .Should().Contain(candidate =>
+                candidate.Options.Name ==
+                SubscriptionIndexDefinitions.UsageInvoiceOrganizationIndexName);
     }
 }

--- a/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionServiceRegistrationTests.cs
@@ -35,6 +35,8 @@ public sealed class SubscriptionServiceRegistrationTests
     [InlineData(typeof(IBillingAccountRepository))]
     [InlineData(typeof(ISubscriptionRepository))]
     [InlineData(typeof(ISubscriptionUsageRepository))]
+    [InlineData(typeof(ISubscriptionUsageActivityRollupRepository))]
+    [InlineData(typeof(ISubscriptionUsageActorRollupRepository))]
     [InlineData(typeof(ISubscriptionPaymentLinkRepository))]
     [InlineData(typeof(ISubscriptionSimulationRunRepository))]
     public void Repositories_are_singletons(Type serviceType)

--- a/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageRatingProcessorTests.cs
@@ -122,6 +122,42 @@ public sealed class SubscriptionUsageRatingProcessorTests
         _createdInvoice.NextAttemptAtUtc.Should().BeNull();
     }
 
+    /// <summary>
+    /// A meter that was rated but priced to zero (fully within allowance) still gets an invoice
+    /// line — recording what it included and used, not just what it charged for — while the
+    /// aggregate charged total must stay byte-identical to what it was before this line existed.
+    /// </summary>
+    [Fact]
+    public async Task A_period_entirely_within_allowance_still_records_a_zero_amount_line()
+    {
+        _due = [NewSubscription("sub-1")];
+        _usage
+            .Setup(repository => repository.ListCountersAsync(
+                TenantId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([NewCounter("screening", 100), NewCounter("envelope", 40)]);
+
+        await Processor().CloseDuePeriodsAsync(TenantId, CancellationToken.None);
+
+        _createdInvoice!.State.Should().Be(SubscriptionUsageInvoiceState.NoCharge);
+        _createdInvoice.TotalAmountMinor.Should().Be(0,
+            "a zero-amount line must never change the aggregate charged total");
+        _createdInvoice.NetAmountMinor.Should().Be(0);
+
+        var screening = _createdInvoice.Lines.Should().ContainSingle(
+            line => line.MeterKey == "screening").Which;
+        screening.IncludedQuantity.Should().Be(500);
+        screening.UsedQuantity.Should().Be(100);
+        screening.OverageQuantity.Should().Be(0);
+        screening.AmountMinor.Should().Be(0);
+
+        var envelope = _createdInvoice.Lines.Should().ContainSingle(
+            line => line.MeterKey == "envelope").Which;
+        envelope.IncludedQuantity.Should().Be(100);
+        envelope.UsedQuantity.Should().Be(40);
+        envelope.OverageQuantity.Should().Be(0);
+        envelope.AmountMinor.Should().Be(0);
+    }
+
     [Fact]
     public async Task A_period_with_overage_creates_a_pending_invoice_priced_across_meters()
     {
@@ -135,8 +171,18 @@ public sealed class SubscriptionUsageRatingProcessorTests
 
         // screening: 200 overage * 10 = 2,000. envelope has no counter overage (under included).
         _createdInvoice!.State.Should().Be(SubscriptionUsageInvoiceState.Pending);
-        _createdInvoice.TotalAmountMinor.Should().Be(2_000);
-        _createdInvoice.Lines.Should().ContainSingle(line => line.MeterKey == "screening");
+        _createdInvoice.TotalAmountMinor.Should().Be(2_000,
+            "the aggregate charged total must stay unchanged by the new zero-amount lines");
+        _createdInvoice.NetAmountMinor.Should().Be(2_000);
+        // envelope was still rated (it saw activity) and now gets its own zero-amount line
+        // alongside screening's overage line — the two lines' amounts must still sum to the
+        // unchanged aggregate above.
+        _createdInvoice.Lines.Should().HaveCount(2);
+        _createdInvoice.Lines.Should().ContainSingle(line => line.MeterKey == "screening")
+            .Which.AmountMinor.Should().Be(2_000);
+        _createdInvoice.Lines.Should().ContainSingle(line => line.MeterKey == "envelope")
+            .Which.AmountMinor.Should().Be(0);
+        _createdInvoice.Lines.Sum(line => line.AmountMinor).Should().Be(_createdInvoice.TotalAmountMinor);
         _createdInvoice.NextAttemptAtUtc.Should().NotBeNull();
     }
 

--- a/server/XUnitTest/Subscription/SubscriptionUsageReportServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageReportServiceTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using Moq;
+using Payment.DomainService.Enums;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Requests;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Reading the tenant-usage-analytics rollups, and the query validation and cursor scoping that
+/// keep one filtered page from being read as another.
+/// </summary>
+public sealed class SubscriptionUsageReportServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+
+    private readonly Mock<ISubscriptionContextResolver> _context = new();
+    private readonly Mock<ISubscriptionUsageActivityRollupRepository> _activity = new();
+    private readonly Mock<ISubscriptionUsageActorRollupRepository> _actors = new();
+    private readonly Mock<ISubscriptionUsageInvoiceRepository> _invoices = new();
+    private readonly Mock<ISubscriptionUsageCurrentRepository> _current = new();
+
+    public SubscriptionUsageReportServiceTests()
+    {
+        _context
+            .Setup(resolver => resolver.ResolveAsync(
+                It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionContextResolution.Resolved(
+                new SubscriptionContext(TenantId, OrganizationId, "actor-1", "user-1")));
+
+        _activity
+            .Setup(repository => repository.SumByPeriodAsync(
+                TenantId, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<BillingInterval>(),
+                It.IsAny<int>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageTimeseriesPage([], false));
+
+        _activity
+            .Setup(repository => repository.SumByOrganizationAsync(
+                TenantId, It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<int>(), It.IsAny<UsageOrganizationTotalsCursor?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageOrganizationTotalsPage([], false));
+
+        _actors
+            .Setup(repository => repository.ListAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<int>(), It.IsAny<UsageActorRollupCursor?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageActorRollupPage([], false));
+
+        _invoices
+            .Setup(repository => repository.ListAsync(
+                TenantId, It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<int>(), It.IsAny<UsageInvoiceCursor?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageInvoicePage([], false));
+
+        _current
+            .Setup(repository => repository.ListByOrganizationAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+    }
+
+    [Fact]
+    public async Task A_page_size_above_the_maximum_is_refused()
+    {
+        var result = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest { PageSize = 101 }, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.Validation);
+        result.ErrorCode.Should().Be("subscription_usage_report_query_invalid");
+    }
+
+    /// <summary>
+    /// Zero (and any other non-positive value) is not a bound violation — it means "unspecified"
+    /// and falls back to the default page size, the same convention <c>GetUsageReportRequest</c>'s
+    /// own default expresses.
+    /// </summary>
+    [Fact]
+    public async Task A_page_size_of_zero_falls_back_to_the_default_rather_than_being_refused()
+    {
+        var result = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest { PageSize = 0 }, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.PageInfo.PageSize.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task An_inverted_date_range_is_refused()
+    {
+        var result = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest
+            {
+                FromUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+                ToUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc)
+            },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_usage_report_query_invalid");
+    }
+
+    [Fact]
+    public async Task An_unrecognized_granularity_is_refused()
+    {
+        var result = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest { Granularity = "Fortnight" },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_usage_report_query_invalid");
+    }
+
+    [Fact]
+    public async Task A_valid_granularity_is_parsed_and_passed_through_to_the_repository()
+    {
+        var result = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest { Granularity = "week" },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _activity.Verify(repository => repository.SumByPeriodAsync(
+            TenantId, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+            It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), BillingInterval.Week,
+            It.IsAny<int>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Getting_actors_without_an_organization_id_is_refused()
+    {
+        var result = await Service().GetActorsAsync(
+            new GetUsageReportRequest { OrganizationId = null }, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_usage_report_query_invalid");
+    }
+
+    [Fact]
+    public async Task Getting_allowances_without_an_organization_id_is_refused()
+    {
+        var result = await Service().GetAllowancesAsync(
+            new GetUsageReportRequest { OrganizationId = null }, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_usage_report_query_invalid");
+    }
+
+    [Fact]
+    public async Task Getting_actors_with_an_organization_id_succeeds()
+    {
+        var result = await Service().GetActorsAsync(
+            new GetUsageReportRequest { OrganizationId = OrganizationId },
+            "corr-1",
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A cursor issued under one filter set (one MeterKey) must be refused when presented back
+    /// under a different filter set (a different MeterKey) — directly against the codec.
+    /// </summary>
+    [Fact]
+    public void A_cursor_issued_under_one_meter_key_is_refused_under_a_different_meter_key()
+    {
+        var issuedScope = new UsageReportCursorScope(
+            TenantId, OrganizationId, null, "screening", "Month", null, null);
+        var cursor = UsageReportCursorCodec.Encode(issuedScope, "2026-08-01T00:00:00.0000000Z");
+
+        var presentedScope = issuedScope with { MeterKey = "envelope" };
+
+        UsageReportCursorCodec.TryDecode(cursor, presentedScope, out _).Should().BeFalse();
+        UsageReportCursorCodec.TryDecode(cursor, issuedScope, out var boundary).Should().BeTrue();
+        boundary.Should().Be("2026-08-01T00:00:00.0000000Z");
+    }
+
+    /// <summary>
+    /// The same scoping, exercised through the service: a cursor from a first page under one
+    /// MeterKey is refused when the second call names a different MeterKey.
+    /// </summary>
+    [Fact]
+    public async Task A_cursor_from_the_service_is_refused_when_the_meter_key_filter_changes()
+    {
+        _activity
+            .Setup(repository => repository.SumByPeriodAsync(
+                TenantId, It.IsAny<string?>(), It.IsAny<string?>(), "screening",
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<BillingInterval>(),
+                It.IsAny<int>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageTimeseriesPage(
+                [new UsageTimeseriesBucket(
+                    new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), 10, 2)],
+                true));
+
+        var first = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest { MeterKey = "screening" }, "corr-1", CancellationToken.None);
+
+        first.IsSuccess.Should().BeTrue();
+        first.Value!.PageInfo.HasNextPage.Should().BeTrue();
+        var cursor = first.Value.PageInfo.NextCursor;
+        cursor.Should().NotBeNullOrEmpty();
+
+        var second = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest { MeterKey = "envelope", After = cursor },
+            "corr-1",
+            CancellationToken.None);
+
+        second.IsSuccess.Should().BeFalse();
+        second.ErrorCode.Should().Be("subscription_usage_report_query_invalid");
+    }
+
+    [Fact]
+    public async Task A_successful_timeseries_call_maps_repository_results_into_the_response()
+    {
+        _activity
+            .Setup(repository => repository.SumByPeriodAsync(
+                TenantId, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(), It.IsAny<BillingInterval>(),
+                It.IsAny<int>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageTimeseriesPage(
+                [new UsageTimeseriesBucket(
+                    new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), 42.5m, 7)],
+                false));
+
+        var result = await Service().GetTimeseriesAsync(
+            new GetUsageReportRequest { Granularity = "Month" }, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var point = result.Value!.Items.Should().ContainSingle().Which;
+        point.PeriodStartUtc.Should().Be(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        point.ConsumedQuantity.Should().Be(42.5m);
+        point.EntryCount.Should().Be(7);
+        result.Value.PageInfo.HasNextPage.Should().BeFalse();
+        result.Value.PageInfo.NextCursor.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_successful_organizations_call_maps_repository_results_into_the_response()
+    {
+        _activity
+            .Setup(repository => repository.SumByOrganizationAsync(
+                TenantId, It.IsAny<string?>(), It.IsAny<string?>(),
+                It.IsAny<DateTime?>(), It.IsAny<DateTime?>(),
+                It.IsAny<int>(), It.IsAny<UsageOrganizationTotalsCursor?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageOrganizationTotalsPage(
+                [new UsageOrganizationTotal("org-9", 15m, 3)], false));
+
+        var result = await Service().GetOrganizationsAsync(
+            new GetUsageReportRequest(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var item = result.Value!.Items.Should().ContainSingle().Which;
+        item.OrganizationId.Should().Be("org-9");
+        item.ConsumedQuantity.Should().Be(15m);
+        item.EntryCount.Should().Be(3);
+    }
+
+    private ISubscriptionUsageReportService Service() => new SubscriptionUsageReportService(
+        _context.Object,
+        _activity.Object,
+        _actors.Object,
+        _invoices.Object,
+        _current.Object);
+}

--- a/server/XUnitTest/Subscription/SubscriptionUsageReportsControllerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionUsageReportsControllerTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Api.Controllers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// The tenant-usage-analytics endpoints' authorization gate.
+/// </summary>
+/// <remarks>
+/// Unlike every other subscription read, which is scoped to the caller's own organization by
+/// construction, this controller crosses organizations within a tenant — so it is gated by its own
+/// claim (<c>subscription.usage-report.read</c>, registered in <c>Program.cs</c> under the
+/// <c>SubscriptionUsageReportReader</c> policy) rather than the general authenticated-user bar.
+/// Asserting the exact policy name, not merely that some <see cref="AuthorizeAttribute"/> is
+/// present, is what catches a typo or an accidental swap to a weaker policy.
+/// </remarks>
+public sealed class SubscriptionUsageReportsControllerTests
+{
+    [Fact]
+    public void The_controller_requires_the_usage_report_reader_policy()
+    {
+        typeof(SubscriptionUsageReportsController)
+            .GetCustomAttribute<AuthorizeAttribute>()?.Policy
+            .Should().Be(
+                "SubscriptionUsageReportReader",
+                "tenant-wide usage reporting crosses organizations and must never be reachable " +
+                "under a weaker or different policy, or under mere authentication alone");
+    }
+}

--- a/server/XUnitTest/Subscription/UsageChargePreviewParityTests.cs
+++ b/server/XUnitTest/Subscription/UsageChargePreviewParityTests.cs
@@ -311,7 +311,19 @@ public sealed class UsageChargePreviewParityTests
         // this fix removes, not as behaviour under test.
         SubscriptionUsageRater.OverageAmountMinor(subscription.Plan.Meters[0], 300, "CHF")
             .Should().Be(1_500, "this is what the pre-fix computation would have billed");
-        createdInvoice!.Lines.Should().BeEmpty("300 usage is under the 500 trial allowance");
+        // A rated meter now always records a line, even fully within allowance — see
+        // SubscriptionUsageRatingProcessor's own remarks on why the invoice must record what was
+        // included and used, not just what it charged for. The charge itself is unaffected: a
+        // zero-amount line contributes nothing to the total asserted below.
+        createdInvoice!.Lines.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new
+            {
+                MeterKey = "screening",
+                IncludedQuantity = 500m,
+                UsedQuantity = 300m,
+                OverageQuantity = 0m,
+                AmountMinor = 0L
+            });
         createdInvoice.TotalAmountMinor.Should().Be(0);
 
         // The preview must agree: usage arrives as a hypothetical addition on top of nothing

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -217,6 +217,28 @@ public sealed class UsageRecordingServiceTests
         _ledger[1].CompensatesRecordId.Should().Be(_ledger[0].ItemId);
     }
 
+    /// <summary>
+    /// A future per-actor usage rollup sums <c>RecordedByUserId</c>-attributed ledger deltas, so a
+    /// reversal must net out of the same actor who caused it — not land unattributed.
+    /// </summary>
+    [Fact]
+    public async Task A_reversals_recorded_by_user_id_matches_the_record_it_reverses()
+    {
+        _subscription.Plan.Meters[0].OverageAllowed = false;
+        _balance = 500;
+
+        var request = NewRequest("usage-1");
+        request.Enforce = true;
+
+        await Service().RecordAsync(request, "corr-1", CancellationToken.None);
+
+        _ledger.Should().HaveCount(2);
+        _ledger[0].RecordedByUserId.Should().Be("user-1");
+        _ledger[1].EntryType.Should().Be(UsageEntryType.Reversal);
+        _ledger[1].RecordedByUserId.Should().Be(_ledger[0].RecordedByUserId,
+            "the reversal must be attributed to the same actor whose call it is undoing");
+    }
+
     [Fact]
     public async Task A_trial_uses_its_own_grant_rather_than_the_plans_allowance()
     {

--- a/server/XUnitTest/Subscription/UsageRollupServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRollupServiceTests.cs
@@ -1,0 +1,260 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Subscription.DomainService.Entities;
+using Subscription.DomainService.Enums;
+using Subscription.DomainService.Repositories;
+using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
+using XUnitTest.Payment;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Folding the append-only usage ledger into the tenant-wide activity and actor rollups.
+/// </summary>
+public sealed class UsageRollupServiceTests
+{
+    private const string TenantId = "tenant-1";
+    private const string OrganizationId = "org-1";
+    private const string SubscriptionId = "sub-1";
+
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+    private readonly Mock<ISubscriptionUsageActivityRollupRepository> _activity = new();
+    private readonly Mock<ISubscriptionUsageActorRollupRepository> _actors = new();
+    private readonly Mock<ISubscriptionRepository> _subscriptions = new();
+    private readonly Mock<ISubscriptionDocumentCursorRepository> _cursors = new();
+    private readonly ControlledTimeProvider _time =
+        new(new DateTimeOffset(2026, 9, 4, 12, 0, 0, TimeSpan.Zero));
+
+    private IReadOnlyList<SubscriptionUsageRecord> _records = [];
+    private FinancialDocumentSweepMark? _cursorMark;
+
+    public UsageRollupServiceTests()
+    {
+        _usage
+            .Setup(repository => repository.ListRecordedSinceAsync(
+                TenantId, It.IsAny<DateTime>(), It.IsAny<string?>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _records);
+
+        _subscriptions
+            .Setup(repository => repository.GetByIdAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string tenantId, string subscriptionId, CancellationToken _) =>
+                NewSubscription(subscriptionId));
+
+        _cursors
+            .Setup(repository => repository.GetAsync(
+                TenantId, UsageRollupService.RollupCursorName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _cursorMark);
+
+        _cursors
+            .Setup(repository => repository.SetAsync(
+                TenantId, UsageRollupService.RollupCursorName,
+                It.IsAny<FinancialDocumentSweepMark>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, FinancialDocumentSweepMark, CancellationToken>(
+                (_, _, mark, _) => _cursorMark = mark)
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task A_batch_applies_each_record_to_the_activity_rollup_and_advances_the_cursor()
+    {
+        var first = NewRecord(
+            "rec-1", "screening",
+            occurredAtUtc: new DateTime(2026, 9, 1, 8, 0, 0, DateTimeKind.Utc),
+            recordedAtUtc: new DateTime(2026, 9, 1, 8, 0, 5, DateTimeKind.Utc),
+            delta: 3);
+        var second = NewRecord(
+            "rec-2", "envelope",
+            occurredAtUtc: new DateTime(2026, 9, 2, 14, 0, 0, DateTimeKind.Utc),
+            recordedAtUtc: new DateTime(2026, 9, 2, 14, 0, 5, DateTimeKind.Utc),
+            delta: 5);
+        _records = [first, second];
+
+        var processed = await Service().RunBatchAsync(TenantId, "corr-1", CancellationToken.None);
+
+        processed.Should().Be(2);
+
+        _activity.Verify(repository => repository.ApplyAsync(
+            TenantId, OrganizationId, SubscriptionId, "screening",
+            It.IsAny<string>(), It.IsAny<string>(),
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), 8, 3m,
+            first.RecordedAtUtc, "rec-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _activity.Verify(repository => repository.ApplyAsync(
+            TenantId, OrganizationId, SubscriptionId, "envelope",
+            It.IsAny<string>(), It.IsAny<string>(),
+            new DateTime(2026, 9, 2, 0, 0, 0, DateTimeKind.Utc), 14, 5m,
+            second.RecordedAtUtc, "rec-2", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _cursors.Verify(repository => repository.SetAsync(
+            TenantId, UsageRollupService.RollupCursorName,
+            new FinancialDocumentSweepMark(second.RecordedAtUtc, "rec-2"),
+            It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the cursor advances to the last record's RecordedAtUtc and id, not the first's");
+    }
+
+    /// <summary>
+    /// A record reported late — recorded well after it actually occurred — must still be folded
+    /// into the bucket for the day it happened, not the day the rollup job caught up to it. The
+    /// cursor itself still advances on RecordedAtUtc; only the bucket key uses OccurredAtUtc.
+    /// </summary>
+    [Fact]
+    public async Task A_late_arriving_record_is_bucketed_by_the_day_it_occurred_not_the_day_it_was_recorded()
+    {
+        var lateRecord = NewRecord(
+            "rec-late", "screening",
+            occurredAtUtc: new DateTime(2026, 8, 20, 3, 0, 0, DateTimeKind.Utc),
+            recordedAtUtc: new DateTime(2026, 9, 4, 9, 0, 0, DateTimeKind.Utc),
+            delta: 7);
+        _records = [lateRecord];
+
+        await Service().RunBatchAsync(TenantId, "corr-1", CancellationToken.None);
+
+        _activity.Verify(repository => repository.ApplyAsync(
+            TenantId, OrganizationId, SubscriptionId, "screening",
+            It.IsAny<string>(), It.IsAny<string>(),
+            new DateTime(2026, 8, 20, 0, 0, 0, DateTimeKind.Utc), // the day it occurred.
+            3, 7m,
+            lateRecord.RecordedAtUtc, "rec-late", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a late-arriving record must land in the day it occurred, not the day it was recorded");
+
+        _activity.Verify(repository => repository.ApplyAsync(
+            TenantId, OrganizationId, SubscriptionId, "screening",
+            It.IsAny<string>(), It.IsAny<string>(),
+            new DateTime(2026, 9, 4, 0, 0, 0, DateTimeKind.Utc), // the day it was recorded.
+            It.IsAny<int>(), It.IsAny<decimal>(),
+            It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task A_record_with_an_actor_is_also_applied_to_the_actor_rollup()
+    {
+        var record = NewRecord(
+            "rec-1", "screening",
+            occurredAtUtc: new DateTime(2026, 9, 1, 8, 0, 0, DateTimeKind.Utc),
+            recordedAtUtc: new DateTime(2026, 9, 1, 8, 0, 5, DateTimeKind.Utc),
+            delta: 3,
+            recordedByUserId: "user-1");
+        _records = [record];
+
+        await Service().RunBatchAsync(TenantId, "corr-1", CancellationToken.None);
+
+        _actors.Verify(repository => repository.ApplyAsync(
+            TenantId, OrganizationId, "screening",
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc), "user-1", 3m,
+            record.RecordedAtUtc, "rec-1", It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_record_with_no_actor_is_not_applied_to_the_actor_rollup()
+    {
+        var record = NewRecord(
+            "rec-1", "screening",
+            occurredAtUtc: new DateTime(2026, 9, 1, 8, 0, 0, DateTimeKind.Utc),
+            recordedAtUtc: new DateTime(2026, 9, 1, 8, 0, 5, DateTimeKind.Utc),
+            delta: 3,
+            recordedByUserId: null);
+        _records = [record];
+
+        await Service().RunBatchAsync(TenantId, "corr-1", CancellationToken.None);
+
+        _actors.Verify(repository => repository.ApplyAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+            It.IsAny<string>(), It.IsAny<decimal>(), It.IsAny<DateTime>(), It.IsAny<string>(),
+            It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a record with no attributed actor must not create an unattributed actor bucket");
+    }
+
+    [Fact]
+    public async Task Nothing_new_since_the_cursor_returns_zero_and_does_not_advance_it()
+    {
+        _records = [];
+
+        var processed = await Service().RunBatchAsync(TenantId, "corr-1", CancellationToken.None);
+
+        processed.Should().Be(0);
+        _cursors.Verify(repository => repository.SetAsync(
+            TenantId, It.IsAny<string>(), It.IsAny<FinancialDocumentSweepMark>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a re-run that finds nothing new must not touch the cursor");
+        _activity.Verify(repository => repository.ApplyAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<int>(),
+            It.IsAny<decimal>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<DateTime>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static SubscriptionUsageRecord NewRecord(
+        string itemId,
+        string meterKey,
+        DateTime occurredAtUtc,
+        DateTime recordedAtUtc,
+        decimal delta,
+        string? recordedByUserId = "user-1") => new()
+    {
+        ItemId = itemId,
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        SubscriptionId = SubscriptionId,
+        MeterKey = meterKey,
+        PeriodKey = "M20260901T000000Z",
+        EntryType = UsageEntryType.Consumption,
+        Delta = delta,
+        IdempotencyKey = itemId,
+        OccurredAtUtc = occurredAtUtc,
+        RecordedAtUtc = recordedAtUtc,
+        RecordedByUserId = recordedByUserId,
+        CorrelationId = "corr-1"
+    };
+
+    private static SubscriptionDetail NewSubscription(string id) => new()
+    {
+        ItemId = id,
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        Status = SubscriptionStatus.Active,
+        CurrencyCode = "CHF",
+        Plan = new PlanSnapshot
+        {
+            PlanId = "plan-1",
+            Code = "professional",
+            Meters =
+            [
+                new PlanMeter { MeterKey = "screening", IncludedQuantity = 500 },
+                new PlanMeter { MeterKey = "envelope", IncludedQuantity = 100 }
+            ]
+        }
+    };
+
+    private UsageRollupService Service() => new(
+        _usage.Object,
+        _activity.Object,
+        _actors.Object,
+        _subscriptions.Object,
+        _cursors.Object,
+        new OptionsStub(),
+        NullLogger<UsageRollupService>.Instance,
+        _time);
+
+    private sealed class OptionsStub : IOptionsMonitor<SubscriptionOptions>
+    {
+        public SubscriptionOptions CurrentValue { get; } = new();
+
+        public SubscriptionOptions Get(string? name) => CurrentValue;
+
+        public IDisposable? OnChange(Action<SubscriptionOptions, string?> listener) => null;
+    }
+}


### PR DESCRIPTION
## Summary

Adds read-only, tenant-wide metered-usage analytics for Tenant Admins: volume over time, per-organization and per-actor breakdowns, and allowance/overage history — backed by precomputed daily rollup collections so the report never scans the live usage ledger.

- **Money-path fix**: a closed usage period now records what it *included* and *used*, not just its overage — `UsageInvoiceLine` gains `IncludedQuantity`/`UsedQuantity`. A meter rated but priced to zero (fully within allowance) now gets a line at `AmountMinor = 0` instead of being skipped; a meter with no activity at all is still skipped. **The charged total is unchanged** — this is purely what gets recorded, not what gets billed.
- **Reversal-attribution fix**: the compensating ledger entry built in `UsageRecordingService.RefuseAsync` now copies the original entry's `RecordedByUserId`, so a reversal nets out of the correct actor in the new per-actor rollup instead of an unattributed bucket.
- **Two new collections**: `SubscriptionUsageActivityRollup` (per subscription/meter/day) and `SubscriptionUsageActorRollup` (per organization/meter/day/user), both derived and disposable — never authoritative, rebuildable from the ledger.
- **New background work**: `SubscriptionWorkType.UsageActivityRollup`, a scoped `ISubscriptionWorkHandler` (`UsageActivityRollupWorkHandler`) dispatched through the existing work-queue infrastructure, hooked into `SubscriptionRepairAnnouncer`'s due-check. Walks the ledger forward from a **persisted, named cursor** (`ISubscriptionDocumentCursorRepository`, `"usage-activity-rollup"`) rather than the in-memory backfill cursor used elsewhere, since a large tenant should not re-scan on every restart. Buckets by `OccurredAtUtc` (so late-arriving usage lands in the day it happened) while the cursor itself advances on `RecordedAtUtc`. A new additive index `{TenantId, RecordedAtUtc, ItemId}` on `SubscriptionUsageRecords` makes the incremental scan indexed rather than a collection scan.
- **New API surface**: `GET subscription-usage/reports/{timeseries,organizations,actors,allowances}`, gated by a new `SubscriptionUsageReportReader` policy (claim `subscription.usage-report.read`). Every query is scoped by the caller's `TenantId` alone; `organizationId` on a request is a filter *within* the tenant, never a scope escalation (no reuse of `PaymentOrganizationScope.RequestMayNameOrganization`, which answers a narrower question). A new `UsageReportCursorCodec` binds a page cursor to the tenant *and* the full filter set (organization/meter/subscription/granularity/date-range), since these endpoints are tenant-scoped-with-optional-org-filter rather than purely organization-scoped.
- Returns ids only — organization and user display names resolve client-side through IAM. Server-only change; client `type-check` passes as a no-op confirmation.

## Dropped from scope

The separately-filed `CarryForwardCap` mapping bug is **already fixed** in `PlanCatalogueService.cs` and `SubscriptionSnapshotBuilder.cs` (confirmed by reading both, including the historical-bug comment left by that fix's own commit). It is **not touched** by this PR.

## Deviations from the original plan

- **Reversal attribution** is fixed by copying `RecordedByUserId` directly onto the reversal record at write time (`UsageRecordingService.RefuseAsync`), rather than resolving it at rollup time via `CompensatesRecordId`. The plan allowed either approach and suggested rollup-time resolution as "likely simpler"; in practice, a direct field copy is a one-line change with no extra repository round-trip per reversal during rollup, so it was preferred.
- The `/allowances` and `/actors` endpoints require `organizationId` (refused with a validation error if omitted) — a per-user or per-period-allowance view only makes sense within one organization; a tenant-wide list of every user or every open period across every organization was judged out of scope for a first cut.
- The end-to-end simulation-harness reconciliation (Testing item 7 in the plan) was **deferred** — it would have required non-trivial changes to the simulation harness to expose the new rollup/report endpoints, and the plan explicitly allowed deferring this without blocking the rest.
- Mongo integration tests (`SubscriptionUsageActivityRollupIntegrationTests`) were written (bucket contents, idempotent re-apply, actor-reversal netting to zero) but **could not be run locally** — no local `mongod` was available in this environment. They rely on this repo's CI `mongo-integration`/scheduling-integration job for verification.

## Test plan

- [x] Service unit tests for the rating fix (zero-overage line recorded, charged total pinned unchanged) — `SubscriptionUsageRatingProcessorTests`
- [x] Reversal-attribution unit test — `UsageRecordingServiceTests`
- [x] `UsageRollupService` unit tests: bucketing, late-arrival lands in the occurred day not the recorded day, actor-rollup gating on `RecordedByUserId`, cursor no-op when nothing new — `UsageRollupServiceTests`
- [x] `SubscriptionUsageReportService` unit tests: page-size/date-range validation, granularity parsing, `OrganizationId` requirement for actor/allowance endpoints, cursor refused under a changed filter set (both directly against the codec and through the service) — `SubscriptionUsageReportServiceTests`
- [x] Authorization test: reflection-asserts the exact `SubscriptionUsageReportReader` policy string on the controller — `SubscriptionUsageReportsControllerTests`
- [x] Registration/index tests updated — `SubscriptionServiceRegistrationTests`, `SubscriptionIndexDefinitionsTests`
- [x] Mongo integration tests written (bucket contents, idempotent re-run, actor netting) — not run locally, relies on CI's mongo-integration job
- [ ] End-to-end simulation-harness reconciliation — deferred (see Deviations)
- [x] `dotnet build server/Api/Api.csproj --no-incremental` — 0 errors
- [x] `dotnet test --filter "FullyQualifiedName!~Integration"` from `server/` — full suite passes except the pre-existing, unrelated `SubscriptionSimulation*` failures (confirmed unrelated: those files are untouched by this branch)
- [x] `npm run type-check` from `client/` — 0 errors (server-only feature, no-op confirmation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)