### PR TITLE
chore: drop 17 unused package pins and a commented-out reference

### DIFF
--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -5,34 +5,21 @@
   <ItemGroup>
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="DeviceDetector.NET" Version="6.4.2" />
-    <PackageVersion Include="Handlebars.Net" Version="2.1.6" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="SixLabors.Fonts" Version="2.1.2" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.13" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.5.0" />
     <PackageVersion Include="SeliseBlocks.Genesis.OS" Version="4.1.5" />
     <PackageVersion Include="SeliseBlocks.ConfigurationDriver" Version="10.0.0-preview.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.71.0" />
-    <!-- Both are pinned to what SeliseBlocks.Genesis.OS already resolves to transitively;
-         anything lower is a package downgrade and fails the build. -->
+    <!-- Pinned to what SeliseBlocks.Genesis.OS already resolves to transitively; anything lower
+         is a package downgrade and fails the build. -->
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
-    <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageVersion Include="SeliseBlocks.StorageDriver.OS" Version="4.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.16.16" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
-    <PackageVersion Include="SSH.NET" Version="2024.2.0" />
-    <PackageVersion Include="Otp.NET" Version="1.4.0" />
-    <PackageVersion Include="QRCoder" Version="1.6.0" />
-    <PackageVersion Include="SeliseBlocks.MailDriver.OS" Version="4.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />
@@ -48,9 +35,5 @@
     <PackageVersion Include="PdfSharp" Version="6.2.4" />
     <PackageVersion Include="PuppeteerSharp" Version="20.2.5" />
     <PackageVersion Include="Shark.PdfConvert" Version="1.0.5" />
-    <PackageVersion Include="MailKit" Version="4.16.0" />
-    <PackageVersion Include="Microsoft.Graph" Version="5.68.0" />
-    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.0" />
-    <PackageVersion Include="MimeKit" Version="4.16.0" />
   </ItemGroup>
 </Project>

--- a/server/Utility.DomainService/Utility.DomainService.csproj
+++ b/server/Utility.DomainService/Utility.DomainService.csproj
@@ -15,7 +15,6 @@
 	<PackageReference Include="SeliseBlocks.Genesis.OS" />
 	<PackageReference Include="SeliseBlocks.StorageDriver.OS" />
 	<PackageReference Include="Shark.PdfConvert" />
-	<!-- <PackageReference Include="SeliseBlocks.MailDriver.OS" /> -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What

`Directory.Packages.props` held **47** `PackageVersion` entries; only **30** are referenced by any `.csproj`. The other 17 name packages that reach the build *transitively* through `SeliseBlocks.Genesis.OS` and its siblings:

`MongoDB.Driver` · `MailKit` · `MimeKit` · `Microsoft.Graph` · `Microsoft.Kiota.Abstractions` · `SixLabors.Fonts` · `SixLabors.ImageSharp` · `SixLabors.ImageSharp.Drawing` · `Handlebars.Net` · `System.IdentityModel.Tokens.Jwt` · `Grpc.AspNetCore` · `Azure.ResourceManager.ServiceBus` · `SSH.NET` · `Otp.NET` · `QRCoder` · `DeviceDetector.NET` · `SeliseBlocks.MailDriver.OS`

The last four are leftovers of the deleted captcha and MFA drivers; `MailDriver` is a leftover of mail moving out of this service.

**Why it matters more than tidiness:** `CentralPackageTransitivePinningEnabled` is not set, so a `PackageVersion` with no matching `PackageReference` feeds nothing. These lines look authoritative while deciding nothing — someone checking which MongoDB driver this service uses finds `3.5.0` here with no way to tell it is inert. Worse, the real resolved version could drift with a Genesis upgrade and this file would keep saying `3.5.0`.

Also removed the commented-out `SeliseBlocks.MailDriver.OS` `PackageReference` in `Utility.DomainService.csproj`, and narrowed the Azure comment from "Both" now that only `Azure.Identity` sits beneath it.

## Verification — proof, not assertion

The removal is provably inert:

```
dotnet list package --include-transitive   (before) → 186 resolved entries
dotnet list package --include-transitive   (after)  → 186 resolved entries
diff before after → IDENTICAL
```

Nothing about what actually restores has moved. Plus:

- `dotnet build server/Blocks.slnx` — **0 errors**
- Full suite excluding `Integration` — **3662 passed, 4 failed**

The 4 failures are pre-existing on `dev`: the `SubscriptionSimulationGuard` permission tests, red because that check was commented out in `8d7a4389`.

## ⚠️ What I did NOT remove, and why it matters

`find_dead_code` reports **`PdfFontConfig`** and its `Initialize` as unused. **Removing them would have been a production bug.**

```csharp
internal static class PdfFontConfig
{
    [ModuleInitializer]
    internal static void Initialize() => EnsureConfigured();
```

`[ModuleInitializer]` means the runtime calls it on assembly load. It is *designed* to have no callers — it installs the global PdfSharp font resolver "so any `XFont` created by the PDF engines (or their tests) has a resolver available before the first font is used." Delete it and every PDF render loses font resolution, with nothing referencing the gap to point at the cause.

This is the convention-bound false positive class that reference-search dead-code detection cannot see. It stays, and it is worth knowing the detector flags it before someone acts on that report.

## Not in this PR

`client/package.json` depends on `@beefree.io/sdk` (^11.4.0), imported nowhere in `client/app`. Removing it rewrites `package-lock.json` and needs a client build to verify, and this repo validates the client in a separate workflow — so it belongs in its own PR rather than mixed into .NET package hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
