### PR TITLE
Send document-conversion notifications through Notifier/Notify, targeted at the user

### DIFF
--- a/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
@@ -140,12 +140,86 @@ namespace Utility.DomainService.PdfGenerator.service
         {
             _logger.LogInformation("NotifyConvertDocumentToPdfEvent: Sending notification for fileId={FileId}, success={Success}", LogSanitizer.Scrub(fileId), success);
 
-            await SendNotificationAsync("Convert Document to PDF", success, messageCoRelationId, new
+            await SendUserNotificationAsync(success, messageCoRelationId, new
             {
                 FileId = fileId,
                 MessageCoRelationId = messageCoRelationId,
                 Success = success
             });
+        }
+
+        /// <summary>
+        /// Sends a document-conversion notification to <c>POST /api/Notifier/Notify</c>, targeted
+        /// at the requesting user rather than a push connection.
+        /// </summary>
+        /// <remarks>
+        /// The other Notify* methods target a <c>connectionId</c> (<see cref="SendNotificationAsync"/>
+        /// sets it from <c>subscriptionFilterId</c>, i.e. the caller's correlation id) and skip
+        /// sending entirely when the caller supplied none, because there is nothing to push to
+        /// otherwise. Document conversion targets <c>userIds</c> instead — the ambient
+        /// <see cref="BlocksContext"/>'s user, the same identity every other notification here
+        /// already includes — so there is a valid target as long as that identity resolves, and the
+        /// gate on the correlation id no longer applies: an empty one means only that the client has
+        /// no way to correlate the push with its original request, not that there is nowhere to
+        /// send it.
+        /// <para>
+        /// <c>connectionId</c> is left unset (the real request schema, <c>NotifyRequest</c>, allows
+        /// it to be null) rather than reused for anything else, and <c>configurationName</c> is the
+        /// fixed <c>"SignatureNotification"</c> rather than the configurable/defaulted value the
+        /// other methods use — both per the notification service's own contract for this
+        /// notification type, not something derived from configuration.
+        /// </para>
+        /// </remarks>
+        private async Task SendUserNotificationAsync(bool success, string? messageCoRelationId, object payload)
+        {
+            try
+            {
+                var userId = BlocksContext.GetContext()?.UserId;
+                if (string.IsNullOrEmpty(userId))
+                {
+                    _logger.LogInformation(
+                        "SendUserNotificationAsync: No authenticated user in context, skipping notification");
+                    return;
+                }
+
+                var requestData = new
+                {
+                    UserIds = new List<string> { userId },
+                    DenormalizedPayload = JsonSerializer.Serialize(payload),
+                    SaveDenormalizedPayloadAsAnObject = false,
+                    ConfigurationName = "SignatureNotification",
+                    ContentAvailable = true,
+                    ResponseKey = string.IsNullOrEmpty(messageCoRelationId) ? null : messageCoRelationId,
+                    ResponseValue = success.ToString()
+                };
+
+                var rootTenantId = _configuration["RootTenantId"];
+                var salt = _tenants.GetTenantByID(rootTenantId)?.TenantSalt;
+                var actualSecret = _cryptoService.Hash(rootTenantId, salt);
+
+                var url = _configuration["NotificationServiceUrl"];
+                var headers = new Dictionary<string, string>
+                {
+                    { "x-blocks-key", rootTenantId },
+                    { "Secret", actualSecret }
+                };
+
+                var (result, _) = await _httpHelperServices.MakeHttpPostRequest<NotificationResponse>(
+                    requestData, url, headers);
+
+                if (result != null && result.isSuccess)
+                {
+                    _logger.LogInformation("SendUserNotificationAsync: Notification sent successfully for userId={UserId}", LogSanitizer.Scrub(userId));
+                }
+                else
+                {
+                    _logger.LogWarning("SendUserNotificationAsync: Failed to send notification. Error: {Errors}", result?.errors);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SendUserNotificationAsync: Error sending notification");
+            }
         }
 
         private async Task SendNotificationAsync(string title, bool success, string subscriptionFilterId, object additionalData)

--- a/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
@@ -172,13 +172,21 @@ namespace Utility.DomainService.PdfGenerator.service
         /// </remarks>
         private async Task SendUserNotificationAsync(bool success, string? messageCoRelationId, object payload)
         {
+            // Read once and kept in scope for the catch block too, so a failure log can still say
+            // who the notification was for even when the exception happens after this point (e.g.
+            // serializing the payload, hashing the secret, or the HTTP call itself).
+            var userId = BlocksContext.GetContext()?.UserId;
+
             try
             {
-                var userId = BlocksContext.GetContext()?.UserId;
                 if (string.IsNullOrEmpty(userId))
                 {
-                    _logger.LogInformation(
-                        "SendUserNotificationAsync: No authenticated user in context, skipping notification");
+                    // Not a transport failure - there is simply no authenticated identity to
+                    // target - but it does mean the notification was silently not sent, which is
+                    // worth a Warning rather than an Information a reader would skim past.
+                    _logger.LogWarning(
+                        "SendUserNotificationAsync: No authenticated user in context; notification not sent. ResponseKey={ResponseKey}",
+                        LogSanitizer.Scrub(messageCoRelationId ?? string.Empty));
                     return;
                 }
 
@@ -193,6 +201,13 @@ namespace Utility.DomainService.PdfGenerator.service
                     ResponseValue = success.ToString()
                 };
 
+                _logger.LogInformation(
+                    "SendUserNotificationAsync: Sending notification to userId={UserId}, configurationName={ConfigurationName}, responseKey={ResponseKey}, success={Success}",
+                    LogSanitizer.Scrub(userId),
+                    requestData.ConfigurationName,
+                    LogSanitizer.Scrub(requestData.ResponseKey ?? string.Empty),
+                    success);
+
                 var rootTenantId = _configuration["RootTenantId"];
                 var salt = _tenants.GetTenantByID(rootTenantId)?.TenantSalt;
                 var actualSecret = _cryptoService.Hash(rootTenantId, salt);
@@ -204,21 +219,36 @@ namespace Utility.DomainService.PdfGenerator.service
                     { "Secret", actualSecret }
                 };
 
-                var (result, _) = await _httpHelperServices.MakeHttpPostRequest<NotificationResponse>(
+                var (result, rawResponse) = await _httpHelperServices.MakeHttpPostRequest<NotificationResponse>(
                     requestData, url, headers);
 
                 if (result != null && result.isSuccess)
                 {
-                    _logger.LogInformation("SendUserNotificationAsync: Notification sent successfully for userId={UserId}", LogSanitizer.Scrub(userId));
+                    _logger.LogInformation(
+                        "SendUserNotificationAsync: Notification sent successfully to userId={UserId}",
+                        LogSanitizer.Scrub(userId));
                 }
                 else
                 {
-                    _logger.LogWarning("SendUserNotificationAsync: Failed to send notification. Error: {Errors}", result?.errors);
+                    // Both possible failure shapes are logged: a well-formed but unsuccessful
+                    // response (result.errors) and a request that never produced one at all
+                    // (MakeHttpPostRequest returns a null result plus its own explanatory message
+                    // as rawResponse when the HTTP call itself throws) - the previous version only
+                    // logged result?.errors, which is null in exactly that second case and left the
+                    // log saying "Error: " with no reason at all.
+                    _logger.LogError(
+                        "SendUserNotificationAsync: Failed to send notification to userId={UserId}. Errors={Errors}, Response={RawResponse}",
+                        LogSanitizer.Scrub(userId),
+                        LogSanitizer.Scrub(result?.errors ?? string.Empty),
+                        LogSanitizer.Scrub(rawResponse ?? string.Empty));
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "SendUserNotificationAsync: Error sending notification");
+                _logger.LogError(
+                    ex,
+                    "SendUserNotificationAsync: Error sending notification to userId={UserId}",
+                    LogSanitizer.Scrub(userId ?? string.Empty));
             }
         }
 

--- a/server/XUnitTest/PdfGenerator/PdfGeneratorNotificationServiceTests.cs
+++ b/server/XUnitTest/PdfGenerator/PdfGeneratorNotificationServiceTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Blocks.Genesis;
+using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -112,6 +114,95 @@ namespace XUnitTest.PdfGenerator
                 It.IsAny<string>(),
                 It.IsAny<string>()), Times.Exactly(6));
         }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_Sends_EvenWithoutACorrelationId()
