### PR TITLE
Quote the target period, not its stub, as the next renewal amount

### DIFF
--- a/server/Subscription.DomainService/Responses/SubscriptionPlanChangePreviewResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionPlanChangePreviewResponse.cs
@@ -75,7 +75,16 @@ public sealed class SubscriptionPlanChangePreviewResponse
 
     public DateTime NewPeriodEndUtc { get; init; }
 
-    /// <summary>What a full period costs at the target plan and price, once this change has settled.</summary>
+    /// <summary>
+    /// What a full period costs at the target plan and price, once this change has settled — never
+    /// the stub a move onto a calendar-aligned price buys first.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <c>settlement.target.periodTotalMinor</c>, which is the period this settlement
+    /// actually prices. For a calendar-aligned target those differ: the stub is scaled by the days
+    /// to the next boundary, and a yearly target's stub is priced from the monthly amount it was
+    /// linked to rather than from the annual amount at all.
+    /// </remarks>
     public long NextRenewalAmountMinor { get; init; }
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -300,7 +300,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
         // would not actually collect.
         long chargeMinor;
         long rawSettlementMinor;
-        long targetPeriodTotalMinor;
+        long nextRenewalAmountMinor;
         FinancialDocumentSettlementResponse settlementResponse;
 
         if (r.Subscription.PendingAnnualPeriod is { IsPrepaid: true } prepaidAnnual &&
@@ -317,7 +317,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
 
             chargeMinor = stubUpgrade.ChargeMinor;
             rawSettlementMinor = stubUpgrade.RawSettlementMinor;
-            targetPeriodTotalMinor = stubUpgrade.Annual.Target.PeriodTotalMinor;
+            nextRenewalAmountMinor = stubUpgrade.Annual.Target.PeriodTotalMinor;
             settlementResponse = SettlementResponseOf(stubUpgrade);
         }
         else
@@ -335,7 +335,7 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
             chargeMinor = outcome.ChargeMinor;
             rawSettlementMinor =
                 outcome.Breakdown.Target.ProratedValueMinor - outcome.Breakdown.Outgoing.ProratedValueMinor;
-            targetPeriodTotalMinor = outcome.Breakdown.Target.PeriodTotalMinor;
+            nextRenewalAmountMinor = outcome.TargetFullPeriodTotalMinor;
             settlementResponse = SettlementResponseOf(outcome.Breakdown);
         }
 
@@ -411,11 +411,14 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 Settlement = settlementResponse,
                 NewPeriodStartUtc = quotedSchedule.CurrentPeriodStartUtc,
                 NewPeriodEndUtc = quotedSchedule.CurrentPeriodEndUtc,
-                // Already the whole target period, tax included, undiminished by proration — see
-                // ProrationSide.PeriodTotalMinor — so there is nothing left to compute here. For an
-                // opening-stub upgrade this is the target annual period's own total, which is the
-                // figure that will actually recur once the year opens.
-                NextRenewalAmountMinor = targetPeriodTotalMinor,
+                // What recurs, which is not the same figure as the settlement's target side. A
+                // move onto a calendar-aligned price buys a stub first — priced by day fraction,
+                // and for a yearly target from the linked monthly basis — and the period that
+                // then recurs is the whole one at the target's own price. See
+                // ProrationOutcome.TargetFullPeriodTotalMinor for why the two are carried
+                // separately. For an opening-stub upgrade this is already the target annual
+                // period's own total, which is exactly the figure that recurs once the year opens.
+                NextRenewalAmountMinor = nextRenewalAmountMinor,
                 Blockers = blockers,
                 QuotedAtUtc = r.Now
             },

--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -105,6 +105,22 @@ public static class SubscriptionProrationCalculator
             newPrice.TaxRateBasisPoints,
             newPrice.TaxMode).TotalAmountMinor;
 
