### PR TITLE
feat(subscription): invoice an opening period that activated with nothing due

### DIFF
--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -452,11 +452,9 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             // Announced after the transition commits, so a document is only ever promised for a
             // subscription that actually started.
             //
-            // Never for a card setup. The payment row behind a setup exists so the provider
+            // Never a charge for a card setup. The payment row behind a setup exists so the provider
             // machinery has something to hang a session off and holds no money at all; invoicing it
-            // would issue a document for a charge that was never taken. A trial that collects a
-            // card now takes nothing on the day it starts, so this is the only announcement it
-            // gets until it converts.
+            // as a charge would issue a document describing money that was never taken.
             if (!IsCardSetup(link))
             {
                 await _documents.AnnounceChargeAsync(
@@ -464,6 +462,21 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                     payment.ItemId,
                     SubscriptionChargeKind.Initial,
                     null,
+                    link.CorrelationId,
+                    cancellationToken,
+                    SubscriptionDocumentSourceFactory.ActorOf(payment.UserId));
+            }
+            else if (target == SubscriptionStatus.Active)
+            {
+                // A card setup landing directly on Active, rather than on Trialing, is an opening
+                // period that owed nothing today — a price discounted to zero, or one that was
+                // already zero — not a trial. It still deserves a document stating what it was
+                // worth, the same reasoning a trial invoice already applies to a period nobody paid
+                // for; see AnnounceOpeningDiscountAsync for why its figures are frozen here rather
+                // than read off this payment.
+                await _documents.AnnounceOpeningDiscountAsync(
+                    subscription,
+                    payment.ItemId,
                     link.CorrelationId,
                     cancellationToken,
                     SubscriptionDocumentSourceFactory.ActorOf(payment.UserId));

--- a/server/Subscription.DomainService/Services/ISubscriptionFinancialDocumentAnnouncer.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionFinancialDocumentAnnouncer.cs
@@ -63,6 +63,27 @@ public interface ISubscriptionFinancialDocumentAnnouncer
         FinancialDocumentPerson? initiatedBy = null);
 
     /// <summary>
+    /// Announces an opening period that activated with nothing due — a price discounted to zero, or
+    /// one that was already zero — which owes a document stating what it was worth even though
+    /// nothing was collected.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="AnnounceChargeAsync"/>, the figures are frozen into the obligation itself
+    /// rather than left for the issuer to read off a payment: the card-setup payment behind this
+    /// event carries no money and its status is never asked to reach "settled", because there is
+    /// nothing for it to settle.
+    /// </remarks>
+    /// <param name="paymentMethodSetupPaymentId">
+    /// The card-setup payment's id, used only to key the obligation for idempotency.
+    /// </param>
+    Task AnnounceOpeningDiscountAsync(
+        SubscriptionDetail subscription,
+        string paymentMethodSetupPaymentId,
+        string correlationId,
+        CancellationToken cancellationToken,
+        FinancialDocumentPerson? initiatedBy = null);
+
+    /// <summary>
     /// Asks for whatever a subscription already owes to be written now.
     /// </summary>
     /// <remarks>

--- a/server/Subscription.DomainService/Services/SubscriptionDocumentSourceFactory.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionDocumentSourceFactory.cs
@@ -64,6 +64,57 @@ public static class SubscriptionDocumentSourceFactory
         };
     }
 
