### PR TITLE
fix(subscription): activate on the webhook that confirms the payment

### DIFF
--- a/server/Payment.DomainService/Scheduling/PaymentWorkHandlers.cs
+++ b/server/Payment.DomainService/Scheduling/PaymentWorkHandlers.cs
@@ -51,7 +51,10 @@ public sealed class WebhookRecoveryWorkHandler : IPaymentWorkHandler
 
     public async Task<PaymentWorkOutcome> ExecuteAsync(PaymentBackgroundWork work, CancellationToken token)
     {
-        await _webhooks.ProcessDueAsync(work.TenantId, token);
+        // The transitioned payment ids go unused here on purpose: this handler lives in the
+        // payment domain and cannot reach subscriptions. The activation repair sweep still picks
+        // up anything this pass confirms.
+        _ = await _webhooks.ProcessDueAsync(work.TenantId, token);
         return PaymentWorkOutcome.Completed();
     }
 }

--- a/server/Payment.DomainService/Services/IPaymentWebhookProcessor.cs
+++ b/server/Payment.DomainService/Services/IPaymentWebhookProcessor.cs
@@ -8,7 +8,24 @@ using Payment.DomainService.Utilities;
 
 namespace Payment.DomainService.Services;
 
+/// <summary>
+/// What a webhook pass did: how many records it processed, and which payments those records
+/// moved.
+/// </summary>
+/// <remarks>
+/// The ids are reported because a caller that can see both domains — the worker — can settle the
+/// subscription waiting on a payment in the same tick the confirmation arrived, instead of
+/// leaving it to the next repair sweep. Nothing in the payment domain reads them.
+/// </remarks>
+public sealed record PaymentWebhookProcessingResult(
+    int ProcessedCount,
+    IReadOnlyList<string> TransitionedPaymentDetailIds)
+{
+    public static PaymentWebhookProcessingResult Empty { get; } =
+        new(0, Array.Empty<string>());
+}
+
 public interface IPaymentWebhookProcessor
 {
-    Task<int> ProcessDueAsync(string tenantId, CancellationToken cancellationToken);
+    Task<PaymentWebhookProcessingResult> ProcessDueAsync(string tenantId, CancellationToken cancellationToken);
 }

--- a/server/Payment.DomainService/Services/PaymentWebhookProcessor.cs
+++ b/server/Payment.DomainService/Services/PaymentWebhookProcessor.cs
@@ -31,7 +31,7 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
         _logger = logger;
     }
 
-    public async Task<int> ProcessDueAsync(string tenantId, CancellationToken cancellationToken)
+    public async Task<PaymentWebhookProcessingResult> ProcessDueAsync(string tenantId, CancellationToken cancellationToken)
     {
         var stopwatch = Stopwatch.StartNew();
         var options = _options.CurrentValue;
@@ -56,7 +56,7 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
                 tenantHash,
                 stopwatch.Elapsed.TotalMilliseconds);
 
-            return 0;
+            return PaymentWebhookProcessingResult.Empty;
         }
 
         _logger.LogInformation(
@@ -65,6 +65,12 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
             due.Count);
 
         var processed = 0;
+
+        // The payments this pass actually transitioned, in the order they were applied. Ordinal
+        // dedupe because two events for one payment in a single batch is ordinary — an
+        // authorisation and its capture, say — and the caller should look the link up once.
+        var transitioned = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (var candidate in due)
         {
@@ -134,6 +140,17 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
                 await _inbox.MarkProcessedAsync(tenantId, claimed.WebhookId, leaseId, cancellationToken);
                 processed++;
 
+                // Only after the record is marked processed: an id reported for a transition that
+                // then failed to commit would send the caller looking for a confirmation that
+                // does not exist.
+                var paymentDetailId = claimed.NormalizedPayload.PaymentDetailId;
+
+                if (!string.IsNullOrWhiteSpace(paymentDetailId) &&
+                    seen.Add(paymentDetailId))
+                {
+                    transitioned.Add(paymentDetailId);
+                }
+
                 _logger.LogInformation(
                     "Webhook worker record completed FinalStatus=Processed DurationMs={DurationMs}",
                     itemStopwatch.Elapsed.TotalMilliseconds);
@@ -188,6 +205,6 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
             processed,
             stopwatch.Elapsed.TotalMilliseconds);
 
-        return processed;
+        return new PaymentWebhookProcessingResult(processed, transitioned);
     }
 }

--- a/server/Subscription.DomainService/Outbox/ISubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/ISubscriptionActivationProcessor.cs
@@ -21,6 +21,27 @@ public interface ISubscriptionActivationProcessor
     Task<bool> SettleLinkAsync(SubscriptionPaymentLink link, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Settles the links waiting on these specific payments, whatever their own retry schedule
+    /// says.
+    /// </summary>
+    /// <remarks>
+    /// The fast path for a confirmation that has just arrived. A webhook consumer holds both the
+    /// confirmation and the subscription in one tick, and without this the link is only looked at
+    /// when its deferred <c>NextCheckAtUtc</c> comes round — or, failing that, by the repair
+    /// sweep two minutes later, which is where the paid-but-inactive window came from.
+    ///
+    /// Deliberately does nothing at all to a payment that is still undecided: no reschedule, no
+    /// attempt burned, no audit row. Retry accounting belongs to the sweep alone, and a targeted
+    /// pass that deferred would push the sweep's next look further out, making activation slower
+    /// rather than faster.
+    /// </remarks>
+    /// <returns>How many links were settled.</returns>
+    Task<int> SettleForPaymentsAsync(
+        string tenantId,
+        IReadOnlyCollection<string> paymentDetailIds,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Finds subscriptions whose first charge was raised but never recorded, and either
     /// recovers the link or gives up on them.
     /// </summary>

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -124,6 +124,52 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         CancellationToken cancellationToken) =>
         SettleAsync(link, _options.CurrentValue, _time.GetUtcNow().UtcDateTime, cancellationToken);
 
+    public async Task<int> SettleForPaymentsAsync(
+        string tenantId,
+        IReadOnlyCollection<string> paymentDetailIds,
+        CancellationToken cancellationToken)
+    {
+        if (paymentDetailIds is null || paymentDetailIds.Count == 0)
+        {
+            return 0;
+        }
+
+        var settled = 0;
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var paymentDetailId in paymentDetailIds)
+        {
+            if (string.IsNullOrWhiteSpace(paymentDetailId) ||
+                !seen.Add(paymentDetailId))
+            {
+                continue;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // A point read, not a scan: (TenantId, PaymentDetailId) is uniquely indexed.
+            var link = await _links.FindByPaymentAsync(
+                tenantId,
+                paymentDetailId,
+                cancellationToken);
+
+            // No link means this payment is not a subscription's — most payments are not — and a
+            // link that is no longer pending has already had its outcome carried across.
+            if (link is null ||
+                link.State != SubscriptionPaymentLinkState.Pending)
+            {
+                continue;
+            }
+
+            if (await SettleDecidedAsync(link, cancellationToken))
+            {
+                settled++;
+            }
+        }
+
+        return settled;
+    }
+
     public async Task<int> RecoverStaleAsync(
         string tenantId,
         CancellationToken cancellationToken)
@@ -211,20 +257,34 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
         return recovered;
     }
 