+        // What recurs, as distinct from what is being bought. Everything above prices the period
+        // this settlement covers, and for a calendar-aligned target that period is a stub: priced
+        // by day fraction, and for a yearly target from the linked monthly basis rather than the
+        // annual amount at all. Neither is what the subscriber pays from the next boundary on, so
+        // the whole period is priced separately — against the *original* target price, not the
+        // stub-swapped one, and with no fraction.
+        //
+        // Only when there is a fraction to undo. Prorate returns an amount untouched once
+        // coveredDays reaches totalDays (see CalendarBillingAlignment.Prorate), so for a whole
+        // period — every anniversary target, and every change landing on the first —
+        // newTaxInclusive already *is* the full period, and reusing it keeps those quotes
+        // bit-identical rather than merely equal by inspection.
+        var targetFullPeriodTotalMinor = targetFraction.IsPartial
+            ? FullPeriod(subscription, targetPlan, targetPrice, targetQuantityItems, nowUtc)
+            : newTaxInclusive;
+
         var oldRemainingValue = Prorate(oldTaxInclusive, remainingTicks, totalTicks);
         var targetTotalTicks = (targetPeriodEndUtc - targetPeriodStartUtc).Ticks;
         var targetRemainingTicks = Math.Clamp(
@@ -149,7 +165,45 @@ public static class SubscriptionProrationCalculator
         var breakdown = new ProrationBreakdown(
             outgoing, target, settled.CreditConsumedMinor, settled.NetSettlementMinor);
 
-        return new ProrationOutcome(settled.ChargeMinor, settled.NewCreditBalanceMinor, breakdown);
+        return new ProrationOutcome(
+            settled.ChargeMinor,
+            settled.NewCreditBalanceMinor,
+            breakdown,
+            targetFullPeriodTotalMinor);
+    }
+
+    /// <summary>
+    /// A whole period at a plan and price, tax included, with no day fraction applied — what a
+    /// renewal on these terms will charge.
+    /// </summary>
+    /// <remarks>
+    /// Priced through the same pair every other full period in this module goes through, so it
+    /// cannot drift from what a renewal actually charges: the subscriber's own discount at their
+    /// own period index, then the price's own tax rate and mode.
+    /// <para>
+    /// Deliberately not <see cref="SubscriptionAmountCalculator.PeriodAmountMinor"/>, which
+    /// subtracts <see cref="SubscriptionDetail.CreditBalanceMinor"/>. The settlement already spends
+    /// that same balance in <see cref="SettleRawDelta"/>, so a subscriber holding credit would see
+    /// it deducted twice — once off the charge, and again off the recurring price they were quoted.
+    /// </para>
+    /// </remarks>
+    private static long FullPeriod(
+        SubscriptionDetail subscription,
+        PlanSnapshot plan,
+        PriceSnapshot price,
+        IReadOnlyList<SubscriptionQuantityItem> quantityItems,
+        DateTime nowUtc)
+    {
+        var discounted = SubscriptionAmountCalculator.DiscountedAmountMinor(
+            plan,
+            subscription.Discount,
+            price,
+            quantityItems,
+            subscription.DiscountPeriodsApplied,
+            nowUtc);
+
+        return SubscriptionAmountCalculator.TaxBreakdownFor(
+            discounted.AmountMinor, price.TaxRateBasisPoints, price.TaxMode).TotalAmountMinor;
     }
 
     /// <param name="currentAnnual">
@@ -357,10 +411,24 @@ public static class SubscriptionProrationCalculator
 /// The two sides the charge came from, for the payment record. Default when the period was malformed
 /// and nothing could be prorated.
 /// </param>
