### PR TITLE
chore(client): drop the unused BeeFree SDK dependency

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,6 @@
       "name": "blocks-utilities-client",
       "version": "0.0.1",
       "dependencies": {
-        "@beefree.io/sdk": "^11.4.0",
         "@hcaptcha/react-hcaptcha": "^1.12.0",
         "@hookform/resolvers": "^3.9.0",
         "@microsoft/signalr": "^10.0.0",
@@ -438,16 +437,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@beefree.io/sdk": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/@beefree.io/sdk/-/sdk-11.6.1.tgz",
-      "integrity": "sha512-cy3SitUc5EKMbZpDCsCwmhuOJS138BzGvlIfoHL2FuW8opqTBgzEn51gnkhgTI4Jk60908WoQVlMvtrBg0K9IA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "fp-ts": "^2.13.1",
-        "load-script": "^2.0.0"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -5751,12 +5740,6 @@
         "node": ">=0.4.x"
       }
     },
-    "node_modules/fp-ts": {
-      "version": "2.16.11",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
-      "integrity": "sha512-LaI+KaX2NFkfn1ZGHoKCmcfv7yrZsC3b8NtWsTVQeHkq4F27vI5igUuO53sxqDEa2gNQMHFPmpojDw/1zmUK7w==",
-      "license": "MIT"
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -7389,12 +7372,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/load-script": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-2.0.0.tgz",
-      "integrity": "sha512-km6cyoPW4rM22JMGb+SHUKPMZVDpUaMpMAKrv8UHWllIxc/qjgMGHD91nY+5hM+/NFs310OZ2pqQeJKs7HqWPA==",
       "license": "MIT"
     },
     "node_modules/locate-path": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,6 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@beefree.io/sdk": "^11.4.0",
     "@hcaptcha/react-hcaptcha": "^1.12.0",
     "@hookform/resolvers": "^3.9.0",
     "@microsoft/signalr": "^10.0.0",


### PR DESCRIPTION
## What

`@beefree.io/sdk` (^11.4.0) is imported **nowhere** in the client. I checked every `.ts`, `.tsx`, `.js`, `.jsx` and `.html` under `client/`, not just `client/app/` — zero references.

It is a leftover of the mail template editor, a capability that left this repository along with the mail projects. The README advertised it until PR #447; the console has no page for it.

## Why bother

An unused dependency is not free: it ships in every install, it is one more package the SCA gate clears on every pull request, and it invites the next person to conclude the template editor still lives here.

## The diff is a pure deletion

```
client/package.json      |  1 -
client/package-lock.json | 23 -----------------------
2 files changed, 24 deletions(-)
```

**No insertions.** The lockfile lost the entry and nothing else moved version — this is not a `npm install` that quietly bumped unrelated packages.

## Verification

Full client gate, all green:

- `npm --prefix client run type-check` (`tsc --noEmit`) — **clean**
- `npm --prefix client run test` — **339 test files, 2565 tests, all passed**
- `npm --prefix client run build` (`tsc -b && vite build`) — **✓ built in 35.61s**, exit 0

The `HTMLCanvasElement.getContext()` notices during tests and the >500 kB chunk-size warning at build are both pre-existing jsdom/rolldown noise, unrelated to this change.

## Related

Split out of #450 deliberately. That PR removes 17 unused .NET package pins; this one touches the client lockfile, which `client-pr-validation.yml` gates separately. Mixing the two would have made both harder to review and tied a .NET change to a client CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
