### PR TITLE
fix(payment): read the clock through TimeProvider in payment services

### DIFF
--- a/server/Payment.DomainService/Services/CheckoutCallbackStateProtector.cs
+++ b/server/Payment.DomainService/Services/CheckoutCallbackStateProtector.cs
@@ -8,6 +8,13 @@ public sealed class CheckoutCallbackStateProtector : ICheckoutCallbackStateProte
 {
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
+    private readonly TimeProvider _time;
+
+    public CheckoutCallbackStateProtector(TimeProvider? time = null)
+    {
+        _time = time ?? TimeProvider.System;
+    }
+
     public ProtectedCheckoutCallbackState Create(
         string tenantId,
         string? organizationId,
@@ -16,7 +23,7 @@ public sealed class CheckoutCallbackStateProtector : ICheckoutCallbackStateProte
         TimeSpan lifetime,
         string key)
     {
-        var now = DateTime.UtcNow;
+        var now = _time.GetUtcNow().UtcDateTime;
         var state = new CheckoutCallbackState(
             tenantId,
             paymentId,
@@ -57,7 +64,7 @@ public sealed class CheckoutCallbackStateProtector : ICheckoutCallbackStateProte
         if (!TryDecodeBase64Url(parts[0], out var payload) || !TryDecodeBase64Url(parts[1], out var supplied)) return false;
         var valid = Verify(payload, supplied, activeKey) ||
                     !string.IsNullOrWhiteSpace(previousKey) && Verify(payload, supplied, previousKey);
-        var now = DateTime.UtcNow;
+        var now = _time.GetUtcNow().UtcDateTime;
         return valid && state.ExpiresAtUtc >= now && state.IssuedAtUtc <= now.AddMinutes(5) && state.ExpiresAtUtc > state.IssuedAtUtc;
     }
 

--- a/server/Payment.DomainService/Services/HostedCheckoutInitiationService.cs
+++ b/server/Payment.DomainService/Services/HostedCheckoutInitiationService.cs
@@ -25,6 +25,7 @@ public sealed class HostedCheckoutInitiationService : IPaymentInitiationService
     private readonly IStoredPaymentMethodRepository _storedPaymentMethods;
     private readonly IProviderInitiationRequestFactoryResolver _requestFactories;
     private readonly IOptionsMonitor<PaymentOptions> _options;
+    private readonly TimeProvider _time;
 
     public HostedCheckoutInitiationService(
         IPaymentRepository repository,
@@ -38,7 +39,8 @@ public sealed class HostedCheckoutInitiationService : IPaymentInitiationService
         IPaymentWebhookReferenceService webhookReferenceService,
         IStoredPaymentMethodRepository storedPaymentMethods,
         IProviderInitiationRequestFactoryResolver requestFactories,
-        IOptionsMonitor<PaymentOptions> options)
+        IOptionsMonitor<PaymentOptions> options,
+        TimeProvider? time = null)
     {
         _repository = repository;
         _providerCache = providerCache;
@@ -52,6 +54,7 @@ public sealed class HostedCheckoutInitiationService : IPaymentInitiationService
         _storedPaymentMethods = storedPaymentMethods;
         _requestFactories = requestFactories;
         _options = options;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentOperationResult> InitiateAsync(
@@ -251,7 +254,7 @@ public sealed class HostedCheckoutInitiationService : IPaymentInitiationService
         if (payment.InitiationRequest == null) return;
 
         var leaseId = Guid.NewGuid().ToString("N");
-        var leaseUntil = DateTime.UtcNow.AddSeconds(
+        var leaseUntil = _time.GetUtcNow().UtcDateTime.AddSeconds(
             Math.Clamp(_options.CurrentValue.ProcessingLeaseSeconds, 10, 120));
         var claimed = await _repository.TryClaimInitiationAsync(
             payment.TenantId,

--- a/server/Payment.DomainService/Services/PaymentCaptureInitiationService.cs
+++ b/server/Payment.DomainService/Services/PaymentCaptureInitiationService.cs
@@ -17,6 +17,7 @@ public sealed class PaymentCaptureInitiationService :
     private readonly IPaymentCaptureOutboxEventFactory _events;
     private readonly IPaymentCaptureResponseMapper _responses;
     private readonly IPaymentWorkDispatcher _workDispatcher;
+    private readonly TimeProvider _time;
 
     public PaymentCaptureInitiationService(
         IPaymentCaptureProviderGatewayResolver gateways,
@@ -24,7 +25,8 @@ public sealed class PaymentCaptureInitiationService :
         IPaymentCaptureRepository captures,
         IPaymentCaptureOutboxEventFactory events,
         IPaymentCaptureResponseMapper responses,
-        IPaymentWorkDispatcher workDispatcher)
+        IPaymentWorkDispatcher workDispatcher,
+        TimeProvider? time = null)
     {
         _gateways = gateways;
         _requests = requests;
@@ -32,6 +34,7 @@ public sealed class PaymentCaptureInitiationService :
         _events = events;
         _responses = responses;
         _workDispatcher = workDispatcher;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentCaptureOperationResult> SubmitAsync(
@@ -111,7 +114,7 @@ public sealed class PaymentCaptureInitiationService :
             capture.ProviderCaptureReference =
                 providerResult.ProviderCaptureReference;
             capture.ProviderResultStatus = providerResult.ProviderStatus;
-            capture.SubmittedAtUtc = DateTime.UtcNow;
+            capture.SubmittedAtUtc = _time.GetUtcNow().UtcDateTime;
 
             return PaymentCaptureOperationResult.Success(
                 _responses.Map(payment.ItemId, capture),
@@ -213,8 +216,8 @@ public sealed class PaymentCaptureInitiationService :
         capture.Status = PaymentCaptureStatuses.Succeeded;
         capture.ProviderCaptureReference = providerResult.ProviderCaptureReference;
         capture.ProviderResultStatus = providerResult.ProviderStatus;
-        capture.SubmittedAtUtc = DateTime.UtcNow;
-        capture.CompletedAtUtc = DateTime.UtcNow;
+        capture.SubmittedAtUtc = _time.GetUtcNow().UtcDateTime;
+        capture.CompletedAtUtc = _time.GetUtcNow().UtcDateTime;
 
         return PaymentCaptureOperationResult.Success(
             _responses.Map(payment.ItemId, capture),
@@ -241,7 +244,7 @@ public sealed class PaymentCaptureInitiationService :
             capture.CaptureId,
             leaseId,
             failureCode,
-            DateTime.UtcNow.AddSeconds(30),
+            _time.GetUtcNow().UtcDateTime.AddSeconds(30),
             cancellationToken);
 
         await _workDispatcher.TryDispatchAsync(

--- a/server/Payment.DomainService/Services/PaymentCaptureReservationService.cs
+++ b/server/Payment.DomainService/Services/PaymentCaptureReservationService.cs
@@ -15,17 +15,20 @@ public sealed class PaymentCaptureReservationService :
     private readonly IPaymentCaptureWebhookReferenceService _references;
     private readonly IPaymentCaptureResponseMapper _responses;
     private readonly IOptionsMonitor<PaymentOptions> _options;
+    private readonly TimeProvider _time;
 
     public PaymentCaptureReservationService(
         IPaymentCaptureRepository captures,
         IPaymentCaptureWebhookReferenceService references,
         IPaymentCaptureResponseMapper responses,
-        IOptionsMonitor<PaymentOptions> options)
+        IOptionsMonitor<PaymentOptions> options,
+        TimeProvider? time = null)
     {
         _captures = captures;
         _references = references;
         _responses = responses;
         _options = options;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentCaptureReservationResult> ReserveAsync(
@@ -54,7 +57,7 @@ public sealed class PaymentCaptureReservationService :
             payment.ItemId,
             request);
         var leaseId = Guid.NewGuid().ToString("N");
-        var now = DateTime.UtcNow;
+        var now = _time.GetUtcNow().UtcDateTime;
         var capture = new PaymentCapture
         {
             CaptureId = captureId,
@@ -155,7 +158,7 @@ public sealed class PaymentCaptureReservationService :
             existingPayment.ItemId,
             existingCapture.CaptureId,
             recoveryLeaseId,
-            DateTime.UtcNow.Add(
+            _time.GetUtcNow().UtcDateTime.Add(
                 PaymentCaptureLeasePolicy.Resolve(
                     _options.CurrentValue)),
             cancellationToken);

--- a/server/Payment.DomainService/Services/PaymentKeyRingStore.cs
+++ b/server/Payment.DomainService/Services/PaymentKeyRingStore.cs
@@ -23,15 +23,18 @@ public sealed class PaymentKeyRingStore : IPaymentKeyRingStore
     private readonly IKeyVaultSecretGateway _gateway;
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ILogger<PaymentKeyRingStore> _logger;
+    private readonly TimeProvider _time;
 
     public PaymentKeyRingStore(
         IKeyVaultSecretGateway gateway,
         IOptionsMonitor<PaymentOptions> options,
-        ILogger<PaymentKeyRingStore> logger)
+        ILogger<PaymentKeyRingStore> logger,
+        TimeProvider? time = null)
     {
         _gateway = gateway;
         _options = options;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<KeyRingProvisionOutcome> TryCreateAsync(
@@ -65,7 +68,7 @@ public sealed class PaymentKeyRingStore : IPaymentKeyRingStore
         }
 
         var keys = await SeedFromSharedRingAsync(cancellationToken);
-        var activeKeyId = NextKeyId(keys);
+        var activeKeyId = NextKeyId(keys, _time.GetUtcNow().UtcDateTime);
 
         keys[activeKeyId] = Convert.ToBase64String(
             RandomNumberGenerator.GetBytes(KeyLengthBytes));
@@ -165,13 +168,13 @@ public sealed class PaymentKeyRingStore : IPaymentKeyRingStore
         return keys;
     }
 
-    private static string NextKeyId(Dictionary<string, string> keys)
+    private static string NextKeyId(Dictionary<string, string> keys, DateTime nowUtc)
     {
         var candidate =
-            $"payment-token-key-{DateTime.UtcNow:yyyy-MM}";
+            $"payment-token-key-{nowUtc:yyyy-MM}";
 
         return keys.ContainsKey(candidate)
-            ? $"payment-token-key-{DateTime.UtcNow:yyyy-MM-dd-HHmmss}"
+            ? $"payment-token-key-{nowUtc:yyyy-MM-dd-HHmmss}"
             : candidate;
     }
 }

--- a/server/Payment.DomainService/Services/PaymentMethodSetupService.cs
+++ b/server/Payment.DomainService/Services/PaymentMethodSetupService.cs
@@ -45,6 +45,7 @@ public sealed class PaymentMethodSetupService : IPaymentMethodSetupService
     private readonly IPaymentOrganizationResolver _organizationResolver;
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ILogger<PaymentMethodSetupService> _logger;
+    private readonly TimeProvider _time;
 
     public PaymentMethodSetupService(
         IPaymentExecutionContextResolver contextResolver,
@@ -63,7 +64,8 @@ public sealed class PaymentMethodSetupService : IPaymentMethodSetupService
         IPaymentResponseMapper responseMapper,
         IPaymentOrganizationResolver organizationResolver,
         IOptionsMonitor<PaymentOptions> options,
-        ILogger<PaymentMethodSetupService> logger)
+        ILogger<PaymentMethodSetupService> logger,
+        TimeProvider? time = null)
     {
         _contextResolver = contextResolver;
         _distributedLock = distributedLock;
@@ -82,6 +84,7 @@ public sealed class PaymentMethodSetupService : IPaymentMethodSetupService
         _organizationResolver = organizationResolver;
         _options = options;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentOperationResult> CreateSetupAsync(
@@ -159,7 +162,7 @@ public sealed class PaymentMethodSetupService : IPaymentMethodSetupService
     {
         var requestHash = PaymentHashing.CreateRequestHash(request);
         var leaseId = Guid.NewGuid().ToString("N");
-        var leaseUntilUtc = DateTime.UtcNow.AddSeconds(
+        var leaseUntilUtc = _time.GetUtcNow().UtcDateTime.AddSeconds(
             Math.Clamp(_options.CurrentValue.ProcessingLeaseSeconds, 10, 120));
 
         var payment = CreateRecord(
@@ -537,9 +540,9 @@ public sealed class PaymentMethodSetupService : IPaymentMethodSetupService
             ProcessingLeaseId = leaseId,
             ProcessingLeaseExpiresAtUtc = leaseUntilUtc,
             InitiationAttemptCount = 1,
-            CreatedAtUtc = DateTime.UtcNow,
-            LastUpdatedDateUtc = DateTime.UtcNow,
-            PaymentDate = DateTime.UtcNow
+            CreatedAtUtc = _time.GetUtcNow().UtcDateTime,
+            LastUpdatedDateUtc = _time.GetUtcNow().UtcDateTime,
+            PaymentDate = _time.GetUtcNow().UtcDateTime
         };
 
     private Task<PaymentOperationResult> FailAsync(

--- a/server/Payment.DomainService/Services/PaymentProviderCache.cs
+++ b/server/Payment.DomainService/Services/PaymentProviderCache.cs
@@ -13,13 +13,16 @@ public sealed class PaymentProviderCache : IPaymentProviderCache
     private readonly object _refreshGate = new();
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly IPaymentProviderSecretHydrator _secrets;
+    private readonly TimeProvider _time;
 
     public PaymentProviderCache(
         IOptionsMonitor<PaymentOptions> options,
-        IPaymentProviderSecretHydrator secrets)
+        IPaymentProviderSecretHydrator secrets,
+        TimeProvider? time = null)
     {
         _options = options;
         _secrets = secrets;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentProvider?> GetAsync(
@@ -31,7 +34,7 @@ public sealed class PaymentProviderCache : IPaymentProviderCache
         var key = CreateKey(tenantId, organizationId, providerName);
 
         if (_entries.TryGetValue(key, out var existing) &&
-            existing.ExpiresAtUtc > DateTime.UtcNow)
+            existing.ExpiresAtUtc > _time.GetUtcNow().UtcDateTime)
         {
             return existing.Provider;
         }
@@ -53,7 +56,7 @@ public sealed class PaymentProviderCache : IPaymentProviderCache
 
         _entries[key] = new Entry(
             provider,
-            DateTime.UtcNow.AddSeconds(
+            _time.GetUtcNow().UtcDateTime.AddSeconds(
                 Math.Clamp(
                     _options.CurrentValue.ProviderCacheSeconds,
                     10,
@@ -92,7 +95,7 @@ public sealed class PaymentProviderCache : IPaymentProviderCache
 
         _entries[key] = new Entry(
             provider,
-            DateTime.UtcNow.AddSeconds(
+            _time.GetUtcNow().UtcDateTime.AddSeconds(
                 Math.Clamp(
                     _options.CurrentValue.ProviderCacheSeconds,
                     10,
@@ -141,7 +144,7 @@ public sealed class PaymentProviderCache : IPaymentProviderCache
 
     private bool ShouldRefresh(string key)
     {
-        var now = DateTime.UtcNow;
+        var now = _time.GetUtcNow().UtcDateTime;
         var throttle = TimeSpan.FromSeconds(
             Math.Clamp(
                 _options.CurrentValue
@@ -180,7 +183,7 @@ public sealed class PaymentProviderCache : IPaymentProviderCache
 
     private void RemoveExpired()
     {
-        var now = DateTime.UtcNow;
+        var now = _time.GetUtcNow().UtcDateTime;
 
         foreach (var item in _entries
                      .Where(entry =>

--- a/server/Payment.DomainService/Services/PaymentRefundInitiationService.cs
+++ b/server/Payment.DomainService/Services/PaymentRefundInitiationService.cs
@@ -22,6 +22,7 @@ public sealed class PaymentRefundInitiationService :
     private readonly IPaymentWorkDispatcher _workDispatcher;
     private readonly ILogger<PaymentRefundInitiationService>
         _logger;
+    private readonly TimeProvider _time;
 
     public PaymentRefundInitiationService(
         IPaymentRefundProviderGatewayResolver gateways,
@@ -30,7 +31,8 @@ public sealed class PaymentRefundInitiationService :
         IPaymentRefundOutboxEventFactory events,
         IPaymentRefundResponseMapper responses,
         IPaymentWorkDispatcher workDispatcher,
-        ILogger<PaymentRefundInitiationService> logger)
+        ILogger<PaymentRefundInitiationService> logger,
+        TimeProvider? time = null)
     {
         _gateways = gateways;
         _requestFactory = requestFactory;
@@ -39,6 +41,7 @@ public sealed class PaymentRefundInitiationService :
         _responses = responses;
         _workDispatcher = workDispatcher;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentRefundOperationResult> SubmitAsync(
@@ -130,7 +133,7 @@ public sealed class PaymentRefundInitiationService :
                 providerResult.ProviderRefundReference;
             refund.ProviderResultStatus =
                 providerResult.ProviderStatus;
-            refund.SubmittedAtUtc = DateTime.UtcNow;
+            refund.SubmittedAtUtc = _time.GetUtcNow().UtcDateTime;
 
             _logger.LogInformation(
                 "Payment refund submitted TenantHash={TenantHash} PaymentHash={PaymentHash} RefundHash={RefundHash}",
@@ -223,7 +226,7 @@ public sealed class PaymentRefundInitiationService :
             ],
             PaymentRefundStatuses.Succeeded,
             providerResult.ProviderRefundReference!,
-            DateTime.UtcNow,
+            _time.GetUtcNow().UtcDateTime,
             -refund.Amount,
             0,
             PaymentStatuses.Cancelled,
@@ -246,8 +249,8 @@ public sealed class PaymentRefundInitiationService :
         refund.Status = PaymentRefundStatuses.Succeeded;
         refund.ProviderRefundReference = providerResult.ProviderRefundReference;
         refund.ProviderResultStatus = providerResult.ProviderStatus;
-        refund.SubmittedAtUtc = DateTime.UtcNow;
-        refund.CompletedAtUtc = DateTime.UtcNow;
+        refund.SubmittedAtUtc = _time.GetUtcNow().UtcDateTime;
+        refund.CompletedAtUtc = _time.GetUtcNow().UtcDateTime;
 
         _logger.LogInformation(
             "Payment reversal settled during submission TenantHash={TenantHash} PaymentHash={PaymentHash} RefundHash={RefundHash}",
@@ -282,7 +285,7 @@ public sealed class PaymentRefundInitiationService :
             refund.RefundId,
             leaseId,
             failureCode,
-            DateTime.UtcNow.AddSeconds(30),
+            _time.GetUtcNow().UtcDateTime.AddSeconds(30),
             cancellationToken);
 
         await _workDispatcher.TryDispatchAsync(

--- a/server/Payment.DomainService/Services/PaymentRefundPreflightService.cs
+++ b/server/Payment.DomainService/Services/PaymentRefundPreflightService.cs
@@ -17,6 +17,7 @@ public sealed class PaymentRefundPreflightService :
     private readonly IPaymentRepository _payments;
     private readonly IPaymentProviderCache _providers;
     private readonly IPaymentFundReturnStrategyResolver _strategies;
+    private readonly TimeProvider _time;
 
     public PaymentRefundPreflightService(
         IValidator<CreatePaymentRefundRequest> validator,
@@ -25,7 +26,8 @@ public sealed class PaymentRefundPreflightService :
         IPaymentRefundRepository refunds,
         IPaymentRepository payments,
         IPaymentProviderCache providers,
-        IPaymentFundReturnStrategyResolver strategies)
+        IPaymentFundReturnStrategyResolver strategies,
+        TimeProvider? time = null)
     {
         _validator = validator;
         _minorUnits = minorUnits;
@@ -34,6 +36,7 @@ public sealed class PaymentRefundPreflightService :
         _payments = payments;
         _providers = providers;
         _strategies = strategies;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentRefundPreflightResult>
@@ -205,7 +208,7 @@ public sealed class PaymentRefundPreflightService :
         if (provider.MaxRefundDays > 0 &&
             paymentDate != default &&
             paymentDate.AddDays(provider.MaxRefundDays) <
-            DateTime.UtcNow)
+            _time.GetUtcNow().UtcDateTime)
         {
             return Failed(
                 PaymentFailureKind.Conflict,

--- a/server/Payment.DomainService/Services/PaymentRefundReservationService.cs
+++ b/server/Payment.DomainService/Services/PaymentRefundReservationService.cs
@@ -16,17 +16,20 @@ public sealed class PaymentRefundReservationService :
         _references;
     private readonly IPaymentRefundResponseMapper _responses;
     private readonly IOptionsMonitor<PaymentOptions> _options;
+    private readonly TimeProvider _time;
 
     public PaymentRefundReservationService(
         IPaymentRefundRepository refunds,
         IPaymentRefundWebhookReferenceService references,
         IPaymentRefundResponseMapper responses,
-        IOptionsMonitor<PaymentOptions> options)
+        IOptionsMonitor<PaymentOptions> options,
+        TimeProvider? time = null)
     {
         _refunds = refunds;
         _references = references;
         _responses = responses;
         _options = options;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentRefundReservationResult>
@@ -58,7 +61,7 @@ public sealed class PaymentRefundReservationService :
                 payment.ItemId,
                 request);
         var leaseId = Guid.NewGuid().ToString("N");
-        var now = DateTime.UtcNow;
+        var now = _time.GetUtcNow().UtcDateTime;
         var refund = new PaymentRefund
         {
             RefundId = refundId,
@@ -174,7 +177,7 @@ public sealed class PaymentRefundReservationService :
                 existingPayment.ItemId,
                 existingRefund.RefundId,
                 recoveryLeaseId,
-                DateTime.UtcNow.Add(
+                _time.GetUtcNow().UtcDateTime.Add(
                     PaymentRefundLeasePolicy.Resolve(
                         _options.CurrentValue)),
                 cancellationToken);

--- a/server/Payment.DomainService/Services/PaymentReservationService.cs
+++ b/server/Payment.DomainService/Services/PaymentReservationService.cs
@@ -15,19 +15,22 @@ public sealed class PaymentReservationService : IPaymentReservationService
     private readonly IPaymentResponseMapper _responseMapper;
     private readonly IPaymentOrganizationResolver _organizationResolver;
     private readonly IOptionsMonitor<PaymentOptions> _options;
+    private readonly TimeProvider _time;
 
     public PaymentReservationService(
         IPaymentRepository repository,
         IPaymentIdempotencyCache idempotencyCache,
         IPaymentResponseMapper responseMapper,
         IPaymentOrganizationResolver organizationResolver,
-        IOptionsMonitor<PaymentOptions> options)
+        IOptionsMonitor<PaymentOptions> options,
+        TimeProvider? time = null)
     {
         _repository = repository;
         _idempotencyCache = idempotencyCache;
         _responseMapper = responseMapper;
         _organizationResolver = organizationResolver;
         _options = options;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentReservationResult> ReserveAsync(
@@ -39,7 +42,7 @@ public sealed class PaymentReservationService : IPaymentReservationService
     {
         var requestHash = PaymentHashing.CreateRequestHash(request);
         var leaseId = Guid.NewGuid().ToString("N");
-        var leaseUntil = DateTime.UtcNow.AddSeconds(
+        var leaseUntil = _time.GetUtcNow().UtcDateTime.AddSeconds(
             Math.Clamp(_options.CurrentValue.ProcessingLeaseSeconds, 10, 120));
         // Which organization the payment belongs to decides which merchant account takes the
         // money, because provider lookup keys off the payment's organization rather than the
@@ -82,7 +85,8 @@ public sealed class PaymentReservationService : IPaymentReservationService
             correlationId,
             requestHash,
             leaseId,
-            leaseUntil);
+            leaseUntil,
+            _time.GetUtcNow().UtcDateTime);
 
         if (await _repository.TryCreateAsync(payment, cancellationToken))
         {
@@ -177,7 +181,8 @@ public sealed class PaymentReservationService : IPaymentReservationService
         string correlationId,
         string requestHash,
         string leaseId,
-        DateTime leaseUntil) => new()
+        DateTime leaseUntil,
+        DateTime nowUtc) => new()
         {
             TenantId = context.TenantId,
             ProviderName = request.ProviderName.ToUpperInvariant(),
@@ -202,9 +207,9 @@ public sealed class PaymentReservationService : IPaymentReservationService
             ProcessingLeaseId = leaseId,
             ProcessingLeaseExpiresAtUtc = leaseUntil,
             InitiationAttemptCount = 1,
-            CreatedAtUtc = DateTime.UtcNow,
-            LastUpdatedDateUtc = DateTime.UtcNow,
-            PaymentDate = DateTime.UtcNow
+            CreatedAtUtc = nowUtc,
+            LastUpdatedDateUtc = nowUtc,
+            PaymentDate = nowUtc
         };
 
     private static PaymentReservationResult Terminal(PaymentOperationResult result) => new(null, null, result);

--- a/server/Payment.DomainService/Services/PaymentWebhookProcessor.cs
+++ b/server/Payment.DomainService/Services/PaymentWebhookProcessor.cs
@@ -16,19 +16,22 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
     private readonly IPaymentWorkDispatcher _workDispatcher;
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ILogger<PaymentWebhookProcessor> _logger;
+    private readonly TimeProvider _time;
 
     public PaymentWebhookProcessor(
         IPaymentWebhookInboxRepository inbox,
         IPaymentWebhookStateTransitionService transitions,
         IPaymentWorkDispatcher workDispatcher,
         IOptionsMonitor<PaymentOptions> options,
-        ILogger<PaymentWebhookProcessor> logger)
+        ILogger<PaymentWebhookProcessor> logger,
+        TimeProvider? time = null)
     {
         _inbox = inbox;
         _transitions = transitions;
         _workDispatcher = workDispatcher;
         _options = options;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentWebhookProcessingResult> ProcessDueAsync(string tenantId, CancellationToken cancellationToken)
@@ -45,7 +48,7 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
 
         var due = await _inbox.GetDueAsync(
             tenantId,
-            DateTime.UtcNow,
+            _time.GetUtcNow().UtcDateTime,
             batchSize,
             cancellationToken);
 
@@ -110,7 +113,7 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
                 tenantId,
                 candidate.WebhookId,
                 leaseId,
-                DateTime.UtcNow.AddSeconds(leaseSeconds),
+                _time.GetUtcNow().UtcDateTime.AddSeconds(leaseSeconds),
                 cancellationToken);
 
             if (claimed == null)
@@ -162,7 +165,7 @@ public sealed class PaymentWebhookProcessor : IPaymentWebhookProcessor
                     ? PaymentWebhookStatus.DeadLettered
                     : PaymentWebhookStatus.RetryScheduled;
                 var delay = Math.Min(300, (int)Math.Pow(2, Math.Min(attempts, 8)) + Random.Shared.Next(0, 5));
-                var nextAttemptAtUtc = DateTime.UtcNow.AddSeconds(delay);
+                var nextAttemptAtUtc = _time.GetUtcNow().UtcDateTime.AddSeconds(delay);
 
                 await _inbox.MarkFailedAsync(
                     tenantId,

--- a/server/Payment.DomainService/Services/PaymentWorkDispatcher.cs
+++ b/server/Payment.DomainService/Services/PaymentWorkDispatcher.cs
@@ -10,15 +10,18 @@ public sealed class PaymentWorkDispatcher : IPaymentWorkDispatcher
     private readonly IMessageClient _messageClient;
     private readonly IPaymentTenantContextScopeFactory _contexts;
     private readonly ILogger<PaymentWorkDispatcher> _logger;
+    private readonly TimeProvider _time;
 
     public PaymentWorkDispatcher(
         IMessageClient messageClient,
         IPaymentTenantContextScopeFactory contexts,
-        ILogger<PaymentWorkDispatcher> logger)
+        ILogger<PaymentWorkDispatcher> logger,
+        TimeProvider? time = null)
     {
         _messageClient = messageClient;
         _contexts = contexts;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task DispatchAsync(
@@ -46,7 +49,7 @@ public sealed class PaymentWorkDispatcher : IPaymentWorkDispatcher
                     TenantId = tenantId,
                     IncludeRecovery = includeRecovery,
                     CorrelationId = correlationId,
-                    DispatchedAtUtc = DateTime.UtcNow
+                    DispatchedAtUtc = _time.GetUtcNow().UtcDateTime
                 },
                 ScheduledEnqueueTimeUtc = scheduledAtUtc
             });

--- a/server/Payment.DomainService/Services/RecurringPaymentInitiationService.cs
+++ b/server/Payment.DomainService/Services/RecurringPaymentInitiationService.cs
@@ -33,6 +33,7 @@ public sealed class RecurringPaymentInitiationService :
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ILogger<RecurringPaymentInitiationService>
         _logger;
+    private readonly TimeProvider _time;
 
     public RecurringPaymentInitiationService(
         IPaymentRepository payments,
@@ -48,7 +49,8 @@ public sealed class RecurringPaymentInitiationService :
         ICurrencyMinorUnitResolver minorUnits,
         IPaymentWorkDispatcher workDispatcher,
         IOptionsMonitor<PaymentOptions> options,
-        ILogger<RecurringPaymentInitiationService> logger)
+        ILogger<RecurringPaymentInitiationService> logger,
+        TimeProvider? time = null)
     {
         _payments = payments;
         _storedPaymentMethods = storedPaymentMethods;
@@ -64,6 +66,7 @@ public sealed class RecurringPaymentInitiationService :
         _workDispatcher = workDispatcher;
         _options = options;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentOperationResult> InitiateAsync(
@@ -82,7 +85,7 @@ public sealed class RecurringPaymentInitiationService :
                 storedPaymentMethod.ItemId,
                 payment.ShopperReference ?? string.Empty,
                 methodClaimId,
-                DateTime.UtcNow.AddSeconds(
+                _time.GetUtcNow().UtcDateTime.AddSeconds(
                     Math.Clamp(
                         _options.CurrentValue
                             .ProviderTimeoutSeconds * 2,
@@ -222,7 +225,7 @@ public sealed class RecurringPaymentInitiationService :
         }
 
         var leaseId = Guid.NewGuid().ToString("N");
-        var leaseUntilUtc = DateTime.UtcNow.AddSeconds(
+        var leaseUntilUtc = _time.GetUtcNow().UtcDateTime.AddSeconds(
             Math.Clamp(
                 _options.CurrentValue.ProcessingLeaseSeconds,
                 10,

--- a/server/Payment.DomainService/Services/RecurringPaymentReservationService.cs
+++ b/server/Payment.DomainService/Services/RecurringPaymentReservationService.cs
@@ -14,15 +14,18 @@ public sealed class RecurringPaymentReservationService :
     private readonly IPaymentRepository _payments;
     private readonly IPaymentResponseMapper _responseMapper;
     private readonly IOptionsMonitor<PaymentOptions> _options;
+    private readonly TimeProvider _time;
 
     public RecurringPaymentReservationService(
         IPaymentRepository payments,
         IPaymentResponseMapper responseMapper,
-        IOptionsMonitor<PaymentOptions> options)
+        IOptionsMonitor<PaymentOptions> options,
+        TimeProvider? time = null)
     {
         _payments = payments;
         _responseMapper = responseMapper;
         _options = options;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<PaymentReservationResult> ReserveAsync(
@@ -36,7 +39,7 @@ public sealed class RecurringPaymentReservationService :
         var requestHash =
             PaymentHashing.CreateRequestHash(request);
         var leaseId = Guid.NewGuid().ToString("N");
-        var leaseUntilUtc = DateTime.UtcNow.AddSeconds(
+        var leaseUntilUtc = _time.GetUtcNow().UtcDateTime.AddSeconds(
             Math.Clamp(
                 _options.CurrentValue.ProcessingLeaseSeconds,
                 10,
@@ -49,7 +52,8 @@ public sealed class RecurringPaymentReservationService :
             correlationId,
             requestHash,
             leaseId,
-            leaseUntilUtc);
+            leaseUntilUtc,
+            _time.GetUtcNow().UtcDateTime);
 
         if (await _payments.TryCreateAsync(
                 payment,
@@ -153,7 +157,8 @@ public sealed class RecurringPaymentReservationService :
         string correlationId,
         string requestHash,
         string leaseId,
-        DateTime leaseUntilUtc)
+        DateTime leaseUntilUtc,
+        DateTime nowUtc)
     {
         var breakdown = request.SubscriptionInvoiceBreakdown;
 
@@ -186,9 +191,9 @@ public sealed class RecurringPaymentReservationService :
             ProcessingLeaseExpiresAtUtc =
                 leaseUntilUtc,
             InitiationAttemptCount = 1,
-            CreatedAtUtc = DateTime.UtcNow,
-            LastUpdatedDateUtc = DateTime.UtcNow,
-            PaymentDate = DateTime.UtcNow,
+            CreatedAtUtc = nowUtc,
+            LastUpdatedDateUtc = nowUtc,
+            PaymentDate = nowUtc,
             // Recorded whenever the caller composed one -- every subscription renewal, dunning
             // retry, settlement and usage invoice charged through this provider-neutral path.
             // Null on a plain unscheduled-card-on-file charge, which never sets it.

--- a/server/Payment.DomainService/Services/StoredPaymentMethodLifecycleService.cs
+++ b/server/Payment.DomainService/Services/StoredPaymentMethodLifecycleService.cs
@@ -20,6 +20,7 @@ public sealed class StoredPaymentMethodLifecycleService :
     private readonly IPaymentOutboxEventFactory _events;
     private readonly ILogger<
         StoredPaymentMethodLifecycleService> _logger;
+    private readonly TimeProvider _time;
 
     public StoredPaymentMethodLifecycleService(
         IStoredPaymentMethodRepository methods,
@@ -29,7 +30,8 @@ public sealed class StoredPaymentMethodLifecycleService :
         IStoredPaymentMethodProviderGatewayResolver removals,
         IPaymentProviderCache providers,
         IPaymentOutboxEventFactory events,
-        ILogger<StoredPaymentMethodLifecycleService> logger)
+        ILogger<StoredPaymentMethodLifecycleService> logger,
+        TimeProvider? time = null)
     {
         _methods = methods;
         _payments = payments;
@@ -39,6 +41,7 @@ public sealed class StoredPaymentMethodLifecycleService :
         _providers = providers;
         _events = events;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -561,7 +564,7 @@ public sealed class StoredPaymentMethodLifecycleService :
             TenantId = webhook.TenantId,
             OrganizationId = organizationId,
             EncryptionOrganizationId = encryptionScope.OrganizationId,
-            EncryptionScopeResolvedAtUtc = DateTime.UtcNow,
+            EncryptionScopeResolvedAtUtc = _time.GetUtcNow().UtcDateTime,
             ShopperReference = payload.ShopperReference!,
             ProviderPayerReference = payload.ProviderPayerReference,
             ProviderName = providerName,

--- a/server/Payment.DomainService/Services/StoredPaymentMethodRemovalRecoveryProcessor.cs
+++ b/server/Payment.DomainService/Services/StoredPaymentMethodRemovalRecoveryProcessor.cs
@@ -19,6 +19,7 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ILogger<
         StoredPaymentMethodRemovalRecoveryProcessor> _logger;
+    private readonly TimeProvider _time;
 
     public StoredPaymentMethodRemovalRecoveryProcessor(
         IStoredPaymentMethodRepository methods,
@@ -28,7 +29,8 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
         IProviderTokenProtector tokenProtector,
         IOptionsMonitor<PaymentOptions> options,
         ILogger<
-            StoredPaymentMethodRemovalRecoveryProcessor> logger)
+            StoredPaymentMethodRemovalRecoveryProcessor> logger,
+        TimeProvider? time = null)
     {
         _methods = methods;
         _payments = payments;
@@ -37,6 +39,7 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
         _tokenProtector = tokenProtector;
         _options = options;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<int> RecoverDueRemovalsAsync(
@@ -51,7 +54,7 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
         var candidates =
             await _methods.GetDueRemovalCandidatesAsync(
                 tenantId,
-                DateTime.UtcNow,
+                _time.GetUtcNow().UtcDateTime,
                 batchSize,
                 cancellationToken);
         var recovered = 0;
@@ -61,7 +64,7 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
             cancellationToken.ThrowIfCancellationRequested();
 
             var leaseId = Guid.NewGuid().ToString("N");
-            var leaseExpiresAtUtc = DateTime.UtcNow.AddSeconds(
+            var leaseExpiresAtUtc = _time.GetUtcNow().UtcDateTime.AddSeconds(
                 Math.Clamp(
                     options.StoredPaymentMethodRemovalLeaseSeconds,
                     10,
@@ -71,7 +74,7 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
                 candidate.ItemId,
                 leaseId,
                 leaseExpiresAtUtc,
-                DateTime.UtcNow,
+                _time.GetUtcNow().UtcDateTime,
                 cancellationToken);
 
             if (claimed == null)
@@ -136,7 +139,7 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
                         tenantId,
                         claimed.ItemId,
                         leaseId,
-                        DateTime.UtcNow,
+                        _time.GetUtcNow().UtcDateTime,
                         cancellationToken))
                 {
                     recovered++;
@@ -209,7 +212,7 @@ public sealed class StoredPaymentMethodRemovalRecoveryProcessor :
             method.TenantId,
             method.ItemId,
             leaseId,
-            DateTime.UtcNow.AddSeconds(delaySeconds),
+            _time.GetUtcNow().UtcDateTime.AddSeconds(delaySeconds),
             errorCode,
             cancellationToken);
     }

--- a/server/Payment.DomainService/Services/StoredPaymentMethodRemovalService.cs
+++ b/server/Payment.DomainService/Services/StoredPaymentMethodRemovalService.cs
@@ -27,6 +27,7 @@ public sealed class StoredPaymentMethodRemovalService :
     private readonly IPaymentWorkDispatcher _workDispatcher;
     private readonly IOptionsMonitor<PaymentOptions> _options;
     private readonly ILogger<StoredPaymentMethodRemovalService> _logger;
+    private readonly TimeProvider _time;
 
     public StoredPaymentMethodRemovalService(
         IPaymentExecutionContextResolver contexts,
@@ -40,7 +41,8 @@ public sealed class StoredPaymentMethodRemovalService :
         IProviderTokenProtector tokenProtector,
         IPaymentWorkDispatcher workDispatcher,
         IOptionsMonitor<PaymentOptions> options,
-        ILogger<StoredPaymentMethodRemovalService> logger)
+        ILogger<StoredPaymentMethodRemovalService> logger,
+        TimeProvider? time = null)
     {
         _contexts = contexts;
         _payments = payments;
@@ -54,6 +56,7 @@ public sealed class StoredPaymentMethodRemovalService :
         _workDispatcher = workDispatcher;
         _options = options;
         _logger = logger;
+        _time = time ?? TimeProvider.System;
     }
 
     public async Task<StoredPaymentMethodRemovalResult>
@@ -159,7 +162,7 @@ public sealed class StoredPaymentMethodRemovalService :
                 cancellationToken);
 
         var leaseId = Guid.NewGuid().ToString("N");
-        var leaseExpiresAtUtc = DateTime.UtcNow.AddSeconds(
+        var leaseExpiresAtUtc = _time.GetUtcNow().UtcDateTime.AddSeconds(
             Math.Clamp(
                 _options.CurrentValue
                     .StoredPaymentMethodRemovalLeaseSeconds,
@@ -241,7 +244,7 @@ public sealed class StoredPaymentMethodRemovalService :
                 context.TenantId,
                 claimed.ItemId,
                 leaseId,
-                DateTime.UtcNow,
+                _time.GetUtcNow().UtcDateTime,
                 cancellationToken);
 
             return persisted
@@ -274,7 +277,7 @@ public sealed class StoredPaymentMethodRemovalService :
             context.TenantId,
             claimed.ItemId,
             leaseId,
-            DateTime.UtcNow.AddSeconds(30),
+            _time.GetUtcNow().UtcDateTime.AddSeconds(30),
             "provider_outcome_unknown",
             cancellationToken);
 

--- a/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Payment.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -21,6 +21,11 @@ public static class ApplicationServiceCollectionExtensions
 {
     public static IServiceCollection RegisterPaymentDomainServices(this IServiceCollection services, IConfiguration configuration)
     {
+        // The clock every payment service reads. TryAdd so a host that has already substituted a
+        // controlled clock -- or the subscription module, which registers the same production
+        // default -- keeps the one instance both modules then share.
+        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+
         // Singletons for the same reason the queue itself is: it lives in the root database and
         // needs no ambient tenant, and a Meter's instruments are process-wide.
         services.AddSingleton<IPaymentWorkQueue, PaymentWorkQueue>();

--- a/server/XUnitTest/Payment/PaymentServiceClockTests.cs
+++ b/server/XUnitTest/Payment/PaymentServiceClockTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+
+namespace XUnitTest.Payment;
+
+/// <summary>
+/// The payment services read the clock they were given, not the machine's.
+/// </summary>
+/// <remarks>
+/// Moving a service off <c>DateTime.UtcNow</c> compiles whether or not the injected clock is
+/// actually consulted — a leftover static read behaves identically until the day something needs
+/// to control time, and then fails silently by being right about the wrong instant. These tests
+/// move a controlled clock and require the service to notice, which a static read cannot do.
+/// <para>
+/// Expiry is the property worth pinning: a checkout callback that outlives its window, or a
+/// provider cache that serves a stale secret, are both failures that only appear under a clock
+/// nobody can steer in a test.
+/// </para>
+/// </remarks>
+public sealed class PaymentServiceClockTests
+{
+    private const string ActiveKey = "return-state-key-that-is-longer-than-thirty-two-bytes";
+
+    private static readonly DateTimeOffset Noon =
+        new(2026, 3, 4, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void A_callback_state_is_issued_at_the_injected_clocks_instant()
+    {
+        var clock = new ControlledTimeProvider(Noon);
+        var protector = new CheckoutCallbackStateProtector(clock);
+
+        var protectedState = protector.Create(
+            "tenant-a", null, "payment-1", "ADYEN-ONLINE", TimeSpan.FromMinutes(30), ActiveKey);
+
+        protectedState.State.IssuedAtUtc.Should().Be(
+            Noon.UtcDateTime,
+            "the state is stamped from the injected clock, so a controlled clock decides it");
+        protectedState.State.ExpiresAtUtc.Should().Be(Noon.UtcDateTime.AddMinutes(30));
+    }
+
+    [Fact]
+    public void A_callback_state_stops_verifying_once_the_injected_clock_passes_its_expiry()
+    {
+        var clock = new ControlledTimeProvider(Noon);
+        var protector = new CheckoutCallbackStateProtector(clock);
+        var protectedState = protector.Create(
+            "tenant-a", null, "payment-1", "ADYEN-ONLINE", TimeSpan.FromMinutes(30), ActiveKey);
+
+        protector.TryUnprotect(protectedState.Token, ActiveKey, null, out _)
+            .Should().BeTrue("the clock has not moved, so the state is still inside its window");
+
+        clock.Advance(TimeSpan.FromMinutes(31));
+
+        protector.TryUnprotect(protectedState.Token, ActiveKey, null, out _)
+            .Should().BeFalse(
+                "the window closed on the injected clock -- a static DateTime.UtcNow read here " +
+                "would still accept the token, which is exactly the bug this guards");
+    }
+
+    /// <summary>
+    /// The default keeps every existing caller — production hosts included — on the system clock.
+    /// </summary>
+    [Fact]
+    public void A_protector_built_without_a_clock_still_works_on_the_system_clock()
+    {
+        var protector = new CheckoutCallbackStateProtector();
+
+        var protectedState = protector.Create(
+            "tenant-a", null, "payment-1", "ADYEN-ONLINE", TimeSpan.FromMinutes(30), ActiveKey);
+
+        protector.TryUnprotect(protectedState.Token, ActiveKey, null, out _).Should().BeTrue();
+        protectedState.State.IssuedAtUtc.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
+    }
+
+    /// <summary>
+    /// Registration has to supply the clock, or every service falls back to its own default and
+    /// a host that substitutes a controlled clock silently does not get one.
+    /// </summary>
+    [Fact]
+    public void The_payment_module_registers_a_clock()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterPaymentDomainServices(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetService<TimeProvider>()
+            .Should().NotBeNull("the payment services take a TimeProvider and must be able to get one");
+    }
+
+    /// <summary>
+    /// TryAdd, so the module cannot displace a clock the host or another module already chose.
+    /// Both payment and subscription register the same production default.
+    /// </summary>
+    [Fact]
+    public void Registration_does_not_replace_a_clock_the_host_already_chose()
+    {
+        var chosen = new ControlledTimeProvider(Noon);
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<TimeProvider>(chosen);
+
+        services.RegisterPaymentDomainServices(
+            new ConfigurationBuilder().AddInMemoryCollection([]).Build());
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<TimeProvider>().Should().BeSameAs(chosen);
+    }
+}


### PR DESCRIPTION
## What

Every service in `Payment.DomainService/Services` read `DateTime.UtcNow` directly — **51 reads across 18 files**, covering lease expiry, capture and refund timestamps, webhook retry scheduling and checkout callback validity. None of it could be steered from a test, so the behaviour that matters most in this module — what happens *at* a boundary instant — was only reachable by waiting for it.

This is not a new convention. `Subscription.DomainService` already resolves time this way (~113 uses), and two payment services (`PaymentMethodSetupExpiryProcessor`, `ProviderTokenEncryptionKeyRingProvider`) had already been converted. This applies that same convention to the rest of the folder.

## Why this is safe

This is the part worth reviewing closely, given payment and subscription are time-critical.

1. **The parameter is optional.** `TimeProvider? time = null`, assigned `time ?? TimeProvider.System` — the existing convention. Every existing construction site (production DI and all 1426 payment tests) compiles and behaves exactly as before, with no call-site changes.
2. **The replacement is semantically identical.** `TimeProvider.System.GetUtcNow().UtcDateTime` *is* `DateTime.UtcNow` — same clock, same `DateTimeKind.Utc`. With the default in place, runtime behaviour is unchanged.
3. **No logic was touched.** Every hunk is a 1:1 expression swap. No comparison, ordering, lease duration or retry interval was altered.
4. **The clock is registered defensively.** `RegisterPaymentDomainServices` now does `TryAddSingleton<TimeProvider>(TimeProvider.System)` — `TryAdd`, so it cannot displace a clock the host or the subscription module already chose. A test pins this.

### The one behavioural difference

Two static builders — `PaymentReservationService.CreatePayment` and `RecurringPaymentReservationService.CreatePayment` — can't hold a field, so they take the instant as a parameter. Inside them, `CreatedAtUtc`, `LastUpdatedDateUtc` and `PaymentDate` now share **one** instant instead of reading the clock three times microseconds apart. This is the only semantic change in the PR, and it makes a payment record self-consistent rather than carrying three near-identical stamps. `PaymentKeyRingStore.NextKeyId` takes the instant the same way.

Note that the *other* multi-read sites (`PaymentCaptureInitiationService`, `PaymentMethodSetupService`) were deliberately left as separate reads, so their behaviour is bit-for-bit unchanged.

## Tests

New `PaymentServiceClockTests` — these exist because the refactor compiles whether or not the injected clock is actually consulted; a leftover static read is invisible until something needs to control time:

- `A_callback_state_is_issued_at_the_injected_clocks_instant`
- `A_callback_state_stops_verifying_once_the_injected_clock_passes_its_expiry` — advances a controlled clock past the window and requires the token to be rejected. **A static read would still accept it**, so this is the test that proves the seam is real.
- `A_protector_built_without_a_clock_still_works_on_the_system_clock` — pins the default that keeps existing callers safe
- `The_payment_module_registers_a_clock`
- `Registration_does_not_replace_a_clock_the_host_already_chose`

## Verification

- `dotnet build server/Blocks.slnx` — **0 errors**
- `XUnitTest.Payment` — **1426 passed, 0 failed**
- `XUnitTest.Subscription` — 1649 passed, 4 failed
- Full suite excluding `Integration` — 3662 passed, 4 failed
- `grep DateTime.UtcNow Payment.DomainService/Services` — **0 remaining**

The 4 failures are pre-existing on `dev` and unrelated: the `SubscriptionSimulationGuard` permission tests, red because that check was commented out in `8d7a4389`.

One flaky failure appeared in an early full run — `PeriodicPingBackgroundServiceTests.PingAsync_WithServerError_LogsError(BadGateway)`. It passed 3/3 in isolation and passed on the next full run. It lives in `Worker`, has no dependency on Payment and no `TimeProvider`, and drives a real `PeriodicTimer`, so it is timing-sensitive rather than affected by this change.

`XUnitTest.Integration` needs a reachable MongoDB and was not run here.

## Scope

Deliberately limited to the `Services` folder. `Repositories` (56), `Outbox` (14), `Entities` (12), `Scheduling` (3), `Providers` (3) and `Responses` (1) still read `DateTime.UtcNow` — matching Subscription, where entity audit stamps were also left alone. Worth a follow-up for Repositories; the entity defaults are arguably fine as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
