### PR TITLE
fix(subscription): price a plan change's outgoing calendar stub at its own fraction

### DIFF
--- a/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionProrationCalculator.cs
@@ -24,6 +24,15 @@ public static class SubscriptionProrationCalculator
     /// one for a plan change — its volume bands and combination policy are what the new side is
     /// held to, since those are what the subscriber is moving onto.
     /// </param>
+    /// <param name="targetIsCurrentPeriod">
+    /// True for a quantity change, whose target is not a newly bought calendar period but the
+    /// subscription's own current one — the same dates, just a different quantity. The outgoing
+    /// side's own resolved calendar fraction is then reused for the target instead of
+    /// <paramref name="targetFraction"/>, and, unlike a plan change onto a fresh calendar period,
+    /// the result still goes through the elapsed-time ratio below rather than being taken as
+    /// already exactly the period bought — a quantity change made partway through a stub owes for
+    /// what is left of it, not for the whole stub over again.
+    /// </param>
     public static ProrationOutcome Calculate(
         SubscriptionDetail subscription,
         PlanSnapshot targetPlan,
@@ -32,7 +41,8 @@ public static class SubscriptionProrationCalculator
         DateTime nowUtc,
         DateTime targetPeriodStartUtc,
         DateTime targetPeriodEndUtc,
-        BillingDayFraction targetFraction = default)
+        BillingDayFraction targetFraction = default,
+        bool targetIsCurrentPeriod = false)
     {
         ArgumentNullException.ThrowIfNull(subscription);
         ArgumentNullException.ThrowIfNull(targetPlan);
@@ -53,6 +63,19 @@ public static class SubscriptionProrationCalculator
             0,
             totalTicks);
 
+        // The outgoing period's own calendar fraction, when it has one — a plan change replaces
+        // CurrentPeriodStartUtc/EndUtc, so this cannot be read from InitialChargeProrated or the
+        // fraction frozen at signup; both survive renewals and would describe a period that is no
+        // longer the one being left. Resolved fresh instead, exactly as the target side resolves
+        // its own.
+        var outgoingFraction = CurrentPeriodFraction(subscription);
+
+        // A quantity change's target is not a period being purchased today — it is the current
+        // period, priced at a different quantity — so it is charged the identical fraction the
+        // outgoing side just resolved rather than whatever the caller supplied for a freshly
+        // bought calendar period.
+        var effectiveTargetFraction = targetIsCurrentPeriod ? outgoingFraction : targetFraction;
+
         // Both sides through the same band-aware path a renewal uses, so a quantity change is
         // priced at the band its quantity actually selects rather than at the flat unit amount.
         var oldDiscounted = SubscriptionAmountCalculator.DiscountedAmountMinor(
@@ -61,7 +84,8 @@ public static class SubscriptionProrationCalculator
             subscription.Price,
             subscription.QuantityItems,
             subscription.DiscountPeriodsApplied,
-            nowUtc);
+            nowUtc,
+            outgoingFraction);
 
         // A partial period on a calendar-aligned yearly target is charged from the monthly price
         // that annual price was linked to, exactly as a fresh signup on it would be. Prorating the
@@ -69,7 +93,7 @@ public static class SubscriptionProrationCalculator
         var newPrice = targetPrice;
         var newQuantityItems = targetQuantityItems;
 