+    /// <summary>
+    /// The obligation an opening period that activated with nothing due leaves behind: a document
+    /// stating what it was worth, even though nothing was collected.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="ForCharge"/>, this freezes <see cref="SubscriptionDocumentSource.Amounts"/>.
+    /// There is no payment behind this event to read them from later — the card-setup record it
+    /// keys off carries no money at all — so the figures have to be pinned down here or nowhere, the
+    /// same reason a banked-credit source freezes them.
+    /// </remarks>
+    /// <param name="paymentMethodSetupPaymentId">
+    /// The card-setup payment's id, used only to key the obligation for idempotency. It carries no
+    /// money and is never read back as the document's payment.
+    /// </param>
+    /// <param name="amounts">
+    /// The breakdown to freeze, from <c>SubscriptionFinancialDocumentIssuer.RecomposeInitialCharge</c>
+    /// — computed here, at activation, because there is no later moment a payment would let it be
+    /// recomputed at.
+    /// </param>
+    public static SubscriptionDocumentSource ForOpeningDiscount(
+        SubscriptionDetail subscription,
+        string paymentMethodSetupPaymentId,
+        FinancialDocumentAmounts amounts,
+        FinancialDocumentPerson? initiatedBy,
+        DateTime occurredAtUtc,
+        string correlationId)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+        ArgumentNullException.ThrowIfNull(amounts);
+
+        var charge = new SubscriptionChargeReference(
+            subscription.ItemId,
+            SubscriptionChargeKind.Initial,
+            null);
+
+        return new SubscriptionDocumentSource
+        {
+            SourceKey = FinancialDocumentSourceKey.ForPayment(paymentMethodSetupPaymentId),
+            DocumentType = FinancialDocumentType.Invoice,
+            ChargeKind = SubscriptionChargeKind.Initial,
+            CurrencyCode = subscription.CurrencyCode,
+            Subject = SubjectOf(subscription),
+            QuantityItems = Frozen(subscription.QuantityItems),
+            Period = PeriodFor(subscription, charge),
+            Amounts = amounts,
+            InitiatedBy = initiatedBy,
+            OccurredAtUtc = occurredAtUtc,
+            CorrelationId = correlationId
+        };
+    }
+
     /// <summary>The obligation a trial start leaves behind: a document stating terms, not a charge.</summary>
     public static SubscriptionDocumentSource? ForTrial(
         SubscriptionDetail subscription,

--- a/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentAnnouncer.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentAnnouncer.cs
@@ -108,6 +108,60 @@ public sealed class SubscriptionFinancialDocumentAnnouncer :
             cancellationToken);
     }
 
