### PR TITLE
docs(payment): explain the swallowed base64 failure in DecodeKey

### DIFF
--- a/server/Payment.DomainService/Services/CheckoutCallbackStateProtector.cs
+++ b/server/Payment.DomainService/Services/CheckoutCallbackStateProtector.cs
@@ -71,6 +71,17 @@ public sealed class CheckoutCallbackStateProtector : ICheckoutCallbackStateProte
         catch (FormatException) { return false; }
     }
 
+    /// <summary>
+    /// Reads a configured HMAC key, which may be written as base64, as hex, or as raw text.
+    /// </summary>
+    /// <remarks>
+    /// The three are tried in that order and the first that yields at least 256 bits wins. The
+    /// order is not cosmetic: a value that is legible as more than one encoding decodes to
+    /// different bytes under each, and the bytes are the key. A 64-character hex string is also
+    /// valid base64, for instance, and is read as base64 here. Reordering these branches would
+    /// silently re-key every deployment that configured such a value, invalidating every callback
+    /// token already in flight.
+    /// </remarks>
     private static byte[] DecodeKey(string value)
     {
         if (string.IsNullOrWhiteSpace(value)) throw new FormatException("Missing key.");
@@ -79,7 +90,13 @@ public sealed class CheckoutCallbackStateProtector : ICheckoutCallbackStateProte
             var bytes = Convert.FromBase64String(value);
             if (bytes.Length >= 32) return bytes;
         }