-    private async Task<bool> SettleAsync(
+    /// <summary>What the payment behind a link says should happen to it.</summary>
+    private enum SettlementOutcome
+    {
+        /// <summary>The money is ours and a webhook said so.</summary>
+        Activate,
+
+        /// <summary>The payment will never be confirmed.</summary>
+        Abandon,
+
+        /// <summary>Still in flight. Nothing to carry across yet.</summary>
+        Undecided,
+
+        /// <summary>The payment row could not be read at all.</summary>
+        PaymentMissing
+    }
+
+    /// <summary>
+    /// Reads the payment behind a link and decides its fate, without acting on it.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the sweep and the targeted pass so the two can never disagree about what a
+    /// payment status means. Only what happens to an undecided payment differs, and that is the
+    /// callers' business rather than this method's.
+    /// </remarks>
+    private async Task<(SettlementOutcome Outcome, PaymentDetail? Payment)> ClassifyAsync(
         SubscriptionPaymentLink link,
-        SubscriptionOptions options,
-        DateTime now,
         CancellationToken cancellationToken)
     {
-        using var logScope = _logger.BeginScope(new Dictionary<string, object?>
-        {
-            ["TenantHash"] = PaymentLogValue.Hash(link.TenantId),
-            ["SubscriptionHash"] = PaymentLogValue.Hash(link.SubscriptionId),
-            ["CorrelationId"] = link.CorrelationId
-        });
-        await AuditAsync(link, "SettlementStarted", "InProgress", null, cancellationToken);
-
         var payment = await _payments.GetByIdAsync(
             link.TenantId,
             link.PaymentDetailId,
@@ -232,39 +292,129 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
 
         if (payment is null)
         {
-            await RescheduleAsync(link, options, now, "payment_not_found", cancellationToken);
-            await AuditAsync(link, "PaymentRead", "Deferred", "payment_not_found", cancellationToken);
-
-            return false;
+            return (SettlementOutcome.PaymentMissing, null);
         }
 
         if (IsConfirmed(payment))
         {
-            var activated = await ActivateAsync(link, payment, cancellationToken);
-            await AuditAsync(link, "ActivationApplied", activated ? "Succeeded" : "Deferred",
-                activated ? null : "activation_state_conflict", cancellationToken);
-            return activated;
+            return (SettlementOutcome.Activate, payment);
         }
 
         if (TerminalFailureStatuses.Contains(payment.PaymentStatus, StringComparer.Ordinal))
         {
-            var abandoned = await AbandonAsync(link, cancellationToken);
-            await AuditAsync(link, "PaymentConfirmed", "Failed",
-                payment.PaymentStatus, cancellationToken);
-            return abandoned;
+            return (SettlementOutcome.Abandon, payment);
         }
 
-        await RescheduleAsync(
-            link,
-            options,
-            now,
-            $"awaiting_confirmation:{PaymentLogValue.Label(payment.PaymentStatus)}",
-            cancellationToken);
-        await AuditAsync(link, "PaymentConfirmation", "Deferred",
+        return (SettlementOutcome.Undecided, payment);
+    }
+
+    /// <summary>
+    /// The sweep's pass over one link: settles it when the payment has decided, and defers it,
+    /// burning an attempt, when it has not.
+    /// </summary>
+    private async Task<bool> SettleAsync(
+        SubscriptionPaymentLink link,
+        SubscriptionOptions options,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        using var logScope = BeginLinkScope(link);
+        await AuditAsync(link, "SettlementStarted", "InProgress", null, cancellationToken);
+
+        var (outcome, payment) = await ClassifyAsync(link, cancellationToken);
+
+        switch (outcome)
+        {
+            case SettlementOutcome.PaymentMissing:
+                await RescheduleAsync(link, options, now, "payment_not_found", cancellationToken);
+                await AuditAsync(link, "PaymentRead", "Deferred", "payment_not_found", cancellationToken);
+
+                return false;
+
+            case SettlementOutcome.Activate:
+                return await ApplyActivationAsync(link, payment!, cancellationToken);
+
+            case SettlementOutcome.Abandon:
+                return await ApplyAbandonmentAsync(link, payment!, cancellationToken);
+
+            default:
+                await RescheduleAsync(
+                    link,
+                    options,
+                    now,
+                    $"awaiting_confirmation:{PaymentLogValue.Label(payment!.PaymentStatus)}",
+                    cancellationToken);
+                await AuditAsync(link, "PaymentConfirmation", "Deferred",
+                    payment.PaymentStatus, cancellationToken);
+
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// The targeted pass over one link: settles it when the payment has decided, and otherwise
+    /// leaves it exactly as it found it.
+    /// </summary>
+    /// <remarks>
+    /// Nothing is written for an undecided payment — not <c>AttemptCount</c>, not
+    /// <c>NextCheckAtUtc</c>, not an audit row. This runs on every webhook tick, so deferring here
+    /// would burn attempts against <c>ActivationMaxAttempts</c>, push the sweep's next look
+    /// further out, and fill the trail with deferral pairs. The sweep keeps sole ownership of
+    /// retry accounting.
+    /// </remarks>
+    private async Task<bool> SettleDecidedAsync(
+        SubscriptionPaymentLink link,
+        CancellationToken cancellationToken)
+    {
+        using var logScope = BeginLinkScope(link);
+
+        // Classified before the first audit row is written, so an undecided payment leaves no
+        // trace at all.
+        var (outcome, payment) = await ClassifyAsync(link, cancellationToken);
+
+        if (outcome is SettlementOutcome.Undecided or SettlementOutcome.PaymentMissing)
+        {
+            return false;
+        }
+
+        await AuditAsync(link, "SettlementStarted", "InProgress", null, cancellationToken);
+
+        return outcome == SettlementOutcome.Activate
+            ? await ApplyActivationAsync(link, payment!, cancellationToken)
+            : await ApplyAbandonmentAsync(link, payment!, cancellationToken);
+    }
+
+    private async Task<bool> ApplyActivationAsync(
+        SubscriptionPaymentLink link,
+        PaymentDetail payment,
+        CancellationToken cancellationToken)
+    {
+        var activated = await ActivateAsync(link, payment, cancellationToken);
+        await AuditAsync(link, "ActivationApplied", activated ? "Succeeded" : "Deferred",
+            activated ? null : "activation_state_conflict", cancellationToken);
+
+        return activated;
+    }
+
+    private async Task<bool> ApplyAbandonmentAsync(
+        SubscriptionPaymentLink link,
+        PaymentDetail payment,
+        CancellationToken cancellationToken)
+    {
+        var abandoned = await AbandonAsync(link, cancellationToken);
+        await AuditAsync(link, "PaymentConfirmed", "Failed",
             payment.PaymentStatus, cancellationToken);
 
-        return false;
+        return abandoned;
     }
+
+    private IDisposable? BeginLinkScope(SubscriptionPaymentLink link) =>
+        _logger.BeginScope(new Dictionary<string, object?>
+        {
+            ["TenantHash"] = PaymentLogValue.Hash(link.TenantId),
+            ["SubscriptionHash"] = PaymentLogValue.Hash(link.SubscriptionId),
+            ["CorrelationId"] = link.CorrelationId
+        });
 
     private Task AuditAsync(
         SubscriptionPaymentLink link,

--- a/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
+++ b/server/Subscription.DomainService/Outbox/SubscriptionActivationProcessor.cs
@@ -337,7 +337,7 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
             case SettlementOutcome.Abandon:
                 return await ApplyAbandonmentAsync(link, payment!, cancellationToken);
 
-            default:
+            case SettlementOutcome.Undecided:
                 await RescheduleAsync(
                     link,
                     options,
@@ -348,6 +348,13 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
                     payment.PaymentStatus, cancellationToken);
 
                 return false;
+
+            // Named rather than folded into the reschedule branch above: a new outcome silently
+            // treated as "still in flight" would defer a link forever, and the branch it landed
+            // in dereferences a payment that PaymentMissing does not have.
+            default:
+                throw new InvalidOperationException(
+                    $"Unhandled settlement outcome {outcome}.");
         }
     }
 
@@ -379,9 +386,15 @@ public sealed class SubscriptionActivationProcessor : ISubscriptionActivationPro
 
         await AuditAsync(link, "SettlementStarted", "InProgress", null, cancellationToken);
 
-        return outcome == SettlementOutcome.Activate
-            ? await ApplyActivationAsync(link, payment!, cancellationToken)
-            : await ApplyAbandonmentAsync(link, payment!, cancellationToken);
+        return outcome switch
+        {
+            SettlementOutcome.Activate =>
+                await ApplyActivationAsync(link, payment!, cancellationToken),
+            SettlementOutcome.Abandon =>
+                await ApplyAbandonmentAsync(link, payment!, cancellationToken),
+            _ => throw new InvalidOperationException(
+                $"Unhandled settlement outcome {outcome}.")
+        };
     }
 
     private async Task<bool> ApplyActivationAsync(

--- a/server/Worker/Consumers/Payment/PaymentWorkCommandConsumer.cs
+++ b/server/Worker/Consumers/Payment/PaymentWorkCommandConsumer.cs
@@ -96,10 +96,11 @@ public sealed class PaymentWorkCommandConsumer :
             IPaymentOutboxProcessor>();
         var refundOutbox = services.GetRequiredService<
             IPaymentRefundOutboxProcessor>();
-        var processedWebhooks =
+        var webhookResult =
             await webhooks.ProcessDueAsync(
                 command.TenantId,
                 CancellationToken.None);
+        var processedWebhooks = webhookResult.ProcessedCount;
         var publishedPaymentEvents =
             await paymentOutbox.PublishDueAsync(
                 command.TenantId,
@@ -151,6 +152,15 @@ public sealed class PaymentWorkCommandConsumer :
             ISubscriptionActivationProcessor>();
         var subscriptionOutbox = services.GetRequiredService<
             ISubscriptionOutboxProcessor>();
+        // The fast path. This tick holds both the confirmation and the subscription waiting on
+        // it, so settle that exact link now rather than waiting for its deferred next-check to
+        // come round — or, failing that, the two-minute repair sweep. Runs before the sweep
+        // below so a link settled here is no longer pending and is not looked at twice.
+        var targetedSettlements =
+            await subscriptionActivation.SettleForPaymentsAsync(
+                command.TenantId,
+                webhookResult.TransitionedPaymentDetailIds,
+                CancellationToken.None);
         var activatedSubscriptions =
             await subscriptionActivation.ProcessDueAsync(
                 command.TenantId,
@@ -161,12 +171,13 @@ public sealed class PaymentWorkCommandConsumer :
                 CancellationToken.None);
 
         _logger.LogInformation(
-            "Payment work command processing completed Phase={Phase} DurationMs={DurationMs} ProcessedWebhookCount={ProcessedWebhookCount} PublishedPaymentEventCount={PublishedPaymentEventCount} PublishedRefundEventCount={PublishedRefundEventCount} ActivatedSubscriptionCount={ActivatedSubscriptionCount} PublishedSubscriptionEventCount={PublishedSubscriptionEventCount}",
+            "Payment work command processing completed Phase={Phase} DurationMs={DurationMs} ProcessedWebhookCount={ProcessedWebhookCount} PublishedPaymentEventCount={PublishedPaymentEventCount} PublishedRefundEventCount={PublishedRefundEventCount} TargetedSettlementCount={TargetedSettlementCount} ActivatedSubscriptionCount={ActivatedSubscriptionCount} PublishedSubscriptionEventCount={PublishedSubscriptionEventCount}",
             PaymentPhases.Completed,
             stopwatch.Elapsed.TotalMilliseconds,
             processedWebhooks,
             publishedPaymentEvents,
             publishedRefundEvents,
+            targetedSettlements,
             activatedSubscriptions,
             publishedSubscriptionEvents);
     }

--- a/server/Worker/PaymentReconciliationBackgroundService.cs
+++ b/server/Worker/PaymentReconciliationBackgroundService.cs
@@ -80,7 +80,9 @@ public sealed class PaymentReconciliationBackgroundService : BackgroundService
             .RecoverDueAsync(tenantId, token);
         await services.GetRequiredService<IPaymentRefundRecoveryProcessor>()
             .RecoverDueAsync(tenantId, token);
-        await services.GetRequiredService<IPaymentWebhookProcessor>()
+        // Result discarded: the targeted subscription settle rides the webhook-driven work
+        // command, and this periodic reconciliation pass has the repair sweep behind it.
+        _ = await services.GetRequiredService<IPaymentWebhookProcessor>()
             .ProcessDueAsync(tenantId, token);
         await services.GetRequiredService<IStoredPaymentMethodRemovalRecoveryProcessor>()
             .RecoverDueRemovalsAsync(tenantId, token);

--- a/server/XUnitTest/Payment/PaymentWebhookProcessorTests.cs
+++ b/server/XUnitTest/Payment/PaymentWebhookProcessorTests.cs
@@ -46,9 +46,9 @@ public sealed class PaymentWebhookProcessorTests
     {
         SetupDue();
 
-        var processed = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
 
-        processed.Should().Be(0);
+        result.ProcessedCount.Should().Be(0);
         _inbox.Verify(i => i.TryClaimAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -59,9 +59,9 @@ public sealed class PaymentWebhookProcessorTests
         _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((PaymentWebhookInbox?)null);
 
-        var processed = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
 
-        processed.Should().Be(0);
+        result.ProcessedCount.Should().Be(0);
         _transitions.Verify(t => t.ApplyAsync(It.IsAny<PaymentWebhookInbox>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -73,9 +73,9 @@ public sealed class PaymentWebhookProcessorTests
         _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(candidate);
 
-        var processed = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
 
-        processed.Should().Be(1);
+        result.ProcessedCount.Should().Be(1);
         _inbox.Verify(i => i.MarkProcessedAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -88,9 +88,9 @@ public sealed class PaymentWebhookProcessorTests
             .ReturnsAsync(candidate);
         _transitions.Setup(t => t.ApplyAsync(candidate, It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("boom"));
 
-        var processed = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
 
-        processed.Should().Be(0);
+        result.ProcessedCount.Should().Be(0);
         _inbox.Verify(i => i.MarkFailedAsync("tenant", "wh-1", It.IsAny<string>(), PaymentWebhookStatus.RetryScheduled, 1, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Once);
         _workDispatcher.Verify(d => d.TryDispatchAsync("tenant", false, It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -105,10 +105,97 @@ public sealed class PaymentWebhookProcessorTests
             .ReturnsAsync(candidate);
         _transitions.Setup(t => t.ApplyAsync(candidate, It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("boom"));
 
-        var processed = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
 
-        processed.Should().Be(0);
+        result.ProcessedCount.Should().Be(0);
         _inbox.Verify(i => i.MarkFailedAsync("tenant", "wh-1", It.IsAny<string>(), PaymentWebhookStatus.DeadLettered, 3, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Once);
         _workDispatcher.Verify(d => d.TryDispatchAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<DateTimeOffset?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Why the ids are reported at all: the worker joins them to the subscription waiting on the
+    /// payment and activates it in this same tick, instead of leaving it to a repair sweep two
+    /// minutes out.
+    /// </summary>
+    [Fact]
+    public async Task ProcessDueAsync_TransitionSucceeds_ReportsTheTransitionedPayment()
+    {
+        var candidate = Candidate();
+        SetupDue(candidate);
+        _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(candidate);
+
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+
+        result.TransitionedPaymentDetailIds.Should().Equal("pay-1");
+    }
+
+    /// <summary>
+    /// Two events for one payment in a single batch is ordinary — an authorisation and its
+    /// capture, say — and the caller should look its link up once.
+    /// </summary>
+    [Fact]
+    public async Task ProcessDueAsync_TwoEventsForOnePayment_ReportsItOnce()
+    {
+        var first = Candidate();
+        var second = Candidate();
+        second.WebhookId = "wh-2";
+        second.EventCode = "CAPTURE";
+        SetupDue(first, second);
+        _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(first);
+        _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-2", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(second);
+
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+
+        result.ProcessedCount.Should().Be(2);
+        result.TransitionedPaymentDetailIds.Should().Equal("pay-1");
+    }
+
+    [Fact]
+    public async Task ProcessDueAsync_ClaimSkipped_ReportsNoTransitionedPayments()
+    {
+        SetupDue(Candidate());
+        _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PaymentWebhookInbox?)null);
+
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+
+        result.TransitionedPaymentDetailIds.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// An id reported for a transition that failed would send the worker looking for a
+    /// confirmation that does not exist.
+    /// </summary>
+    [Fact]
+    public async Task ProcessDueAsync_TransitionThrows_ReportsNoTransitionedPayments()
+    {
+        var candidate = Candidate();
+        SetupDue(candidate);
+        _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(candidate);
+        _transitions.Setup(t => t.ApplyAsync(candidate, It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("boom"));
+
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+
+        result.TransitionedPaymentDetailIds.Should().BeEmpty();
+    }
+
+    /// <summary>A webhook that names no payment — a dispute or account event — reports nothing.</summary>
+    [Fact]
+    public async Task ProcessDueAsync_WebhookWithoutAPaymentId_ReportsNoTransitionedPayments()
+    {
+        var candidate = Candidate();
+        candidate.NormalizedPayload.PaymentDetailId = null;
+        SetupDue(candidate);
+        _inbox.Setup(i => i.TryClaimAsync("tenant", "wh-1", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(candidate);
+
+        var result = await CreateService().ProcessDueAsync("tenant", CancellationToken.None);
+
+        result.ProcessedCount.Should().Be(1);
+        result.TransitionedPaymentDetailIds.Should().BeEmpty();
     }
 }

--- a/server/XUnitTest/Payment/PaymentWorkCommandConsumerTests.cs
+++ b/server/XUnitTest/Payment/PaymentWorkCommandConsumerTests.cs
@@ -73,7 +73,7 @@ public sealed class PaymentWorkCommandConsumerTests
             .Setup(processor => processor.ProcessDueAsync(
                 It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Callback(() => observed = PaymentCorrelation.Current)
-            .ReturnsAsync(0);
+            .ReturnsAsync(PaymentWebhookProcessingResult.Empty);
 
         await fixture.Consumer.Consume(new ProcessPaymentWorkCommand
         {
@@ -98,7 +98,7 @@ public sealed class PaymentWorkCommandConsumerTests
             .Setup(processor => processor.ProcessDueAsync(
                 It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Callback(() => observed = PaymentCorrelation.Current)
-            .ReturnsAsync(0);
+            .ReturnsAsync(PaymentWebhookProcessingResult.Empty);
 
         await fixture.Consumer.Consume(new ProcessPaymentWorkCommand
         {
@@ -146,6 +146,38 @@ public sealed class PaymentWorkCommandConsumerTests
         PaymentCorrelation.Current.Should().Be("none");
     }
 
+    /// <summary>
+    /// The fast path: this tick holds both the confirmation and the subscription waiting on it.
+    /// </summary>
+    /// <remarks>
+    /// The targeted settle must run <em>before</em> the due sweep, so a link it settles is no
+    /// longer pending and the sweep does not look at the same link twice in one tick. The sweep
+    /// still runs — it remains the backstop for everything the webhook did not name.
+    /// </remarks>
+    [Fact]
+    public async Task Consume_settles_the_confirmed_payments_links_before_running_the_sweep()
+    {
+        var fixture = new Fixture();
+
+        await fixture.Consumer.Consume(new ProcessPaymentWorkCommand
+        {
+            TenantId = TenantId
+        });
+
+        fixture.SubscriptionActivation.Verify(processor => processor.SettleForPaymentsAsync(
+                TenantId,
+                It.Is<IReadOnlyCollection<string>>(ids => ids.SequenceEqual(new[] { "pay-1" })),
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the ids the webhook pass just transitioned are what makes the direct lookup possible");
+        fixture.SubscriptionActivation.Verify(processor => processor.ProcessDueAsync(
+                TenantId,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the sweep keeps its job as the backstop");
+        fixture.SubscriptionCalls.Should().Equal("settle-for-payments", "process-due");
+    }
+
     private sealed class Fixture
     {
         public Mock<IPaymentWebhookProcessor> Webhooks { get; } = new();
@@ -158,6 +190,9 @@ public sealed class PaymentWorkCommandConsumerTests
         public Mock<IPaymentCaptureRecoveryProcessor> CaptureRecovery { get; } = new();
         public Mock<ISubscriptionActivationProcessor> SubscriptionActivation { get; } = new();
         public Mock<ISubscriptionOutboxProcessor> SubscriptionOutbox { get; } = new();
+
+        /// <summary>The order the subscription passes ran in, which is the thing under test.</summary>
+        public List<string> SubscriptionCalls { get; } = [];
         public PaymentWorkCommandConsumer Consumer { get; }
 
         public Fixture()
@@ -168,7 +203,7 @@ public sealed class PaymentWorkCommandConsumerTests
             Webhooks.Setup(processor => processor.ProcessDueAsync(
                     TenantId,
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(1);
+                .ReturnsAsync(new PaymentWebhookProcessingResult(1, ["pay-1"]));
             PaymentOutbox.Setup(processor => processor.PublishDueAsync(
                     TenantId,
                     It.IsAny<CancellationToken>()))
@@ -194,6 +229,17 @@ public sealed class PaymentWorkCommandConsumerTests
                     TenantId,
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(1);
+            SubscriptionActivation.Setup(processor => processor.SettleForPaymentsAsync(
+                    TenantId,
+                    It.IsAny<IReadOnlyCollection<string>>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => SubscriptionCalls.Add("settle-for-payments"))
+                .ReturnsAsync(1);
+            SubscriptionActivation.Setup(processor => processor.ProcessDueAsync(
+                    TenantId,
+                    It.IsAny<CancellationToken>()))
+                .Callback(() => SubscriptionCalls.Add("process-due"))
+                .ReturnsAsync(0);
 
             var services = new ServiceCollection();
             services.AddSingleton(contexts.Object);

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -833,6 +833,8 @@ public sealed class SubscriptionActivationProcessorTests
 
     private readonly Mock<ISubscriptionRenewalService> _renewals = new();
 
+    private readonly Mock<ISubscriptionAuditTrail> _audit = new();
+
     private SubscriptionActivationProcessor Processor() => new(
         _links.Object,
         _subscriptions.Object,
@@ -843,8 +845,202 @@ public sealed class SubscriptionActivationProcessorTests
         new SubscriptionOptionsMonitorStub(new SubscriptionOptions()),
         NullLogger<SubscriptionActivationProcessor>.Instance,
         _time,
+        audit: _audit.Object,
         renewals: _renewals.Object,
         documents: _documents.Object);
+
+    /// <summary>
+    /// The reported bug: a paid signup sat Incomplete for 128 seconds.
+    /// </summary>
+    /// <remarks>
+    /// The first settlement pass ran before Stripe had decided, so it deferred the link 30 seconds
+    /// out. The webhook then arrived inside that window — the worker held the confirmation and the
+    /// subscription in the same tick — but the sweep only ever asks which links are <em>due</em>,
+    /// and this one was not for another 20 seconds. Nothing re-fires at the 30-second mark, so the
+    /// activation fell through to the two-minute repair sweep.
+    /// </remarks>
+    [Fact]
+    public async Task A_confirmed_payment_settles_its_link_even_before_its_next_check_is_due()
+    {
+        GivenLinkForPayment(nextCheckAtUtc: _time.GetUtcNow().UtcDateTime.AddSeconds(20));
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            ["pay-1"],
+            CancellationToken.None);
+
+        settled.Should().Be(1);
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.Active);
+    }
+
+    /// <summary>
+    /// The rule that keeps the fast path from making things slower: retry accounting belongs to
+    /// the sweep alone.
+    /// </summary>
+    /// <remarks>
+    /// This runs on every webhook tick, and a great many of those carry a payment that is still in
+    /// flight. Deferring here would burn attempts against <c>ActivationMaxAttempts</c>, push the
+    /// sweep's next look further out, and fill the audit trail with deferral pairs.
+    /// </remarks>
+    [Fact]
+    public async Task An_undecided_payment_leaves_its_link_completely_untouched()
+    {
+        GivenLinkForPayment(attemptCount: 1);
+        GivenPayment(PaymentStatuses.Processing, webhookConfirmed: false);
+
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            ["pay-1"],
+            CancellationToken.None);
+
+        settled.Should().Be(0);
+        _links.Verify(
+            repository => repository.RescheduleAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "deferring here would spend an attempt the sweep is counting, and move its next " +
+            "look further away");
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionPaymentLinkState>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _audit.Verify(
+            trail => trail.RecordAsync(
+                It.IsAny<SubscriptionAuditEvent>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "a pass that decided nothing has nothing to record, and this one runs on every tick");
+    }
+
+    [Fact]
+    public async Task A_terminally_refused_payment_is_abandoned_through_the_targeted_path()
+    {
+        GivenLinkForPayment();
+        GivenPayment(PaymentStatuses.Refused, webhookConfirmed: true);
+
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            ["pay-1"],
+            CancellationToken.None);
+
+        settled.Should().Be(1);
+        _transition!.NewStatus.Should().Be(SubscriptionStatus.IncompleteExpired);
+    }
+
+    [Fact]
+    public async Task A_payment_no_subscription_is_waiting_on_is_a_no_op()
+    {
+        // FindByPaymentAsync unmocked: most payments are not a subscription's.
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            ["pay-1"],
+            CancellationToken.None);
+
+        settled.Should().Be(0);
+        _payments.Verify(
+            repository => repository.GetByIdAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "there is no link to settle, so there is no reason to read the payment");
+    }
+
+    [Fact]
+    public async Task A_link_whose_outcome_was_already_applied_is_a_no_op()
+    {
+        GivenLinkForPayment(state: SubscriptionPaymentLinkState.Applied);
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            ["pay-1"],
+            CancellationToken.None);
+
+        settled.Should().Be(0);
+        _subscriptions.Verify(
+            repository => repository.TryTransitionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "this outcome has already been carried across");
+    }
+
+    /// <summary>
+    /// The targeted pass now races the sweep, the durable queue and other replicas.
+    /// </summary>
+    /// <remarks>
+    /// The transition is a compare-and-set, so exactly one racer wins it. A loser must leave the
+    /// link pending: settling it would erase the record the winner still needs to settle itself.
+    /// </remarks>
+    [Fact]
+    public async Task Losing_the_transition_race_through_the_targeted_path_leaves_the_link_unsettled()
+    {
+        GivenLinkForPayment();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId,
+                "sub-1",
+                It.IsAny<SubscriptionTransition>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            ["pay-1"],
+            CancellationToken.None);
+
+        settled.Should().Be(0);
+        _links.Verify(
+            repository => repository.TrySettleAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<SubscriptionPaymentLinkState>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the winner of the transition settles the link; a loser that settled it first would " +
+            "take that record away");
+    }
+
+    /// <summary>The link the targeted pass finds by payment id, rather than by being due.</summary>
+    private void GivenLinkForPayment(
+        SubscriptionPaymentLinkState state = SubscriptionPaymentLinkState.Pending,
+        DateTime? nextCheckAtUtc = null,
+        int attemptCount = 0,
+        SubscriptionPaymentPurpose purpose = SubscriptionPaymentPurpose.InitialCharge) =>
+        _links
+            .Setup(repository => repository.FindByPaymentAsync(
+                TenantId,
+                "pay-1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SubscriptionPaymentLink
+            {
+                ItemId = "link-1",
+                TenantId = TenantId,
+                OrganizationId = "org-1",
+                SubscriptionId = "sub-1",
+                PaymentDetailId = "pay-1",
+                Purpose = purpose,
+                CorrelationId = "corr-1",
+                State = state,
+                AttemptCount = attemptCount,
+                NextCheckAtUtc = nextCheckAtUtc ?? _time.GetUtcNow().UtcDateTime
+            });
 
     private static SubscriptionDetail NewSubscription() => new()
     {

--- a/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionActivationProcessorTests.cs
@@ -367,19 +367,29 @@ public sealed class SubscriptionActivationProcessorTests
                 It.IsAny<DateTime>(),
                 It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(
-            [
-                new SubscriptionPaymentLink
-                {
-                    ItemId = "link-1",
-                    TenantId = TenantId,
-                    OrganizationId = "org-1",
-                    SubscriptionId = "sub-1",
-                    PaymentDetailId = "pay-1",
-                    Purpose = purpose,
-                    CorrelationId = "corr-1"
-                }
-            ]);
+            .ReturnsAsync([NewLink(purpose)]);
+
+    /// <summary>
+    /// The link both settlement paths act on. Shared so the sweep and the targeted pass are
+    /// provably testing the same object rather than two literals that can drift apart.
+    /// </summary>
+    private static SubscriptionPaymentLink NewLink(
+        SubscriptionPaymentPurpose purpose = SubscriptionPaymentPurpose.InitialCharge,
+        SubscriptionPaymentLinkState state = SubscriptionPaymentLinkState.Pending,
+        DateTime? nextCheckAtUtc = null,
+        int attemptCount = 0) => new()
+    {
+        ItemId = "link-1",
+        TenantId = TenantId,
+        OrganizationId = "org-1",
+        SubscriptionId = "sub-1",
+        PaymentDetailId = "pay-1",
+        Purpose = purpose,
+        CorrelationId = "corr-1",
+        State = state,
+        AttemptCount = attemptCount,
+        NextCheckAtUtc = nextCheckAtUtc
+    };
 
     private void GivenPayment(
         string status,
@@ -1017,6 +1027,69 @@ public sealed class SubscriptionActivationProcessorTests
             "take that record away");
     }
 
+    /// <summary>
+    /// The second dedupe on this path — the webhook processor already dedupes its own batch — and
+    /// the one that protects the point read.
+    /// </summary>
+    /// <remarks>
+    /// Pinned rather than left to inspection precisely because it looks redundant: someone
+    /// removing it as duplication would otherwise break nothing, and the link would be looked up
+    /// and settled once per event naming the same payment.
+    /// </remarks>
+    [Fact]
+    public async Task A_payment_named_twice_in_one_call_is_looked_up_and_settled_once()
+    {
+        GivenLinkForPayment();
+        GivenPayment(PaymentStatuses.Authorized, webhookConfirmed: true);
+
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            ["pay-1", "pay-1"],
+            CancellationToken.None);
+
+        settled.Should().Be(1);
+        _links.Verify(
+            repository => repository.FindByPaymentAsync(
+                TenantId,
+                "pay-1",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Most webhook ticks confirm nothing a subscription is waiting on, so the common case must
+    /// cost no database calls at all.
+    /// </summary>
+    [Fact]
+    public async Task A_tick_that_transitioned_no_payments_touches_nothing()
+    {
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            [],
+            CancellationToken.None);
+
+        settled.Should().Be(0);
+        _links.VerifyNoOtherCalls();
+        _payments.VerifyNoOtherCalls();
+        _subscriptions.VerifyNoOtherCalls();
+    }
+
+    /// <summary>
+    /// Defensive: the parameter is non-nullable, so this guards against a caller that ignores
+    /// that rather than against anything the worker does today.
+    /// </summary>
+    [Fact]
+    public async Task A_null_collection_is_treated_as_nothing_to_settle()
+    {
+        var settled = await Processor().SettleForPaymentsAsync(
+            TenantId,
+            null!,
+            CancellationToken.None);
+
+        settled.Should().Be(0);
+        _links.VerifyNoOtherCalls();
+    }
+
     /// <summary>The link the targeted pass finds by payment id, rather than by being due.</summary>
     private void GivenLinkForPayment(
         SubscriptionPaymentLinkState state = SubscriptionPaymentLinkState.Pending,
@@ -1028,19 +1101,11 @@ public sealed class SubscriptionActivationProcessorTests
                 TenantId,
                 "pay-1",
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new SubscriptionPaymentLink
-            {
-                ItemId = "link-1",
-                TenantId = TenantId,
-                OrganizationId = "org-1",
-                SubscriptionId = "sub-1",
-                PaymentDetailId = "pay-1",
-                Purpose = purpose,
-                CorrelationId = "corr-1",
-                State = state,
-                AttemptCount = attemptCount,
-                NextCheckAtUtc = nextCheckAtUtc ?? _time.GetUtcNow().UtcDateTime
-            });
+            .ReturnsAsync(NewLink(
+                purpose,
+                state,
+                nextCheckAtUtc ?? _time.GetUtcNow().UtcDateTime,
+                attemptCount));
 
     private static SubscriptionDetail NewSubscription() => new()
     {


### PR DESCRIPTION
## The problem

A paid signup took **128 seconds** to move from `Incomplete` to `Active`, even though the money was taken immediately. Nothing was broken — the subscription was always going to activate — but it went out through the slow path instead of the fast one.

1. `POST /api/subscriptions` created the subscription as `Incomplete`, raised the charge, and wrote a `SubscriptionPaymentLink` (`State = Pending`).
2. The worker ran a settlement pass in the same second. Stripe was still `PROCESSING` with no webhook yet, so `RescheduleAsync` deferred the link: `AttemptCount = 1`, `NextCheckAtUtc = now + 30s`.
3. **The webhook arrived inside that 30-second window.** The consumer applied it (setting `WebhookConfirmedAtUtc`) and then called `ProcessDueAsync` — which asks `ListDueAsync` for links with `NextCheckAtUtc <= now`. This one was not due for another ~20 seconds, so the pass found nothing.
4. Nothing re-fires at the 30-second mark. The deferral is passive: it records *when* the link may next be looked at, it does not schedule anything.
5. The only remaining pickup was the 120-second repair sweep. Total: 128s.

The worker was **holding the confirmation and the subscription in the same tick and throwing the connection away**, because it only ever asked "which links are due?" and never "which link belongs to the payment I just confirmed?".

## The change

The payment side reports *which* payments it transitioned; the subscription side settles *those specific* links, reusing the existing decision logic rather than duplicating it.

Layering is preserved: `Subscription.DomainService` references `Payment.DomainService`, never the reverse. Payment code reports payment ids and learns nothing about subscriptions. The join happens in `Worker`, which already references both.

- **`IPaymentWebhookProcessor.ProcessDueAsync`** now returns `PaymentWebhookProcessingResult(ProcessedCount, TransitionedPaymentDetailIds)` instead of `int`. Ids are collected after `MarkProcessedAsync` succeeds, skipping null/empty and deduping ordinally. Webhook processing itself is unchanged, including its failure/retry path. Changing the signature rather than adding a parallel method is deliberate — the compiler then forces every caller to be updated.
- **`SettleForPaymentsAsync`** on `ISubscriptionActivationProcessor` looks each link up with the existing `FindByPaymentAsync`, backed by the **unique** `(TenantId, PaymentDetailId)` index, so it is a point read and not a scan. Links that are null or not `Pending` are skipped.
- **The consumer** calls the targeted settle **before** the existing `ProcessDueAsync` sweep, so a link settled by the fast path is no longer `Pending` and `ListDueAsync` will not return it in the same tick. Both still run. The settled count joins the completion log line so the fast path is observable.
- The two callers that discard the ids (`WebhookRecoveryWorkHandler`, `PaymentReconciliationBackgroundService`) do so through an explicit `_ =` plus a comment saying why, so the reason the ids are dropped sits where someone would otherwise be tempted to add a second settle site.

### The critical rule: the targeted path never reschedules

On an undecided payment it leaves `AttemptCount`, `NextCheckAtUtc` and `LastError` **completely untouched** and writes **no audit rows**. It runs on every webhook tick, so deferring there would burn attempts against `ActivationMaxAttempts` (10), push the sweep's next check *further* into the future — making latency worse, not better — and spam the trail with a `SettlementStarted` pair every time.

The read-and-classify step is extracted into a shared helper returning `Activate` / `Abandon` / `Undecided` / `PaymentMissing`:

- **Sweep path** (`ProcessDueAsync`, `SettleLinkAsync`): unchanged behaviour, including `RescheduleAsync` on `Undecided`/`PaymentMissing` and the exact existing audit sequence.
- **Targeted path**: acts only on `Activate` and `Abandon`, writing the same audit rows via the same `AuditAsync` helper; returns silently otherwise and leaves the link for the sweep, which keeps sole ownership of retry accounting.

Both switches name every outcome and throw on an unhandled one, so adding an outcome later fails loudly rather than being silently treated as "still in flight" (sweep) or as `Abandon` (targeted).

`ActivateAsync`, `AbandonAsync`, `AuditAsync`, `IsConfirmed` and `TerminalFailureStatuses` are reused as-is. `SubscriptionSimulationService` — the only caller of `SettleLinkAsync` — keeps full sweep semantics.

The 120-second repair sweep stays exactly as it is, as the backstop for the rarer cases.

## Why this is concurrency-safe

The targeted pass can now race the 120s sweep, the durable-queue `ActivationSettlementWorkHandler`, and other replicas. Every write on the path was already a compare-and-set:

- `TryTransitionAsync` filters on the expected status and returns `ModifiedCount == 1` — exactly one racer wins `Incomplete → Active/Trialing`. The loser returns `false` **without settling the link**, so the winner's settle stands.
- `TrySettleAsync` filters on `State == Pending` — a link settles once.
- Everything after the transition (campaign redemption, usage projection, card adoption, document announcement) is reached **only by the winner** of the transition CAS, so it runs once per activation. `AnnounceChargeAsync` is additionally keyed by payment id, and `TryMarkRedeemedAsync` is idempotent in the repository.
- `RescheduleAsync` has no state guard, so a concurrent sweep could write `NextCheckAtUtc` onto a link the targeted pass just settled. Harmless: `ListDueAsync` filters on `State == Pending`.

No new locks, leases or bus plumbing. No DI, configuration, schema or index changes — both interfaces are already registered and `FindByPaymentAsync` and its unique index already exist.

## Result

Typical activation latency drops from ~120s to milliseconds.

## Behaviour worth knowing before merge

Three consequences that are correct but visible in operations:

- **`activation_state_conflict` will get more common.** Today it is rare — two sweep replicas racing. Now the targeted pass and a concurrent queue handler can genuinely collide on a hot signup, and the loser writes `ActivationApplied / Deferred / activation_state_conflict`. That is existing, correct behaviour (already covered by `Losing_the_transition_race_leaves_the_link_for_the_winner`), but **if anything alerts on that error code, expect the rate to rise.**
- **More audit rows on a card-setup link that cannot adopt its card.** `ActivateAsync` returns `false` when `AdoptProviderCustomerAsync` finds no durable stored method — deliberate, so the card is not lost, and pinned by `A_confirmed_setup_waits_until_its_card_is_usable_for_renewal`. Through the targeted path that now writes `SettlementStarted` + `ActivationApplied / Deferred` on **every** webhook tick naming that payment, without consuming an attempt. Bounded by webhooks-per-payment, so it is not a leak, but it is a real increase in audit volume for that case.
- **The residual race is still on the sweep.** If the confirming webhook is processed before `TryCreateAsync` commits the link, `FindByPaymentAsync` returns null, the link is then written immediately-due, and nothing fires a tick — so it waits for the 120s sweep as before. This needs the webhook to beat the rest of the HTTP handler, so it is unlikely but real, and it is the one case this change does not speed up.

## Verification

14 new tests, all passing:

**`SubscriptionActivationProcessorTests`**
- A webhook-confirmed payment settles through `SettleForPaymentsAsync` and activates, **even when `NextCheckAtUtc` is in the future** — the reported bug.
- An undecided payment leaves the link completely untouched: `RescheduleAsync` never called, never settled, zero audit rows.
- A terminally refused payment abandons through the targeted path.
- An unknown payment id, and a link already `Applied`, are both no-ops.
- Losing the transition race through the targeted path leaves the link unsettled.
- A payment named twice in one call is looked up and settled once — pinning the ordinal dedupe, which reads as redundant next to the processor's own and would otherwise break nothing if removed.
- An empty collection touches no repository at all; a null one is treated the same.
- Existing tests pass unchanged — including `A_pending_payment_is_rescheduled_rather_than_abandoned`, which pins the sweep's retry accounting.

**`PaymentWebhookProcessorTests`** — the result reports the ids it transitioned; reports it once for two events on one payment; reports none when the claim was skipped, the transition threw, or the webhook names no payment.

**`PaymentWorkCommandConsumerTests`** — the webhook result's ids reach `SettleForPaymentsAsync`, and a recorded call order pins targeted-then-sweep.

**Full local suite: 3655 passed, 4 failed.** The 4 are the pre-existing `SubscriptionSimulation*` permission-guard failures, verified failing identically on pristine `dev`. The `XUnitTest.Integration` tests need a live Mongo and are covered by CI's mongo-integration job rather than locally. `PeriodicPingBackgroundServiceTests.ExecuteAsync_WhenExceptionInLoop_ContinuesRunning` failed once under parallel load and passes in isolation on both pristine `dev` and this branch — flaky, unrelated.

**Not done:** the end-to-end simulation run and the audit-trail check on a real signup, both of which need a running worker and provider. Worth doing before merge — after subscribing, expect `Subscribe/Completed`, one `InitialPaymentActivation/SettlementStarted` + `PaymentConfirmation/Deferred`, then `SettlementStarted` + `ActivationApplied/Succeeded` **seconds later, not two minutes**, with no extra deferral rows in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
