### PR TITLE
feat(subscription): carry quantity bounds on the subscription read

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.test.tsx
@@ -166,6 +166,45 @@ describe("ChangeQuantityDialog", () => {
     });
   });
 
+  it("holds the subscriber to the bounds their own subscription reports, not the live plan's", () => {
+    // The plan can be edited after signup. What this subscription was sold under is what its
+    // snapshot says, and that is what the response now carries alongside the held quantity.
+    renderDialog({
+      ...subscription,
+      quantities: [
+        {
+          itemKey: "user",
+          quantity: 4,
+          unitLabel: "user",
+          minQuantity: 2,
+          maxQuantity: 6,
+          defaultQuantity: 2,
+        },
+      ],
+    });
+
+    setQuantity("7");
+    click(/^Preview$/);
+    expect(screen.getByText(/allows at most 6 users/)).toBeInTheDocument();
+
+    setQuantity("1");
+    click(/^Preview$/);
+    expect(screen.getByText(/needs at least 2 users/)).toBeInTheDocument();
+
+    // Refused locally: nothing was quoted at a quantity the plan does not sell.
+    expect(previewQuantityChange).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the plan when a subscription reports no bounds of its own", () => {
+    renderDialog();
+
+    // plan.quantityItems says min 1, and the subscription (min absent) has nothing to say.
+    setQuantity("0");
+    click(/^Preview$/);
+
+    expect(screen.getByText(/needs at least 1 user/)).toBeInTheDocument();
+  });
+
   it("cannot confirm before a preview", () => {
     renderDialog();
     setQuantity("5");

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
@@ -71,12 +71,21 @@ export const ChangeQuantityDialog = ({
           (candidate) => candidate.itemKey === held.itemKey,
         );
 
+        // The subscription's own quantities carry the bounds of the plan snapshot it is priced
+        // against, so they win over the live plan, which may have been edited since signup. Read
+        // as a pair off minQuantity: a null maxQuantity from the server means no ceiling, not a
+        // missing answer to look up elsewhere.
+        const bounds =
+          held.minQuantity === undefined
+            ? { min: defined?.minQuantity ?? 1, max: defined?.maxQuantity ?? null }
+            : { min: held.minQuantity, max: held.maxQuantity ?? null };
+
         return {
           itemKey: held.itemKey,
           unitLabel: held.unitLabel ?? defined?.unitLabel ?? held.itemKey,
           held: held.quantity,
-          minQuantity: defined?.minQuantity ?? 1,
-          maxQuantity: defined?.maxQuantity ?? null,
+          minQuantity: bounds.min,
+          maxQuantity: bounds.max,
         };
       }),
     [subscription.quantities, currentPlan],

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -11,9 +11,21 @@ export type SubscriptionStatus =
 
 export interface SubscriptionQuantity {
   itemKey: string;
+  /** How many units are held today. */
   quantity: number;
   /** Present on reads, absent on writes: the server owns the label. */
   unitLabel?: string;
+  /**
+   * The bounds and starting point the plan sells this item in, as the subscription's own plan
+   * snapshot states them.
+   *
+   * Optional because only the reads that carry a plan report them — a write echoes the quantity
+   * back and nothing else — and because a subscription snapshotted before the plan carried
+   * bounds has none to give. A client that needs them must still cope with their absence.
+   */
+  minQuantity?: number;
+  maxQuantity?: number | null;
+  defaultQuantity?: number;
 }
 
 /**

--- a/docs/subscription/lifecycle/README.md
+++ b/docs/subscription/lifecycle/README.md
@@ -254,6 +254,13 @@ Two guarantees in the flow:
 
 An increase also re-evaluates the volume band, so the unit price can fall at the same time.
 
+**What a client needs to render the screen is already on the read.** Each entry in the
+subscription's `quantities` carries `minQuantity`, `maxQuantity` (null = uncapped) and
+`defaultQuantity` alongside `quantity`, which is what is held today. They come from the
+subscription's own plan snapshot, so the bounds a client enforces are the ones this subscriber was
+sold and the ones the server will validate the change against — fetching the live plan instead
+risks policing terms that were authored after signup.
+
 > ### Test 5.1 — both directions
 > Held 4, band `5–10 → 10%`. Increase to 7 → applied now, prorated charge > 0, next renewal reflects
 > the band. Decrease to 4 → scheduled, **charge 0**, still holding 7 today. Cancel the pending

--- a/docs/subscription/plan-authoring/README.md
+++ b/docs/subscription/plan-authoring/README.md
@@ -108,6 +108,18 @@ defaultQuantity: 1          ← what a new subscriber starts with
 **These are three different numbers and "up to 40 users" is only the ceiling.** It is not what they
 get and not what they pay for.
 
+All three travel onto the subscription and come back on `GET /subscriptions/current`, beside the
+quantity actually held:
+
+```json
+{ "itemKey": "user", "unitLabel": "user", "quantity": 4,
+  "minQuantity": 1, "maxQuantity": 40, "defaultQuantity": 1 }
+```
+
+So a screen that offers to change the quantity does not need to fetch the plan to know what it may
+offer — and the bounds it reads are the ones **this** subscriber was sold, from their snapshot,
+even if you have since authored a new plan with different ones.
+
 ### The alternative most people miss: an unpriced quantity item
 
 A quantity item that **no price multiplies** is valid — the schema only checks the reverse (a price

--- a/server/Api/Documentation/subscription/v1/index.html
+++ b/server/Api/Documentation/subscription/v1/index.html
@@ -1697,6 +1697,11 @@ Content-Type: application/json
             <code>chargeMinor</code> is zero for anything not charged today.
             <code>timing</code> is <code>Immediate</code> or <code>NextRenewal</code>, and
             <code>effectiveAtUtc</code> is when the change lands.
+            <code>quantities</code> carries the <strong>target</strong> plan's
+            <code>minQuantity</code>, <code>maxQuantity</code> and <code>defaultQuantity</code>
+            beside each quantity, since those are the terms the subscriber would be held to once
+            the change lands — the same fields <code>pendingPlanChange</code> reports on the
+            subscription read while a change is waiting for the period to end.
             <code>creditBankedMinor</code> is always <code>0</code> and is retained only so
             existing clients keep deserializing. <code>nextRenewalAmountMinor</code> is already the
             whole target period, tax included, undiminished by proration.
@@ -1849,6 +1854,16 @@ Content-Type: application/json
         A quantity change moves the number of units bought, never the plan. If the item carries
         volume bands, crossing one is an ordinary consequence of the quantity moving — the
         subscriber keeps their plan, their snapshot and their billing period.
+      </p>
+      <p class="prose">
+        The floor and ceiling a change is held to arrive with the subscription itself:
+        <code>minQuantity</code> and <code>maxQuantity</code> on each entry of
+        <code>quantities</code> from
+        <a href="#api-current"><code>GET /api/subscriptions/current</code></a>. They are read from
+        that subscription's plan snapshot, which is what these endpoints validate against, so a
+        client bounding its input from the read and the server refusing the request cannot
+        disagree. The response below states the quantity a change settled on; the bounds it must
+        respect stay on the subscription read.
       </p>
       <p class="prose">
         The two directions are not symmetrical, because the money is not. Direction is decided by
@@ -3090,10 +3105,38 @@ POST /api/subscriptions
             subscriptions.
           </p>
           <p class="prose">
-            <code>quantities</code> is what the subscriber holds and is paying for now.
+            <code>quantities</code> is what the subscriber holds and is paying for now, and each
+            entry carries the bounds the plan sells that item in:
+          </p>
+          <pre><code>"quantities": [
+  {
+    "itemKey": "user",
+    "unitLabel": "user",
+    "quantity": 4,          // held today
+    "minQuantity": 1,       // floor
+    "maxQuantity": 40,      // ceiling; null is unbounded
+    "defaultQuantity": 1    // what a new subscriber starts on
+  }
+]</code></pre>
+          <p class="prose">
+            <code>quantity</code> and <code>defaultQuantity</code> are different numbers and agree
+            only until somebody changes the quantity — read <code>quantity</code> for what is held
+            and paid for, <code>defaultQuantity</code> only to describe the plan. The bounds come
+            from this subscription's <strong>own plan snapshot</strong>, the same copy the
+            change-quantity endpoints validate against, so a client can bound its input here
+            without a second call to the catalogue — and must not read them from the live plan
+            instead, which may have been edited since this subscriber signed up. An item written
+            before the plan carried bounds for it reports <code>minQuantity: 1</code>,
+            <code>maxQuantity: null</code> and its own held quantity as the default, rather than
+            bounds it was never sold under.
+          </p>
+          <p class="prose">
             <code>pendingQuantityChange</code>, when present, is a reduction already booked for
             <code>currentPeriodEndUtc</code> — render both, or a page reload will show the larger
-            quantity with nothing to say a smaller one is coming.
+            quantity with nothing to say a smaller one is coming. Its entries state
+            <code>itemKey</code>, <code>unitLabel</code> and <code>quantity</code> only: the booked
+            quantity is held to the same bounds above, which are a property of the item rather than
+            of the change.
             <code>recurringAmountMinor</code> is what the next renewal costs at the quantity, band and
             discount in force, and <code>currentTier</code> the band it selects; take both from here
             rather than multiplying <code>unitAmountMinor</code> in the browser.

--- a/server/Subscription.DomainService/README.md
+++ b/server/Subscription.DomainService/README.md
@@ -126,6 +126,46 @@ Entitlement is then one document read with no join, and editing the catalogue st
 retroactive: a subscriber keeps the terms they were sold until something deliberately migrates
 them. That is the correct billing semantic as well as the faster read.
 
+### Quantity bounds are read from the snapshot, not the catalogue
+
+Because of that rule, a subscription's quantities describe themselves. `GET /subscriptions/current`
+carries the plan's bounds beside the quantity actually held:
+
+```json
+"quantities": [
+  {
+    "itemKey": "User",
+    "unitLabel": "user",
+    "quantity": 4,
+    "minQuantity": 1,
+    "maxQuantity": 40,
+    "defaultQuantity": 1
+  }
+]
+```
+
+`quantity` is **what this subscription holds today**; `defaultQuantity` is what the plan starts a
+subscriber on. They agree until somebody changes the quantity and then they do not, which is why
+both are stated rather than one standing in for the other. `maxQuantity` is null when the item is
+uncapped.
+
+The bounds come from `SubscriptionDetail.Plan`, the subscription's own copy — not from the
+catalogue. A client that fetched the live plan instead would police a change against terms this
+subscriber was never sold under, and the change-quantity flow itself validates against the
+snapshot, so the two would disagree about what is allowed.
+
+The same three fields are filled in wherever quantities are reported against a plan.
+`pendingPlanChange` and the plan-change preview take theirs from the **target** plan, since those
+quantities answer to the plan coming into force rather than the one being left.
+
+An item the snapshot does not describe — written before the plan carried bounds for it — reports
+`minQuantity: 1`, no ceiling, and its own held quantity as the default. Inventing bounds there
+would have a client refuse a quantity the subscription is already sitting on.
+
+`QuantityResponseMapper.Subscription` is the one place this mapping lives, for the same reason the
+rest of that type exists: two surfaces describing the same quantities differently is how a client
+comes to enforce one rule on the read and another on the write.
+
 ## Editing a plan ends when the first subscriber arrives
 
 `PUT /subscription-plans/{planId}` rewrites what a plan sells. It refuses with

--- a/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
+++ b/server/Subscription.DomainService/Responses/SubscriptionResponse.cs
@@ -306,5 +306,26 @@ public sealed class SubscriptionQuantityResponse
 
     public string UnitLabel { get; init; } = string.Empty;
 
+    /// <summary>How many of this item the subscription holds today.</summary>
     public long Quantity { get; init; }
+
+    /// <summary>
+    /// The smallest quantity the plan sells this item in, from the plan the subscription is on.
+    /// </summary>
+    /// <remarks>
+    /// The bounds travel with the held quantity because every client that shows the quantity also
+    /// has to police a change to it. Reading them from the plan endpoint instead means a second
+    /// call, and the plan a subscription is priced against is its own snapshot -- so a plan edited
+    /// after signup would hand back bounds this subscription was never sold under.
+    /// </remarks>
+    public long MinQuantity { get; init; }
+
+    /// <summary>The largest quantity the plan sells this item in. Null means no ceiling.</summary>
+    public long? MaxQuantity { get; init; }
+
+    /// <summary>
+    /// What the plan starts a subscriber on. Distinct from <see cref="Quantity"/>, which is what
+    /// this subscription actually holds after any change since signup.
+    /// </summary>
+    public long DefaultQuantity { get; init; }
 }

--- a/server/Subscription.DomainService/Services/QuantityResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/QuantityResponseMapper.cs
@@ -20,6 +20,33 @@ internal static class QuantityResponseMapper
         Quantity = item.Quantity
     };
 
+    /// <summary>
+    /// A held quantity described alongside the bounds the plan sells it in.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="planItems"/> comes from the plan the quantity is priced against -- the
+    /// subscription's own snapshot for what it holds today, the target plan for a change being
+    /// previewed or scheduled. An item with no match there is a snapshot written before the plan
+    /// carried bounds for it; all such an item can honestly say is what it holds.
+    /// </remarks>
+    public static SubscriptionQuantityResponse Subscription(
+        SubscriptionQuantityItem item,
+        IReadOnlyCollection<PlanQuantityItem>? planItems)
+    {
+        var planItem = planItems?.FirstOrDefault(
+            p => string.Equals(p.ItemKey, item.ItemKey, StringComparison.OrdinalIgnoreCase));
+
+        return new SubscriptionQuantityResponse
+        {
+            ItemKey = item.ItemKey,
+            UnitLabel = item.UnitLabel,
+            Quantity = item.Quantity,
+            MinQuantity = planItem?.MinQuantity ?? 1,
+            MaxQuantity = planItem?.MaxQuantity,
+            DefaultQuantity = planItem?.DefaultQuantity ?? item.Quantity
+        };
+    }
+
     public static QuantityDiscountTierResponse? Tier(QuantityDiscountTier? tier) =>
         tier is null
             ? null

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -393,12 +393,9 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 TargetPriceId = r.NewPrice.PriceId,
                 Interval = r.NewPrice.Interval.ToString(),
                 IntervalCount = r.NewPrice.IntervalCount,
-                Quantities = [.. r.Quantities.Select(item => new SubscriptionQuantityResponse
-                {
-                    ItemKey = item.ItemKey,
-                    UnitLabel = item.UnitLabel,
-                    Quantity = item.Quantity
-                })],
+                Quantities = [.. r.Quantities.Select(item => QuantityResponseMapper.Subscription(
+                    item,
+                    r.NewPlan.QuantityItems))],
                 ChargeMinor = chargeMinor,
                 Timing = timing.ToString(),
                 EffectiveAtUtc = effectiveAtUtc,

--- a/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionResponseMapper.cs
@@ -59,12 +59,9 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
             UsageIntervalCount = subscription.Plan.UsageIntervalCount,
             DisplayPriceNote = subscription.Price.DisplayPriceNote,
             Quantities = subscription.QuantityItems
-                .Select(item => new SubscriptionQuantityResponse
-                {
-                    ItemKey = item.ItemKey,
-                    UnitLabel = item.UnitLabel,
-                    Quantity = item.Quantity
-                })
+                .Select(item => QuantityResponseMapper.Subscription(
+                    item,
+                    subscription.Plan.QuantityItems))
                 .ToList(),
             CurrentPeriodStartUtc = subscription.CurrentPeriodStartUtc,
             CurrentPeriodEndUtc = subscription.CurrentPeriodEndUtc,
@@ -101,12 +98,11 @@ public sealed class SubscriptionResponseMapper : ISubscriptionResponseMapper
                     IntervalCount = pendingPlan.Price.IntervalCount,
                     Quantities =
                     [
-                        .. pendingPlan.QuantityItems.Select(item => new SubscriptionQuantityResponse
-                        {
-                            ItemKey = item.ItemKey,
-                            UnitLabel = item.UnitLabel,
-                            Quantity = item.Quantity
-                        })
+                        // Bounds from the plan coming into force, not the one being left: the
+                        // quantities listed here are the ones that plan will hold the subscriber to.
+                        .. pendingPlan.QuantityItems.Select(item => QuantityResponseMapper.Subscription(
+                            item,
+                            pendingPlan.Plan.QuantityItems))
                     ],
                     RequestedAtUtc = pendingPlan.RequestedAtUtc,
                     EffectiveAtUtc = pendingPlan.EffectiveAtUtc

--- a/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionResponseMapperTests.cs
@@ -45,6 +45,51 @@ public sealed class SubscriptionResponseMapperTests
     }
 
     [Fact]
+    public void A_held_quantity_is_read_back_with_the_bounds_the_plan_sells_it_in()
+    {
+        var subscription = NewSubscription(10);
+        var planItem = subscription.Plan.QuantityItems.Single();
+        planItem.MinQuantity = 2;
+        planItem.MaxQuantity = 50;
+        planItem.DefaultQuantity = 3;
+
+        var response = _mapper.ToResponse(subscription);
+
+        var quantity = response.Quantities.Single();
+        quantity.Quantity.Should().Be(10, "the held quantity is not the plan's default");
+        quantity.MinQuantity.Should().Be(2);
+        quantity.MaxQuantity.Should().Be(50);
+        quantity.DefaultQuantity.Should().Be(3);
+    }
+
+    [Fact]
+    public void An_uncapped_item_reports_no_ceiling_rather_than_a_made_up_one()
+    {
+        var subscription = NewSubscription(10);
+        subscription.Plan.QuantityItems.Single().MaxQuantity = null;
+
+        var response = _mapper.ToResponse(subscription);
+
+        response.Quantities.Single().MaxQuantity.Should().BeNull();
+    }
+
+    [Fact]
+    public void An_item_the_plan_snapshot_never_described_says_only_what_it_holds()
+    {
+        // Written before the plan carried this item. Inventing bounds here would have a client
+        // refuse a quantity the subscription is already sitting on.
+        var subscription = NewSubscription(10);
+        subscription.Plan.QuantityItems.Clear();
+
+        var quantity = _mapper.ToResponse(subscription).Quantities.Single();
+
+        quantity.Quantity.Should().Be(10);
+        quantity.MinQuantity.Should().Be(1);
+        quantity.MaxQuantity.Should().BeNull();
+        quantity.DefaultQuantity.Should().Be(10);
+    }
+
+    [Fact]
     public void A_subscription_with_nothing_scheduled_says_so()
     {
         var response = _mapper.ToResponse(NewSubscription(10));


### PR DESCRIPTION
## What

`GET /api/subscriptions/current` returned each quantity as `{ itemKey, unitLabel, quantity }`. It now also carries the bounds the plan sells that item in:

```json
"quantities": [
  {
    "itemKey": "User",
    "unitLabel": "user",
    "quantity": 1,
    "minQuantity": 1,
    "maxQuantity": null,
    "defaultQuantity": 1
  }
]
```

`quantity` keeps its meaning — how many units this subscription **holds today**, which stops matching the plan's default the moment anyone changes it. `defaultQuantity` is the plan's own starting point, reported separately rather than by renaming `quantity`, so no existing client breaks and neither value has to stand in for the other.

## Where the bounds come from

The **plan snapshot the subscription is priced against**, not the live plan. A plan edited after signup would otherwise hand back bounds this subscriber was never sold under. The same shape is filled in wherever quantities are reported against a plan — `pendingPlanChange` and the plan-change preview read theirs from the *target* plan, since that is the plan those quantities will answer to.

An item the snapshot never described (written before the plan carried bounds for it) reports `minQuantity: 1`, no ceiling, and its own held quantity as the default — inventing bounds there would have a client refuse a quantity the subscription is already sitting on.

## Client

`ChangeQuantityDialog` had to look up `currentPlan.quantityItems` to validate a requested quantity, falling back to 1/unbounded when the plan was not loaded. It now prefers the bounds the subscription itself reports and keeps the plan lookup as the fallback for older payloads.

## Testing

- `SubscriptionResponseMapperTests` — bounds reported alongside a held quantity that differs from the default; an uncapped item reports no ceiling; an item absent from the snapshot says only what it holds.
- `change-quantity-dialog.test.tsx` — the dialog enforces the subscription's own bounds and falls back to the plan when they are absent.
- Server: 1689 non-integration subscription tests pass. The 105 integration failures are `MongoDB is not reachable` on this machine and are unrelated to the change.
- Client: `tsc --noEmit` clean, subscription-simulation suites pass (80 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Docs

- `server/Subscription.DomainService/README.md` — a subsection under **Snapshots** with the payload, why the snapshot rather than the catalogue is the authority for the bounds, what the target plan supplies for a pending/previewed plan change, and the fallback for an item the snapshot never described.
- `docs/subscription/plan-authoring/README.md` — the three numbers an author writes, shown in the shape they arrive in on the read.
- `docs/subscription/lifecycle/README.md` — Stage 5 (changing quantity) points at them where a client would otherwise go to the catalogue.
- `server/Api/Documentation/subscription/v1/index.html` — the served v1 API reference: the `/subscriptions/current` entry shown in full, `quantity` vs `defaultQuantity` spelled out, the snapshot named as the source of the bounds, the change-quantity section pointed at them, the plan-change preview noted as carrying the *target* plan's bounds, and `pendingQuantityChange` noted as carrying none.

