### PR TITLE
fix(client): clarify plan builder pricing-model copy

### DIFF
--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx
@@ -909,6 +909,10 @@ export const PlanPriceFields = ({
                         ))}
                     </SelectContent>
                   </Select>
+                  <FormDescription className="text-xs">
+                    Flat fee charges the same whatever the quantity. Per unit multiplies the
+                    amount above by the units held.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
+++ b/client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx
@@ -285,7 +285,11 @@ export const StepPricingModel = ({
                     <FormLabel className="text-xs">
                       {meterValues?.[index]?.resetPolicy === 1
                         ? "Included for subscription lifetime"
-                        : "Included per period"}
+                        : `Included per period${
+                            meterValues?.[index]?.unitLabel
+                              ? ` (${meterValues[index].unitLabel})`
+                              : ""
+                          }`}
                     </FormLabel>
                     <FormControl>
                       {/* Stepped to the meter's own granularity. Without it the browser's own
@@ -306,7 +310,7 @@ export const StepPricingModel = ({
                 name={`meters.${index}.resetPolicy`}
                 render={({ field: inputField }) => (
                   <FormItem>
-                    <FormLabel className="text-xs">Allowance resets</FormLabel>
+                    <FormLabel className="text-xs">Unused allowance</FormLabel>
                     <Select
                       value={String(inputField.value)}
                       onValueChange={(value) => {
@@ -337,8 +341,8 @@ export const StepPricingModel = ({
                       </SelectContent>
                     </Select>
                     <p className="text-xs text-muted-foreground">
-                      Choose Never for capacity that must remain consumed after renewal, or Carry
-                      forward to let an unused allowance roll into the next period.
+                      Choose &ldquo;Does not apply&rdquo; for capacity that must remain consumed
+                      after renewal, or let it roll into the next period instead.
                     </p>
                     <FormMessage />
                   </FormItem>
@@ -350,7 +354,9 @@ export const StepPricingModel = ({
                   name={`meters.${index}.carryForwardCap`}
                   render={({ field: inputField }) => (
                     <FormItem>
-                      <FormLabel className="text-xs">Most one period may carry in</FormLabel>
+                      <FormLabel className="text-xs">
+                        Most {meterValues?.[index]?.unitLabel || "units"} one period may carry in
+                      </FormLabel>
                       <FormControl>
                         <Input
                           {...inputField}
@@ -363,7 +369,8 @@ export const StepPricingModel = ({
                       <p className="text-xs text-muted-foreground">
                         Caps what rolls in, not the total — the included amount is always
                         available on top. Required, because without a ceiling a dormant
-                        subscription banks allowance indefinitely.
+                        subscription banks allowance indefinitely. The most a subscriber can ever
+                        hold in one period is the included amount plus this cap.
                       </p>
                       <FormMessage />
                     </FormItem>
@@ -375,7 +382,7 @@ export const StepPricingModel = ({
                 name={`meters.${index}.aggregation`}
                 render={({ field: inputField }) => (
                   <FormItem>
-                    <FormLabel className="text-xs">How usage is measured</FormLabel>
+                    <FormLabel className="text-xs">How recordings are combined</FormLabel>
                     <Select
                       value={String(inputField.value)}
                       onValueChange={(value) => inputField.onChange(Number(value))}
@@ -457,7 +464,7 @@ export const StepPricingModel = ({
               name="usageInterval"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel className="text-xs">Allowance resets every</FormLabel>
+                  <FormLabel className="text-xs">Allowance period</FormLabel>
                   <Select
                     value={String(field.value)}
                     onValueChange={(value) => field.onChange(Number(value))}
@@ -475,6 +482,10 @@ export const StepPricingModel = ({
                       ))}
                     </SelectContent>
                   </Select>
+                  <p className="text-xs text-muted-foreground">
+                    How long one allowance lasts. Independent of how often you bill — a yearly
+                    price can still grant a monthly allowance, and usually should.
+                  </p>
                   <FormMessage />
                 </FormItem>
               )}

--- a/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
+++ b/client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts
@@ -101,9 +101,9 @@ export const METER_AGGREGATION_OPTIONS = [
 ] as const;
 
 export const METER_RESET_POLICY_OPTIONS = [
-  { value: 0, label: "Every allowance period — tokens, requests, generations" },
-  { value: 1, label: "Never — persistent capacity such as storage" },
-  { value: 2, label: "Carry forward — unused allowance rolls into the next period" },
+  { value: 0, label: "Expires at the end of each period — tokens, requests, generations" },
+  { value: 1, label: "Does not apply — one lifetime balance, such as storage" },
+  { value: 2, label: "Rolls into the next period, up to a cap" },
 ] as const;
 
 export const ENTITLEMENT_LIMIT_KIND_OPTIONS = [


### PR DESCRIPTION
## Summary

Copy-only fixes to the plan builder's pricing-model step, zero logic changes.

**1. "Resets" named two different fields** — the root cause of confusion:
- Per-meter [step-pricing-model.tsx](client/app/cross-modules/utilities/subscription/components/plan-builder/step-pricing-model.tsx): `"Allowance resets"` → `"Unused allowance"`
- Plan level: `"Allowance resets every"` → `"Allowance period"`
- Retitled [`METER_RESET_POLICY_OPTIONS`](client/app/cross-modules/utilities/subscription/constants/subscription.constants.ts) to complete the sentence "Unused allowance…": *"Expires at the end of each period"*, *"Does not apply — one lifetime balance, such as storage"*, *"Rolls into the next period, up to a cap"*. On a carry-forward meter, "resets" was simply wrong — the allowance accumulates, it doesn't reset.

**2. Quantity field labelled with "period"** — carry-forward cap label now interpolates the meter's own unit label: *"Most {unitLabel} one period may carry in."*

**3. Allowance-period block had no hint** — added: *"How long one allowance lasts. Independent of how often you bill — a yearly price can still grant a monthly allowance, and usually should."*

**4. "What this multiplies" had no hint** ([plan-price-fields.tsx](client/app/cross-modules/utilities/subscription/components/plan-builder/plan-price-fields.tsx)) — added: *"Flat fee charges the same whatever the quantity. Per unit multiplies the amount above by the units held."*

**Smaller, same pass:**
- "Included per period" → interpolates the meter's unit label
- "How usage is measured" → "How recordings are combined" (the choice is how recordings collapse into one number, not units)
- Carry-forward hint now states the real ceiling explicitly: "The most a subscriber can ever hold in one period is the included amount plus this cap."

## Testing

- `npx vitest run app/cross-modules/utilities/subscription` — 56 files / 703 tests passed (no test asserted on any of the changed strings)
- `npx tsc --noEmit` — clean
- `npx eslint` on all three touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)