-        if (targetFraction.IsPartial &&
+        if (effectiveTargetFraction.IsPartial &&
             CalendarBillingAlignment.TryStubBasis(
                 targetPrice,
                 targetQuantityItems,
@@ -90,7 +114,7 @@ public static class SubscriptionProrationCalculator
             newQuantityItems,
             subscription.DiscountPeriodsApplied,
             nowUtc,
-            targetFraction);
+            effectiveTargetFraction);
 
         // Each side settled at its own price's rate *and* mode, before the two are netted against
         // each other. A plan change can move a subscriber from a tax-exclusive price to an inclusive
@@ -117,7 +141,7 @@ public static class SubscriptionProrationCalculator
         // period — every anniversary target, and every change landing on the first —
         // newTaxInclusive already *is* the full period, and reusing it keeps those quotes
         // bit-identical rather than merely equal by inspection.
-        var targetFullPeriodTotalMinor = targetFraction.IsPartial
+        var targetFullPeriodTotalMinor = effectiveTargetFraction.IsPartial
             ? FullPeriod(subscription, targetPlan, targetPrice, targetQuantityItems, nowUtc)
             : newTaxInclusive;
 
@@ -134,7 +158,11 @@ public static class SubscriptionProrationCalculator
         // Every calendar-priced target, not only the partial ones. A change landing on the first
         // buys a whole month, and letting the clock scale it would charge a subscriber who moved
         // at noon less than one who signed up fresh at noon for the identical month.
-        var newRemainingCost = targetFraction.IsCalendarPriced
+        //
+        // Except a quantity change's target: it is not a period being bought today, it is the
+        // current period at a different quantity, so it still owes only for what is left of it —
+        // the same elapsed-time ratio the outgoing side was just charged.
+        var newRemainingCost = effectiveTargetFraction.IsCalendarPriced && !targetIsCurrentPeriod
             ? newTaxInclusive
             : targetTotalTicks <= 0
                 ? 0
@@ -399,6 +427,29 @@ public static class SubscriptionProrationCalculator
     /// </remarks>
     private static long Prorate(long amountMinor, long remainingTicks, long totalTicks) =>
         (long)((Int128)amountMinor * remainingTicks / totalTicks);
+
+    /// <summary>
+    /// The current period's own calendar fraction, when its bounds are actually a calendar-aligned
+    /// stub or whole month rather than an anniversary period.
+    /// </summary>
+    /// <remarks>
+    /// Re-derived from <see cref="SubscriptionDetail.CurrentPeriodStartUtc"/> rather than trusted
+    /// from anywhere stored on the subscription, because a plan change is exactly the event that
+    /// replaces those dates — nothing frozen earlier can describe the period being left.
+    /// <see cref="CalendarBillingAlignment.TryResolveFirstPeriod"/> is asked what a period starting
+    /// there would cover, and the answer is trusted only if it actually ends where this period
+    /// does; an anniversary period, or a full annual period, will not, and falls back to full-period
+    /// pricing exactly as before this method existed.
+    /// </remarks>
+    private static BillingDayFraction CurrentPeriodFraction(SubscriptionDetail subscription) =>
+        CalendarBillingAlignment.IsCalendarAligned(subscription.Price) &&
+        CalendarBillingAlignment.TryResolveFirstPeriod(
+            subscription.CurrentPeriodStartUtc,
+            subscription.FeeSchedule.TimeZoneId,
+            out var period) &&
+        period.EndUtc == subscription.CurrentPeriodEndUtc
+            ? BillingDayFraction.Of(period)
+            : default;
 }
 
 /// <param name="ChargeMinor">What to charge now. Zero when the change is fully covered by credit.</param>

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -466,7 +466,10 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 target,
                 now,
                 subscription.CurrentPeriodStartUtc,
-                subscription.CurrentPeriodEndUtc);
+                subscription.CurrentPeriodEndUtc,
+                // The target is this same current period at a new quantity, not a calendar period
+                // bought today — see Calculate's own remarks on targetIsCurrentPeriod.
+                targetIsCurrentPeriod: true);
 
             chargeMinor = outcome.ChargeMinor;
             newCreditBalanceMinor = outcome.NewCreditBalanceMinor;

--- a/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
@@ -247,6 +247,59 @@ public sealed class CalendarAlignedPlanChangeTests
         outcome.TargetFullPeriodTotalMinor.Should().Be(1_200_000);
     }
 
+    /// <summary>
+    /// The bug this fix closes: a subscription whose own current period is a calendar stub must be
+    /// credited unused time at the stub's own price, not at a full month's.
+    /// </summary>
+    /// <remarks>
+    /// A CHF 150 monthly plan bought for the last two days of a 30-day April costs CHF 10 — 150 x
+    /// 2/30. An immediate upgrade taken the instant that stub opens has consumed none of it yet, so
+    /// crediting it back at anything more than CHF 10 hands back money the subscriber never paid.
+    /// </remarks>
+    [Fact]
+    public void An_upgrade_out_of_a_calendar_stub_credits_the_stubs_own_price_not_a_full_month()
+    {
+        var stubStart = new DateTime(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc);
+        var stubEnd = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = "sub-1",
+            CurrencyCode = "CHF",
+            Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 15_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            CurrentPeriodStartUtc = stubStart,
+            CurrentPeriodEndUtc = stubEnd
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 40_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            [],
+            stubStart,
+            stubStart,
+            stubEnd,
+            new BillingDayFraction(2, 30));
+
+        // 15000 x 2/30, rounded to the nearest minor unit — not the full 15000 a missing fraction
+        // would credit.
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(1_000);
+    }
+
     private static ProrationOutcome Calculate(
         long targetUnitAmountMinor,
         BillingDayFraction? fraction = null,

--- a/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
+++ b/server/XUnitTest/Subscription/CalendarAlignedPlanChangeTests.cs
@@ -300,6 +300,106 @@ public sealed class CalendarAlignedPlanChangeTests
         outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(1_000);
     }
 