+/// <param name="TargetFullPeriodTotalMinor">
+/// What a whole period at the target costs, tax included — what recurs from the next boundary on,
+/// as opposed to <see cref="ProrationBreakdown.Target"/>'s
+/// <see cref="ProrationSide.PeriodTotalMinor"/>, which is the period this settlement actually
+/// prices.
+/// </param>
+/// <remarks>
+/// <see cref="TargetFullPeriodTotalMinor"/> is deliberately here rather than on
+/// <see cref="ProrationSide"/>. A side is what reaches storage and the financial documents —
+/// <c>SettlementCharge.SideOf</c>, <c>SubscriptionSettlementBreakdown</c>, the invoice HTML and its
+/// React mirror all read one — and widening it would rewrite records already written. An outcome is
+/// returned by <see cref="SubscriptionProrationCalculator.Calculate"/> and never serialised.
+/// </remarks>
 public readonly record struct ProrationOutcome(
     long ChargeMinor,
     long NewCreditBalanceMinor,
-    ProrationBreakdown Breakdown = default);
+    ProrationBreakdown Breakdown = default,
+    long TargetFullPeriodTotalMinor = 0);
 
 /// <summary>
 /// One side of a settlement: what a period costs, and how much of that this instant is worth.

--- a/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
@@ -126,6 +126,51 @@ public sealed class CalendarAlignedPlanChangeTests
         // side is discounted by the whole 1000 because it is a whole period: (8900 - 1000) x 16/31
         // = 4077. 8806 - 4077 = 4729.
         outcome.ChargeMinor.Should().Be(4_729);
+
+        // The recurring period carries the subscriber's discount too — the whole 1000, since a
+        // full month is not scaled. A full period priced without the subscription's discount would
+        // report 40000, and one that let the day fraction through would report the 8806 stub.
+        outcome.TargetFullPeriodTotalMinor.Should().Be(39_000);
+    }
+
+    /// <summary>
+    /// A tax-inclusive target, where the configured amount already contains the tax rather than
+    /// having it added on top.
+    /// </summary>
+    /// <remarks>
+    /// The mode is the point. An inclusive price's total is its own configured amount, so this
+    /// figure separates a full period that read the price's real mode from one that assumed
+    /// exclusive (which would add 8.1% on top and report 39781) or that read no mode at all
+    /// (the pre-modes truncating path, 39780). It cannot, by construction, catch a missing tax
+    /// call — an inclusive total equals its input either way — which is why the yearly service
+    /// test asserts an <em>exclusive</em> figure, where the tax is visible in the number.
+    /// </remarks>
+    [Fact]
+    public void A_tax_inclusive_target_recurs_at_its_own_configured_amount()
+    {
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            Subscription(),
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 40_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth,
+                AutomaticDiscountBasisPoints = 800,
+                TaxRateBasisPoints = 810,
+                TaxMode = TaxMode.Inclusive
+            },
+            [],
+            Now,
+            Now,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            new BillingDayFraction(7, 31));
+
+        // 40000 less the 8% automatic discount is 36800, and the 8.1% VAT is already inside that
+        // — so the whole month costs the subscriber 36800, of which 2757 is tax.
+        outcome.TargetFullPeriodTotalMinor.Should().Be(36_800);
     }
 
     /// <summary>

--- a/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
@@ -128,6 +128,80 @@ public sealed class CalendarAlignedPlanChangeTests
         outcome.ChargeMinor.Should().Be(4_729);
     }
 
