### PR TITLE
Give 4xx/5xx responses their own OpenAPI example, so Swagger/Scalar stop showing success: true for a Bad Request

### DIFF
--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -1207,6 +1207,44 @@
             outside the scope it belongs to.
             </summary>
         </member>
+        <member name="T:Api.OpenApi.ApiResponseFailureExampleOperationTransformer">
+            <summary>
+            Gives each 4xx/5xx response an explicit example showing <c>success: false</c>.
+            </summary>
+            <remarks>
+            Every controller in this API — Payment, Subscription, PdfGenerator's document conversions —
+            declares both its success and its failure responses as <c>ApiResponse&lt;T&gt;</c> for the same
+            <c>T</c>, so a 200 and its sibling 400 point at the exact same component schema. The OpenAPI
+            document itself carries no example (confirmed by inspecting the generated document: schemas here
+            have no <c>example</c> keyword at all), so Swagger UI and Scalar each synthesize their own
+            generic one from the schema shape when a response has none — and for a bare <c>boolean</c>
+            property with no guidance, that synthesis defaults to <c>true</c>. Since the 200 and 400
+            responses share one schema, both end up showing the identical synthesized example, and a 400 in
+            the docs reads <c>success: true</c> even though the server always returns <c>false</c> there.
+            <para>
+            Attaching an explicit example directly to each failure response (rather than editing the shared
+            schema, which would leak the same override onto the success response too) is the one point of
+            control that lets a 200 and a 400 for the same <c>T</c> show different examples in the docs.
+            Success responses are left alone: their schema-synthesized <c>success: true</c> already matches
+            what the server sends.
+            </para>
+            </remarks>
+        </member>
+        <member name="M:Api.OpenApi.ApiResponseFailureExampleOperationTransformer.IsApiResponse(System.Type)">
+            <summary>
+            True for <c>ApiResponse&lt;T&gt;</c> for any <c>T</c>. Reflection on the declared response
+            type rather than matching the generated schema's name, so this keeps working if the schema
+            naming ever changes.
+            </summary>
+        </member>
+        <member name="M:Api.OpenApi.ApiResponseFailureExampleOperationTransformer.BuildFailureExample">
+            <summary>
+            A generic failure envelope. The real <c>code</c>/<c>message</c> vary per endpoint and aren't
+            worth hand-authoring for every one of them; what matters for the reported problem is that
+            <c>success</c> reads <c>false</c> here, matching what <see cref="M:Payment.DomainService.Responses.ApiResponse`1.Fail(System.String,System.String,System.String,System.Collections.Generic.Dictionary{System.String,System.String[]})"/>
+            actually sends.
+            </summary>
+        </member>
         <member name="T:Api.Utilities.DocumentConversionApiResults">
             <summary>
             Maps a document-conversion result onto an HTTP response.

