### PR TITLE
chore(payment): make PaymentHashing and PaymentSlug internal

### DIFF
--- a/server/Payment.DomainService/Payment.DomainService.csproj
+++ b/server/Payment.DomainService/Payment.DomainService.csproj
@@ -1,5 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <!-- PaymentHashing and PaymentSlug are implementation details of this module, but the tests
+         that pin their output live in the test assembly. Note the cost: this grants XUnitTest
+         access to every internal in this project, present and future, not only those two. Keep
+         new types public when another project genuinely consumes them, rather than reaching for
+         internal and widening what this line already exposes. -->
+    <InternalsVisibleTo Include="XUnitTest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="FluentValidation" />

--- a/server/Payment.DomainService/Utilities/PaymentHashing.cs
+++ b/server/Payment.DomainService/Utilities/PaymentHashing.cs
@@ -5,7 +5,7 @@ using Payment.DomainService.Requests;
 
 namespace Payment.DomainService.Utilities;
 
-public static class PaymentHashing
+internal static class PaymentHashing
 {
     public static string CreateRequestHash(MakePaymentRequest request)
     {

--- a/server/Payment.DomainService/Utilities/PaymentSlug.cs
+++ b/server/Payment.DomainService/Utilities/PaymentSlug.cs
@@ -13,7 +13,7 @@ namespace Payment.DomainService.Utilities;
 /// short hash of the original value is appended so distinct inputs always produce distinct
 /// slugs, while the readable part still tells an operator which merchant they are looking at.
 /// </remarks>
-public static class PaymentSlug
+internal static class PaymentSlug
 {
     private const int MaximumReadableLength = 40;
     private const int HashCharacters = 8;


### PR DESCRIPTION
## What

`PaymentHashing` and `PaymentSlug` were `public static class`. Both are implementation details of the payment module, and nothing outside `Payment.DomainService` referenced either — `Api`, `Worker` and `Subscription.DomainService` all resolve to **zero** usages. Being public advertised a contract no caller had.

Two lines changed from `public` to `internal`, plus the `InternalsVisibleTo` those two lines now require.

**No behaviour change. Accessibility only.**

## The cost, stated up front

The tests that pin their output live in `XUnitTest`, a separate assembly — `PaymentSlugTests` alone has 8 cases, and `PaymentHashing` appears in 6 test files. So this needs `InternalsVisibleTo`, and there was none anywhere in the solution before this PR.

That attribute grants `XUnitTest` access to **every internal in `Payment.DomainService`, present and future** — a wider opening than the two types it closes. It buys correctness of intent, not isolation. The csproj carries a comment saying exactly that, so the next person reaching for `internal` in this project knows what the line already exposes and doesn't treat it as free.

**If a reviewer would rather not introduce `InternalsVisibleTo` for this, closing the PR costs nothing.** It is the smallest item on the cleanup list and I said as much when it came up; it is here because it was asked for, not because the payoff is large.

`PeriodKey`, the third candidate from the same audit, stays public — 32 files outside its own project use it.

## Verification

- `dotnet build server/Blocks.slnx` — **0 errors**. The build is the proof that nothing outside the assembly consumed either type, and that no public signature exposed them (`internal` in a public signature is `CS0050`).
- Full suite excluding `Integration` — **3662 passed, 4 failed**
- No new warnings on either file. The `CA1308` (`ToLowerInvariant`) and `CA1707` (test naming) warnings there are pre-existing and unrelated to accessibility.

The 4 failures are pre-existing on `dev`: the `SubscriptionSimulationGuard` permission tests, red because that check was commented out in `8d7a4389`.

## Context

This came out of re-checking the health check's API Surface finding, which turned out to be largely wrong. The claim "6 provider clients with no interface" was an artifact of a `I<ClassName>` naming heuristic — 5 of the 6 implement shared strategy interfaces (`IPaymentSessionClient`, `ICheckoutResultClient`, `IPaymentInitiationService`) and are registered polymorphically, which is the better design. These two helpers were the only part of that finding that survived scrutiny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