+    /// <summary>
+    /// The stub being bought and the period that recurs afterward are two different amounts, and
+    /// the settlement needs both.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ProrationSide.PeriodTotalMinor"/> is the period this settlement actually prices
+    /// — the stub — which is what the invoice explains. What recurs from the next boundary on is
+    /// the whole month at the target's own price, and quoting the stub for it understates the
+    /// recurring price by however much of the month the stub missed.
+    /// </remarks>
+    [Fact]
+    public void The_target_full_period_is_the_price_moved_onto_not_the_stub_being_bought()
+    {
+        var outcome = Calculate(targetUnitAmountMinor: 40_000);
+
+        // The stub: 40000 x 7/31 = 9032, as the charge tests above already pin.
+        outcome.Breakdown.Target.PeriodTotalMinor.Should().Be(9_032,
+            "the settlement prices the seven dates to the boundary, and says so");
+
+        // What recurs: the whole month, untouched by the fraction.
+        outcome.TargetFullPeriodTotalMinor.Should().Be(40_000);
+    }
+
+    /// <summary>
+    /// A whole target period has no stub to tell apart, so the two figures must agree exactly —
+    /// this is what keeps every existing anniversary and land-on-the-first quote unchanged.
+    /// </summary>
+    [Fact]
+    public void A_whole_target_period_reports_the_identical_figure_both_ways()
+    {
+        var outcome = Calculate(
+            targetUnitAmountMinor: 40_000,
+            fraction: new BillingDayFraction(30, 30));
+
+        outcome.TargetFullPeriodTotalMinor.Should().Be(outcome.Breakdown.Target.PeriodTotalMinor);
+        outcome.TargetFullPeriodTotalMinor.Should().Be(40_000);
+    }
+
+    /// <summary>
+    /// The one case that made this worth fixing: a calendar-aligned yearly target is charged from
+    /// its linked monthly basis for the days to the boundary, and quoting that basis as the
+    /// recurring price understates the year by roughly twelve times.
+    /// </summary>
+    [Fact]
+    public void A_calendar_yearly_target_recurs_at_the_annual_rate_not_the_monthly_stub()
+    {
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            Subscription(),
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 1_200_000,
+                Interval = BillingInterval.Year,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth,
+                CalendarStubBasePriceId = "price-monthly",
+                CalendarStubBaseUnitAmountMinor = 110_000
+            },
+            [],
+            Now,
+            Now,
+            new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+            new BillingDayFraction(7, 31));
+
+        // The stub is priced from the monthly basis, exactly as a fresh signup's would be:
+        // 110000 x 7/31 = 24839.
+        outcome.Breakdown.Target.PeriodTotalMinor.Should().Be(24_839,
+            "the days before the year begins are bought at the monthly rate");
+
+        // The year itself, which is what the subscriber will actually be charged on 1 September.
+        outcome.TargetFullPeriodTotalMinor.Should().Be(1_200_000);
+    }
+
     private static ProrationOutcome Calculate(
         long targetUnitAmountMinor,
         BillingDayFraction? fraction = null,

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -1250,6 +1250,103 @@ public sealed class SubscriptionPlanChangeServiceTests
         result.Value!.NextRenewalAmountMinor.Should().Be(2_000);
     }
 