+    /// <remarks>
+    /// The breakdown is recomputed and frozen here rather than left for the issuer to read off a
+    /// payment, because there is no payment to read it off: a card-setup activation carries no
+    /// money. <c>subscription</c> is exactly the terms just committed, so this is the one moment the
+    /// recomputation is guaranteed to still describe what actually activated.
+    /// <para>
+    /// No dedicated recovery sweep backstops this the way <see cref="AnnounceTrialAsync"/> is backed
+    /// by one over trials, or a settled charge is backed by one over payments: there is no query that
+    /// finds "activated with nothing due" the way there is for "trial started" or "payment captured".
+    /// A crash between the activation transition committing and this call landing would lose the
+    /// document silently. Accepted for now as the same risk class a banked-credit source already
+    /// carries — recorded on nothing but the one call — rather than building a new sweep for it.
+    /// </para>
+    /// </remarks>
+    public async Task AnnounceOpeningDiscountAsync(
+        SubscriptionDetail subscription,
+        string paymentMethodSetupPaymentId,
+        string correlationId,
+        CancellationToken cancellationToken,
+        FinancialDocumentPerson? initiatedBy = null)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+
+        if (string.IsNullOrWhiteSpace(paymentMethodSetupPaymentId))
+        {
+            return;
+        }
+
+        if (SubscriptionFinancialDocumentIssuer.RecomposeInitialCharge(subscription) is { } amounts)
+        {
+            await RecordAsync(
+                subscription,
+                SubscriptionDocumentSourceFactory.ForOpeningDiscount(
+                    subscription,
+                    paymentMethodSetupPaymentId,
+                    amounts,
+                    initiatedBy,
+                    _time.GetUtcNow().UtcDateTime,
+                    correlationId),
+                cancellationToken);
+        }
+
+        // Keyed on the subscription, not on the setup payment: the handler drains whatever that
+        // subscription owes, the same way a trial's announcement does — and unlike a real charge,
+        // the setup payment's own status will never reach "settled", so naming it here the way
+        // AnnounceChargeAsync does would queue work that can never complete.
+        await ScheduleAsync(
+            subscription,
+            $"{SubscriptionWorkKeyPrefix}{subscription.ItemId}",
+            subscription.ItemId,
+            correlationId,
+            cancellationToken);
+    }
+
     public Task RequestPendingAsync(
         SubscriptionDetail subscription,
         string correlationId,

--- a/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionFinancialDocumentIssuer.cs
@@ -293,7 +293,10 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
     /// </summary>
     /// <remarks>
     /// A charge defers to <see cref="IssueForPaymentAsync"/>, which reads the figures off the payment
-    /// — the source froze what the charge was for, never what it came to.
+    /// — the source froze what the charge was for, never what it came to. An opening period that
+    /// activated with nothing due has no payment to defer to — the card-setup record behind it
+    /// carries no money at all — so its figures were frozen on the source itself instead, the same
+    /// reason a banked-credit source freezes them.
     /// </remarks>
     private async Task<SubscriptionFinancialDocument?> IssueFromSourceAsync(
         SubscriptionDetail subscription,
@@ -306,12 +309,18 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
             // The result carries its reason for the caller that named a payment; here only the
             // document matters, because this path is draining a subscription's own obligations and
             // each one is consumed or abandoned on its own terms.
-            return source.PaymentDetailId is { Length: > 0 } paymentDetailId
-                ? (await IssueForPaymentAsync(
+            if (source.PaymentDetailId is { Length: > 0 } paymentDetailId)
+            {
+                return (await IssueForPaymentAsync(
                     subscription.TenantId,
                     paymentDetailId,
                     correlationId,
-                    cancellationToken)).Document
+                    cancellationToken)).Document;
+            }
+
+            return source.Amounts is not null
+                ? await IssueOpeningDiscountInvoiceAsync(
+                    subscription, source, correlationId, cancellationToken)
                 : await AbandonAsync(subscription, source, cancellationToken);
         }
 
@@ -699,6 +708,60 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
                 RequiresPaymentMethod = trial.RequiresPaymentMethod,
                 FirstBillingAtUtc = subscription.NextFeeBillingAtUtc
             },
