### PR TITLE
fix(client): plan catalogue grouping, search/sort semantics, and presentation

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-card.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-card.tsx
@@ -94,7 +94,7 @@ export const PlanCard = ({
           ? // Muted, not faded away: an archived plan is still read, and text at 60% opacity on a
             // muted panel fails contrast. The tint carries the state, the text keeps its colour.
             "border-dashed bg-muted/40"
-          : "hover:border-blocks-primary-300 hover:shadow-md"
+          : "hover:border-blocks-primary-300 hover:shadow-md focus-within:border-blocks-primary-300 focus-within:shadow-md"
       }`}
     >
       <div className="flex items-start justify-between gap-2">
@@ -125,9 +125,8 @@ export const PlanCard = ({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link to={detailPath}>View details</Link>
-              </DropdownMenuItem>
+              {/* View details already lives on the title and the footer button — a third
+                  identical link here would just be another way to the same place. */}
               {/* Absent rather than disabled for an archived plan: a greyed-out Edit invites a
                   second click and an explanation, where nothing at all says it is not on offer. */}
               {editPath && !isArchived ? (

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.test.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.test.tsx
@@ -1,0 +1,106 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+import type { SubscriptionPlan } from "../models/subscription-plan.model";
+
+const { useSubscriptionPlans } = vi.hoisted(() => ({ useSubscriptionPlans: vi.fn() }));
+
+vi.mock("../hooks/use-subscription-plans", () => ({ useSubscriptionPlans }));
+
+vi.mock("@blocks-idp/iam/hooks/use-organization", () => ({
+  useGetOrganizations: () => ({ data: { organizations: [] }, isError: false }),
+}));
+
+vi.mock("@seliseblocks/genesis-os", () => ({
+  useProjectStore: () => ({ selectedProject: { tenantId: "tenant-1" } }),
+}));
+
+import { SubscriptionPlanListPage } from "./subscription-plan-list-page";
+
+const plan = (overrides: Partial<SubscriptionPlan> = {}): SubscriptionPlan =>
+  ({
+    planId: "plan-1",
+    code: "pro",
+    displayName: "Professional",
+    description: null,
+    featuresJson: null,
+    organizationId: null,
+    trialDays: null,
+    trialRequiresPaymentMethod: false,
+    version: 1,
+    hasSubscribers: false,
+    quantityItems: [],
+    meters: [],
+    entitlements: [],
+    prices: [],
+    status: "Active",
+    ...overrides,
+  }) as SubscriptionPlan;
+
+const renderPage = (plans: SubscriptionPlan[]) => {
+  useSubscriptionPlans.mockReturnValue({
+    data: plans,
+    error: null,
+    isError: false,
+    isFetching: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  });
+
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter>
+        <SubscriptionPlanListPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe("grouping the catalogue", () => {
+  /**
+   * Every family-less plan used to key its own section, so a catalogue of standalone plans was
+   * one full-width row per plan instead of a shared 3-column grid. Guards against that regression.
+   */
+  it("puts every family-less plan in one shared grid instead of one section each", () => {
+    renderPage([
+      plan({ planId: "a", displayName: "Alpha" }),
+      plan({ planId: "b", displayName: "Bravo" }),
+      plan({ planId: "c", displayName: "Charlie" }),
+    ]);
+
+    const cards = screen.getAllByText(/^From |^No price configured yet$/);
+    const sharedGrid = cards[0].closest("section")?.querySelector(".grid");
+
+    expect(sharedGrid?.querySelectorAll(":scope > *")).toHaveLength(3);
+  });
+
+  /**
+   * The heading over a family group must name the family, not whichever level happened to sort
+   * first — the first level's own display name is not the family's name.
+   */
+  it("leads the family heading with the family code, not a level's own name", () => {
+    renderPage([
+      plan({
+        planId: "starter",
+        displayName: "Starter",
+        familyCode: "growth",
+        familyRank: 1,
+      }),
+      plan({
+        planId: "premium",
+        displayName: "Premium",
+        familyCode: "growth",
+        familyRank: 2,
+      }),
+    ]);
+
+    const familyHeading = screen.getByRole("heading", { name: "growth" });
+    const section = familyHeading.closest("section");
+
+    // The group heading names the family; each level still carries its own name on its own
+    // card underneath, so both "growth" and "Starter" are on screen, just at different levels.
+    expect(familyHeading).toBeInTheDocument();
+    expect(section?.querySelector("h3")).toBe(familyHeading);
+  });
+});

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
@@ -35,8 +35,8 @@ import type {
 import { subscriptionService } from "../services/subscription.service";
 import {
   applyCatalogueFilters,
+  clearCatalogueFilters,
   countActiveFilters,
-  DEFAULT_CATALOGUE_FILTERS,
   PLAN_SORT_LABELS,
   PLAN_STATUS_TABS,
   readCatalogueFilters,
@@ -106,16 +106,39 @@ export const SubscriptionPlanListPage = () => {
   );
   const activeFilterCount = countActiveFilters(filters);
 
+  // Family-less plans are collected into a single "standalone" section rather than one section
+  // per plan, so they share the same 3-column grid instead of stacking one full-width row each.
+  // Sections otherwise appear in the order their first plan was encountered, which — since
+  // filteredPlans is already sorted — keeps the catalogue's chosen order intact.
   const catalogueGroups = useMemo(() => {
-    const groups = new Map<string, SubscriptionPlan[]>();
+    const families = new Map<string, SubscriptionPlan[]>();
+    const standalone: SubscriptionPlan[] = [];
+    const order: Array<{ key: string; familyCode: string | null }> = [];
+
     filteredPlans.forEach((plan) => {
-      const key = plan.familyCode ? `family:${plan.familyCode}` : `plan:${plan.planId}`;
-      groups.set(key, [...(groups.get(key) ?? []), plan]);
+      if (plan.familyCode) {
+        if (!families.has(plan.familyCode)) {
+          order.push({ key: `family:${plan.familyCode}`, familyCode: plan.familyCode });
+        }
+        families.set(plan.familyCode, [...(families.get(plan.familyCode) ?? []), plan]);
+
+        return;
+      }
+
+      if (standalone.length === 0) {
+        order.push({ key: "standalone", familyCode: null });
+      }
+      standalone.push(plan);
     });
-    return [...groups.entries()].map(([key, levels]) => ({
+
+    return order.map(({ key, familyCode }) => ({
       key,
-      familyCode: key.startsWith("family:") ? key.slice(7) : null,
-      levels: levels.sort((left, right) => (left.familyRank ?? 0) - (right.familyRank ?? 0)),
+      familyCode,
+      levels: familyCode
+        ? (families.get(familyCode) ?? []).sort(
+            (left, right) => (left.familyRank ?? 0) - (right.familyRank ?? 0),
+          )
+        : standalone,
     }));
   }, [filteredPlans]);
 
@@ -311,7 +334,7 @@ export const SubscriptionPlanListPage = () => {
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => setFilters(DEFAULT_CATALOGUE_FILTERS)}
+                  onClick={() => setFilters(clearCatalogueFilters(filters))}
                 >
                   <X className="mr-1 h-3 w-3" />
                   Clear filters
@@ -362,7 +385,7 @@ export const SubscriptionPlanListPage = () => {
                 <Button
                   variant="outline"
                   className="mt-5"
-                  onClick={() => setFilters(DEFAULT_CATALOGUE_FILTERS)}
+                  onClick={() => setFilters(clearCatalogueFilters(filters))}
                 >
                   Clear filters
                 </Button>
@@ -374,10 +397,9 @@ export const SubscriptionPlanListPage = () => {
                 <section key={group.key} className={group.familyCode ? "rounded-xl border p-4" : ""}>
                   {group.familyCode && (
                     <div className="mb-3">
-                      <h3 className="font-semibold">{group.levels[0]?.displayName}</h3>
+                      <h3 className="font-semibold">{group.familyCode}</h3>
                       <p className="text-xs text-muted-foreground">
-                        {group.familyCode} · {group.levels.length} level
-                        {group.levels.length === 1 ? "" : "s"}
+                        {group.levels.length} level{group.levels.length === 1 ? "" : "s"}
                       </p>
                     </div>
                   )}

--- a/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
+++ b/client/app/cross-modules/utilities/subscription/pages/subscription-plan-list-page.tsx
@@ -1,5 +1,14 @@
 import { useMemo, useState } from "react";
-import { AlertCircle, Archive, Layers, Plus, RefreshCw, Search, X } from "lucide-react";
+import {
+  AlertCircle,
+  Archive,
+  CheckCircle2,
+  Layers,
+  Plus,
+  RefreshCw,
+  Search,
+  X,
+} from "lucide-react";
 import { Link, useParams, useSearchParams } from "react-router";
 import { useGetOrganizations } from "@blocks-idp/iam/hooks/use-organization";
 import { useProjectStore } from "@seliseblocks/genesis-os";
@@ -159,10 +168,23 @@ export const SubscriptionPlanListPage = () => {
     });
   };
 
+  // Active and Archived double as the tab switcher: the number they show is exactly the one the
+  // corresponding tab counts, so making them buttons removes a second, disconnected way of
+  // reading the same fact. Plan families has no matching tab and stays a plain stat.
   const summaryCards = [
-    { label: "Active plans", value: summary.active, icon: Layers },
-    { label: "Archived plans", value: summary.archived, icon: Archive },
-    { label: "Plan families", value: summary.families, icon: Layers },
+    {
+      label: "Active plans",
+      value: summary.active,
+      icon: CheckCircle2,
+      status: "Active" as const,
+    },
+    {
+      label: "Archived plans",
+      value: summary.archived,
+      icon: Archive,
+      status: "Archived" as const,
+    },
+    { label: "Plan families", value: summary.families, icon: Layers, status: null },
   ];
 
   const emptyStateCopy = () => {
@@ -195,6 +217,12 @@ export const SubscriptionPlanListPage = () => {
 
   const empty = emptyStateCopy();
 
+  const tabCount: Record<PlanCatalogueFilterName, number> = {
+    Active: summary.active,
+    Archived: summary.archived,
+    All: summary.all,
+  };
+
   return (
     <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
       <SubscriptionPlanPageHeader
@@ -223,10 +251,17 @@ export const SubscriptionPlanListPage = () => {
       />
 
       <div className="grid gap-3 sm:grid-cols-3">
-        {summaryCards.map((card) => (
-          <Card key={card.label} className="rounded-xl">
+        {summaryCards.map((card) => {
+          const isSelected = card.status !== null && filters.status === card.status;
+          const content = (
             <div className="flex items-center gap-3">
-              <span className="rounded-lg bg-muted p-2 text-muted-foreground">
+              <span
+                className={`rounded-lg p-2 ${
+                  isSelected
+                    ? "bg-blocks-primary-100 text-blocks-primary-700"
+                    : "bg-muted text-muted-foreground"
+                }`}
+              >
                 <card.icon className="h-4 w-4" />
               </span>
               <div>
@@ -234,12 +269,34 @@ export const SubscriptionPlanListPage = () => {
                 <p className="mt-1 text-xs text-muted-foreground">{card.label}</p>
               </div>
             </div>
-          </Card>
-        ))}
+          );
+
+          return card.status ? (
+            <Card
+              key={card.label}
+              className={`rounded-xl p-0 transition ${
+                isSelected ? "border-blocks-primary-300" : ""
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => setFilters({ status: card.status })}
+                aria-pressed={isSelected}
+                className="w-full rounded-xl px-5 py-4 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {content}
+              </button>
+            </Card>
+          ) : (
+            <Card key={card.label} className="rounded-xl">
+              {content}
+            </Card>
+          );
+        })}
       </div>
 
       <Card className="rounded-xl p-0">
