### PR TITLE
chore(client): bump @seliseblocks/genesis-os to 4.3.4

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -33,7 +33,7 @@
         "@radix-ui/react-tabs": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.2",
         "@radix-ui/react-tooltip": "^1.1.2",
-        "@seliseblocks/genesis-os": "4.1.0",
+        "@seliseblocks/genesis-os": "4.3.4",
         "@tanstack/react-query": "^5.62.11",
         "@tanstack/react-query-devtools": "^5.62.11",
         "@tanstack/react-table": "^8.20.5",
@@ -2424,6 +2424,20 @@
       "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
       "license": "MIT"
     },
+    "node_modules/@rollbar/react": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollbar/react/-/react-1.0.0.tgz",
+      "integrity": "sha512-e3S9K9k1BLNuqAFA/AD8XH4kcypClYWoMBuW5LO7fnu5Jy1/qiRFIgS5cFZpAFWQqJaSPQAqrLP6n41sH08X9A==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "16.x || 17.x || 18.x || 19.x",
+        "rollbar": "^2.26.4 || ^3.0.0-alpha.3"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -2688,10 +2702,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rrweb/record": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/record/-/record-2.1.1.tgz",
+      "integrity": "sha512-c2u175R+daC37PhbjaQV0migxtIXsLuD0mRgRstj/x/CRmLGctRlDi373/4miIUclleq4eZIQXAglH9opclFRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.1.1",
+        "@rrweb/utils": "^2.1.1",
+        "rrweb": "^2.1.1"
+      }
+    },
+    "node_modules/@rrweb/types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-g0I3nCNL1S7slDXwhunxOuOoswkY8WVZJQrPFiwixOc6xoD514d1JLTuyAzCKIox8g/PaLKtV5g31Uk42inQSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.1.1.tgz",
+      "integrity": "sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA==",
+      "license": "MIT"
+    },
     "node_modules/@seliseblocks/genesis-os": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@seliseblocks/genesis-os/-/genesis-os-4.1.0.tgz",
-      "integrity": "sha512-lIEK/HWkTGPfw8hTR0QwJrVRbRmsrNMW1A9YF4nFs0QhpSyMKWXSkFjmUydEJdv4sQK96lBOtW1UNHoyQhoOUQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@seliseblocks/genesis-os/-/genesis-os-4.3.4.tgz",
+      "integrity": "sha512-cmxM+Mr5GNP0kVy1es9Yowt1qUCtxCzQHuaqKEYmX3e/8A0pwZJ3SUZwvas+/aPnIB2ewkbFipskFH+wmudK6Q==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -2727,6 +2764,7 @@
         "@radix-ui/react-toggle": "^1.1.18",
         "@radix-ui/react-toggle-group": "^1.1.19",
         "@radix-ui/react-tooltip": "^1.2.16",
+        "@rollbar/react": "^1.0.0",
         "@tanstack/react-table": "8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2743,6 +2781,7 @@
         "react-hook-form": "^7.83.0",
         "react-resizable-panels": "^3.0.6",
         "recharts": "2.15.4",
+        "rollbar": "^3.1.0",
         "tailwind-merge": "^3.6.0",
         "vaul": "^1.1.2",
         "zod": "^3.25.76"
@@ -3163,6 +3202,12 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -3717,6 +3762,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4019,6 +4070,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -4099,6 +4156,15 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -4952,6 +5018,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-abstract": {
@@ -7048,6 +7123,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -7586,6 +7667,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/motion-dom": {
       "version": "12.43.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
@@ -7624,7 +7711,6 @@
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
       "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8093,7 +8179,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -8143,7 +8228,6 @@
       "version": "8.5.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
       "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8843,6 +8927,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==",
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8921,6 +9011,27 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rollbar": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-3.1.0.tgz",
+      "integrity": "sha512-YELG0MDRzOLnV5sa2vL/IiGEgNoK5JAivKlpjcJewEIqgmiVlEAPFQUNNB3fsK1PZy6VdHpsUd+Xp4qEuAylfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/record": "^2.0.0-alpha.18",
+        "async": "~3.2.3",
+        "error-stack-parser-es": "^1.0.5",
+        "json-stringify-safe": "~5.0.0",
+        "lru-cache": "~2.2.1",
+        "request-ip": "~3.3.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "node_modules/rollbar/node_modules/lru-cache": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+      "integrity": "sha512-Q5pAgXs+WEAfoEdw2qKQhNFFhMoFMTYqRVKKUMnzuiR7oKFHS7fWo848cPcTKw+4j/IdN17NyzdhVKgabFV0EA==",
+      "license": "MIT"
+    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -8953,6 +9064,40 @@
         "@rolldown/binding-wasm32-wasi": "1.1.5",
         "@rolldown/binding-win32-arm64-msvc": "1.1.5",
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/rrdom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.1.1.tgz",
+      "integrity": "sha512-VBkTF3bGNqcZjqnbo/gKi9GVQPIxiG0dofw7CQdAZQFQ2juJdt2YKIf3oS9QudL8HTpGh9bz5TUN+3amBn1Geg==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.1.1"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.1.1.tgz",
+      "integrity": "sha512-ToxhJg3SsrAhw+/DPhI/2iiwZQIrGK5BGkZ0kHn4qUExcvQYRaolkciD1FWX2+r6vf1IxFyhsoRY18h3D+XoCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.1.1",
+        "@rrweb/utils": "^2.1.1",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.1.1",
+        "rrweb-snapshot": "^2.1.1"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.1.1.tgz",
+      "integrity": "sha512-al4Kx7Am7YlIn/5Yb2EMr7cdmjGiK+cLhdilJEXqkFXgpnys8t/yMJumXy2Ormgirpg3MBnFha0GTgny+iIL2w==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/run-parallel": {
@@ -9237,11 +9382,19 @@
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/client/package.json
+++ b/client/package.json
@@ -43,7 +43,7 @@
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.1.2",
-    "@seliseblocks/genesis-os": "4.1.0",
+    "@seliseblocks/genesis-os": "4.3.4",
     "@tanstack/react-query": "^5.62.11",
     "@tanstack/react-query-devtools": "^5.62.11",
     "@tanstack/react-table": "^8.20.5",


### PR DESCRIPTION
## Summary
- Bump `@seliseblocks/genesis-os` npm package from 4.1.0 to 4.3.4 in client/package.json and package-lock.json.

Note: the NuGet package `SeliseBlocks.Genesis.OS` was already pinned at 4.1.5 in server/Directory.Packages.props, so no change was needed there.

## Test plan
- [ ] `npm ci --prefix client` installs cleanly
- [ ] `npm --prefix client run type-check`
- [ ] `npm --prefix client run test`