+        {
+            // Unlike every other Notify* method, this one targets a user, not a push connection,
+            // so there is always a valid target once BlocksContext resolves one -- the previous
+            // gate on the correlation id being present no longer applies.
+            SetAuthenticatedUser("user-42");
+            try
+            {
+                await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", string.Empty, "p1");
+
+                _httpHelper.Verify(h => h.MakeHttpPostRequest<NotificationResponse>(
+                    It.IsAny<object>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()), Times.Once);
+            }
+            finally
+            {
+                BlocksContext.ClearContext();
+            }
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_Skips_WhenNoAuthenticatedUser()
+        {
+            BlocksContext.ClearContext();
+
+            await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", "corr-1", "p1");
+
+            _httpHelper.Verify(h => h.MakeHttpPostRequest<NotificationResponse>(
+                It.IsAny<object>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_RequestBody_MatchesTheNotifierContract()
+        {
+            SetAuthenticatedUser("user-77");
+            object? capturedRequest = null;
+            _httpHelper
+                .Setup(h => h.MakeHttpPostRequest<NotificationResponse>(
+                    It.IsAny<object>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .Callback<object, string, Dictionary<string, string>, string, string>(
+                    (payload, _, _, _, _) => capturedRequest = payload)
+                .ReturnsAsync((new NotificationResponse { isSuccess = true }, string.Empty));
+
+            try
+            {
+                await _service.NotifyConvertDocumentToPdfEvent(true, "file-9", "corr-9", "p1");
+            }
+            finally
+            {
+                BlocksContext.ClearContext();
+            }
+
+            capturedRequest.Should().NotBeNull();
+            var type = capturedRequest!.GetType();
+
+            // No connectionId at all in the request -- this notification targets the user, not a
+            // push connection, and the real /api/Notifier/Notify contract makes it optional.
+            type.GetProperty("ConnectionId").Should().BeNull();
+
+            var userIds = (List<string>)type.GetProperty("UserIds")!.GetValue(capturedRequest)!;
+            userIds.Should().ContainSingle().Which.Should().Be("user-77");
+
+            type.GetProperty("ConfigurationName")!.GetValue(capturedRequest)
+                .Should().Be("SignatureNotification");
+
+            var denormalizedPayload = (string)type.GetProperty("DenormalizedPayload")!.GetValue(capturedRequest)!;
+            using var payloadJson = JsonDocument.Parse(denormalizedPayload);
+            payloadJson.RootElement.GetProperty("FileId").GetString().Should().Be("file-9");
+            payloadJson.RootElement.GetProperty("Success").GetBoolean().Should().BeTrue();
+            payloadJson.RootElement.GetProperty("MessageCoRelationId").GetString().Should().Be("corr-9");
+        }
+
+        private static void SetAuthenticatedUser(string userId) =>
+            BlocksContext.SetContext(BlocksContext.Create(
+                "tenant-1", null, userId, true, null, "org-1",
+                DateTime.UtcNow.AddHours(1), null, null, null, null, null, null, null));
 
         [Fact]
         public async Task SendNotification_ShouldHandleExceptions_WithoutThrowing()

--- a/server/XUnitTest/PdfGenerator/PdfGeneratorNotificationServiceTests.cs
+++ b/server/XUnitTest/PdfGenerator/PdfGeneratorNotificationServiceTests.cs
@@ -13,11 +13,11 @@ namespace XUnitTest.PdfGenerator
     public class PdfGeneratorNotificationServiceTests
     {
         private readonly Mock<IHttpHelperServices> _httpHelper = new();
+        private readonly Mock<ILogger<PdfGeneratorNotificationService>> _logger = new();
         private readonly PdfGeneratorNotificationService _service;
 
         public PdfGeneratorNotificationServiceTests()
         {
-            var logger = new Mock<ILogger<PdfGeneratorNotificationService>>();
             var crypto = new Mock<ICryptoService>();
             var tenants = new Mock<ITenants>();
             var config = new Mock<IConfiguration>();
@@ -38,12 +38,22 @@ namespace XUnitTest.PdfGenerator
                 .ReturnsAsync((new NotificationResponse { isSuccess = true }, string.Empty));
 
             _service = new PdfGeneratorNotificationService(
-                logger.Object,
+                _logger.Object,
                 crypto.Object,
                 tenants.Object,
                 config.Object,
                 _httpHelper.Object);
         }
+
+        private void VerifyLog(LogLevel level, string containing, Times times) =>
+            _logger.Verify(
+                x => x.Log(
+                    level,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains(containing)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                times);
 
         [Fact]
         public async Task NotifyMergePdfsEvent_ShouldSend_WhenCorrelationIdProvided()
@@ -197,6 +207,127 @@ namespace XUnitTest.PdfGenerator
             payloadJson.RootElement.GetProperty("FileId").GetString().Should().Be("file-9");
             payloadJson.RootElement.GetProperty("Success").GetBoolean().Should().BeTrue();
             payloadJson.RootElement.GetProperty("MessageCoRelationId").GetString().Should().Be("corr-9");
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_LogsWhoTheNotificationIsBeingSentTo()
+        {
+            SetAuthenticatedUser("user-55");
+            try
+            {
+                await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", "corr-1", "p1");
+            }
+            finally
+            {
+                BlocksContext.ClearContext();
+            }
+
+            VerifyLog(LogLevel.Information, "Sending notification to userId=user-55", Times.Once());
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_LogsSuccess_WithTheRecipient()
+        {
+            SetAuthenticatedUser("user-56");
+            try
+            {
+                await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", "corr-1", "p1");
+            }
+            finally
+            {
+                BlocksContext.ClearContext();
+            }
+
+            VerifyLog(LogLevel.Information, "Notification sent successfully to userId=user-56", Times.Once());
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_LogsError_WhenTheApiReportsFailure()
+        {
+            _httpHelper
+                .Setup(h => h.MakeHttpPostRequest<NotificationResponse>(
+                    It.IsAny<object>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync((new NotificationResponse { isSuccess = false, errors = "recipient not found" }, string.Empty));
+
+            SetAuthenticatedUser("user-57");
+            try
+            {
+                await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", "corr-1", "p1");
+            }
+            finally
+            {
+                BlocksContext.ClearContext();
+            }
+
+            VerifyLog(LogLevel.Error, "Failed to send notification to userId=user-57", Times.Once());
+            VerifyLog(LogLevel.Error, "recipient not found", Times.Once());
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_LogsTheRawResponse_WhenTheHttpCallItselfFailed()
+        {
+            // MakeHttpPostRequest returns a null result with its own explanatory message as the
+            // second tuple element when the HTTP call throws internally -- errors is null in that
+            // case, so the log must fall back to the raw response rather than say nothing at all.
+            _httpHelper
+                .Setup(h => h.MakeHttpPostRequest<NotificationResponse>(
+                    It.IsAny<object>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ReturnsAsync(((NotificationResponse?)null, "Operation Failed."));
+
+            SetAuthenticatedUser("user-58");
+            try
+            {
+                await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", "corr-1", "p1");
+            }
+            finally
+            {
+                BlocksContext.ClearContext();
+            }
+
+            VerifyLog(LogLevel.Error, "Operation Failed.", Times.Once());
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_LogsError_WhenSendingThrows()
+        {
+            _httpHelper
+                .Setup(h => h.MakeHttpPostRequest<NotificationResponse>(
+                    It.IsAny<object>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Dictionary<string, string>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>()))
+                .ThrowsAsync(new InvalidOperationException("network unreachable"));
+
+            SetAuthenticatedUser("user-59");
+            try
+            {
+                await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", "corr-1", "p1");
+            }
+            finally
+            {
+                BlocksContext.ClearContext();
+            }
+
+            VerifyLog(LogLevel.Error, "Error sending notification to userId=user-59", Times.Once());
+        }
+
+        [Fact]
+        public async Task NotifyConvertDocumentToPdfEvent_LogsWarning_WhenThereIsNoUserToNotify()
+        {
+            BlocksContext.ClearContext();
+
+            await _service.NotifyConvertDocumentToPdfEvent(true, "file-1", "corr-1", "p1");
+
+            VerifyLog(LogLevel.Warning, "No authenticated user in context", Times.Once());
         }
 
         private static void SetAuthenticatedUser(string userId) =>


### PR DESCRIPTION
Scoped to the one notification path this was asked about — `NotifyConvertDocumentToPdfEvent`. The other five `Notify*` methods in `PdfGeneratorNotificationService` are untouched.

## What was wrong

`SendNotificationAsync`, shared by every `Notify*` method, invents its own JSON envelope (`IsSuccess`/`Title`/`Description`/`Data`) and targets a `connectionId` — skipping the send entirely when the caller's `messageCoRelationId` is empty, because there's nothing to push a connection-targeted notification to without one.

I fetched and inspected the real service's OpenAPI document at `https://logic.seliseblocks.com/swagger/v1/swagger.json` to get the actual contract rather than guess:

```
POST /api/Notifier/Notify
```
```json
{
  "connectionId": "string | null",
  "userIds": ["string"] ,
  "roles": ["string"],
  "organizationIds": ["string"],
  "subscriptionFilters": [ /* SubscriptionFilter */ ],
  "denormalizedPayload": "string",
  "saveDenormalizedPayloadAsAnObject": true,
  "responseKey": "string | null",
  "responseValue": "string | null",
  "contentAvailable": true,
  "configurationName": "string | null"
}
```
`additionalProperties: false` — nothing outside this list is accepted.

## What changes

`NotifyConvertDocumentToPdfEvent` now calls a new `SendUserNotificationAsync` shaped for this specific requirement:

- **No `connectionId`** — omitted from the request entirely (verified in a test via `type.GetProperty("ConnectionId").Should().BeNull()`).
- **`userIds` from the ambient `BlocksContext`** — the same identity every other `Notify*` method already reads (`BlocksContext.GetContext()?.UserId`), just promoted from a decoration on a connection-targeted push to the actual delivery target.
- **`configurationName` is the fixed `"SignatureNotification"`** rather than the configurable/defaulted value the other methods use.
- **`denormalizedPayload` holds the conversion outcome directly** — `{ FileId, MessageCoRelationId, Success }` — rather than wrapped in the generic `{IsSuccess, Title, Description, Data}` envelope.

Sending is now gated on the user id resolving, not on the correlation id. Once the target is a user instead of a push connection, an empty `messageCoRelationId` means only that the client has no way to correlate the push with its original request — not that there's nowhere to send it. `responseKey`/`responseValue` are kept (set from the correlation id when present, and success/failure) since nothing asked for those to be dropped and they're still useful for a client that does supply a correlation id.

Auth headers (`x-blocks-key` + `Secret`, from `RootTenantId` and `ICryptoService.Hash`) and the `NotificationServiceUrl` posted to are unchanged — same credential mechanism the other five methods already use successfully; only the payload shape and targeting changed.

## Testing

3 new tests cover: sends without a correlation id (given a resolved user), skips when no authenticated user is in context, and the request body matches the real contract (no `connectionId` property, `userIds` from context, `configurationName` fixed, `denormalizedPayload` parses to the expected fields). Full non-integration suite: 3719 passing, 0 failing.

## Not verified

I did not call the live `/api/Notifier/Notify` endpoint — this is built directly from its published OpenAPI contract, not from an observed successful call. Worth a smoke test against a real environment before this handles production traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)