### PR TITLE
feat(payment): name a machine caller from the context's own client id

### DIFF
--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.13" />
-    <PackageVersion Include="SeliseBlocks.Genesis.OS" Version="4.1.5" />
+    <PackageVersion Include="SeliseBlocks.Genesis.OS" Version="4.1.6" />
     <PackageVersion Include="SeliseBlocks.ConfigurationDriver" Version="10.0.0-preview.1" />
     <!-- Pinned to what SeliseBlocks.Genesis.OS already resolves to transitively; anything lower
          is a package downgrade and fails the build. -->

--- a/server/Payment.DomainService/Services/PaymentExecutionContextResolver.cs
+++ b/server/Payment.DomainService/Services/PaymentExecutionContextResolver.cs
@@ -17,13 +17,18 @@ public sealed class PaymentExecutionContextResolver : IPaymentExecutionContextRe
         // outright. Treating blank as absent is what makes the fallback work as intended.
         var userId = Present(blocksContext?.UserId);
 
-        // A client-credentials caller is named by none of these: it authenticates as an
-        // application, so the context reports no user id and no email and the ladder used to run
-        // out with nothing. Its identifier is in the token it presented, which is the last place
-        // left to look — see PaymentTokenActor for why reading it there is sound and why it is
-        // never allowed to decide anything but the actor.
+        // A client-credentials caller is named by neither of the first two: it authenticates as
+        // an application, so the context reports no user id and no email and the ladder used to
+        // run out with nothing.
+        //
+        // The platform now carries that application's identifier itself, which is where it is
+        // read from — the same value the token holds, without parsing anything, and present on
+        // any path that resolves a context rather than only on one carrying a bearer token.
+        // Reading it back out of the token stays as the rung below: it costs nothing when the
+        // context supplies the identifier, and it is what an older Blocks release falls back to.
         var actorId = userId
             ?? Present(blocksContext?.Email)
+            ?? Application(blocksContext?.ClientId)
             ?? Present(PaymentTokenActor.ClientId(blocksContext?.OAuthToken))
             ?? string.Empty;
 
@@ -54,4 +59,18 @@ public sealed class PaymentExecutionContextResolver : IPaymentExecutionContextRe
 
     private static string? Present(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value;
+
+    /// <summary>
+    /// An application named the same way whichever rung supplied it.
+    /// </summary>
+    /// <remarks>
+    /// Wearing <see cref="PaymentTokenActor.ClientPrefix"/> for the same reason the token rung
+    /// does: a bare identifier in an actor field cannot be told apart from a person's later, and
+    /// the same application recorded under two spellings — once from the context, once from the
+    /// token — would read as two actors in an audit trail.
+    /// </remarks>
+    private static string? Application(string? clientId) =>
+        Present(clientId) is { } identifier
+            ? PaymentTokenActor.ClientPrefix + identifier
+            : null;
 }

--- a/server/XUnitTest/Payment/PaymentRateLimitingAndCacheTests.cs
+++ b/server/XUnitTest/Payment/PaymentRateLimitingAndCacheTests.cs
@@ -109,6 +109,112 @@ public sealed class PaymentRateLimitingAndCacheTests
         resolution.Failure!.ErrorCode.Should().Be("payment_context_missing");
     }
 