+    /// <summary>
+    /// The recurring price of a calendar-aligned yearly target is the year, never the monthly
+    /// stub the move onto it buys first.
+    /// </summary>
+    /// <remarks>
+    /// The subscriber is shown "next full period" for a period they will never be on: the change
+    /// lands on the first, where no stub exists, and the whole year is charged. Quoting the stub
+    /// understated the recurring price by roughly the ratio of a month to a year.
+    /// </remarks>
+    [Fact]
+    public async Task NextRenewalAmountMinor_is_the_whole_year_for_a_calendar_aligned_yearly_target()
+    {
+        // 5 August, so the days to the 1 September boundary are 27 of the month's 31.
+        _time.Advance(TimeSpan.FromDays(4));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price
+            {
+                ItemId = "price-2",
+                TenantId = TenantId,
+                PlanId = "plan-2",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 1_200_000,
+                Interval = BillingInterval.Year,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth,
+                CalendarStubBasePriceId = "price-monthly-2",
+                CalendarStubBaseUnitAmountMinor = 110_000,
+                Status = CatalogueStatus.Active
+            });
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.NextRenewalAmountMinor.Should().Be(1_200_000,
+            "the year is what recurs on 1 September");
+
+        // Asserted alongside, so this fix cannot be mistaken for a repricing of the settlement:
+        // the stub really is 110000 x 27/31 = 95806, and the invoice still explains that.
+        result.Value.Settlement.Target.PeriodTotalMinor.Should().Be(95_806);
+    }
+
+    /// <summary>
+    /// The same defect without a stub basis in sight: a calendar-aligned monthly target has no
+    /// price swap, but the day fraction still scaled the figure being quoted as recurring.
+    /// </summary>
+    [Fact]
+    public async Task NextRenewalAmountMinor_is_the_whole_month_for_a_calendar_aligned_monthly_target()
+    {
+        _time.Advance(TimeSpan.FromDays(4));
+
+        _catalogue
+            .Setup(repository => repository.GetPriceAsync(
+                TenantId, "price-2", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Price
+            {
+                ItemId = "price-2",
+                TenantId = TenantId,
+                PlanId = "plan-2",
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 3_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth,
+                Status = CatalogueStatus.Active
+            });
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.NextRenewalAmountMinor.Should().Be(3_000);
+
+        // 3000 x 27/31 = 2613 — the stub, unchanged.
+        result.Value.Settlement.Target.PeriodTotalMinor.Should().Be(2_613);
+    }
+
+    /// <summary>
+    /// An anniversary target is never day-scaled, so its quote must come out bit-identical — the
+    /// guard that keeps this fix from touching every ordinary plan change.
+    /// </summary>
+    [Fact]
+    public async Task NextRenewalAmountMinor_is_unchanged_for_an_anniversary_target_mid_period()
+    {
+        // Half-way through the paid period, so proration is live on both sides.
+        _time.Advance(TimeSpan.FromDays(14));
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.NextRenewalAmountMinor.Should().Be(2_000);
+    }
+
     // ---- Timing: what applies now and what waits for the paid period to end ------------------
 
     [Fact]

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceTests.cs
@@ -1280,6 +1280,13 @@ public sealed class SubscriptionPlanChangeServiceTests
                 BillingAlignment = BillingAlignment.CalendarMonth,
                 CalendarStubBasePriceId = "price-monthly-2",
                 CalendarStubBaseUnitAmountMinor = 110_000,
+                // The rates from the report that motivated this: 8% for paying yearly, 8.1% VAT
+                // on top. Both non-zero deliberately — with either at zero its stage of the
+                // pricing is the identity function, and a full period that skipped that stage
+                // would report the right figure for the wrong reason.
+                AutomaticDiscountBasisPoints = 800,
+                TaxRateBasisPoints = 810,
+                TaxMode = TaxMode.Exclusive,
                 Status = CatalogueStatus.Active
             });
 
@@ -1287,12 +1294,17 @@ public sealed class SubscriptionPlanChangeServiceTests
             "sub-1", Request(), "corr-1", CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value!.NextRenewalAmountMinor.Should().Be(1_200_000,
-            "the year is what recurs on 1 September");
 
-        // Asserted alongside, so this fix cannot be mistaken for a repricing of the settlement:
-        // the stub really is 110000 x 27/31 = 95806, and the invoice still explains that.
-        result.Value.Settlement.Target.PeriodTotalMinor.Should().Be(95_806);
+        // 1200000 less the 8% automatic discount is 1104000; 8.1% VAT on that is 89424 exactly.
+        // Both stages of the pricing are visible in this one number, so a full period computed
+        // from the gross, or one that never reached the tax breakdown, cannot reach it.
+        result.Value!.NextRenewalAmountMinor.Should().Be(1_193_424,
+            "the year, discounted and taxed, is what recurs on 1 September");
+
+        // Asserted alongside, so this fix cannot be mistaken for a repricing of the settlement.
+        // The stub is the monthly basis through the identical pipeline: 110000 x 27/31 = 95806
+        // gross, less a truncated 8% (7664) is 88142, plus half-up 8.1% (7140) is 95282.
+        result.Value.Settlement.Target.PeriodTotalMinor.Should().Be(95_282);
     }
 
     /// <summary>


### PR DESCRIPTION
## The bug

A subscriber on a CHF 145/month calendar-aligned plan previewed a change to a calendar-aligned **yearly** price of CHF 3,201.60. The dialog said:

```
Next full period    CHF 129.78      <- should be ~CHF 3,460.93
Net settlement     -CHF 26.96
Nothing due today
```

CHF 129.78 is `145 x 27/30 x 0.92 x 1.081` — a **September stub priced from the monthly basis**. The change is scheduled to 1 October, where the fraction becomes 31/31, no stub exists, and the subscriber is charged the full year. So the field labelled "Next full period" described a period that will never be bought, understating the real recurring price by roughly 26x.