-        catch (FormatException) { }
+        catch (FormatException)
+        {
+            // Not base64. That is an ordinary outcome for a key written as hex or as raw text,
+            // not an error: the next branch gets its turn. Nothing is lost by staying quiet,
+            // because a value that matches none of the three still ends in a throw below.
+        }
+
         if (value.Length % 2 == 0 && value.All(Uri.IsHexDigit))
         {
             var bytes = Convert.FromHexString(value);

--- a/server/XUnitTest/Payment/CheckoutCallbackKeyEncodingTests.cs
+++ b/server/XUnitTest/Payment/CheckoutCallbackKeyEncodingTests.cs
@@ -1,0 +1,115 @@
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Payment.DomainService.Services;
+
+namespace XUnitTest.Payment;
+
+/// <summary>
+/// A callback key may be configured as base64, as hex, or as raw text, and which one it is read
+/// as decides the bytes the HMAC is taken with.
+/// </summary>
+/// <remarks>
+/// Every existing test in this area uses a raw-text key, so the base64 and hex branches were
+/// reachable only in production. That matters more than the usual untested-branch case: the three
+/// encodings are tried in a fixed order, a value can be legible as more than one of them, and the
+/// branch that wins produces different key bytes from the branch that would have. Re-keying a
+/// deployment that way invalidates every callback token in flight, and nothing would fail until a
+/// shopper returned from the provider.
+/// <para>
+/// These pin the order and the fallthrough, so it cannot be rearranged by accident.
+/// </para>
+/// </remarks>
+public sealed class CheckoutCallbackKeyEncodingTests
+{
+    private static string RoundTrip(string key)
+    {
+        var protector = new CheckoutCallbackStateProtector();
+        var issued = protector.Create(
+            "tenant-a", null, "payment-1", "ADYEN-ONLINE", TimeSpan.FromMinutes(30), key);
+
+        protector.TryUnprotect(issued.Token, key, null, out _).Should().BeTrue();
+        return issued.Token;
+    }
+
+    [Fact]
+    public void A_base64_key_is_accepted()
+    {
+        RoundTrip(Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
+    }
+
+    [Fact]
+    public void A_hex_key_is_accepted()
+    {
+        // 66 hex characters: an odd count of bytes keeps the length off a multiple of four, so
+        // this reaches the hex branch rather than being swallowed as base64 first.
+        RoundTrip(Convert.ToHexString(RandomNumberGenerator.GetBytes(33)));
+    }
+
+    [Fact]
+    public void A_raw_text_key_is_accepted()
+    {
+        RoundTrip("return-state-key-that-is-longer-than-thirty-two-bytes");
+    }
+
+    /// <summary>
+    /// The base64 attempt failing is the ordinary path for the other two encodings, not an error.
+    /// </summary>
+    [Fact]
+    public void A_key_that_is_not_base64_falls_through_instead_of_failing()
+    {
+        // '-' is outside the base64 alphabet, so the decode throws and is deliberately swallowed.
+        var act = () => RoundTrip("not-base64-but-still-far-longer-than-thirty-two-bytes");
+
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// A value legible as two encodings is read as the first one that fits, and that is base64.
+    /// </summary>
+    [Fact]
+    public void A_hex_looking_key_that_is_also_valid_base64_is_read_as_base64()
+    {
+        // 64 characters drawn from [0-9a-f]: valid hex, and also a valid base64 string whose
+        // length is a multiple of four. Base64 is tried first, so these are the bytes used.
+        const string Ambiguous =
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+        var expected = Convert.FromBase64String(Ambiguous);
+        expected.Should().NotEqual(
+            Convert.FromHexString(Ambiguous),
+            "the two readings must actually differ, or this test proves nothing");
+
+        var protector = new CheckoutCallbackStateProtector();
+        var issued = protector.Create(
+            "tenant-a", null, "payment-1", "ADYEN-ONLINE", TimeSpan.FromMinutes(30), Ambiguous);
+
+        // Re-sign the payload with the base64 reading and require the same signature, which is
+        // only true if the implementation chose base64 too.
+        var parts = issued.Token.Split('.');
+        var payload = FromBase64Url(parts[0]);
+        var signature = FromBase64Url(parts[1]);
+
+        HMACSHA256.HashData(expected, payload).Should().Equal(
+            signature,
+            "base64 is tried before hex, so an ambiguous key is keyed by its base64 bytes");
+    }
+
+    [Fact]
+    public void A_key_shorter_than_256_bits_is_refused()
+    {
+        var protector = new CheckoutCallbackStateProtector();
+
+        var act = () => protector.Create(
+            "tenant-a", null, "payment-1", "ADYEN-ONLINE", TimeSpan.FromMinutes(30), "too-short");
+
+        act.Should().Throw<FormatException>();
+    }
+
+    private static byte[] FromBase64Url(string value)
+    {
+        var padded = value.Replace('-', '+').Replace('_', '/');
+        padded += new string('=', (4 - padded.Length % 4) % 4);
+        return Convert.FromBase64String(padded);
+    }
+}


### PR DESCRIPTION
## What

`CheckoutCallbackStateProtector.DecodeKey` was the **only genuinely undocumented empty catch in the codebase** — finding #4 from the health check. Of the 17 `AP007` hits the detector reports, 16 are either exception-filtered (`when (exception.Code == 27)`) or already carry a comment explaining the intent. This one did not, and it sits in key-decoding code, where a reader has to reconstruct the intent before they can trust it.

**No behaviour changes.** The catch swallows exactly what it swallowed before.

## Why the catch is correct

`DecodeKey` accepts a configured HMAC key written as base64, hex, or raw text, and tries them in that order. The base64 attempt failing is the *ordinary* path for the other two encodings, not an error — the next branch gets its turn, and a value matching none of the three still ends in a `throw`. The catch is already narrow (`FormatException` only).

I also added a `<remarks>` on the method recording that **the order of the three branches is load-bearing**. A value can be legible as more than one encoding, and each reading produces different key bytes:

- A 64-character hex string is *also* valid base64 (length divisible by 4, all characters in the alphabet) and is read as base64 here.
- Reordering the branches would silently re-key any deployment configured that way, invalidating every callback token in flight — and nothing would fail until a shopper returned from the provider.

## Tests

Every existing test in this area used a raw-text key, so **both the base64 and hex branches were reachable only in production**. New `CheckoutCallbackKeyEncodingTests` covers:

- each of the three encodings round-tripping
- the fallthrough itself — a non-base64 key does not throw
- `A_hex_looking_key_that_is_also_valid_base64_is_read_as_base64` — pins the precedence by re-signing an ambiguous key's payload with the base64 reading and requiring the same signature. It first asserts the two readings actually differ, so the test cannot pass vacuously.
- a key shorter than 256 bits is refused

## Verification

- `dotnet build server/Blocks.slnx` — **0 errors**
- `CheckoutCallback*` tests — **30 passed, 0 failed**
- Full suite excluding `Integration` — **3668 passed, 4 failed**

The 4 failures are pre-existing on `dev`: the `SubscriptionSimulationGuard` permission tests, red because that check was commented out in `8d7a4389`.

## One honest caveat

This will **not** reduce the `AP007` count. The detector flags empty-bodied catches regardless of comments — `PdfFontResolver.cs:144` carries `// Skip unreadable directories.` and is still reported. What this change does is satisfy the rule's own stated remedy ("if intentionally ignoring, add a comment explaining why") and bring the last outlier in line with the other sixteen. Silencing the detector would mean logging a routine, expected outcome on a key-decoding path, which would be noise in exchange for nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