+    /// <summary>
+    /// Guards the elapsed-time half of the fix: pricing right at the stub's own start (as the test
+    /// above does) cannot tell a working elapsed-time ratio from one silently skipped, since
+    /// remaining and total time are equal either way there. Asking partway through the stub is the
+    /// only way to catch the outgoing side being treated as already-fully-owed.
+    /// </summary>
+    [Fact]
+    public void An_upgrade_partway_through_a_calendar_stub_credits_only_the_time_left_in_it()
+    {
+        var stubStart = new DateTime(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc);
+        var stubEnd = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = "sub-1",
+            CurrencyCode = "CHF",
+            Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 15_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            CurrentPeriodStartUtc = stubStart,
+            CurrentPeriodEndUtc = stubEnd
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 40_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            [],
+            // One of the stub's two days has already elapsed.
+            stubStart.AddDays(1),
+            stubStart.AddDays(1),
+            stubEnd,
+            new BillingDayFraction(1, 30));
+
+        // The stub is worth 15000 x 2/30 = 1000, halved by the one remaining day of two: 500.
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(500);
+    }
+
+    /// <summary>
+    /// A price marked calendar-aligned whose current period does not actually end on the boundary
+    /// <see cref="CalendarBillingAlignment.TryResolveFirstPeriod"/> would derive from its start —
+    /// an anniversary-shaped period, or a full annual period — must still be priced as a whole
+    /// period rather than have some unrelated fraction forced onto it.
+    /// </summary>
+    [Fact]
+    public void An_outgoing_period_whose_boundary_does_not_match_falls_back_to_the_full_period()
+    {
+        var subscription = new SubscriptionDetail
+        {
+            ItemId = "sub-1",
+            CurrencyCode = "CHF",
+            Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 15_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            // Starts on the 29th, as the stub tests above do, but ends on the 29th of the
+            // following month rather than on the 1st — not a shape TryResolveFirstPeriod would
+            // ever produce from this start, so the boundary check must refuse it.
+            CurrentPeriodStartUtc = new DateTime(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc),
+            CurrentPeriodEndUtc = new DateTime(2026, 5, 29, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 40_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            [],
+            subscription.CurrentPeriodStartUtc,
+            subscription.CurrentPeriodStartUtc,
+            subscription.CurrentPeriodEndUtc,
+            new BillingDayFraction(30, 30));
+
+        // The full 15000, never a fraction derived from a boundary this period does not have.
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(15_000);
+    }
+
     private static ProrationOutcome Calculate(
         long targetUnitAmountMinor,
         BillingDayFraction? fraction = null,

--- a/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Subscription.DomainService.Entities;
 using Subscription.DomainService.Enums;
 using Subscription.DomainService.Services;
+using Subscription.DomainService.Utilities;
 
 namespace XUnitTest.Subscription;
 
@@ -357,8 +358,115 @@ public sealed class SubscriptionProrationCalculatorTests
     [Fact]
     public void A_quantity_increase_during_a_calendar_stub_prices_both_sides_from_the_same_stub()
     {
-        var stubStart = new DateTime(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc);
-        var stubEnd = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var outcome = QuantityIncreaseDuringStub(StubStart);
+
+        // Outgoing: 15000 x 2/30 = 1000. Target: 18000 x 2/30 = 1200. Neither is a fresh month.
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(1_000);
+        outcome.Breakdown.Target.ProratedValueMinor.Should().Be(1_200);
+        outcome.ChargeMinor.Should().Be(200);
+    }
+
+    /// <summary>
+    /// Guards the elapsed-time half of <c>targetIsCurrentPeriod</c>: pricing right at the stub's
+    /// start (as the test above does) cannot tell a working elapsed-time ratio from one silently
+    /// skipped by the calendar-priced shortcut, since remaining and total time are equal either
+    /// way. Asking partway through the stub is the only way to catch that shortcut firing where it
+    /// must not.
+    /// </summary>
+    [Fact]
+    public void A_quantity_increase_partway_through_a_calendar_stub_prices_only_the_time_left()
+    {
+        // One of the stub's two days has already elapsed.
+        var outcome = QuantityIncreaseDuringStub(StubStart.AddDays(1));
+
+        // Half of each side's calendar-priced amount: 1000/2 = 500, 1200/2 = 600.
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(500);
+        outcome.Breakdown.Target.ProratedValueMinor.Should().Be(600);
+        outcome.ChargeMinor.Should().Be(100);
+
+        // What recurs from the next boundary on is unaffected by how much of the stub is left.
+        outcome.TargetFullPeriodTotalMinor.Should().Be(18_000);
+    }
+
+    /// <summary>
+    /// At the stub's own end there is no time left on either side, so nothing is owed and nothing
+    /// is credited — the same zero-remaining floor an ordinary anniversary period already has.
+    /// </summary>
+    [Fact]
+    public void A_quantity_increase_at_the_stubs_end_owes_and_credits_nothing_further()
+    {
+        var outcome = QuantityIncreaseDuringStub(StubEnd);
+
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(0);
+        outcome.Breakdown.Target.ProratedValueMinor.Should().Be(0);
+        outcome.ChargeMinor.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The fraction is read from where the current period actually starts, never from the
+    /// signup-time fields, which is what makes it correct after a renewal moves those dates
+    /// without clearing them.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="SubscriptionDetail.InitialChargeProrated"/> and its day counts are frozen once,
+    /// at signup, and nothing clears them on a later renewal or plan change — see
+    /// <see cref="CalendarBillingAlignment.FrozenFraction"/>'s own remarks. This subscription is
+    /// stamped with a stale 7/31 from a signup stub that ended long ago, but is now sitting in a
+    /// full calendar month starting on the first: reading the stale fields instead of resolving
+    /// fresh from <see cref="SubscriptionDetail.CurrentPeriodStartUtc"/> would scale the outgoing
+    /// side down to a week's worth of an already-whole month.
+    /// </remarks>
+    [Fact]
+    public void The_outgoing_fraction_ignores_a_stale_signup_fraction_frozen_on_the_subscription()
+    {
+        var periodStart = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+        var periodEnd = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+        var subscription = new SubscriptionDetail
+        {
+            Plan = new PlanSnapshot { Code = "professional", DisplayName = "Professional" },
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 30_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            CurrentPeriodStartUtc = periodStart,
+            CurrentPeriodEndUtc = periodEnd,
+            // A signup stub from a previous cycle, long since superseded by this full month.
+            InitialChargeProrated = true,
+            ProrationDays = 7,
+            ProrationTotalDays = 31
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 60_000,
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            [],
+            periodStart,
+            periodStart,
+            periodEnd,
+            new BillingDayFraction(31, 31));
+
+        // The full 30000, not 30000 x 7/31 = 6774 — the current period is a whole month, and the
+        // stale signup fields must never be read to say otherwise.
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(30_000);
+    }
+
+    private static readonly DateTime StubStart = new(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime StubEnd = new(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static ProrationOutcome QuantityIncreaseDuringStub(DateTime nowUtc)
+    {
         var subscription = new SubscriptionDetail
         {
             Plan = new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
@@ -375,28 +483,23 @@ public sealed class SubscriptionProrationCalculatorTests
             [
                 new SubscriptionQuantityItem { ItemKey = "user", Quantity = 10, UnitAmountMinor = 1_500 }
             ],
-            CurrentPeriodStartUtc = stubStart,
-            CurrentPeriodEndUtc = stubEnd
+            CurrentPeriodStartUtc = StubStart,
+            CurrentPeriodEndUtc = StubEnd
         };
         var target = new List<SubscriptionQuantityItem>
         {
             new() { ItemKey = "user", Quantity = 12, UnitAmountMinor = 1_500 }
         };
 
-        var outcome = SubscriptionProrationCalculator.Calculate(
+        return SubscriptionProrationCalculator.Calculate(
             subscription,
             subscription.Plan,
             subscription.Price,
             target,
-            stubStart,
-            stubStart,
-            stubEnd,
+            nowUtc,
+            StubStart,
+            StubEnd,
             targetIsCurrentPeriod: true);
-
-        // Outgoing: 15000 x 2/30 = 1000. Target: 18000 x 2/30 = 1200. Neither is a fresh month.
-        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(1_000);
-        outcome.Breakdown.Target.ProratedValueMinor.Should().Be(1_200);
-        outcome.ChargeMinor.Should().Be(200);
     }
 
     private static SubscriptionDetail NewSubscription(

--- a/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionProrationCalculatorTests.cs
@@ -349,6 +349,56 @@ public sealed class SubscriptionProrationCalculatorTests
         outcome.Breakdown.Should().Be(default(ProrationBreakdown));
     }
 
+    /// <summary>
+    /// A quantity change's target is the current period itself, not a calendar period bought
+    /// today — so a quantity increase during a calendar stub owes only for the days and the time
+    /// actually left in it, not for a fresh month at the new quantity.
+    /// </summary>
+    [Fact]
+    public void A_quantity_increase_during_a_calendar_stub_prices_both_sides_from_the_same_stub()
+    {
+        var stubStart = new DateTime(2026, 4, 29, 0, 0, 0, DateTimeKind.Utc);
+        var stubEnd = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var subscription = new SubscriptionDetail
+        {
+            Plan = new PlanSnapshot { Code = "scale", DisplayName = "Scale" },
+            Price = new PriceSnapshot
+            {
+                CurrencyCode = "CHF",
+                UnitAmountMinor = 1_500,
+                QuantityItemKey = "user",
+                Interval = BillingInterval.Month,
+                IntervalCount = 1,
+                BillingAlignment = BillingAlignment.CalendarMonth
+            },
+            QuantityItems =
+            [
+                new SubscriptionQuantityItem { ItemKey = "user", Quantity = 10, UnitAmountMinor = 1_500 }
+            ],
+            CurrentPeriodStartUtc = stubStart,
+            CurrentPeriodEndUtc = stubEnd
+        };
+        var target = new List<SubscriptionQuantityItem>
+        {
+            new() { ItemKey = "user", Quantity = 12, UnitAmountMinor = 1_500 }
+        };
+
+        var outcome = SubscriptionProrationCalculator.Calculate(
+            subscription,
+            subscription.Plan,
+            subscription.Price,
+            target,
+            stubStart,
+            stubStart,
+            stubEnd,
+            targetIsCurrentPeriod: true);
+
+        // Outgoing: 15000 x 2/30 = 1000. Target: 18000 x 2/30 = 1200. Neither is a fresh month.
+        outcome.Breakdown.Outgoing.ProratedValueMinor.Should().Be(1_000);
+        outcome.Breakdown.Target.ProratedValueMinor.Should().Be(1_200);
+        outcome.ChargeMinor.Should().Be(200);
+    }
+
     private static SubscriptionDetail NewSubscription(
         long oldAmountMinor,
         long creditBalanceMinor = 0,


### PR DESCRIPTION
## Summary
- `SubscriptionProrationCalculator.Calculate` always priced the outgoing side of a plan/quantity change as a full period, even when the subscription's current period was itself a calendar-aligned stub (e.g. signing up two days before month end). An immediate upgrade during that stub credited back nearly a full month instead of the fraction actually paid for.
- The current period's own calendar fraction is now resolved fresh from `CurrentPeriodStartUtc`/`CurrentPeriodEndUtc` (never from `InitialChargeProrated`/the signup-time fraction, which survive renewals and are replaced by a plan change) and applied to the outgoing amount.
- Added an optional `targetIsCurrentPeriod` parameter: a quantity change's target is the same current period at a different quantity, not a freshly bought calendar period, so it now prices from the same resolved fraction with elapsed-time proration still applied on top, instead of defaulting to a full month.
- Plan-change callers are unaffected — they already supply their own target fraction for a newly bought calendar period.

## Test plan
- [x] `dotnet build server/Blocks.slnx` — 0 errors (warning count unchanged from baseline)
- [x] `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName~Subscription.SubscriptionProrationCalculatorTests|FullyQualifiedName~Subscription.CalendarAlignedPlanChangeTests|FullyQualifiedName~Subscription.SubscriptionPlanChangeServiceTests|FullyQualifiedName~Subscription.SubscriptionQuantityChangeServiceTests|FullyQualifiedName~Subscription.CalendarAlignedYearlyLifecycleTests|FullyQualifiedName~Subscription.CalendarAlignedAutomaticDiscountTests|FullyQualifiedName~Subscription.AutomaticPriceDiscountTests"` — 190/190 passed
- [x] Added `An_upgrade_out_of_a_calendar_stub_credits_the_stubs_own_price_not_a_full_month` reproducing the reported CHF 150 → CHF 10 stub-credit bug
- [x] Added `A_quantity_increase_during_a_calendar_stub_prices_both_sides_from_the_same_stub` covering the quantity-change path

🤖 Generated with [Claude Code](https://claude.com/claude-code)