+            cancellationToken: cancellationToken);
+
+        if (document is not null)
+        {
+            await ConsumeAsync(subscription, source, cancellationToken);
+        }
+
+        return document;
+    }
+
+    /// <summary>
+    /// The document for an opening period that activated with nothing due — a price discounted to
+    /// zero, or one that was already zero.
+    /// </summary>
+    /// <remarks>
+    /// Reads its figures off the source, not off a payment: the card-setup record behind this event
+    /// carries no money at all, so <see cref="SubscriptionFinancialDocumentAnnouncer"/> froze the
+    /// breakdown on the source itself at the moment of activation, via
+    /// <see cref="RecomposeInitialCharge"/>. Otherwise the same shape as any other invoice — a real
+    /// gross, a real discount and a real (zero) total, not the zero-throughout statement a trial
+    /// invoice makes.
+    /// </remarks>
+    private async Task<SubscriptionFinancialDocument?> IssueOpeningDiscountInvoiceAsync(
+        SubscriptionDetail subscription,
+        SubscriptionDocumentSource source,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (source.Amounts is not { } amounts)
+        {
+            return await AbandonAsync(subscription, source, cancellationToken);
+        }
+
+        var terms = TermsFor(
+            subscription,
+            source,
+            new SubscriptionChargeReference(subscription.ItemId, SubscriptionChargeKind.Initial, null),
+            subscription.ItemId);
+
+        var document = await ComposeAndIssueAsync(
+            subscription,
+            FinancialDocumentType.Invoice,
+            source.SourceKey,
+            source.OccurredAtUtc,
+            amounts,
+            LinesFor(terms, SubscriptionChargeKind.Initial, amounts),
+            source.Period,
+            terms,
+            correlationId,
+            paymentDetailId: null,
+            settlement: null,
+            initiatedBy: source.InitiatedBy,
+            initiatedByUserId: source.InitiatedBy?.UserId,
+            settlementReservationId: null,
             cancellationToken: cancellationToken);
 
         if (document is not null)
@@ -1237,8 +1300,15 @@ public sealed class SubscriptionFinancialDocumentIssuer : ISubscriptionFinancial
     /// discount terms and the calendar fraction are all on the subscription and none of them can be
     /// moved by editing the catalogue, so the calculator is being asked the same question it was
     /// asked at checkout rather than a fresh one.
+    /// <para>
+    /// Internal rather than private: <see cref="SubscriptionFinancialDocumentAnnouncer"/> reuses it
+    /// to freeze the same breakdown on a source for an opening period that activated with nothing
+    /// due — a card-setup activation carries no payment to read a breakdown off later, so this is
+    /// called at the moment of activation instead of at issue, while <c>subscription</c> is still
+    /// exactly the terms the customer was quoted.
+    /// </para>
     /// </remarks>
-    private static FinancialDocumentAmounts? RecomposeInitialCharge(
+    internal static FinancialDocumentAmounts? RecomposeInitialCharge(
         SubscriptionDetail subscription)
     {
         if (subscription.InitialChargeAmountMinor is not { } frozen)

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -40,6 +40,7 @@ public sealed class SubscriptionActivationProcessorTests
     private readonly Mock<IBillingAccountRepository> _accounts = new();
     private readonly Mock<IPaymentRepository> _payments = new();
     private readonly Mock<IStoredPaymentMethodRepository> _storedMethods = new();
+    private readonly Mock<ISubscriptionFinancialDocumentAnnouncer> _documents = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 8, 14, 12, 0, 0, TimeSpan.Zero));
 
@@ -701,6 +702,82 @@ public sealed class SubscriptionActivationProcessorTests
             "no money moved, so there is no opening charge and no invoice behind one");
     }
 
+    /// <summary>
+    /// The D-01 scenario: a card setup that lands directly on Active, not Trialing, is an opening
+    /// period that owed nothing today — a discount to zero, or a price already at zero — not a
+    /// trial. It still owes a document, the same reasoning a trial invoice already gets, so this
+    /// is announced instead of being silently skipped the way an ordinary charge is for a setup.
+    /// </summary>
+    [Fact]
+    public async Task A_card_setup_that_activates_directly_announces_the_opening_period()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
+        GivenSubscription(subscription => subscription.InitialChargeAmountMinor = 0);
+
+        var settled = await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        settled.Should().Be(1);
+        _documents.Verify(
+            documents => documents.AnnounceOpeningDiscountAsync(
+                It.Is<SubscriptionDetail>(s => s.ItemId == "sub-1"),
+                "pay-1",
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<FinancialDocumentPerson?>()),
+            Times.Once);
+
+        // Never a charge announcement for a card setup — that would issue a document describing
+        // money that was never taken.
+        _documents.Verify(
+            documents => documents.AnnounceChargeAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionChargeKind>(),
+                It.IsAny<string?>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<FinancialDocumentPerson?>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// The control: a card setup that starts a trial is announced as a trial, not as an opening
+    /// discount — the two document types describe different things, and a trial already has its
+    /// own announcement.
+    /// </summary>
+    [Fact]
+    public async Task A_card_setup_that_starts_a_trial_does_not_announce_an_opening_discount()
+    {
+        GivenDueLink(SubscriptionPaymentPurpose.PaymentMethodSetup);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+        GivenSavedCard();
+        GivenSubscription(subscription => subscription.Trial = new TrialTerms
+        {
+            StartsAtUtc = DateTime.UtcNow,
+            EndsAtUtc = DateTime.UtcNow.AddDays(14)
+        });
+
+        await Processor().ProcessDueAsync(TenantId, CancellationToken.None);
+
+        _documents.Verify(
+            documents => documents.AnnounceOpeningDiscountAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<FinancialDocumentPerson?>()),
+            Times.Never);
+        _documents.Verify(
+            documents => documents.AnnounceTrialAsync(
+                It.IsAny<SubscriptionDetail>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<FinancialDocumentPerson?>()),
+            Times.Once);
+    }
+
     [Fact]
     public async Task A_confirmed_setup_waits_until_its_card_is_usable_for_renewal()
     {
@@ -766,7 +843,8 @@ public sealed class SubscriptionActivationProcessorTests
         new SubscriptionOptionsMonitorStub(new SubscriptionOptions()),
         NullLogger<SubscriptionActivationProcessor>.Instance,
         _time,
-        renewals: _renewals.Object);
+        renewals: _renewals.Object,
+        documents: _documents.Object);
 
     private static SubscriptionDetail NewSubscription() => new()
     {

--- a/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionFinancialDocumentIssuerTests.cs
@@ -362,6 +362,82 @@ public sealed class SubscriptionFinancialDocumentIssuerTests
     }
 
     [Fact]
