### PR TITLE
fix(utility): resolve storage HttpClient from IHttpClientFactory

### DIFF
--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -262,6 +262,11 @@ public static class ApplicationServiceCollectionExtensions
         // with two browsers.
         services.TryAddSingleton<PuppeteerSharpEngine>();
         services.TryAddSingleton<PdfStorageHelper>();
+        // PdfStorageHelper resolves its HttpClient from the factory, so the named client has to
+        // exist even in a host that registers this module without the utility module. Idempotent,
+        // so the utility module's own call adds nothing on top of this one.
+        services.AddHttpClient(
+            Utility.DomainService.Storage.StorageHelperBase.StorageHttpClientName);
         services.AddSingleton<
             IFinancialDocumentPdfRenderer,
             PuppeteerFinancialDocumentPdfRenderer>();

--- a/server/Utility.DomainService/PdfGenerator/service/PdfStorageHelper.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfStorageHelper.cs
@@ -17,8 +17,9 @@ namespace Utility.DomainService.PdfGenerator.service
 
         public PdfStorageHelper(
             ILogger<PdfStorageHelper> logger,
-            IStorageDriverService storageDriverService)
-            : base(logger)
+            IStorageDriverService storageDriverService,
+            IHttpClientFactory httpClientFactory)
+            : base(logger, httpClientFactory)
         {
             _storageDriverService = storageDriverService;
         }
@@ -62,7 +63,7 @@ namespace Utility.DomainService.PdfGenerator.service
 
             _logger.LogInformation("SavePdfToStorage: Got upload URL for fileId={FileId}", fileId);
 