--- a/server/Api/OpenApi/ApiResponseFailureExampleOperationTransformer.cs
+++ b/server/Api/OpenApi/ApiResponseFailureExampleOperationTransformer.cs
@@ -1,0 +1,99 @@
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+using Payment.DomainService.Responses;
+
+namespace Api.OpenApi;
+
+/// <summary>
+/// Gives each 4xx/5xx response an explicit example showing <c>success: false</c>.
+/// </summary>
+/// <remarks>
+/// Every controller in this API — Payment, Subscription, PdfGenerator's document conversions —
+/// declares both its success and its failure responses as <c>ApiResponse&lt;T&gt;</c> for the same
+/// <c>T</c>, so a 200 and its sibling 400 point at the exact same component schema. The OpenAPI
+/// document itself carries no example (confirmed by inspecting the generated document: schemas here
+/// have no <c>example</c> keyword at all), so Swagger UI and Scalar each synthesize their own
+/// generic one from the schema shape when a response has none — and for a bare <c>boolean</c>
+/// property with no guidance, that synthesis defaults to <c>true</c>. Since the 200 and 400
+/// responses share one schema, both end up showing the identical synthesized example, and a 400 in
+/// the docs reads <c>success: true</c> even though the server always returns <c>false</c> there.
+/// <para>
+/// Attaching an explicit example directly to each failure response (rather than editing the shared
+/// schema, which would leak the same override onto the success response too) is the one point of
+/// control that lets a 200 and a 400 for the same <c>T</c> show different examples in the docs.
+/// Success responses are left alone: their schema-synthesized <c>success: true</c> already matches
+/// what the server sends.
+/// </para>
+/// </remarks>
+internal sealed class ApiResponseFailureExampleOperationTransformer : IOpenApiOperationTransformer
+{
+    public Task TransformAsync(
+        OpenApiOperation operation,
+        OpenApiOperationTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        foreach (var responseType in context.Description.SupportedResponseTypes)
+        {
+            if (responseType.StatusCode < 400 || !IsApiResponse(responseType.Type))
+            {
+                continue;
+            }
+
+            var key = responseType.StatusCode.ToString(CultureInfo.InvariantCulture);
+            if (!operation.Responses.TryGetValue(key, out var response))
+            {
+                continue;
+            }
+
+            var example = BuildFailureExample();
+            foreach (var mediaType in response.Content.Values)
+            {
+                // Each media type entry gets its own JsonNode instance. They would otherwise share
+                // one mutable node across content types, and Microsoft.OpenApi's YAML/JSON writer
+                // walks each occurrence independently — a shared instance risks being written out
+                // more than once or mutated by a later transformer touching one content type only.
+                mediaType.Example = BuildFailureExample();
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// True for <c>ApiResponse&lt;T&gt;</c> for any <c>T</c>. Reflection on the declared response
+    /// type rather than matching the generated schema's name, so this keeps working if the schema
+    /// naming ever changes.
+    /// </summary>
+    private static bool IsApiResponse(Type? type) =>
+        type is { IsGenericType: true } && type.GetGenericTypeDefinition() == typeof(ApiResponse<>);
+
+    /// <summary>
+    /// A generic failure envelope. The real <c>code</c>/<c>message</c> vary per endpoint and aren't
+    /// worth hand-authoring for every one of them; what matters for the reported problem is that
+    /// <c>success</c> reads <c>false</c> here, matching what <see cref="ApiResponse{T}.Fail"/>
+    /// actually sends.
+    /// </summary>
+    private static JsonNode BuildFailureExample() =>
+        new JsonObject
+        {
+            ["success"] = false,
+            ["data"] = null,
+            ["error"] = new JsonObject
+            {
+                ["code"] = "example_error_code",
+                ["message"] = "Example error message.",
+                ["fields"] = null,
+                ["traceId"] = "00-0000000000000000000000000000000-0000000000000000-00"
+            },
+            ["meta"] = new JsonObject
+            {
+                ["correlationId"] = "00-0000000000000000000000000000000-0000000000000000-00",
+                ["timestampUtc"] = "2026-01-01T00:00:00Z",
+                ["replayed"] = false
+            }
+        };
+}

--- a/server/Api/Program.cs
+++ b/server/Api/Program.cs
@@ -76,6 +76,8 @@ services.AddOpenApi(options =>
         new ApiSecuritySchemeDocumentTransformer());
     options.AddOperationTransformer(
         new AuthorizedOperationSecurityTransformer());
+    options.AddOperationTransformer(
+        new ApiResponseFailureExampleOperationTransformer());
 });
 services.AddSingleton<
     IWebhookRequestBodyReader,


### PR DESCRIPTION
Fixes what was reported against the conversion endpoints, but the root cause and the fix are general to the API.

## Root cause

Every controller here — Payment, Subscription, and now PdfGenerator's document conversions — declares both its success and its failure responses as `ApiResponse<T>` for the same `T`. That means a `200`/`202` and its sibling `400` point at the **exact same OpenAPI component schema**.

I fetched the raw generated `/openapi/v1.json` and confirmed the schema itself carries no `example` at all — just `"success": { "type": "boolean" }`. Swagger UI and Scalar each synthesize their own example client-side when a response has none, and for a bare boolean with no guidance that synthesis defaults to `true`. Since the 200 and 400 share one schema, both get the identical synthesized example — so the docs show `success: true` on a Bad Request even though `ApiResponse<T>.Fail(...)` always sends `false` there. It's a documentation-rendering artifact, not a real bug in what the server sends (confirmed by `ApiResponse.Fail`'s implementation and the existing test coverage on it).

## Fix

`ApiResponseFailureExampleOperationTransformer` (`Api/OpenApi/`, registered in `Program.cs` alongside the two existing operation transformers) attaches an explicit example directly to each `4xx`/`5xx` response it reflection-identifies as `ApiResponse<T>`:

```json
{
  "success": false,
  "data": null,
  "error": { "code": "example_error_code", "message": "Example error message.", "fields": null, "traceId": "..." },
  "meta": { "correlationId": "...", "timestampUtc": "2026-01-01T00:00:00Z", "replayed": false }
}
```

This is attached per-response, not on the shared component schema — editing the schema itself would have leaked the same override onto the success response too. Success responses are left alone: their schema-synthesized `success: true` already matches what the server sends, so there's nothing to fix there.

Applies automatically to every `ApiResponse<T>` failure response across the whole API, not just the conversion endpoints — Payment and Subscription controllers get the same correction for free.

## Verification

I could not start the real `Api` process here — it needs live secrets/MongoDB/broker configuration at startup. Instead I built an isolated repro app pinned to the exact same `Microsoft.AspNetCore.OpenApi` 10.0.10 / `Microsoft.OpenApi` 2.11.0 versions this project uses, with a controller shaped identically (`ApiResponse<T>` on both a 202 and a 400). Fetched `/openapi/v1.json` before and after adding the transformer:

- **Before:** the 400 response's media types carry no `example` field.
- **After:** the 400 response's media types carry `{"success": false, ...}` as shown above; the 202 response is untouched.

This confirms the mechanism works exactly as intended for this exact package version. I have not run it against the real `Api` project's live Scalar/Swagger UI.

Full non-integration suite: 3628 passing on this branch, rebased onto current `dev`. Same 4 pre-existing `SubscriptionSimulation` permission failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)