+    public async Task An_opening_discount_period_gets_an_invoice_describing_what_it_was_worth()
+    {
+        var subscription = Subscribed();
+
+        // What SubscriptionFinancialDocumentAnnouncer would have frozen at activation: a real
+        // gross, a real discount, and a total of zero — not the zero-throughout statement a trial
+        // invoice makes.
+        var amounts = new FinancialDocumentAmounts
+        {
+            GrossSubtotalMinor = 29_000,
+            PromotionalDiscountMinor = 29_000,
+            NetSubtotalMinor = 0,
+            TaxRateBasisPoints = 770,
+            TaxMode = nameof(TaxMode.Exclusive),
+            TaxAmountMinor = 0,
+            TotalMinor = 0
+        };
+
+        Owing(
+            subscription,
+            SubscriptionDocumentSourceFactory.ForOpeningDiscount(
+                subscription, "pay-1", amounts, null, SettledAt, "corr-1"));
+
+        var issuer = Issuer();
+        (await issuer.IssueForSubscriptionAsync(
+            TenantId, SubscriptionId, "corr-1", CancellationToken.None))
+            .Should().Be(1);
+
+        var document = _documents.Documents.Single();
+        document.DocumentType.Should().Be(FinancialDocumentType.Invoice);
+        document.PaymentDetailId.Should().BeNull(
+            "the card-setup payment behind this event carries no money and is never named as it");
+        document.Amounts.GrossSubtotalMinor.Should().Be(29_000);
+        document.Amounts.PromotionalDiscountMinor.Should().Be(29_000);
+        document.Amounts.TotalMinor.Should().Be(0);
+        document.Lines.Should().ContainSingle();
+
+        // Numbered in the invoice series, same as any other invoice — this states what a real
+        // charge was for, unlike a trial invoice's separate statement of terms.
+        document.DocumentNumber.Should().StartWith("INV-");
+
+        // And exactly one, however many times the activation is announced.
+        Owing(
+            subscription,
+            SubscriptionDocumentSourceFactory.ForOpeningDiscount(
+                subscription, "pay-1", amounts, null, SettledAt, "corr-2"));
+
+        await issuer.IssueForSubscriptionAsync(
+            TenantId, SubscriptionId, "corr-2", CancellationToken.None);
+
+        _documents.Documents.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task An_opening_discount_source_with_no_frozen_amounts_is_abandoned()
+    {
+        // Internally impossible: no payment to read a breakdown off, and no breakdown frozen on
+        // the source either. Discarded rather than retried forever, the same as an ordinary
+        // invoice source naming no payment.
+        var subscription = Subscribed();
+
+        Owing(subscription, new SubscriptionDocumentSource
+        {
+            SourceKey = "payment:pay-1",
+            DocumentType = FinancialDocumentType.Invoice
+        });
+
+        (await Issuer().IssueForSubscriptionAsync(
+            TenantId, SubscriptionId, "corr-1", CancellationToken.None))
+            .Should().Be(0);
+
+        _documents.Documents.Should().BeEmpty();
+        _consumed.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task A_full_refund_reverses_exactly_what_was_charged_and_links_to_its_invoice()
     {
         Subscribed();


### PR DESCRIPTION
## Summary
- Today, an opening period whose price is fully discounted to zero (e.g. a `FreeOpeningCalendarPeriod` campaign like the "D-01" scenario) — or one that is genuinely priced at zero — activates through a card-*setup* instead of a charge, since there is nothing to collect. No `SubscriptionInvoice`-flow payment is ever created, so nothing ever announces a document for it, and the customer's invoice history simply starts at the first paid period. The two-sided reality (a real gross fully offset by a real discount) never gets stated anywhere.
- Fixes it by mirroring the existing `TrialInvoice` precedent: a document decoupled from payment settlement. This is deliberate — the card-setup payment behind this event settles at `Authorized`, never `Captured`/`PartiallyRefunded`/`Refunded`, so wiring it through the ordinary payment-driven pipeline would just dead-letter waiting for a capture that will never come.
- `SubscriptionActivationProcessor` now announces an opening-discount invoice for the one quadrant that previously announced nothing at all: a card-setup activation landing directly on `Active` (not `Trialing`).
- The breakdown (gross, discount, net, tax, total = 0) is frozen at the moment of activation via the issuer's existing `RecomposeInitialCharge` (now `internal`, shared rather than duplicated) — there's no later payment to read it off, unlike an ordinary charge.
- The resulting document is a real `Invoice` — a real gross, a real discount, a real (zero) total — not a `TrialInvoice`'s zero-throughout statement of terms.

## Design decisions (confirmed before implementing)
- Decoupled-from-payment-settlement issuance path, mirroring `TrialInvoice`, rather than teaching the payment-driven pipeline about the `PaymentMethodSetup` flow.
- Every $0 opening period gets a document, not only ones with a nonzero gross — a genuinely free price is treated the same as one discounted down to zero, matching how `TrialInvoice` already documents a period nobody paid for regardless of why.

## Known limitation (documented in code, not fixed here)
Unlike a trial (which has `IssueMissedTrialsAsync` as a recovery-sweep backstop) or a real charge (backstopped by `IssueMissedChargesAsync` over settled payments), there's no dedicated recovery sweep for this new obligation — a crash between the activation transition committing and the announcement landing would lose the document silently. This is the same risk class an existing banked-credit source already carries (recorded on nothing but the one call), and building a new sweep for it felt like a separate, larger change. Flagged in `SubscriptionFinancialDocumentAnnouncer.AnnounceOpeningDiscountAsync`'s remarks as a follow-up opportunity.

## Test plan
- [x] `dotnet build` on `Subscription.DomainService` and `XUnitTest` — 0 errors
- [x] `SubscriptionActivationProcessorTests` (28/28) — new coverage: a card-setup landing on `Active` announces the opening-discount invoice and never a charge; a card-setup landing on `Trialing` still announces only the trial, not an opening discount
- [x] `SubscriptionFinancialDocumentIssuerTests` (38/38) — new coverage: an opening-discount source produces a real `Invoice` with the frozen gross/discount/total, numbered in the invoice series, issued exactly once however many times announced; a malformed source (no payment, no frozen amounts) is abandoned rather than retried forever
- [x] Broader regression pass (`SubscriptionActivationProcessor|FinancialDocument|SubscriptionCheckoutService` filter): 250/265 passing — the 15 failures are pre-existing `MongoDB is not reachable` integration-test failures in this sandbox, unrelated to this change
- [ ] Manual: run the D-01 scenario end to end (subscribe with a 100%-off opening-period campaign, confirm activation without a charge) and confirm the invoice history now shows a CHF 0.00 document with the discount stated, not nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)