-        <div className="space-y-3 border-b p-4 sm:p-5">
+        <div className="sticky top-0 z-10 space-y-3 rounded-t-xl border-b bg-card p-4 sm:p-5">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
             <Tabs
               value={filters.status}
@@ -250,10 +307,7 @@ export const SubscriptionPlanListPage = () => {
               <TabsList>
                 {PLAN_STATUS_TABS.map((tab) => (
                   <TabsTrigger key={tab} value={tab}>
-                    {tab}
-                    {tab === "Archived" && summary.archived > 0
-                      ? ` (${summary.archived})`
-                      : ""}
+                    {tab} ({tabCount[tab]})
                   </TabsTrigger>
                 ))}
               </TabsList>
@@ -307,24 +361,39 @@ export const SubscriptionPlanListPage = () => {
               </Select>
 
               <div className="relative min-w-0 sm:w-64">
-                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                 <Input
                   value={filters.search}
                   onChange={(event) => setFilters({ search: event.target.value })}
-                  placeholder="Search plan name or code"
-                  className="pl-9"
+                  placeholder="Search name, code, family, or description"
+                  className={filters.search ? "px-9" : "pl-9"}
                   aria-label="Search subscription plans"
                 />
+                {filters.search ? (
+                  <button
+                    type="button"
+                    onClick={() => setFilters({ search: "" })}
+                    aria-label="Clear search"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
               </div>
             </div>
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <p className="text-xs text-muted-foreground">
-              {organizationScope
-                ? "Showing this organization's own plans alongside the tenant-wide ones."
-                : "Showing tenant-wide plans. Choose an organization to see plans scoped to it."}
-            </p>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <p className="text-xs text-muted-foreground">
+                {organizationScope
+                  ? "Showing this organization's own plans alongside the tenant-wide ones."
+                  : "Showing tenant-wide plans. Choose an organization to see plans scoped to it."}
+              </p>
+              <p className="text-xs text-muted-foreground" role="status" aria-live="polite">
+                Showing {filteredPlans.length} of {plans?.length ?? 0} plans
+              </p>
+            </div>
 
             {activeFilterCount > 0 ? (
               <div className="flex items-center gap-2">
@@ -344,13 +413,22 @@ export const SubscriptionPlanListPage = () => {
           </div>
         </div>
 
-        <div className="p-4 sm:p-5">
+        {isFetching && !isLoading ? (
+          // A background refetch (after archiving, or a manual refresh) has nothing else to show
+          // for it besides the spinning header icon, which sits well away from the grid the user
+          // is actually looking at.
+          <div className="h-0.5 overflow-hidden bg-muted">
+            <div className="h-full w-1/3 animate-pulse bg-blocks-primary-500" />
+          </div>
+        ) : null}
+
+        <div className={`p-4 sm:p-5 ${isFetching && !isLoading ? "opacity-60" : ""}`}>
           {isLoading ? (
             <div
               className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
               aria-label="Loading plans"
             >
-              {Array.from({ length: 3 }, (_, index) => (
+              {Array.from({ length: 6 }, (_, index) => (
                 <Skeleton key={index} className="h-56 w-full rounded-xl" />
               ))}
             </div>

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.test.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { SubscriptionPlan } from "../models/subscription-plan.model";
 import {
   applyCatalogueFilters,
+  clearCatalogueFilters,
   countActiveFilters,
   readCatalogueFilters,
   startingPrice,
@@ -88,7 +89,32 @@ describe("reading catalogue filters from a URL", () => {
 
   it("counts only the controls that are away from their default", () => {
     expect(countActiveFilters({ status: "Active", search: "", sort: "name" })).toBe(0);
-    expect(countActiveFilters({ status: "Archived", search: "a", sort: "price" })).toBe(3);
+    expect(countActiveFilters({ status: "Archived", search: "a", sort: "price" })).toBe(2);
+  });
+
+  /**
+   * Sort changes the order of what's on screen, not which plans are on it. Counting it as a
+   * filter (and resetting it from Clear filters) would misrepresent an ordering choice as a
+   * narrowing one.
+   */
+  it("does not count sort as a filter", () => {
+    expect(countActiveFilters({ status: "Active", search: "", sort: "price" })).toBe(0);
+  });
+
+  /**
+   * The search box is fully controlled from this value. Trimming on read would strip a trailing
+   * space the instant it was typed, making the cursor look stuck after "pro ".
+   */
+  it("keeps a trailing space in the search value instead of trimming it away", () => {
+    const filters = readCatalogueFilters(new URLSearchParams({ q: "pro " }));
+
+    expect(filters.search).toBe("pro ");
+  });
+
+  it("clears status and search but leaves the current sort alone", () => {
+    expect(
+      clearCatalogueFilters({ status: "Archived", search: "pro", sort: "price" }),
+    ).toEqual({ status: "Active", search: "", sort: "price" });
   });
 });
 
@@ -156,6 +182,41 @@ describe("filtering and ordering the catalogue", () => {
     expect(result.map((entry) => entry.planId)).toEqual(["b"]);
   });
 
+  /**
+   * The family badge and the description are both visible on the card, so a term the user can
+   * see on screen must be able to find the plan, not just its name and code.
+   */
+  it("also searches family code and description", () => {
+    const familyPlan = plan({
+      planId: "d",
+      displayName: "Delta",
+      familyCode: "growth",
+      status: "Active",
+    });
+    const describedPlan = plan({
+      planId: "e",
+      displayName: "Echo",
+      description: "Built for teams scaling fast",
+      status: "Active",
+    });
+
+    expect(
+      applyCatalogueFilters([active, familyPlan, describedPlan], {
+        status: "All",
+        search: "growth",
+        sort: "name",
+      }).map((entry) => entry.planId),
+    ).toEqual(["d"]);
+
+    expect(
+      applyCatalogueFilters([active, familyPlan, describedPlan], {
+        status: "All",
+        search: "scaling",
+        sort: "name",
+      }).map((entry) => entry.planId),
+    ).toEqual(["e"]);
+  });
+
   it("orders by most recently updated, putting undated plans last", () => {
     const older = plan({
       planId: "older",
@@ -221,6 +282,6 @@ describe("summary counts", () => {
       plan({ planId: "e" }),
     ]);
 
-    expect(summary).toEqual({ active: 3, archived: 2, families: 2 });
+    expect(summary).toEqual({ active: 3, archived: 2, all: 5, families: 2 });
   });
 });

--- a/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.ts
+++ b/client/app/cross-modules/utilities/subscription/utilities/plan-catalogue-filters.ts
@@ -58,7 +58,10 @@ export const readCatalogueFilters = (
 
   return {
     status: PLAN_STATUS_TABS.find((tab) => tab === status) ?? "Active",
-    search: parameters.get(CATALOGUE_QUERY_PARAMS.search)?.trim() ?? "",
+    // Not trimmed here: the input is fully controlled from this value, so trimming on read would
+    // strip a trailing space the instant it is typed and make the cursor look stuck. Trimming for
+    // matching purposes happens in applyCatalogueFilters instead.
+    search: parameters.get(CATALOGUE_QUERY_PARAMS.search) ?? "",
     sort:
       sort === "updated" || sort === "price" || sort === "name" ? sort : "name",
   };
@@ -94,11 +97,26 @@ export const writeCatalogueFilters = (
   return next;
 };
 
-/** How many filters are away from their default, for the "N active" badge and Clear. */
+/**
+ * How many filters are away from their default, for the "N active" badge and Clear.
+ *
+ * Sort is deliberately excluded: it changes the order of what's on screen, not which plans are on
+ * it, so choosing a different order should not read as "a filter is active" or get reset by
+ * Clear filters.
+ */
 export const countActiveFilters = (filters: PlanCatalogueFilters): number =>
-  (filters.status === "Active" ? 0 : 1) +
-  (filters.search === "" ? 0 : 1) +
-  (filters.sort === "name" ? 0 : 1);
+  (filters.status === "Active" ? 0 : 1) + (filters.search === "" ? 0 : 1);
+
+/**
+ * Resets status and search to their defaults while leaving the current sort untouched — Clear
+ * filters clears what was narrowed, not how the (still full) result is ordered.
+ */
+export const clearCatalogueFilters = (
+  filters: PlanCatalogueFilters,
+): PlanCatalogueFilters => ({
+  ...DEFAULT_CATALOGUE_FILTERS,
+  sort: filters.sort,
+});
 
 const isArchived = (plan: SubscriptionPlan) => plan.status === "Archived";
 
@@ -157,7 +175,9 @@ export const applyCatalogueFilters = (
       matchesStatus(plan, filters.status) &&
       (term === "" ||
         plan.displayName.toLowerCase().includes(term) ||
-        plan.code.toLowerCase().includes(term)),
+        plan.code.toLowerCase().includes(term) ||
+        (plan.familyCode?.toLowerCase().includes(term) ?? false) ||
+        (plan.description?.toLowerCase().includes(term) ?? false)),
   );
 
   const sorted = [...matching];
@@ -202,6 +222,7 @@ export const applyCatalogueFilters = (
 export const summariseCatalogue = (plans: SubscriptionPlan[]) => ({
   active: plans.filter((plan) => !isArchived(plan)).length,
   archived: plans.filter(isArchived).length,
+  all: plans.length,
   families: new Set(
     plans
       .map((plan) => plan.familyCode)


### PR DESCRIPTION
## Summary

Two commits, split by review scope:

**Behavioural fixes (1–4)** — `2de5348`
- Family-less plans now share one 3-column grid section instead of one full-width section each.
- The search box no longer trims on read from the URL, so a trailing space no longer makes the cursor look stuck (matching still trims).
- Sort is no longer counted as an active filter, and a new `clearCatalogueFilters` helper resets status/search on Clear filters while leaving the current sort untouched.
- The family group heading now leads with the family code instead of the first level's own display name.

**Presentation/accessibility fixes (5–15)** — `474c7d0`
- Result count ("Showing N of M plans") in a live region beside the filter badge.
- A count on every status tab (Active/Archived/All), not just Archived.
- Active/Archived summary cards now double as the tab switcher with a selected state; dropped the icon duplicated between Active plans and Plan families.
- Clear button inside the search input; icon recentred with `top-1/2 -translate-y-1/2`; search now also matches family code and description.
- A thin progress line and dimmed grid during a background refetch.
- Sticky filter bar for long catalogues.
- `focus-within` affordance on the plan card to match its existing hover state.
- Dropped the redundant "View details" menu item (title and footer button already go there).
- Loading skeleton now renders 6 tiles to fill the 3-column grid instead of under-filling it with 3.

## Testing

- `npx vitest run app/cross-modules/utilities/subscription` — 56 files / 703 tests passed
- `npx tsc --noEmit` — no errors in touched files
- `npx eslint` on all touched files — clean
- Added `subscription-plan-list-page.test.tsx` (new) covering the grouping and family-heading fixes; extended `plan-catalogue-filters.test.ts` for the trim/sort/clear/search changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)