**Not a design choice.** Three places in the code already asserted the opposite:

- the response's own XML doc — *"What a full period costs at the target plan and price, once this change has settled"*
- a test named `NextRenewalAmountMinor_is_the_targets_own_full_period_total`
- the comment above the assignment — *"Already the whole target period, tax included, undiminished by proration."*

All three were false for a calendar-aligned target. The existing test passed only because its fixture uses an **anniversary** price, where no fraction is applied — the calendar case had no coverage at all.

A calendar-aligned **monthly** target hit the same defect without a stub basis in sight: no price swap, but the day fraction still scaled the figure being quoted as recurring.

## Root cause

In `SubscriptionProrationCalculator.Calculate`, the target side's `PeriodTotalMinor` is `newTaxInclusive` — which is computed **after** two reductions the recurring price must not carry:

1. the price is swapped to the linked monthly stub basis when the target is a calendar-aligned *yearly* price (`TryStubBasis`)
2. `targetFraction` is then applied to it

`SubscriptionPlanChangeService` read that figure straight into `NextRenewalAmountMinor`.

## The fix

`ProrationOutcome` gains `TargetFullPeriodTotalMinor` — the whole period at the target, priced against the **original** target price rather than the stub-swapped one, and with no fraction. The preview reads that.

Two deliberate placements:

- **On the outcome, not on `ProrationSide`.** A side is what reaches storage and the financial documents (`SettlementCharge.SideOf`, `SubscriptionSettlementBreakdown`, `PaymentDetail.SubscriptionSettlement`, the invoice HTML and its React mirror). Widening one would rewrite records already written. An outcome is returned by `Calculate` and never serialised.
- **Not `SubscriptionAmountCalculator.PeriodAmountMinor`**, which subtracts `CreditBalanceMinor`. The settlement already spends that same balance in `SettleRawDelta`, so a subscriber holding credit would have seen it deducted twice — once off the charge, and again off the recurring price they were quoted.

Guarded on `targetFraction.IsPartial`. That is not an optimisation: `CalendarBillingAlignment.Prorate` returns an amount **untouched** once `coveredDays >= totalDays`, so for a whole period the existing figure already *is* the full period, and reusing it makes every anniversary and land-on-the-first quote provably bit-identical rather than merely equal by inspection.

## What does not change

| Surface | Why |
|---|---|
| `ChargeMinor` — what is actually collected | The new figure is not an input to `SettleRawDelta` or any charge |
| `SubscriptionSettlementBreakdown`, `PaymentDetail.SubscriptionSettlement` | `ProrationSide` and `SettlementCharge.SideOf` untouched; no migration |
| Invoice HTML + React `financial-document-format.ts` | Same values into the same rows |
| `settlement.*` on the preview response | `SettlementResponseOf(outcome.Breakdown)` untouched |
| Timing (`Immediate` / `NextRenewal`) | `PlanChangeClassifier` still reads `rawSettlementMinor` |
| `nextRenewalAmountMinor` on subscribe + quantity-change previews | Different services — the quantity path computes its own via `PeriodAmountMinor` with no fraction, already correct |
| Anniversary and land-on-the-first previews | Bit-identical via the `IsPartial` guard |

No client change: `change-plan-dialog.tsx` already labels the field "Next full period", which is now true.

## Tests

**7 new** (4 calculator, 3 service), plus a full-period assertion added to an existing one. Each was written first, and every guard proved by reverting it.

### Routing — which figure, from which price

| Revert | Fails |
|---|---|
| the service repoint | `..._whole_year_for_a_calendar_aligned_yearly_target`, `..._whole_month_for_a_calendar_aligned_monthly_target` |
| `FullPeriod` against the stub-swapped price instead of the original | `A_calendar_yearly_target_recurs_at_the_annual_rate_not_the_monthly_stub`, `..._whole_year_...` |

### Pipeline — that the figure is actually priced

