### PR TITLE
fix(subscription): name machine callers and stop reporting identity gaps as outages

### DIFF
--- a/server/Api/Controllers/PaymentMethodsController.cs
+++ b/server/Api/Controllers/PaymentMethodsController.cs
@@ -148,6 +148,10 @@ public sealed class PaymentMethodsController : ControllerBase
                 StatusCode(
                     StatusCodes.Status504GatewayTimeout,
                     response),
+            PaymentFailureKind.Unauthenticated =>
+                StatusCode(
+                    StatusCodes.Status401Unauthorized,
+                    response),
             PaymentFailureKind.Unavailable =>
                 StatusCode(
                     StatusCodes.Status503ServiceUnavailable,

--- a/server/Api/Controllers/PaymentProvidersController.cs
+++ b/server/Api/Controllers/PaymentProvidersController.cs
@@ -233,6 +233,9 @@ public sealed class PaymentProvidersController : ControllerBase
             PaymentFailureKind.Validation => BadRequest(response),
             PaymentFailureKind.NotFound => NotFound(response),
             PaymentFailureKind.Conflict => Conflict(response),
+            PaymentFailureKind.Unauthenticated => StatusCode(
+                StatusCodes.Status401Unauthorized,
+                response),
             PaymentFailureKind.Unavailable => StatusCode(
                 StatusCodes.Status503ServiceUnavailable,
                 response),
@@ -269,6 +272,9 @@ public sealed class PaymentProvidersController : ControllerBase
             PaymentFailureKind.Validation => BadRequest(response),
             PaymentFailureKind.NotFound => NotFound(response),
             PaymentFailureKind.Conflict => Conflict(response),
+            PaymentFailureKind.Unauthenticated => StatusCode(
+                StatusCodes.Status401Unauthorized,
+                response),
             PaymentFailureKind.Unavailable => StatusCode(
                 StatusCodes.Status503ServiceUnavailable,
                 response),
@@ -292,6 +298,9 @@ public sealed class PaymentProvidersController : ControllerBase
 
         return failureKind switch
         {
+            PaymentFailureKind.Unauthenticated => StatusCode(
+                StatusCodes.Status401Unauthorized,
+                response),
             PaymentFailureKind.Unavailable => StatusCode(
                 StatusCodes.Status503ServiceUnavailable,
                 response),

--- a/server/Api/Controllers/PaymentsController.cs
+++ b/server/Api/Controllers/PaymentsController.cs
@@ -373,6 +373,7 @@ public sealed class PaymentsController : ControllerBase
             PaymentFailureKind.RateLimited => StatusCode(StatusCodes.Status429TooManyRequests, response),
             PaymentFailureKind.ProviderRejected => UnprocessableEntity(response),
             PaymentFailureKind.ProviderFailure => StatusCode(StatusCodes.Status502BadGateway, response),
+            PaymentFailureKind.Unauthenticated => StatusCode(StatusCodes.Status401Unauthorized, response),
             PaymentFailureKind.Unavailable => StatusCode(StatusCodes.Status503ServiceUnavailable, response),
             PaymentFailureKind.Timeout => StatusCode(StatusCodes.Status504GatewayTimeout, response),
             _ => StatusCode(StatusCodes.Status500InternalServerError, response)
@@ -436,6 +437,10 @@ public sealed class PaymentsController : ControllerBase
                 StatusCode(
                     StatusCodes.Status502BadGateway,
                     response),
+            PaymentFailureKind.Unauthenticated =>
+                StatusCode(
+                    StatusCodes.Status401Unauthorized,
+                    response),
             PaymentFailureKind.Unavailable =>
                 StatusCode(
                     StatusCodes.Status503ServiceUnavailable,
@@ -472,6 +477,9 @@ public sealed class PaymentsController : ControllerBase
             PaymentFailureKind.ProviderFailure => StatusCode(
                 StatusCodes.Status502BadGateway,
                 response),
+            PaymentFailureKind.Unauthenticated => StatusCode(
+                StatusCodes.Status401Unauthorized,
+                response),
             PaymentFailureKind.Unavailable => StatusCode(
                 StatusCodes.Status503ServiceUnavailable,
                 response),
@@ -498,6 +506,9 @@ public sealed class PaymentsController : ControllerBase
             PaymentFailureKind.Validation => BadRequest(response),
             PaymentFailureKind.RateLimited => StatusCode(
                 StatusCodes.Status429TooManyRequests,
+                response),
+            PaymentFailureKind.Unauthenticated => StatusCode(
+                StatusCodes.Status401Unauthorized,
                 response),
             PaymentFailureKind.Unavailable => StatusCode(
                 StatusCodes.Status503ServiceUnavailable,

--- a/server/Api/Utilities/CheckoutCallbackHttpResultMapper.cs
+++ b/server/Api/Utilities/CheckoutCallbackHttpResultMapper.cs
@@ -32,6 +32,8 @@ public static class CheckoutCallbackHttpResultMapper
             PaymentFailureKind.NotFound => controller.NotFound(response),
             PaymentFailureKind.RateLimited =>
                 controller.StatusCode(StatusCodes.Status429TooManyRequests, response),
+            PaymentFailureKind.Unauthenticated =>
+                controller.StatusCode(StatusCodes.Status401Unauthorized, response),
             PaymentFailureKind.Unavailable =>
                 controller.StatusCode(StatusCodes.Status503ServiceUnavailable, response),
             _ => controller.BadRequest(response)

--- a/server/Api/Utilities/SubscriptionApiResults.cs
+++ b/server/Api/Utilities/SubscriptionApiResults.cs
@@ -48,6 +48,7 @@ public static class SubscriptionApiResults
         PaymentFailureKind.RateLimited => StatusCodes.Status429TooManyRequests,
         PaymentFailureKind.ProviderRejected => StatusCodes.Status422UnprocessableEntity,
         PaymentFailureKind.ProviderFailure => StatusCodes.Status502BadGateway,
+        PaymentFailureKind.Unauthenticated => StatusCodes.Status401Unauthorized,
         PaymentFailureKind.Unavailable => StatusCodes.Status503ServiceUnavailable,
         PaymentFailureKind.Timeout => StatusCodes.Status504GatewayTimeout,
         _ => StatusCodes.Status500InternalServerError

--- a/server/Payment.DomainService/Enums/PaymentFailureKind.cs
+++ b/server/Payment.DomainService/Enums/PaymentFailureKind.cs
@@ -2,5 +2,28 @@ namespace Payment.DomainService.Enums;
 
 public enum PaymentFailureKind
 {
-    None, Validation, NotFound, Conflict, RateLimited, ProviderRejected, ProviderFailure, Unavailable, Timeout, Unexpected
+    None,
+    Validation,
+    NotFound,
+    Conflict,
+    RateLimited,
+    ProviderRejected,
+    ProviderFailure,
+
+    /// <summary>
+    /// The caller could not be identified well enough to act on: no tenant, no actor, or no
+    /// organization to scope the answer to.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Unavailable"/> because the two ask opposite things of a client.
+    /// A token that carries no identity will carry none on the next attempt either, and
+    /// reporting it as a transient failure told integrations — and the load balancers in front
+    /// of them — to retry something that can never succeed. This says the request needs a
+    /// different token, not a later one.
+    /// </remarks>
+    Unauthenticated,
+
+    Unavailable,
+    Timeout,
+    Unexpected
 }

--- a/server/Payment.DomainService/Services/PaymentExecutionContextResolver.cs
+++ b/server/Payment.DomainService/Services/PaymentExecutionContextResolver.cs
@@ -1,6 +1,7 @@
 ﻿using Blocks.Genesis;
 using Payment.DomainService.Enums;
 using Payment.DomainService.Responses;
+using Payment.DomainService.Utilities;
 
 namespace Payment.DomainService.Services;
 
@@ -15,7 +16,16 @@ public sealed class PaymentExecutionContextResolver : IPaymentExecutionContextRe
         // null-coalescing fallback to the email never fired and such callers were rejected
         // outright. Treating blank as absent is what makes the fallback work as intended.
         var userId = Present(blocksContext?.UserId);
-        var actorId = userId ?? Present(blocksContext?.Email) ?? string.Empty;
+
+        // A client-credentials caller is named by none of these: it authenticates as an
+        // application, so the context reports no user id and no email and the ladder used to run
+        // out with nothing. Its identifier is in the token it presented, which is the last place
+        // left to look — see PaymentTokenActor for why reading it there is sound and why it is
+        // never allowed to decide anything but the actor.
+        var actorId = userId
+            ?? Present(blocksContext?.Email)
+            ?? Present(PaymentTokenActor.ClientId(blocksContext?.OAuthToken))
+            ?? string.Empty;
 
         if (!string.IsNullOrWhiteSpace(tenantId) && !string.IsNullOrWhiteSpace(actorId))
         {
@@ -36,7 +46,7 @@ public sealed class PaymentExecutionContextResolver : IPaymentExecutionContextRe
         return new PaymentContextResolution(
             null,
             PaymentOperationResult.Failure(
-                PaymentFailureKind.Unavailable,
+                PaymentFailureKind.Unauthenticated,
                 "payment_context_missing",
                 "Authenticated tenant context is unavailable.",
                 correlationId));

--- a/server/Payment.DomainService/Utilities/PaymentTokenActor.cs
+++ b/server/Payment.DomainService/Utilities/PaymentTokenActor.cs
@@ -1,0 +1,198 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Payment.DomainService.Utilities;
+
+/// <summary>
+/// The calling application's own identifier, read from the bearer token for callers the
+/// platform context names as nobody.
+/// </summary>
+/// <remarks>
+/// A client-credentials caller authenticates as an application rather than a person, so the
+/// context carries no user id and no email and the resolver has nothing to record as the actor.
+/// The identifier does exist — it is in the token, as <c>client_id</c> — but the platform
+/// context exposes no property for it, so the only way to reach it is to read the token the
+/// request already arrived with.
+/// <para>
+/// Read for identification only, never for authorisation. The token has already been validated
+/// by the authentication middleware before any of this runs — a request that got this far
+/// carries a signature the platform accepted — and nothing here re-checks it or would be
+/// entitled to. What this decides is what to write in an audit record's actor field; what a
+/// caller is allowed to do is still settled entirely by the tenant, the organization and the
+/// endpoint's own permission.
+/// </para>
+/// <para>
+/// Every failure is silent and returns null. A token this cannot read is not a reason to refuse
+/// a request that authentication already accepted, and the caller is then simply left without an
+/// actor exactly as it was before.
+/// </para>
+/// </remarks>
+public static class PaymentTokenActor
+{
+    /// <summary>
+    /// Marks the identifier as an application rather than a person.
+    /// </summary>
+    /// <remarks>
+    /// A bare client id is a GUID, and a GUID in a field named for an actor is indistinguishable
+    /// from a user id when somebody reads the audit trail a year later. The same reasoning keeps
+    /// the email fallback out of <c>UserId</c>: a fallback should not be able to pass itself off
+    /// as the thing it stood in for.
+    /// </remarks>
+    public const string ClientPrefix = "client:";
+
+    // Long enough for any access token worth parsing, short enough that a caller cannot make
+    // this service decode something absurd on every request.
+    private const int MaximumTokenLength = 8 * 1024;
+
+    private const int MaximumIdentifierLength = 128;
+
+    /// <summary>
+    /// The calling application's identifier, prefixed by <see cref="ClientPrefix"/>, or null
+    /// when the token carries none or cannot be read.
+    /// </summary>
+    public static string? ClientId(string? oauthToken)
+    {
+        var identifier = ReadIdentifier(oauthToken);
+
+        return identifier is null ? null : ClientPrefix + identifier;
+    }
+
+    private static string? ReadIdentifier(string? oauthToken)
+    {
+        if (string.IsNullOrWhiteSpace(oauthToken) || oauthToken.Length > MaximumTokenLength)
+        {
+            return null;
+        }
+
+        try
+        {
+            var payload = Payload(oauthToken);
+
+            if (payload is null)
+            {
+                return null;
+            }
+
+            using var document = JsonDocument.Parse(payload);
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            // The dedicated claim first. Falling back to the subject costs nothing and covers an
+            // issuer that names the application only there — the two carry the same identifier,
+            // the subject merely wears an issuer namespace in front of it.
+            return Identifier(document.RootElement, "client_id")
+                ?? Subject(document.RootElement);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static string? Payload(string oauthToken)
+    {
+        var token = oauthToken.Trim();
+
+        // Whether the scheme travels with the token is the caller's business, not ours.
+        if (token.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            token = token["Bearer ".Length..].Trim();
+        }
+
+        var segments = token.Split('.');
+
+        // Three segments is a signed token, whose payload is readable. Five is an encrypted one,
+        // whose payload is not — and guessing at it is worse than having no actor.
+        if (segments.Length != 3)
+        {
+            return null;
+        }
+
+        var bytes = FromBase64Url(segments[1]);
+
+        return bytes is null ? null : Encoding.UTF8.GetString(bytes);
+    }
+
+    private static byte[]? FromBase64Url(string segment)
+    {
+        if (segment.Length == 0)
+        {
+            return null;
+        }
+
+        var padded = new StringBuilder(segment.Length + 3);
+
+        foreach (var character in segment)
+        {
+            padded.Append(character switch
+            {
+                '-' => '+',
+                '_' => '/',
+                _ => character
+            });
+        }
+
+        // Base64url drops the padding that Convert.FromBase64String requires back.
+        padded.Append('=', (4 - (segment.Length % 4)) % 4);
+
+        return Convert.FromBase64String(padded.ToString());
+    }
+
+    private static string? Subject(JsonElement payload)
+    {
+        var subject = Identifier(payload, "sub");
+
+        if (subject is null)
+        {
+            return null;
+        }
+
+        // Issuers namespace the subject — "blocks|<id>" — and the namespace is the issuer's own
+        // bookkeeping rather than part of the identifier.
+        var separator = subject.LastIndexOf('|');
+
+        if (separator < 0)
+        {
+            return subject;
+        }
+
+        var identifier = subject[(separator + 1)..].Trim();
+
+        return identifier.Length == 0 ? null : identifier;
+    }
+
+    private static string? Identifier(JsonElement payload, string claim)
+    {
+        if (!payload.TryGetProperty(claim, out var element) ||
+            element.ValueKind != JsonValueKind.String)
+        {
+            return null;
+        }
+
+        var value = element.GetString()?.Trim();
+
+        if (string.IsNullOrEmpty(value) || value.Length > MaximumIdentifierLength)
+        {
+            return null;
+        }
+
+        // This is written to audit records and to logs, and it came off the wire. A control
+        // character in it would let a token forge whole log entries.
+        foreach (var character in value)
+        {
+            if (char.IsControl(character))
+            {
+                return null;
+            }
+        }
+
+        return value;
+    }
+}

--- a/server/Subscription.DomainService/Services/SubscriptionContextResolver.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionContextResolver.cs
@@ -26,7 +26,7 @@ public sealed class SubscriptionContextResolver : ISubscriptionContextResolver
         if (!resolution.IsSuccess || resolution.Context is null)
         {
             return SubscriptionContextResolution.Unresolved(
-                PaymentFailureKind.Unavailable,
+                PaymentFailureKind.Unauthenticated,
                 "subscription_context_missing",
                 "Authenticated tenant context is unavailable.");
         }
@@ -57,7 +57,7 @@ public sealed class SubscriptionContextResolver : ISubscriptionContextResolver
             // — and answering anyway would mean answering for somebody else. Stricter than the
             // payment resolver it wraps, which is content to leave this blank.
             return SubscriptionContextResolution.Unresolved(
-                PaymentFailureKind.Unavailable,
+                PaymentFailureKind.Unauthenticated,
                 "subscription_organization_missing",
                 "An organization is required to resolve a subscription.");
         }

--- a/server/XUnitTest/Payment/PaymentTokenActorTests.cs
+++ b/server/XUnitTest/Payment/PaymentTokenActorTests.cs
@@ -1,0 +1,249 @@
+using System.Text;
+using System.Text.Json;
+using Blocks.Genesis;
+using FluentAssertions;
+using Payment.DomainService.Services;
+using Payment.DomainService.Utilities;
+
+namespace XUnitTest.Payment;
+
+/// <summary>
+/// Naming a caller that authenticates as an application rather than as a person.
+/// </summary>
+public sealed class PaymentTokenActorTests
+{
+    private const string ClientId = "5e862913-cc88-4c05-aef9-d7ef390f05e4";
+
+    [Fact]
+    public void The_client_id_claim_names_the_application()
+    {
+        var token = Token(new { client_id = ClientId, sub = "blocks|" + ClientId });
+
+        PaymentTokenActor.ClientId(token).Should().Be("client:" + ClientId);
+    }
+
+    [Fact]
+    public void The_subject_names_it_when_there_is_no_client_id_claim()
+    {
+        var token = Token(new { sub = "blocks|" + ClientId });
+
+        PaymentTokenActor.ClientId(token).Should().Be("client:" + ClientId);
+    }
+
+    /// <summary>
+    /// The namespace in front of the subject is the issuer's bookkeeping, and carrying it into
+    /// the audit trail would mean the same application is recorded under two different names
+    /// depending on which claim happened to be read.
+    /// </summary>
+    [Fact]
+    public void The_issuer_namespace_is_not_part_of_the_identifier()
+    {
+        var token = Token(new { sub = "blocks|" + ClientId });
+
+        PaymentTokenActor.ClientId(token).Should().NotContain("blocks|");
+    }
+
+    [Fact]
+    public void A_subject_without_a_namespace_is_taken_whole()
+    {
+        var token = Token(new { sub = ClientId });
+
+        PaymentTokenActor.ClientId(token).Should().Be("client:" + ClientId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-token")]
+    [InlineData("only.two")]
+    [InlineData("a.b.c.d.e")]
+    [InlineData("header.!!!not-base64!!!.signature")]
+    public void An_unreadable_token_leaves_the_caller_without_an_actor(string? token)
+    {
+        // Never throws: authentication has already accepted this request, and a payload this
+        // cannot parse is not grounds to fail one.
+        PaymentTokenActor.ClientId(token).Should().BeNull();
+    }
+
+    [Fact]
+    public void An_encrypted_token_is_not_guessed_at()
+    {
+        var token = string.Join('.', "header", "key", "iv", "ciphertext", "tag");
+
+        PaymentTokenActor.ClientId(token).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_payload_that_names_no_application_yields_nothing()
+    {
+        var token = Token(new { tenant_id = "tenant-1", roles = "clouduser" });
+
+        PaymentTokenActor.ClientId(token).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_scheme_travelling_with_the_token_is_tolerated()
+    {
+        var token = "Bearer " + Token(new { client_id = ClientId });
+
+        PaymentTokenActor.ClientId(token).Should().Be("client:" + ClientId);
+    }
+
+    /// <summary>
+    /// The identifier reaches audit records and log lines, and it came off the wire.
+    /// </summary>
+    [Fact]
+    public void An_identifier_carrying_control_characters_is_refused()
+    {
+        var token = Token(new { client_id = "abc\ndef" });
+
+        PaymentTokenActor.ClientId(token).Should().BeNull();
+    }
+
+    [Fact]
+    public void A_non_string_claim_is_refused()
+    {
+        var token = Token(new { client_id = 42 });
+
+        PaymentTokenActor.ClientId(token).Should().BeNull();
+    }
+
+    // ---- through the resolver ----
+
+    [Fact]
+    public void The_resolver_names_a_client_credentials_caller_by_its_application()
+    {
+        // Tenant and organization present, no user id and no email: the shape of a
+        // client-credentials token, which used to be refused outright.
+        Establish(oauthToken: Token(new { client_id = ClientId }));
+        try
+        {
+            var resolution = new PaymentExecutionContextResolver().Resolve("corr-1");
+
+            resolution.IsSuccess.Should().BeTrue();
+            resolution.Context!.ActorId.Should().Be("client:" + ClientId);
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    /// <summary>
+    /// The same rule that keeps an email out of the user id. A fallback names the caller; it does
+    /// not get to pass itself off as the thing it stood in for, or the payments collection ends
+    /// up holding application ids in a field named for a person.
+    /// </summary>
+    [Fact]
+    public void The_resolver_does_not_record_a_client_id_as_the_user_id()
+    {
+        Establish(oauthToken: Token(new { client_id = ClientId }));
+        try
+        {
+            var resolution = new PaymentExecutionContextResolver().Resolve("corr-2");
+
+            resolution.Context!.UserId.Should().BeNull();
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    /// <summary>
+    /// The token is the last rung, not the first. A caller the context already names is named by
+    /// the context, or the same person would be recorded differently depending on which of the
+    /// two happened to be consulted.
+    /// </summary>
+    [Fact]
+    public void A_caller_the_context_names_is_not_renamed_by_its_token()
+    {
+        Establish(userId: "user-1", oauthToken: Token(new { client_id = ClientId }));
+        try
+        {
+            var resolution = new PaymentExecutionContextResolver().Resolve("corr-3");
+
+            resolution.Context!.ActorId.Should().Be("user-1");
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    [Fact]
+    public void The_email_still_outranks_the_token()
+    {
+        Establish(
+            email: "shopper@example.com",
+            oauthToken: Token(new { client_id = ClientId }));
+        try
+        {
+            var resolution = new PaymentExecutionContextResolver().Resolve("corr-4");
+
+            resolution.Context!.ActorId.Should().Be("shopper@example.com");
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    /// <summary>
+    /// Naming the caller was never the only requirement. A token that carries no tenant is still
+    /// refused, because an actor without one has nothing it could be acting on.
+    /// </summary>
+    [Fact]
+    public void A_token_actor_does_not_excuse_a_missing_tenant()
+    {
+        Establish(
+            tenantId: string.Empty,
+            oauthToken: Token(new { client_id = ClientId }));
+        try
+        {
+            var resolution = new PaymentExecutionContextResolver().Resolve("corr-5");
+
+            resolution.IsSuccess.Should().BeFalse();
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    /// <summary>
+    /// An authenticated context carrying whatever the caller proved, and nothing else.
+    /// </summary>
+    private static void Establish(
+        string tenantId = "tenant-1",
+        string? userId = null,
+        string? email = null,
+        string? oauthToken = null) =>
+        BlocksContext.SetContext(BlocksContext.Create(
+            tenantId,
+            null,
+            userId,
+            true,
+            null,
+            "org-1",
+            DateTime.UtcNow.AddHours(1),
+            email,
+            null,
+            null,
+            null,
+            null,
+            oauthToken,
+            tenantId));
+
+    private static string Token(object payload)
+    {
+        var json = JsonSerializer.Serialize(payload);
+        var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(json))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+
+        return string.Join('.', "header", encoded, "signature");
+    }
+}

--- a/server/XUnitTest/Subscription/SubscriptionApiResultsStatusTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionApiResultsStatusTests.cs
@@ -1,0 +1,82 @@
+using Api.Utilities;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Enums;
+using Payment.DomainService.Responses;
+using Subscription.DomainService.Services;
+
+namespace XUnitTest.Subscription;
+
+/// <summary>
+/// Which failures a client should retry, expressed as status codes.
+/// </summary>
+/// <remarks>
+/// The distinction this pins down is between a request that cannot succeed until something
+/// about the caller changes and one that may succeed on its own later. Both used to arrive as
+/// <c>503</c>, which told integrations — and the infrastructure in front of them — to retry a
+/// token that would never start working.
+/// </remarks>
+public sealed class SubscriptionApiResultsStatusTests
+{
+    private const string Correlation = "corr-1";
+
+    [Theory]
+    [InlineData("subscription_context_missing")]
+    [InlineData("subscription_organization_missing")]
+    public void A_caller_that_cannot_be_identified_is_told_so_with_401(string errorCode)
+    {
+        StatusFor(PaymentFailureKind.Unauthenticated, errorCode)
+            .Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    /// <summary>
+    /// The kind this was split out of keeps its meaning: an organization IAM could not be
+    /// reached to confirm is a genuine outage, and retrying it is the right thing to do.
+    /// </summary>
+    [Fact]
+    public void A_genuine_outage_is_still_503()
+    {
+        StatusFor(PaymentFailureKind.Unavailable, "organization_verification_unavailable")
+            .Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Theory]
+    [InlineData(PaymentFailureKind.Validation, StatusCodes.Status400BadRequest)]
+    [InlineData(PaymentFailureKind.NotFound, StatusCodes.Status404NotFound)]
+    [InlineData(PaymentFailureKind.Conflict, StatusCodes.Status409Conflict)]
+    [InlineData(PaymentFailureKind.RateLimited, StatusCodes.Status429TooManyRequests)]
+    [InlineData(PaymentFailureKind.ProviderRejected, StatusCodes.Status422UnprocessableEntity)]
+    [InlineData(PaymentFailureKind.ProviderFailure, StatusCodes.Status502BadGateway)]
+    [InlineData(PaymentFailureKind.Timeout, StatusCodes.Status504GatewayTimeout)]
+    [InlineData(PaymentFailureKind.Unexpected, StatusCodes.Status500InternalServerError)]
+    public void Every_other_failure_keeps_the_status_it_had(
+        PaymentFailureKind kind,
+        int expected)
+    {
+        // Inserting a kind into the enum must not shift what anything else maps to.
+        StatusFor(kind, "some_error").Should().Be(expected);
+    }
+
+    [Fact]
+    public void The_error_code_still_reaches_the_client()
+    {
+        var result = SubscriptionOperationResult<string>.Failure(
+                PaymentFailureKind.Unauthenticated,
+                "subscription_context_missing",
+                "Authenticated tenant context is unavailable.",
+                Correlation)
+            .ToActionResult(Correlation);
+
+        var body = result.Should().BeOfType<ObjectResult>().Subject.Value
+            .Should().BeOfType<ApiResponse<string>>().Subject;
+
+        body.Success.Should().BeFalse();
+        body.Error!.Code.Should().Be("subscription_context_missing");
+    }
+
+    private static int? StatusFor(PaymentFailureKind kind, string errorCode) =>
+        SubscriptionOperationResult<string>.Failure(kind, errorCode, "message", Correlation)
+            .ToActionResult(Correlation)
+            .Should().BeOfType<ObjectResult>().Subject.StatusCode;
+}

--- a/server/XUnitTest/Subscription/SubscriptionContextResolverTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionContextResolverTests.cs
@@ -73,6 +73,10 @@ public sealed class SubscriptionContextResolverTests
 
         resolution.IsSuccess.Should().BeFalse();
         resolution.ErrorCode.Should().Be("subscription_context_missing");
+
+        // Reported as an identity failure rather than a transient one, so the caller is told to
+        // present a different token instead of the same one again.
+        resolution.FailureKind.Should().Be(PaymentFailureKind.Unauthenticated);
     }
 
     /// <summary>
@@ -89,6 +93,7 @@ public sealed class SubscriptionContextResolverTests
 
         resolution.IsSuccess.Should().BeFalse();
         resolution.ErrorCode.Should().Be("subscription_organization_missing");
+        resolution.FailureKind.Should().Be(PaymentFailureKind.Unauthenticated);
     }
 
     private void Configure(string? organizationId) =>


### PR DESCRIPTION
## Problem

A service calling the subscription API with a **client-credentials token** got `503 subscription_context_missing` on every read:

```
GET /api/subscriptions/current
GET /api/subscription-usage/current
POST /api/subscription-usage
GET /api/entitlements
```

The token authenticates fine. But a client-credentials caller is an application, not a person, so the platform context carries no user id and no email — and the actor ladder in `PaymentExecutionContextResolver` ran out there.

Two problems, fixed independently.

## 1. The actor ladder gains a last rung

`PaymentTokenActor` reads `client_id` from the bearer token the request already arrived with, falling back to `sub` with its issuer namespace (`blocks|`) stripped — both carry the same identifier. The resolver consults it **only** when the context names nobody:

```csharp
var actorId = userId
    ?? Present(blocksContext?.Email)
    ?? Present(PaymentTokenActor.ClientId(blocksContext?.OAuthToken))
    ?? string.Empty;
```

Read for identification, never for authorisation. The token has already been validated by authentication middleware; nothing here re-checks a signature or would be entitled to. What a caller may *do* is still decided by tenant, organization and the endpoint's own permission.

Two properties worth keeping in review:

- **`UserId` stays null.** An application id must not pass itself off as a person — the same rule that already keeps the email fallback out of that field.
- **The value is prefixed `client:`.** A bare GUID in an actor field is indistinguishable from a user id when somebody reads the audit trail a year later.

## 2. Identity gaps return 401, not 503

`PaymentFailureKind` gains `Unauthenticated`, and the three context-resolution failures use it: `payment_context_missing`, `subscription_context_missing`, `subscription_organization_missing`.

A token with no identity will carry none on the next attempt either. Reporting that as 503 told integrations — and the load balancers in front of them — to retry something that could never succeed. **Genuine outages keep their 503**, `organization_verification_unavailable` among them; that distinction is exactly what the single kind could not express.

Every status mapper gained the arm (10 sites across `PaymentsController`, `PaymentProvidersController`, `PaymentMethodsController`, `CheckoutCallbackHttpResultMapper`, `SubscriptionApiResults`). No other failure's status moves — there's a test pinning that.

## Blast radius

- **Existing callers are unchanged.** The token is the *last* rung, so anything the context already names resolves exactly as before. Tested in both directions.
- **Background jobs are unaffected.** `PaymentTenantContextScopeFactory` establishes its context with an empty token, so those scopes still resolve to no actor.
- **Nothing keys off the actor's shape.** No production code compares, parses or prefix-matches `ActorId` — it is a recorded label, never an input to pricing, proration or entitlement.
- **Invoices are safe.** `RememberInitiatorAsync` takes `context.UserId`, not `ActorId`, and early-returns when blank — so no `client:` string can reach an invoice.
- **The enum insert is safe.** `PaymentFailureKind` appears only on in-memory result records, never on an entity; audit rows store it as a string and it is not in any response body. No persisted ordinals shift.

## One behavioural change to be aware of

`POST /api/subscription-usage` starts **succeeding** for callers it previously rejected, and metered usage feeds overage billing. Nothing existing is recalculated — those requests failed and wrote nothing — but any integration currently being turned away will begin incrementing counters once this ships. Worth checking how many distinct callers are hitting `subscription_context_missing` before deploy.

## Deployment note

Separately from this PR: `Payment:ConsoleOrganizationId` is `default` in every environment, and a token carrying that organization gets console reach over its whole tenant. If your IdP issues `org_id: "default"` to credentials that were never assigned an organization, that wants settling before this ships — decoding an ordinary end-user token in the same tenant answers it. If `default` is a deliberately assigned console organization, there is nothing to do.

## Tests

`3733 passed, 0 failed` (excluding `XUnitTest.Integration`, which needs a live MongoDB unavailable in this environment).

New coverage: `PaymentTokenActorTests` (16 — claim extraction, malformed and encrypted tokens, control-character rejection, ladder ordering, tenant still required) and `SubscriptionApiResultsStatusTests` (status mapping, including that every other failure keeps the status it had).

🤖 Generated with [Claude Code](https://claude.com/claude-code)