+    /// <summary>
+    /// The shape of a client-credentials caller: a tenant and an organization it proved, an
+    /// application id, and no person anywhere.
+    /// </summary>
+    private static void MachineCaller(string? clientId, string? oauthToken = null) =>
+        BlocksContext.SetContext(BlocksContext.Create(
+            "tenant-1", null, null, true, null, "org-1",
+            DateTime.UtcNow.AddHours(1), null, null, null, null, null,
+            oauthToken, "tenant-1", clientId: clientId));
+
+    /// <summary>
+    /// An application authenticates as itself, so the context names no user and no email. It is
+    /// named by what it is instead of being refused for not being a person.
+    /// </summary>
+    [Fact]
+    public void Resolver_names_a_machine_caller_by_its_client_id()
+    {
+        MachineCaller("app-1");
+        try
+        {
+            var resolution = new PaymentExecutionContextResolver().Resolve("corr-4");
+
+            resolution.IsSuccess.Should().BeTrue();
+            resolution.Context!.ActorId.Should().Be("client:app-1");
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    /// <summary>
+    /// The same rule that keeps an email out of the user id: a fallback names the caller without
+    /// passing itself off as the thing it stood in for.
+    /// </summary>
+    [Fact]
+    public void Resolver_does_not_record_a_client_id_as_the_user_id()
+    {
+        MachineCaller("app-1");
+        try
+        {
+            new PaymentExecutionContextResolver().Resolve("corr-5")
+                .Context!.UserId.Should().BeNull();
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    /// <summary>
+    /// The client id sits below the person, not in front of one. A caller the context already
+    /// names is named by the context, or the same request would be attributed differently
+    /// depending on which rung happened to be consulted.
+    /// </summary>
+    [Fact]
+    public void A_caller_the_context_names_outranks_its_client_id()
+    {
+        BlocksContext.SetContext(BlocksContext.Create(
+            "tenant-1", null, "user-1", true, null, "org-1",
+            DateTime.UtcNow.AddHours(1), null, null, null, null, null,
+            null, "tenant-1", clientId: "app-1"));
+        try
+        {
+            new PaymentExecutionContextResolver().Resolve("corr-6")
+                .Context!.ActorId.Should().Be("user-1");
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
+    /// <summary>
+    /// An application named identically whichever rung supplied it, so one caller cannot read as
+    /// two actors in an audit trail.
+    /// </summary>
+    [Fact]
+    public void Both_client_id_rungs_spell_the_actor_the_same_way()
+    {
+        // "app-1" as the client_id claim of a signed token, for the rung below.
+        const string Token = "header.eyJjbGllbnRfaWQiOiJhcHAtMSJ9.signature";
+
+        MachineCaller(clientId: null, oauthToken: Token);
+        string? fromToken;
+        try
+        {
+            fromToken = new PaymentExecutionContextResolver().Resolve("corr-7").Context?.ActorId;
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+
+        MachineCaller("app-1");
+        try
+        {
+            new PaymentExecutionContextResolver().Resolve("corr-8")
+                .Context!.ActorId.Should().Be(fromToken);
+        }
+        finally
+        {
+            BlocksContext.ClearContext();
+        }
+    }
+
     // ---- PaymentIdempotencyCache ----
 
     private static PaymentIdempotencyCache IdempotencyCache(ICacheClient cache) =>


### PR DESCRIPTION
Adds one rung to the actor ladder in `PaymentExecutionContextResolver`, so a client-credentials caller is named by what it is instead of being refused for not being a person:

```
UserId  →  Email  →  ClientId (new)  →  client id from the bearer token
```

Takes `SeliseBlocks.Genesis.OS` to **4.1.6**, the release that carries `BlocksContext.ClientId`.

## The bug this actually fixes

A client-credentials token carries no user id and no email, so the ladder ran out and every subscription, usage and entitlement endpoint refused the caller with `subscription_context_missing`.

#459 added the bottom rung — reading `client_id` back out of the bearer token — for exactly this case. **It never fires.** `BlocksContext.OAuthToken` is empty on an authenticated request: the context is built from claims via `CreateFromClaimsIdentity`, and the raw token is not a claim. It passed every test because the tests supplied a token by hand, and only showed up in production once #459's 401 mapping shipped and the failure kept arriving unchanged.

## Verified, not assumed

Running the failing client's exact claim set through `BlocksContext.CreateFromClaimsIdentity` on 4.1.6:

```
TenantId       = 'Dfcd34abea7eb4866a6745a1ab53767b2'
UserId         = ''
Email          = ''
OrganizationId = 'default'
ClientId       = '5e862913-cc88-4c05-aef9-d7ef390f05e4'   <-- populated from client_id
OAuthToken     = ''                                       <-- why the token rung never fired
```

## The token rung stays

Not replaced. It costs nothing when the context supplies the identifier, and it is what an older Blocks release falls back to. `PaymentTokenActor` is untouched.

## Both rungs spell the actor the same way

The context's identifier wears the same `client:` prefix the token rung applies. Without it the same application would be recorded as `client:5e86…` or `5e86…` depending on which rung named it — two actors in an audit trail where there is one. A test pins the two spellings together.

## Unchanged

- **`UserId` stays null** for a machine caller, as with the email fallback above it — a fallback names the caller without passing itself off as the thing it stood in for. Tested.
- **Callers the context already names** are unaffected; the new rung sits below both. Tested.
- **Authorisation does not move.** This decides an audit record's actor field. Tenant, organization and endpoint permission still decide what a caller may do.
- **Background paths** keep no actor: `PaymentTenantContextScopeFactory` establishes its context with no identity and this adds no way for one to appear.

## Tests

`3737 passed, 0 failed` (excluding `XUnitTest.Integration`, which needs a live MongoDB unavailable here). Whole solution builds clean on 4.1.6, so the package bump carries no regression of its own.

Four new tests: the rung itself, the client id never reaching `UserId`, a named caller outranking it, and both rungs producing one spelling.

## Before this ships

`Payment:ConsoleOrganizationId` is `default` in every environment, and this credential carries `org_id: "default"` — which 4.1.6 confirms reaches the platform. Merging this unblocks the caller **and** gives it console reach across its tenant: the ability to name any organization and read or write its subscriptions, usage, payments and provider configuration.

That is fine if `default` is a deliberately assigned console organization. It is not fine if it is what the IdP issues to credentials with no organization, because then every such credential has the same reach. Decoding an ordinary end-user token in this tenant settles it, and it is worth settling before merge rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)