`FullPeriod` is two calls, `DiscountedAmountMinor` then `TaxBreakdownFor`. With a zero tax rate and no discount both are the identity function and it returns `UnitAmountMinor` verbatim — so a first pass at these tests pinned the routing but not the pricing. **Deleting the entire `TaxBreakdownFor` call passed all thirteen of them.** The fixtures now carry the rates from the report that motivated this: 8% for paying yearly, 8.1% VAT.

| Mutation inside `FullPeriod` | Killed by |
|---|---|
| drop the tax call | `..._whole_year_...` (exclusive, so the tax is visible in 1,193,424) |
| price the gross, not the discounted amount | 3 tests |
| hardcode / drop `TaxMode` | `A_tax_inclusive_target_recurs_at_its_own_configured_amount` |

The last one needs its own fixture: `TaxMode.Exclusive` is the enum's **default**, and on the yearly figure half-up and truncation coincide (`1,104,000 x 810/10000 = 89,424` exactly), so an exclusive assertion cannot catch a mode that was hardcoded or never passed. The inclusive test covers it from the other side — an exclusive reading reports 39,781, a null mode 39,780 — and cannot itself catch a *missing* tax call, since an inclusive total equals its input either way. The two are deliberately complementary, and each says so in its docstring.

### Regression

`NextRenewalAmountMinor_is_unchanged_for_an_anniversary_target_mid_period` passes before **and** after — the zero-regression guard, not a demonstration of the bug. `A_whole_target_period_reports_the_identical_figure_both_ways` pins the two figures as equal at 30/30.

Both new service tests also assert `Settlement.Target.PeriodTotalMinor` unchanged (95,282 and 2,613), so this cannot be mistaken for a repricing of the settlement. The stub figure shows both rounding rules at once: a **truncated** 8% off the 95,806 gross, then a **half-up** 8.1% on top.

**Verified:** `dotnet test --filter "FullyQualifiedName!~Integration"` — **3657 passed**. The 4 `SubscriptionSimulation*` permission-guard failures are pre-existing on `dev` and unrelated. Build clean. The pins at `SubscriptionPlanChangeServiceTests.cs:1136` and the original `:1245` both still pass.

## Not in this change

1. **Timing rests on the same phantom period.** For a scheduled monthly-to-yearly change the settlement — and therefore `PlanChangeClassifier`'s verdict — is priced against a stub the subscriber will never be on. Priced against what actually happens (a full year against a remaining month) the settlement is strongly positive, which classifies as `Immediate`. The "paid annual term always waits" guard does not fire, because it only tests the *current* price's cadence, not the target's. Whether monthly-to-yearly should charge immediately or wait for the boundary is a commercial decision, not a defect fix.
2. **The invoice "Full period" row is left alone.** Its *value* is defensible — for a calendar target the period really is the stub, which is what the invoice explains. Only the label over-promises; renaming it to "Period total" in `FinancialDocumentHtmlTemplate.cs` and `financial-document-format.ts` is value-preserving and cosmetic.
3. **Folding `CalculateOpeningStubUpgrade`'s equivalent pair onto `FullPeriod`** was considered and skipped. It needs the annual period's own `annualDiscountPeriodsApplied` (not the subscription's) and the full `PeriodCharge` including `DiscountApplied`, not just a total — so `FullPeriod` would have to change shape to serve it. More churn than value on a defect fix.
4. **Suspected, unproven:** the outgoing side may over-credit inside an opening stub. `oldTaxInclusive` is a full month scaled by the *stub's* elapsed ticks, so at the start of a 27-day stub it credits a full month's value against a stub that cost less. Worth its own test before any change.

## Manual verification

Not run here — needs the simulation harness against a live provider. In it: subscribe to a calendar-aligned monthly plan mid-month, preview a change to a calendar-aligned yearly price, and confirm "Next full period" now shows the annual amount plus tax while "Nothing due today" and the settlement rows are unchanged.

Note that reaching the harness currently depends on #424 (a blank `organizationId` is refused there today; `?organizationId=default` works meanwhile).

Base: `dev`.