-            using var httpClient = new HttpClient();
+            var httpClient = CreateHttpClient();
             using var request = new HttpRequestMessage(HttpMethod.Put, fileInfo.UploadUrl)
             {
                 Content = new StreamContent(stream)

--- a/server/Utility.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Utility.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -25,6 +25,12 @@ namespace DomainService.Utilities
 
         public static void RegisterUtilityServices(this IServiceCollection services)
         {
+            // Backs StorageHelperBase.CreateHttpClient for every storage helper below. Registered
+            // here rather than left to the host so the Api and the Worker cannot disagree about
+            // whether storage traffic is pooled; AddHttpClient is idempotent, so a host that also
+            // calls it adds nothing.
+            services.AddHttpClient(Utility.DomainService.Storage.StorageHelperBase.StorageHttpClientName);
+
             // Sequence Services
             services.AddSingleton<ISequenceService, SequenceService>();
             services.AddSingleton<ISequenceRepository, SequenceRepository>();

--- a/server/Utility.DomainService/Storage/StorageHelperBase.cs
+++ b/server/Utility.DomainService/Storage/StorageHelperBase.cs
@@ -8,12 +8,36 @@ namespace Utility.DomainService.Storage
     /// </summary>
     public abstract class StorageHelperBase
     {
-        protected readonly ILogger _logger;
+        /// <summary>
+        /// Name of the pooled <see cref="HttpClient"/> every storage helper uploads and downloads
+        /// through.
+        /// </summary>
+        /// <remarks>
+        /// Named rather than the default client so a handler policy (timeout, retry) can later be
+        /// attached to storage traffic alone, without touching the other clients in the host.
+        /// </remarks>
+        public const string StorageHttpClientName = "utility-storage";
 
-        protected StorageHelperBase(ILogger logger)
+        protected readonly ILogger _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        protected StorageHelperBase(ILogger logger, IHttpClientFactory httpClientFactory)
         {
             _logger = logger;
+            _httpClientFactory = httpClientFactory;
         }
+
+        /// <summary>
+        /// Creates a storage <see cref="HttpClient"/> from the factory.
+        /// </summary>
+        /// <remarks>
+        /// The factory owns the underlying handler and its connection pool, so the returned client
+        /// is cheap to create per call and must not be disposed — that is the whole point of going
+        /// through the factory rather than <c>new HttpClient()</c>, which leaks a socket pool per
+        /// instance and exhausts ports under load.
+        /// </remarks>
+        protected HttpClient CreateHttpClient() =>
+            _httpClientFactory.CreateClient(StorageHttpClientName);
 
         /// <summary>
         /// Downloads file content as stream from a URL
@@ -22,10 +46,14 @@ namespace Utility.DomainService.Storage
         {
             _logger.LogInformation("GetFileStreamFromUrl: Downloading file from URL={FileUrl}", fileUrl);
 
-            using var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Add("X-Blocks-Key", BlocksContext.GetContext()?.TenantId);
+            var httpClient = CreateHttpClient();
 
-            var response = await httpClient.GetAsync(fileUrl);
+            // Set on the request, not on DefaultRequestHeaders: the tenant comes from the ambient
+            // context and differs call to call, so it must never outlive this one request.
+            using var request = new HttpRequestMessage(HttpMethod.Get, fileUrl);
+            request.Headers.Add("X-Blocks-Key", BlocksContext.GetContext()?.TenantId);
+
+            var response = await httpClient.SendAsync(request);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/server/Utility.DomainService/TemplateEngine/service/StorageHelper.cs
+++ b/server/Utility.DomainService/TemplateEngine/service/StorageHelper.cs
@@ -14,8 +14,9 @@ namespace Utility.DomainService.TemplateEngine.service
 
         public StorageHelper(
             ILogger<StorageHelper> logger,
-            IStorageDriverService storageDriverService)
-            : base(logger)
+            IStorageDriverService storageDriverService,
+            IHttpClientFactory httpClientFactory)
+            : base(logger, httpClientFactory)
         {
             _storageDriverService = storageDriverService;
         }
@@ -59,7 +60,7 @@ namespace Utility.DomainService.TemplateEngine.service
 
             _logger.LogInformation("SaveFileToStorage: Got upload URL for fileId={FileId}", fileId);
 
-            using var httpClient = new HttpClient();
+            var httpClient = CreateHttpClient();
             using var request = new HttpRequestMessage(HttpMethod.Put, fileInfo.UploadUrl)
             {
                 Content = new StreamContent(stream)

--- a/server/XUnitTest/PdfGenerator/PdfStorageHelperTests.cs
+++ b/server/XUnitTest/PdfGenerator/PdfStorageHelperTests.cs
@@ -1,12 +1,14 @@
-﻿using DomainService.Storage;
+﻿using System.Net;
+using DomainService.Storage;
 using Microsoft.Extensions.Logging;
 using Moq;
 using StorageDriver;
 using Utility.DomainService.PdfGenerator.service;
+using Utility.DomainService.Storage;
 
 namespace XUnitTest.PdfGenerator
 {
-    internal class FakeHttpMessageHandler : HttpMessageHandler
+    internal sealed class FakeHttpMessageHandler : HttpMessageHandler
     {
         private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
 
@@ -15,14 +17,16 @@ namespace XUnitTest.PdfGenerator
             _handler = handler;
         }
 
+        public List<HttpRequestMessage> Requests { get; } = [];
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            Requests.Add(request);
             return Task.FromResult(_handler(request));
         }
     }
-
 
     public class PdfStorageHelperTests
     {
@@ -35,6 +39,25 @@ namespace XUnitTest.PdfGenerator
             _storageDriverMock = new Mock<IStorageDriverService>();
         }
 
+        /// <summary>
+        /// Builds a factory that hands out clients over <paramref name="handler"/>, the way
+        /// <c>AddHttpClient</c> does in a host.
+        /// </summary>
+        private static IHttpClientFactory FactoryFor(HttpMessageHandler handler)
+        {
+            var factory = new Mock<IHttpClientFactory>();
+            factory
+                .Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(() => new HttpClient(handler, disposeHandler: false));
+            return factory.Object;
+        }
+
+        private static IHttpClientFactory NeverCalledFactory()
+        {
+            var factory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+            return factory.Object;
+        }
+
         [Fact]
         public async Task SavePdfToStorage_ReturnsFalse_WhenUploadUrlMissing()
         {
@@ -42,7 +65,8 @@ namespace XUnitTest.PdfGenerator
                 .Setup(x => x.GetPerSignedUrlForUploadAsync(It.IsAny<GetPreSignedUrlForUploadRequest>()))
                 .ReturnsAsync((GetPreSignedUrlForUploadResponse?)null);
 
-            var helper = new PdfStorageHelper(_loggerMock.Object, _storageDriverMock.Object);
+            var helper = new PdfStorageHelper(
+                _loggerMock.Object, _storageDriverMock.Object, NeverCalledFactory());
             var input = new MemoryStream(new byte[] { 1 });
             var result = await helper.SavePdfToStorage(input, "file1", "test.pdf");
 
@@ -56,11 +80,65 @@ namespace XUnitTest.PdfGenerator
                 .Setup(x => x.GetUrlForDownloadFileAsync(It.IsAny<GetFileRequest>()))
                 .ReturnsAsync((FileResponse?)null);
 
-            var helper = new PdfStorageHelper(_loggerMock.Object, _storageDriverMock.Object);
+            var helper = new PdfStorageHelper(
+                _loggerMock.Object, _storageDriverMock.Object, NeverCalledFactory());
 
             var result = await helper.GetPdfStream("file1");
 
             Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task An_upload_goes_through_the_factory_rather_than_its_own_client()
+        {
+            _storageDriverMock
+                .Setup(x => x.GetPerSignedUrlForUploadAsync(It.IsAny<GetPreSignedUrlForUploadRequest>()))
+                .ReturnsAsync(new GetPreSignedUrlForUploadResponse
+                {
+                    UploadUrl = "https://storage.example/upload"
+                });
+
+            var handler = new FakeHttpMessageHandler(
+                _ => new HttpResponseMessage(HttpStatusCode.OK));
+            var helper = new PdfStorageHelper(
+                _loggerMock.Object, _storageDriverMock.Object, FactoryFor(handler));
+
+            var result = await helper.SavePdfToStorage(
+                new MemoryStream([1, 2, 3]), "file1", "test.pdf");
+
+            Assert.True(result);
+            var request = Assert.Single(handler.Requests);
+            Assert.Equal(HttpMethod.Put, request.Method);
+            Assert.Equal("BlockBlob", Assert.Single(request.Headers.GetValues("x-ms-blob-type")));
+        }
+
+        [Fact]
+        public async Task A_failed_upload_reads_as_false()
+        {
+            _storageDriverMock
+                .Setup(x => x.GetPerSignedUrlForUploadAsync(It.IsAny<GetPreSignedUrlForUploadRequest>()))
+                .ReturnsAsync(new GetPreSignedUrlForUploadResponse
+                {
+                    UploadUrl = "https://storage.example/upload"
+                });
+
+            var handler = new FakeHttpMessageHandler(
+                _ => new HttpResponseMessage(HttpStatusCode.Forbidden));
+            var helper = new PdfStorageHelper(
+                _loggerMock.Object, _storageDriverMock.Object, FactoryFor(handler));
+
+            var result = await helper.SavePdfToStorage(
+                new MemoryStream([1]), "file1", "test.pdf");
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void The_storage_client_name_is_what_the_modules_register()
+        {
+            // The registration and the lookup are in different projects; if this constant drifts,
+            // CreateClient silently returns a default-configured client instead of failing.
+            Assert.Equal("utility-storage", StorageHelperBase.StorageHttpClientName);
         }
     }
 }

--- a/server/XUnitTest/Subscription/FinancialDocumentLogoResolverTests.cs
+++ b/server/XUnitTest/Subscription/FinancialDocumentLogoResolverTests.cs
@@ -73,6 +73,11 @@ public sealed class FinancialDocumentLogoResolverTests
 
     private static FinancialDocumentLogoResolver Resolver(Mock<IStorageDriverService> storage) =>
         new(
-            new PdfStorageHelper(NullLogger<PdfStorageHelper>.Instance, storage.Object),
+            new PdfStorageHelper(
+                NullLogger<PdfStorageHelper>.Instance,
+                storage.Object,
+                // Strict: every case here fails before a URL is ever produced, so asking the
+                // factory for a client would mean the resolver had started a real download.
+                new Mock<IHttpClientFactory>(MockBehavior.Strict).Object),
             NullLogger<FinancialDocumentLogoResolver>.Instance);
 }


### PR DESCRIPTION
## What

The three storage helpers each built their own `HttpClient` per call:

- `Utility.DomainService/Storage/StorageHelperBase.cs` (download path, shared by both subclasses)
- `Utility.DomainService/PdfGenerator/service/PdfStorageHelper.cs` (PDF upload)
- `Utility.DomainService/TemplateEngine/service/StorageHelper.cs` (template file upload)

Each instance carries its own connection pool, and disposing it leaves sockets in `TIME_WAIT`, so a burst of uploads or downloads can exhaust ephemeral ports while the pooled handler the host already owns sits idle. These were the only three `new HttpClient()` sites left in production code — the rest of the codebase (`GeolocationRepository`, `MagicLinkActionExecutor`, `HttpHelperServices`) already goes through the factory, so this brings the storage helpers in line with the existing convention rather than introducing a new one.

## How

- `StorageHelperBase` takes `IHttpClientFactory` and exposes a `protected CreateHttpClient()` for its subclasses.
- The client is **named** (`utility-storage`) rather than default, so a timeout or retry policy can later be attached to storage traffic alone without touching the other clients in the host.
- Both `RegisterUtilityServices` and `RegisterSubscriptionDomainServices` call `AddHttpClient` for that name. Either module can be registered without the other, and `PdfStorageHelper` is resolved through both; `AddHttpClient` is idempotent, so the second call adds nothing.
- `GetFileStreamFromUrl` now sets `X-Blocks-Key` on the `HttpRequestMessage` instead of on `DefaultRequestHeaders`. The tenant comes from the ambient `BlocksContext` and differs call to call, so it must not outlive the request that read it.

## Tests

`FakeHttpMessageHandler` already existed in `PdfStorageHelperTests` but was unreachable — there was no way to inject a handler, which is why the analyzer flagged it as never instantiated. The new seam makes it usable, so the upload path now has real coverage:

- `An_upload_goes_through_the_factory_rather_than_its_own_client` — asserts the PUT and the `x-ms-blob-type: BlockBlob` header the storage backend requires
- `A_failed_upload_reads_as_false`
- `The_storage_client_name_is_what_the_modules_register` — the registration and the lookup live in different projects, so a drifting constant would silently yield a default-configured client instead of failing

Call sites that construct the helpers directly (`FinancialDocumentLogoResolverTests`) pass a `MockBehavior.Strict` factory: every case there fails before a URL is produced, so asking for a client would mean a real download had started.

## Verification

- `dotnet build server/Blocks.slnx` — **0 errors**
- `dotnet test` (excluding `XUnitTest.Integration`) — **3665 passed, 4 failed**
- MCP `detect_antipatterns` on `Utility.DomainService` — **AP003 now returns 0** (was 3)

The 4 failures are pre-existing on `dev` and unrelated to this change: they are the `SubscriptionSimulationGuard` permission tests, red because the permission check was commented out in `8d7a4389` (`git merge-base --is-ancestor 8d7a4389 origin/dev` confirms it is already on `dev`). Worth a separate fix — that guard currently returns `true` for any console-authenticated caller.

The `XUnitTest.Integration` suite needs a reachable MongoDB and was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
