### PR TITLE
fix(subscription): re-snapshot trial allowance and reconcile stale usage projection rows

### DIFF
--- a/.github/workflows/subscription-scheduling-integration.yml
+++ b/.github/workflows/subscription-scheduling-integration.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - "server/Subscription.DomainService/Scheduling/**"
       - "server/Subscription.DomainService/Services/SubscriptionRenewalService.cs"
+      - "server/Subscription.DomainService/Services/UsageProjectionPublisher.cs"
+      - "server/Subscription.DomainService/Services/MeterAllowanceResolver.cs"
+      - "server/Subscription.DomainService/Utilities/MeterAllowance.cs"
+      - "server/Subscription.DomainService/Repositories/SubscriptionUsage*.cs"
       - "server/XUnitTest/Integration/**"
       - ".github/workflows/subscription-scheduling-integration.yml"
   push:
@@ -12,6 +16,10 @@ on:
     paths:
       - "server/Subscription.DomainService/Scheduling/**"
       - "server/Subscription.DomainService/Services/SubscriptionRenewalService.cs"
+      - "server/Subscription.DomainService/Services/UsageProjectionPublisher.cs"
+      - "server/Subscription.DomainService/Services/MeterAllowanceResolver.cs"
+      - "server/Subscription.DomainService/Utilities/MeterAllowance.cs"
+      - "server/Subscription.DomainService/Repositories/SubscriptionUsage*.cs"
       - "server/XUnitTest/Integration/**"
 
 jobs:

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
@@ -85,4 +85,33 @@ public interface ISubscriptionUsageCurrentRepository
         string tenantId,
         string documentId,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Every stored document for one subscription, with no window predicate.
+    /// </summary>
+    /// <remarks>
+    /// For reconciliation, which must find rows a plan-derived window can no longer describe —
+    /// superseded by a later window, or orphaned because their meter left the plan. Those rows are
+    /// exactly what a window-filtered read like <see cref="ListCurrentAsync"/> can never return.
+    /// </remarks>
+    Task<IReadOnlyList<SubscriptionUsageCurrent>> ListBySubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Clamps a superseded row's window to <paramref name="endUtc"/>, so it stops overlapping the
+    /// window that replaced it.
+    /// </summary>
+    /// <remarks>
+    /// Guarded to only shrink: a no-op unless the stored <c>PeriodEndUtc</c> is still past
+    /// <paramref name="endUtc"/>. A dedicated write rather than folding <c>PeriodEndUtc</c> into the
+    /// merge pipeline's conditional groups, because that field sits in the unconditional identity
+    /// group there and must stay there for every other write.
+    /// </remarks>
+    Task<bool> TryRetireAsync(
+        string tenantId,
+        string itemId,
+        DateTime endUtc,
+        CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageCurrentRepository.cs
@@ -108,10 +108,18 @@ public interface ISubscriptionUsageCurrentRepository
     /// <paramref name="endUtc"/>. A dedicated write rather than folding <c>PeriodEndUtc</c> into the
     /// merge pipeline's conditional groups, because that field sits in the unconditional identity
     /// group there and must stay there for every other write.
+    /// <para>
+    /// <paramref name="expiresAtUtc"/> is taken from the caller rather than derived from
+    /// <paramref name="endUtc"/> in here: <c>endUtc</c> is the new window's start, ordinarily in the
+    /// past relative to when this runs, and a row whose <c>ExpiresAtUtc</c> follows it into the past
+    /// is picked up by the TTL index within a minute — deleting a row this call means to retire, not
+    /// erase.
+    /// </para>
     /// </remarks>
     Task<bool> TryRetireAsync(
         string tenantId,
         string itemId,
         DateTime endUtc,
+        DateTime expiresAtUtc,
         CancellationToken cancellationToken);
 }

--- a/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionUsageRepository.cs
@@ -93,6 +93,26 @@ public interface ISubscriptionUsageRepository
         long appliedRecordCount,
         CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Re-freezes an open window's allowance, for the one event that must move it after the window
+    /// opened: a trial converting to paid, where the opening allowance now resolves to the plan's
+    /// quantity instead of the trial's grant.
+    /// </summary>
+    /// <remarks>
+    /// Guarded so it is idempotent and cannot touch a window that has already closed: filtered on
+    /// <c>LimitSnapshot != allowance</c> and <c>PeriodEndUtc &gt; now</c>. <paramref name="retainedThresholds"/>
+    /// replaces <c>NotifiedThresholds</c> outright — the caller has already recomputed which of the
+    /// previously-notified thresholds are still crossed at the new allowance, so a customer who was
+    /// notified at every threshold of a small trial grant is not left permanently unnotified once the
+    /// grant is replaced by a much larger plan quantity.
+    /// </remarks>
+    Task<bool> TryResnapshotAllowanceAsync(
+        string tenantId,
+        string counterId,
+        decimal allowance,
+        IReadOnlyList<int> retainedThresholds,
+        CancellationToken cancellationToken);
+
     Task<IReadOnlyList<SubscriptionUsageRecord>> ListRecordsAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -371,6 +371,7 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
         string tenantId,
         string itemId,
         DateTime endUtc,
+        DateTime expiresAtUtc,
         CancellationToken cancellationToken)
     {
         var result = await Current(tenantId).UpdateOneAsync(
@@ -383,7 +384,7 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
                     endUtc)),
             Builders<SubscriptionUsageCurrent>.Update
                 .Set(current => current.PeriodEndUtc, endUtc)
-                .Set(current => current.ExpiresAtUtc, endUtc),
+                .Set(current => current.ExpiresAtUtc, expiresAtUtc),
             cancellationToken: cancellationToken);
 
         return result.ModifiedCount == 1;

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageCurrentRepository.cs
@@ -353,6 +353,42 @@ public sealed class SubscriptionUsageCurrentRepository : ISubscriptionUsageCurre
                 documentId))
             .FirstOrDefaultAsync(cancellationToken);
 
+    public async Task<IReadOnlyList<SubscriptionUsageCurrent>> ListBySubscriptionAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken) =>
+        await Current(tenantId)
+            .Find(Builders<SubscriptionUsageCurrent>.Filter.And(
+                Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                    current => current.TenantId,
+                    tenantId),
+                Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                    current => current.SubscriptionId,
+                    subscriptionId)))
+            .ToListAsync(cancellationToken);
+
+    public async Task<bool> TryRetireAsync(
+        string tenantId,
+        string itemId,
+        DateTime endUtc,
+        CancellationToken cancellationToken)
+    {
+        var result = await Current(tenantId).UpdateOneAsync(
+            Builders<SubscriptionUsageCurrent>.Filter.And(
+                Builders<SubscriptionUsageCurrent>.Filter.Eq(
+                    current => current.ItemId,
+                    itemId),
+                Builders<SubscriptionUsageCurrent>.Filter.Gt(
+                    current => current.PeriodEndUtc,
+                    endUtc)),
+            Builders<SubscriptionUsageCurrent>.Update
+                .Set(current => current.PeriodEndUtc, endUtc)
+                .Set(current => current.ExpiresAtUtc, endUtc),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     private IMongoCollection<SubscriptionUsageCurrent> Current(string tenantId) =>
         SubscriptionCollections.Of<SubscriptionUsageCurrent>(
             _dbContextProvider,

--- a/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionUsageRepository.cs
@@ -250,6 +250,33 @@ public sealed class SubscriptionUsageRepository : ISubscriptionUsageRepository
         return result.ModifiedCount == 1;
     }
 
+    public async Task<bool> TryResnapshotAllowanceAsync(
+        string tenantId,
+        string counterId,
+        decimal allowance,
+        IReadOnlyList<int> retainedThresholds,
+        CancellationToken cancellationToken)
+    {
+        var result = await Counters(tenantId).UpdateOneAsync(
+            Builders<SubscriptionUsageCounter>.Filter.And(
+                Builders<SubscriptionUsageCounter>.Filter.Eq(
+                    counter => counter.ItemId,
+                    counterId),
+                Builders<SubscriptionUsageCounter>.Filter.Ne(
+                    counter => counter.LimitSnapshot,
+                    allowance),
+                Builders<SubscriptionUsageCounter>.Filter.Gt(
+                    counter => counter.PeriodEndUtc,
+                    DateTime.UtcNow)),
+            Builders<SubscriptionUsageCounter>.Update
+                .Set(counter => counter.LimitSnapshot, allowance)
+                .Set(counter => counter.NotifiedThresholds, retainedThresholds.ToList())
+                .Set(counter => counter.LastUpdatedAtUtc, DateTime.UtcNow),
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     public async Task<IReadOnlyList<SubscriptionUsageRecord>> ListRecordsAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -772,6 +772,12 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
             var previousStatus = subscription.Status;
             subscription.Status = SubscriptionStatus.Active;
 
+            // Whether any counter actually moved, so a subscription whose trial ended long ago does
+            // not enqueue a projection refresh on every renewal from here to the end of its life —
+            // the per-window check below already skips every meter, so this stays false and nothing
+            // downstream is asked to re-read what did not change.
+            var resnapshotted = false;
+
             try
             {
                 foreach (var meter in subscription.Plan.Meters)
@@ -812,7 +818,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                         .Where(threshold => counter.Balance * 100 >= allowance * threshold)
                         .ToList();
 
-                    await _usage.TryResnapshotAllowanceAsync(
+                    resnapshotted |= await _usage.TryResnapshotAllowanceAsync(
                         subscription.TenantId, counterId, allowance, retainedThresholds,
                         cancellationToken);
                 }
@@ -822,7 +828,7 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 subscription.Status = previousStatus;
             }
 
-            if (_scheduler is not null)
+            if (resnapshotted && _scheduler is not null)
             {
                 await _scheduler.ScheduleUsageProjectionRefreshAsync(
                     subscription.TenantId,

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -699,7 +699,15 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         // allowance: MeterAllowance.Base now resolves the plan's quantity instead of the trial's
         // grant. A plan change riding along on the same renewal needs nothing here — it already
         // re-anchored the usage schedule and opened a correct window of its own.
-        if (subscription.Status == SubscriptionStatus.Trialing && appliedPlanChange is null)
+        //
+        // Gated on the subscription having a trial at all, not on the transition's own from-status.
+        // A card-free trial converts Trialing -> Unpaid, not Trialing -> Active; the renewal that
+        // actually moves it to Active runs later, from Unpaid, through this same method — and by
+        // then subscription.Status is already Unpaid, not Trialing. The per-meter check inside
+        // ResnapshotTrialConversionAsync is what keeps this from re-snapshotting every ordinary
+        // renewal: only a window that opened before the trial ended could still be holding its
+        // grant.
+        if (subscription.Trial is not null && appliedPlanChange is null)
         {
             await ResnapshotTrialConversionAsync(subscription, cancellationToken);
         }
@@ -737,10 +745,11 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
     /// lives in a different collection from the subscription, so it cannot join the transition's own
     /// write regardless of how this is called.
     /// <para>
-    /// ponytail: a lost re-snapshot leaves the subscription Active with a stale allowance until its
-    /// usage window rolls over naturally. The guarded filter on <c>TryResnapshotAllowanceAsync</c>
-    /// makes any retry safe; if that ceiling stops being acceptable, move this onto the outbox
-    /// instead of calling it inline here.
+    /// ponytail: a lost write here is not a dead end — every later renewal or recovery while the
+    /// window still overlaps the trial calls this again, and the repository's
+    /// <c>LimitSnapshot != allowance</c> filter makes an already-correct snapshot a cheap no-op. So
+    /// the ceiling is only "stale until the next renewal," never "stale forever." If even that
+    /// window is unacceptable, move this onto the outbox instead of calling it inline here.
     /// </para>
     /// </remarks>
     private async Task ResnapshotTrialConversionAsync(
@@ -754,11 +763,12 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
 
         try
         {
-            // The subscription just transitioned to Active in the store; this in-memory copy still
-            // reads Trialing, and the opening-allowance resolution below must see it as converted
-            // or it recomputes the trial's grant instead of the plan's quantity. Restored after,
-            // since this same object still names the transition's own "from" status in the log
-            // lines below it.
+            // The subscription just transitioned in the store — to Active on an ordinary or
+            // converting renewal, possibly still Unpaid mid-recovery elsewhere in this method — but
+            // this in-memory copy is not guaranteed to reflect that, and the opening-allowance
+            // resolution below must see a non-Trialing status or it recomputes the trial's grant
+            // instead of the plan's quantity. Restored after, since this same object still names the
+            // transition's own "from" status in the log lines below it.
             var previousStatus = subscription.Status;
             subscription.Status = SubscriptionStatus.Active;
 
@@ -768,6 +778,16 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
                 {
                     if (!MeterPeriodResolver.TryGetPeriod(
                             subscription, meter, _time.GetUtcNow().UtcDateTime, out var period))
+                    {
+                        continue;
+                    }
+
+                    // Only a window whose snapshot could have been the trial's grant. A window that
+                    // opened after the trial ended already froze the plan's own quantity, and
+                    // re-freezing it here would move an allowance the customer is already spending
+                    // against — the invariant
+                    // An_opened_window_is_still_held_to_the_allowance_it_opened_with protects.
+                    if (subscription.Trial is not { } trial || period.StartUtc >= trial.EndsAtUtc)
                     {
                         continue;
                     }

--- a/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionRenewalService.cs
@@ -695,6 +695,15 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
 
         _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);
 
+        // A converted trial is the one event that must move an already-open window's frozen
+        // allowance: MeterAllowance.Base now resolves the plan's quantity instead of the trial's
+        // grant. A plan change riding along on the same renewal needs nothing here — it already
+        // re-anchored the usage schedule and opened a correct window of its own.
+        if (subscription.Status == SubscriptionStatus.Trialing && appliedPlanChange is null)
+        {
+            await ResnapshotTrialConversionAsync(subscription, cancellationToken);
+        }
+
         if (_documents is not null && paymentDetailId is { Length: > 0 } invoiced)
         {
             // After the period is opened and the charge recorded, so the invoice can only describe a
@@ -717,6 +726,102 @@ public sealed class SubscriptionRenewalService : ISubscriptionRenewalService
         await ScheduleNextRenewalAsync(subscription, period, cancellationToken);
         await AuditAsync(subscription, "StateApplied", "Succeeded", null, null,
             paymentDetailId, attemptNumber, cancellationToken);
+    }
+
+    /// <summary>
+    /// Re-freezes each open counter's allowance now that this subscription has converted out of its
+    /// trial, and asks the projection to re-read it.
+    /// </summary>
+    /// <remarks>
+    /// Best-effort and logged only, like every other post-transition follow-up here: the counter
+    /// lives in a different collection from the subscription, so it cannot join the transition's own
+    /// write regardless of how this is called.
+    /// <para>
+    /// ponytail: a lost re-snapshot leaves the subscription Active with a stale allowance until its
+    /// usage window rolls over naturally. The guarded filter on <c>TryResnapshotAllowanceAsync</c>
+    /// makes any retry safe; if that ceiling stops being acceptable, move this onto the outbox
+    /// instead of calling it inline here.
+    /// </para>
+    /// </remarks>
+    private async Task ResnapshotTrialConversionAsync(
+        SubscriptionDetail subscription,
+        CancellationToken cancellationToken)
+    {
+        if (_usage is null || _allowances is null)
+        {
+            return;
+        }
+
+        try
+        {
+            // The subscription just transitioned to Active in the store; this in-memory copy still
+            // reads Trialing, and the opening-allowance resolution below must see it as converted
+            // or it recomputes the trial's grant instead of the plan's quantity. Restored after,
+            // since this same object still names the transition's own "from" status in the log
+            // lines below it.
+            var previousStatus = subscription.Status;
+            subscription.Status = SubscriptionStatus.Active;
+
+            try
+            {
+                foreach (var meter in subscription.Plan.Meters)
+                {
+                    if (!MeterPeriodResolver.TryGetPeriod(
+                            subscription, meter, _time.GetUtcNow().UtcDateTime, out var period))
+                    {
+                        continue;
+                    }
+
+                    var counterId = SubscriptionUsageCounter.CreateId(
+                        subscription.ItemId, meter.MeterKey, period.Key);
+
+                    var counter = await _usage.GetCounterAsync(
+                        subscription.TenantId, counterId, cancellationToken);
+
+                    // No counter means nothing was recorded during the trial; the window will open
+                    // at the correct plan allowance on its own and there is nothing to correct.
+                    if (counter is null)
+                    {
+                        continue;
+                    }
+
+                    var allowance = await _allowances.OpeningAllowanceAsync(
+                        subscription, meter, period, cancellationToken);
+
+                    var retainedThresholds = counter.NotifiedThresholds
+                        .Where(threshold => counter.Balance * 100 >= allowance * threshold)
+                        .ToList();
+
+                    await _usage.TryResnapshotAllowanceAsync(
+                        subscription.TenantId, counterId, allowance, retainedThresholds,
+                        cancellationToken);
+                }
+            }
+            finally
+            {
+                subscription.Status = previousStatus;
+            }
+
+            if (_scheduler is not null)
+            {
+                await _scheduler.ScheduleUsageProjectionRefreshAsync(
+                    subscription.TenantId,
+                    subscription.OrganizationId,
+                    subscription.ItemId,
+                    subscription.CorrelationId,
+                    cancellationToken);
+            }
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            _logger.LogError(
+                exception,
+                "Could not re-snapshot usage allowances after a trial conversion; the window stays " +
+                "at the trial grant until it next rolls over TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId));
+        }
     }
 
     /// <summary>

--- a/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
@@ -332,7 +332,11 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
 
             if (!planMeterKeys.Contains(row.MeterKey))
             {
-                if (await _current.TryPublishAsync(OrphanDocument(subscription, row), cancellationToken))
+                // Only when the subscription's own version has moved past what this row already
+                // carries: a republish that changes nothing still runs the merge's insert fallback
+                // into a guaranteed duplicate-key exception, on every pass, forever.
+                if (subscription.Version > row.SubscriptionVersion &&
+                    await _current.TryPublishAsync(OrphanDocument(subscription, row), cancellationToken))
                 {
                     reconciled++;
                 }
@@ -340,10 +344,20 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
                 continue;
             }
 
+            // Superseded, not merely later: the row must actually precede the current window, or a
+            // window that opens before every stored row (a meter's ResetPolicy moving to Never opens
+            // a lifetime window starting at the subscription's own creation) would retire rows that
+            // are not superseded at all — inverting PeriodStartUtc past PeriodEndUtc and handing the
+            // TTL index a still-live row to delete.
             if (currentStartByMeter.TryGetValue(row.MeterKey, out var currentStart) &&
+                row.PeriodStartUtc < currentStart &&
                 currentStart < row.PeriodEndUtc &&
                 await _current.TryRetireAsync(
-                    subscription.TenantId, row.ItemId, currentStart, cancellationToken))
+                    subscription.TenantId,
+                    row.ItemId,
+                    currentStart,
+                    currentStart.AddDays(Math.Max(1, _options.CurrentValue.CounterRetentionDays)),
+                    cancellationToken))
             {
                 reconciled++;
             }

--- a/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
@@ -181,72 +181,83 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
 
         var windows = CurrentWindows(subscription, asOfUtc).ToList();
 
-        if (windows.Count == 0)
-        {
-            return 0;
-        }
-
-        // One batch for every meter, which matters here as much as on the read path: a repair over a
-        // subscription with a dozen meters would otherwise be a dozen round trips.
-        var counters = await _usage.GetCountersAsync(
-            subscription.TenantId,
-            windows
-                .Select(window => SubscriptionUsageCounter.CreateId(
-                    subscription.ItemId,
-                    window.Meter.MeterKey,
-                    window.Period.Key))
-                .ToList(),
-            cancellationToken);
-
         var published = 0;
 
-        foreach (var (meter, period) in windows)
+        if (windows.Count > 0)
         {
-            counters.TryGetValue(
-                SubscriptionUsageCounter.CreateId(subscription.ItemId, meter.MeterKey, period.Key),
-                out var counter);
-
-            var allowance = await _allowances.EffectiveAsync(
-                subscription,
-                meter,
-                period,
-                counter,
+            // One batch for every meter, which matters here as much as on the read path: a repair
+            // over a subscription with a dozen meters would otherwise be a dozen round trips.
+            var counters = await _usage.GetCountersAsync(
+                subscription.TenantId,
+                windows
+                    .Select(window => SubscriptionUsageCounter.CreateId(
+                        subscription.ItemId,
+                        window.Meter.MeterKey,
+                        window.Period.Key))
+                    .ToList(),
                 cancellationToken);
 
-            SubscriptionUsageCurrent document;
-
-            if (counter is null)
+            foreach (var (meter, period) in windows)
             {
-                // No counter means nothing has been recorded in this window, so the balance is zero
-                // and the counter version is zero.
-                document = Describe(
-                    subscription, meter, period, counter: null, balance: 0, counterVersion: 0, allowance);
+                counters.TryGetValue(
+                    SubscriptionUsageCounter.CreateId(subscription.ItemId, meter.MeterKey, period.Key),
+                    out var counter);
 
-                // Seed first, which creates it if it is missing and refuses to touch it if it is
-                // not. Then publish, which is what carries a changed allowance onto a window that
-                // already has a zero-usage document.
-                //
-                // Both, rather than one: the seed cannot update, and the publish cannot insert past
-                // a zero counter version against a document holding real usage. Together they cover
-                // the two cases without either being able to discard a balance — the publish is
-                // still ordered, so against a document with any recorded usage its counter version
-                // of zero loses, and against a zero-usage document it wins only on a newer
-                // subscription version.
-                if (await _current.TrySeedAsync(document, cancellationToken) ||
-                    await _current.TryPublishAsync(document, cancellationToken))
+                var allowance = await _allowances.EffectiveAsync(
+                    subscription,
+                    meter,
+                    period,
+                    counter,
+                    cancellationToken);
+
+                SubscriptionUsageCurrent document;
+
+                if (counter is null)
+                {
+                    // No counter means nothing has been recorded in this window, so the balance is
+                    // zero and the counter version is zero.
+                    document = Describe(
+                        subscription, meter, period, counter: null, balance: 0, counterVersion: 0,
+                        allowance);
+
+                    // Seed first, which creates it if it is missing and refuses to touch it if it is
+                    // not. Then publish, which is what carries a changed allowance onto a window that
+                    // already has a zero-usage document.
+                    //
+                    // Both, rather than one: the seed cannot update, and the publish cannot insert
+                    // past a zero counter version against a document holding real usage. Together
+                    // they cover the two cases without either being able to discard a balance — the
+                    // publish is still ordered, so against a document with any recorded usage its
+                    // counter version of zero loses, and against a zero-usage document it wins only
+                    // on a newer subscription version.
+                    if (await _current.TrySeedAsync(document, cancellationToken) ||
+                        await _current.TryPublishAsync(document, cancellationToken))
+                    {
+                        published++;
+                    }
+
+                    continue;
+                }
+
+                document = Describe(subscription, meter, period, counter, allowance);
+
+                if (await _current.TryPublishAsync(document, cancellationToken))
                 {
                     published++;
                 }
-
-                continue;
             }
+        }
 
-            document = Describe(subscription, meter, period, counter, allowance);
+        // Plan-derived windows are what a busy meter republishes; stored rows are what is actually
+        // in the collection. The two drift apart on a plan change (superseded rows the new window
+        // never touches) and on a meter leaving the plan entirely (orphaned rows no window can ever
+        // name again), so both must be reconciled for a refresh to be a refresh of what exists rather
+        // than only of what the plan currently implies.
+        published += await ReconcileStoredRowsAsync(subscription, windows, correlationId, cancellationToken);
 
-            if (await _current.TryPublishAsync(document, cancellationToken))
-            {
-                published++;
-            }
+        if (windows.Count == 0 && published == 0)
+        {
+            return 0;
         }
 
         _logger.LogInformation(
@@ -260,6 +271,138 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
 
         return published;
     }
+
+    /// <summary>
+    /// Retires or repairs the stored rows a plan-derived window no longer covers.
+    /// </summary>
+    /// <remarks>
+    /// Two shapes, told apart by whether the row's meter is still on the plan:
+    /// <list type="bullet">
+    /// <item>still on the plan, and the current window for that meter starts before this row's own
+    /// end — a superseded window a plan change re-anchored past. Retired at the current window's
+    /// start, which is what keeps one meter from ever answering with two live rows.</item>
+    /// <item>no longer on the plan at all — an orphaned window. The genuine, possibly still-open
+    /// balance is kept; only the subscription-owned fields are republished, so a reader sees the
+    /// subscription's current status and plan rather than whatever was true when the meter was
+    /// dropped.</item>
+    /// </list>
+    /// </remarks>
+    private async Task<int> ReconcileStoredRowsAsync(
+        SubscriptionDetail subscription,
+        IReadOnlyList<(PlanMeter Meter, BillingPeriod Period)> windows,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var stored = await _current.ListBySubscriptionAsync(
+            subscription.TenantId,
+            subscription.ItemId,
+            cancellationToken);
+
+        if (stored.Count == 0)
+        {
+            return 0;
+        }
+
+        var currentIds = new HashSet<string>(
+            windows.Select(window => SubscriptionUsageCurrent.CreateId(
+                subscription.ItemId,
+                window.Meter.MeterKey,
+                window.Period.Key)),
+            StringComparer.Ordinal);
+
+        var currentStartByMeter = new Dictionary<string, DateTime>(StringComparer.Ordinal);
+
+        foreach (var window in windows)
+        {
+            currentStartByMeter[window.Meter.MeterKey] = window.Period.StartUtc;
+        }
+
+        var planMeterKeys = new HashSet<string>(
+            subscription.Plan.Meters.Select(meter => meter.MeterKey),
+            StringComparer.Ordinal);
+
+        var reconciled = 0;
+
+        foreach (var row in stored)
+        {
+            if (currentIds.Contains(row.ItemId))
+            {
+                continue;
+            }
+
+            if (!planMeterKeys.Contains(row.MeterKey))
+            {
+                if (await _current.TryPublishAsync(OrphanDocument(subscription, row), cancellationToken))
+                {
+                    reconciled++;
+                }
+
+                continue;
+            }
+
+            if (currentStartByMeter.TryGetValue(row.MeterKey, out var currentStart) &&
+                currentStart < row.PeriodEndUtc &&
+                await _current.TryRetireAsync(
+                    subscription.TenantId, row.ItemId, currentStart, cancellationToken))
+            {
+                reconciled++;
+            }
+        }
+
+        if (reconciled > 0)
+        {
+            _logger.LogInformation(
+                "Usage projection reconciled stale stored rows TenantHash={TenantHash} " +
+                "SubscriptionHash={SubscriptionHash} StoredRows={StoredRows} Reconciled={Reconciled} " +
+                "CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                stored.Count,
+                reconciled,
+                correlationId);
+        }
+
+        return reconciled;
+    }
+
+    /// <summary>
+    /// Republishes a row whose meter left the plan, carrying its balance across untouched.
+    /// </summary>
+    /// <remarks>
+    /// Built from the stored row rather than from <see cref="Describe"/>, which needs a
+    /// <see cref="PlanMeter"/> this row no longer has one of. Only the fields the subscription's own
+    /// version owns are overwritten; the merge pipeline in
+    /// <c>SubscriptionUsageCurrentRepository</c> decides the rest by comparing versions the same way
+    /// it does for every other publish, so a stale republish here can still lose to a newer one.
+    /// </remarks>
+    private SubscriptionUsageCurrent OrphanDocument(
+        SubscriptionDetail subscription,
+        SubscriptionUsageCurrent row) => new()
+    {
+        ItemId = row.ItemId,
+        TenantId = row.TenantId,
+        OrganizationId = row.OrganizationId,
+        SubscriptionId = row.SubscriptionId,
+        SubscriptionStatus = subscription.Status,
+        PlanId = subscription.Plan.PlanId,
+        PlanCode = subscription.Plan.Code,
+        MeterKey = row.MeterKey,
+        UnitLabel = row.UnitLabel,
+        QuantityScale = row.QuantityScale,
+        PeriodKey = row.PeriodKey,
+        PeriodStartUtc = row.PeriodStartUtc,
+        PeriodEndUtc = row.PeriodEndUtc,
+        Included = row.Included,
+        Used = row.Used,
+        Remaining = row.Remaining,
+        Overage = row.Overage,
+        OverageAllowed = row.OverageAllowed,
+        CounterVersion = row.CounterVersion,
+        SubscriptionVersion = subscription.Version,
+        SchemaVersion = SubscriptionUsageCurrent.CurrentSchemaVersion,
+        UpdatedAtUtc = _time.GetUtcNow().UtcDateTime,
+        ExpiresAtUtc = row.ExpiresAtUtc
+    };
 
     /// <summary>
     /// Every meter's window containing <paramref name="asOfUtc"/>.

--- a/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
@@ -273,19 +273,29 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
     }
 
     /// <summary>
-    /// Retires or repairs the stored rows a plan-derived window no longer covers.
+    /// Republishes and, where it overlaps, retires every stored row a plan-derived window no longer
+    /// covers.
     /// </summary>
     /// <remarks>
-    /// Two shapes, told apart by whether the row's meter is still on the plan:
+    /// Two independent actions, not two alternative shapes — a row that is both superseded and still
+    /// on the plan needs both, or its status and plan go stale for as long as
+    /// <c>CounterRetentionDays</c> keeps the retired row alive:
     /// <list type="bullet">
-    /// <item>still on the plan, and the current window for that meter starts before this row's own
-    /// end — a superseded window a plan change re-anchored past. Retired at the current window's
-    /// start, which is what keeps one meter from ever answering with two live rows.</item>
-    /// <item>no longer on the plan at all — an orphaned window. The genuine, possibly still-open
-    /// balance is kept; only the subscription-owned fields are republished, so a reader sees the
-    /// subscription's current status and plan rather than whatever was true when the meter was
-    /// dropped.</item>
+    /// <item>Every row no current window describes is republished with this subscription's own
+    /// status, plan and version, whether its meter left the plan entirely or is merely between
+    /// windows. A reader filtering on <c>SubscriptionStatus</c> alone — with no window predicate to
+    /// protect it — must not see a status this subscription no longer holds for as long as a
+    /// superseded row survives.</item>
+    /// <item>Additionally, a row whose meter is still on the plan and that the current window
+    /// genuinely precedes — starts before it, and extends past its start — is retired at the
+    /// current window's start. That is what keeps one meter from ever answering with two live rows;
+    /// it is not a substitute for the republish above, which is what keeps a stale status from
+    /// surviving under a query that never looks at the window at all.</item>
     /// </list>
+    /// Publish before retire, deliberately: <c>PeriodEndUtc</c> sits in the merge pipeline's
+    /// unconditional identity group, so a publish carrying this row's own (not yet clamped)
+    /// <c>PeriodEndUtc</c> after a retire had already shrunk it would write the old, wider window
+    /// straight back.
     /// </remarks>
     private async Task<int> ReconcileStoredRowsAsync(
         SubscriptionDetail subscription,
@@ -317,10 +327,6 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
             currentStartByMeter[window.Meter.MeterKey] = window.Period.StartUtc;
         }
 
-        var planMeterKeys = new HashSet<string>(
-            subscription.Plan.Meters.Select(meter => meter.MeterKey),
-            StringComparer.Ordinal);
-
         var reconciled = 0;
 
         foreach (var row in stored)
@@ -330,18 +336,15 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
                 continue;
             }
 
-            if (!planMeterKeys.Contains(row.MeterKey))
-            {
-                // Only when the subscription's own version has moved past what this row already
-                // carries: a republish that changes nothing still runs the merge's insert fallback
-                // into a guaranteed duplicate-key exception, on every pass, forever.
-                if (subscription.Version > row.SubscriptionVersion &&
-                    await _current.TryPublishAsync(OrphanDocument(subscription, row), cancellationToken))
-                {
-                    reconciled++;
-                }
+            var changed = false;
 
-                continue;
+            // Only when the subscription's own version has moved past what this row already
+            // carries: a republish that changes nothing still runs the merge's insert fallback
+            // into a guaranteed duplicate-key exception, on every pass, forever.
+            if (subscription.Version > row.SubscriptionVersion &&
+                await _current.TryPublishAsync(StoredRowDocument(subscription, row), cancellationToken))
+            {
+                changed = true;
             }
 
             // Superseded, not merely later: the row must actually precede the current window, or a
@@ -358,6 +361,11 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
                     currentStart,
                     currentStart.AddDays(Math.Max(1, _options.CurrentValue.CounterRetentionDays)),
                     cancellationToken))
+            {
+                changed = true;
+            }
+
+            if (changed)
             {
                 reconciled++;
             }
@@ -380,16 +388,19 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
     }
 
     /// <summary>
-    /// Republishes a row whose meter left the plan, carrying its balance across untouched.
+    /// Republishes a stored row this subscription's own status, plan and version have moved past,
+    /// carrying its balance across untouched.
     /// </summary>
     /// <remarks>
     /// Built from the stored row rather than from <see cref="Describe"/>, which needs a
-    /// <see cref="PlanMeter"/> this row no longer has one of. Only the fields the subscription's own
-    /// version owns are overwritten; the merge pipeline in
+    /// <see cref="PlanMeter"/> a row whose meter left the plan no longer has one of — and for a row
+    /// whose meter is still on the plan, this runs before <see cref="ReconcileStoredRowsAsync"/>'s
+    /// own retire step, so its window fields are exactly as valid either way. Only the fields the
+    /// subscription's own version owns are overwritten; the merge pipeline in
     /// <c>SubscriptionUsageCurrentRepository</c> decides the rest by comparing versions the same way
     /// it does for every other publish, so a stale republish here can still lose to a newer one.
     /// </remarks>
-    private SubscriptionUsageCurrent OrphanDocument(
+    private SubscriptionUsageCurrent StoredRowDocument(
         SubscriptionDetail subscription,
         SubscriptionUsageCurrent row) => new()
     {

--- a/server/Subscription.DomainService/Services/UsageRecordingService.cs
+++ b/server/Subscription.DomainService/Services/UsageRecordingService.cs
@@ -466,15 +466,19 @@ public sealed class UsageRecordingService : IUsageRecordingService
             subscription.Plan.Meters.Select(meter => meter.MeterKey),
             StringComparer.Ordinal);
 
+        // A structurally sound read model can still hold two live rows for one meter — a plan
+        // change that re-anchors the window before the reconciliation sweep retires the row it
+        // superseded. Highest SubscriptionVersion wins, mirroring the merge pipeline's own tie
+        // break, so a stale duplicate never outranks the row that superseded it.
+        var deduped = documents
+            .Where(document => meters.Contains(document.MeterKey))
+            .GroupBy(document => document.MeterKey, StringComparer.Ordinal)
+            .Select(group => group.OrderByDescending(document => document.SubscriptionVersion).First());
+
         var results = new List<(UsageResponse, DateTime)>(documents.Count);
 
-        foreach (var document in documents)
+        foreach (var document in deduped)
         {
-            if (!meters.Contains(document.MeterKey))
-            {
-                continue;
-            }
-
             results.Add((
                 new UsageResponse
                 {

--- a/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
@@ -288,7 +288,11 @@ public sealed class SubscriptionRenewalServiceTests
                 "The card was declined.",
                 "corr-1"));
 
-    private SubscriptionRenewalService Service(ISubscriptionWorkScheduler? scheduler = null) => new(
+    private readonly Mock<ISubscriptionUsageRepository> _usage = new();
+
+    private SubscriptionRenewalService Service(
+        ISubscriptionWorkScheduler? scheduler = null,
+        bool withUsage = false) => new(
         _subscriptions.Object,
         _billingAccounts.Object,
         _gateway.Object,
@@ -298,7 +302,117 @@ public sealed class SubscriptionRenewalServiceTests
         NullLogger<SubscriptionRenewalService>.Instance,
         _time,
         audit: null,
-        scheduler: scheduler);
+        scheduler: scheduler,
+        usage: withUsage ? _usage.Object : null,
+        allowances: withUsage ? new MeterAllowanceResolver(_usage.Object) : null);
+
+    // ---- Re-snapshotting a converted trial's allowance ----------------------------------------
+
+    private static SubscriptionDetail NewTrialingSubscription(DateTime trialEndsAtUtc)
+    {
+        var subscription = NewSubscription(SubscriptionStatus.Trialing);
+        subscription.Trial = new TrialTerms
+        {
+            EndsAtUtc = trialEndsAtUtc,
+            RequiresPaymentMethod = true,
+            Grants = [new TrialMeterGrant { MeterKey = "token", IncludedQuantity = 250 }]
+        };
+        subscription.InitialChargeAmountMinor = null;
+        subscription.Plan.Meters =
+        [
+            new PlanMeter
+            {
+                MeterKey = "token",
+                UnitLabel = "token",
+                IncludedQuantity = 1550.55m,
+                OverageAllowed = true,
+                ResetPolicy = MeterResetPolicy.Periodic
+            }
+        ];
+        subscription.UsageSchedule = new BillingSchedule
+        {
+            Interval = BillingInterval.Month,
+            IntervalCount = 1,
+            AnchorInstantUtc = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            TimeZoneId = "UTC",
+            AnchorDayOfMonth = 1
+        };
+
+        return subscription;
+    }
+
+    /// <summary>The 876a7ef4 shape: a converted trial's counter must move off the trial's grant.</summary>
+    [Fact]
+    public async Task A_trial_conversion_resnapshots_the_counter_from_the_grant_to_the_plans_quantity()
+    {
+        var subscription = NewTrialingSubscription(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        var scheduler = new Mock<ISubscriptionWorkScheduler>();
+
+        // Keyed off whichever id the service actually composes rather than a period key spelled out
+        // here: PeriodKey.Create's exact shape is BillingPeriodCalculator's concern, not this test's.
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string counterId, CancellationToken _) => new SubscriptionUsageCounter
+            {
+                ItemId = counterId,
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                SubscriptionId = "sub-1",
+                MeterKey = "token",
+                Balance = 1100.75m,
+                LimitSnapshot = 250,
+                NotifiedThresholds = [50, 75, 90],
+                PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+                PeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+            });
+
+        decimal? resnappedAllowance = null;
+        IReadOnlyList<int>? retainedThresholds = null;
+
+        _usage
+            .Setup(repository => repository.TryResnapshotAllowanceAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<decimal>(), It.IsAny<IReadOnlyList<int>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((string _, string _, decimal allowance, IReadOnlyList<int> thresholds,
+                CancellationToken _) =>
+            {
+                resnappedAllowance = allowance;
+                retainedThresholds = thresholds;
+            })
+            .ReturnsAsync(true);
+
+        await Service(scheduler.Object, withUsage: true).RenewAsync(subscription, CancellationToken.None);
+
+        resnappedAllowance.Should().Be(1550.55m, "the plan's own quantity, not the trial's grant");
+        // 1100.75 clears 50% of 1550.55 but neither 75% nor 90%, so only 50 is still crossed.
+        retainedThresholds.Should().Equal(50);
+        scheduler.Verify(
+            work => work.ScheduleUsageProjectionRefreshAsync(
+                TenantId, OrganizationId, "sub-1", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// A plan change riding on the same renewal already re-anchors the usage schedule and opens a
+    /// correct window of its own; re-snapshotting on top of that would be resolving an allowance for
+    /// a window the renewal is about to replace anyway.
+    /// </summary>
+    [Fact]
+    public async Task A_trial_conversion_with_a_plan_change_riding_along_does_not_resnapshot()
+    {
+        var subscription = NewTrialingSubscription(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        subscription.CurrentPeriodEndUtc = subscription.Trial!.EndsAtUtc;
+        subscription.PendingPlanChange = ScheduledChange(subscription.Trial.EndsAtUtc);
+
+        await Service(withUsage: true).RenewAsync(subscription, CancellationToken.None);
+
+        _usage.Verify(
+            repository => repository.TryResnapshotAllowanceAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<decimal>(),
+                It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 
     /// <summary>
     /// A decrease is not refunded, so it waits for the period it was scheduled against to close.

--- a/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
@@ -308,9 +308,11 @@ public sealed class SubscriptionRenewalServiceTests
 
     // ---- Re-snapshotting a converted trial's allowance ----------------------------------------
 
-    private static SubscriptionDetail NewTrialingSubscription(DateTime trialEndsAtUtc)
+    private static SubscriptionDetail NewTrialingSubscription(
+        DateTime trialEndsAtUtc,
+        SubscriptionStatus status = SubscriptionStatus.Trialing)
     {
-        var subscription = NewSubscription(SubscriptionStatus.Trialing);
+        var subscription = NewSubscription(status);
         subscription.Trial = new TrialTerms
         {
             EndsAtUtc = trialEndsAtUtc,
@@ -345,7 +347,11 @@ public sealed class SubscriptionRenewalServiceTests
     [Fact]
     public async Task A_trial_conversion_resnapshots_the_counter_from_the_grant_to_the_plans_quantity()
     {
-        var subscription = NewTrialingSubscription(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        // Strictly inside the current window (Aug 1 - Sep 1), not on its boundary: the window's
+        // snapshot could only have been the trial's grant if the trial was still open when the
+        // window opened, and a trial ending exactly at the window's own start already resolves the
+        // plan's quantity on its own.
+        var subscription = NewTrialingSubscription(new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Utc));
         var scheduler = new Mock<ISubscriptionWorkScheduler>();
 
         // Keyed off whichever id the service actually composes rather than a period key spelled out
@@ -411,6 +417,76 @@ public sealed class SubscriptionRenewalServiceTests
             repository => repository.TryResnapshotAllowanceAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<decimal>(),
                 It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A card-free trial converts Trialing -&gt; Unpaid, not Trialing -&gt; Active — the renewal that
+    /// actually reaches Active runs later, from Unpaid, once a card is added. Gating the re-snapshot
+    /// on the transition's own from-status would miss this route entirely and leave the window
+    /// capped at the trial's grant forever, the exact overcharge this fix exists to close, reached by
+    /// a different door.
+    /// </summary>
+    [Fact]
+    public async Task A_recovery_from_unpaid_after_a_lapsed_trial_resnapshots_the_counter()
+    {
+        // Strictly inside the current window, not on its boundary — see the comment on the
+        // conversion test above for why the boundary itself is not this case.
+        var trialEndsAtUtc = new DateTime(2026, 8, 15, 0, 0, 0, DateTimeKind.Utc);
+        var subscription = NewTrialingSubscription(trialEndsAtUtc, SubscriptionStatus.Unpaid);
+
+        _usage
+            .Setup(repository => repository.GetCounterAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string counterId, CancellationToken _) => new SubscriptionUsageCounter
+            {
+                ItemId = counterId,
+                TenantId = TenantId,
+                OrganizationId = OrganizationId,
+                SubscriptionId = "sub-1",
+                MeterKey = "token",
+                Balance = 1100.75m,
+                LimitSnapshot = 250,
+                PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+                PeriodEndUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc)
+            });
+
+        decimal? resnappedAllowance = null;
+        _usage
+            .Setup(repository => repository.TryResnapshotAllowanceAsync(
+                TenantId, It.IsAny<string>(), It.IsAny<decimal>(), It.IsAny<IReadOnlyList<int>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((string _, string _, decimal allowance, IReadOnlyList<int> _, CancellationToken _) =>
+                resnappedAllowance = allowance)
+            .ReturnsAsync(true);
+
+        await Service(withUsage: true).RecoverAsync(subscription, CancellationToken.None);
+
+        resnappedAllowance.Should().Be(1550.55m, "the plan's own quantity, not the trial's grant");
+    }
+
+    /// <summary>
+    /// A dunning retry with no trial in its history must never call the resolver down this path —
+    /// <c>subscription.Trial is not null</c> is the whole gate now that the from-status check is
+    /// gone, so this is what proves it actually gates rather than passing by accident.
+    /// </summary>
+    [Fact]
+    public async Task A_dunning_recovery_on_a_non_trial_subscription_does_not_resnapshot()
+    {
+        var subscription = NewSubscription(SubscriptionStatus.PastDue);
+        subscription.DunningAttemptCount = 1;
+        subscription.PastDueSinceUtc = _time.GetUtcNow().UtcDateTime.AddDays(-3);
+
+        await Service(withUsage: true).RenewAsync(subscription, CancellationToken.None);
+
+        _usage.Verify(
+            repository => repository.TryResnapshotAllowanceAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<decimal>(),
+                It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _usage.Verify(
+            repository => repository.GetCounterAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionRenewalServiceTests.cs
@@ -400,6 +400,33 @@ public sealed class SubscriptionRenewalServiceTests
     }
 
     /// <summary>
+    /// The matching negative for the test above: a subscription whose trial window has long since
+    /// rolled must not enqueue a projection refresh on every renewal for the rest of its life. The
+    /// per-window check already reaches no repository call at all here, so nothing is left for the
+    /// scheduler to be told about.
+    /// </summary>
+    [Fact]
+    public async Task A_renewal_of_a_subscription_whose_trial_window_has_rolled_schedules_no_refresh()
+    {
+        var subscription = NewTrialingSubscription(
+            new DateTime(2026, 1, 15, 0, 0, 0, DateTimeKind.Utc), SubscriptionStatus.Active);
+        var scheduler = new Mock<ISubscriptionWorkScheduler>();
+
+        await Service(scheduler.Object, withUsage: true).RenewAsync(subscription, CancellationToken.None);
+
+        _usage.Verify(
+            repository => repository.TryResnapshotAllowanceAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<decimal>(),
+                It.IsAny<IReadOnlyList<int>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        scheduler.Verify(
+            work => work.ScheduleUsageProjectionRefreshAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
     /// A plan change riding on the same renewal already re-anchors the usage schedule and opens a
     /// correct window of its own; re-snapshotting on top of that would be resolving an allowance for
     /// a window the renewal is about to replace anyway.

--- a/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
@@ -50,6 +50,11 @@ public sealed class UsageProjectionPublisherTests
                 _seeded.Add(document))
             .ReturnsAsync(true);
 
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[]);
+
         _usage
             .Setup(repository => repository.GetCountersAsync(
                 TenantId,
@@ -315,6 +320,114 @@ public sealed class UsageProjectionPublisherTests
 
         _published.Should().ContainSingle().Which.ExpiresAtUtc.Should().Be(expires);
     }
+
+    /// <summary>
+    /// The d9f76e26 shape: every meter that recorded the row's usage has since left the plan, so
+    /// <c>CurrentWindows</c> yields nothing at all. A refresh must still find and repair what it left
+    /// behind rather than stopping at "no windows, nothing to do".
+    /// </summary>
+    [Fact]
+    public async Task Refreshing_a_meterless_plan_reconciles_the_orphaned_row_instead_of_returning_zero()
+    {
+        var subscription = Subscription();
+        subscription.Plan.Meters = [];
+
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[OrphanRow()]);
+
+        var written = await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        written.Should().Be(1);
+        _published.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task An_orphaned_row_takes_the_subscriptions_status_and_version_but_keeps_its_balance()
+    {
+        var subscription = Subscription();
+        subscription.Plan.Meters = [];
+        subscription.Status = SubscriptionStatus.Canceled;
+        subscription.Version = 7;
+
+        var orphan = OrphanRow();
+
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[orphan]);
+
+        await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        var document = _published.Should().ContainSingle().Subject;
+        document.SubscriptionStatus.Should().Be(SubscriptionStatus.Canceled);
+        document.SubscriptionVersion.Should().Be(7);
+        document.Used.Should().Be(orphan.Used, "the genuine balance must survive the meter leaving the plan");
+        document.CounterVersion.Should().Be(orphan.CounterVersion);
+    }
+
+    /// <summary>The a00c2376 shape: a plan change re-anchored the window before this row was retired.</summary>
+    [Fact]
+    public async Task A_superseded_row_is_retired_at_the_current_windows_start_and_the_current_row_stands()
+    {
+        var subscription = Subscription();
+
+        var superseded = new SubscriptionUsageCurrent
+        {
+            ItemId = "sub-1:screening:M2026-08",
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            SubscriptionId = "sub-1",
+            MeterKey = "screening",
+            PeriodKey = "M2026-08",
+            PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            // Extends past the current window's own start, which is what makes it superseded rather
+            // than simply an old, already-closed row with nothing wrong with it.
+            PeriodEndUtc = new DateTime(2026, 10, 15, 0, 0, 0, DateTimeKind.Utc),
+            Included = 100,
+            Used = 10,
+            ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[superseded]);
+
+        DateTime? retiredAt = null;
+        _current
+            .Setup(repository => repository.TryRetireAsync(
+                TenantId, superseded.ItemId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, string _, DateTime endUtc, CancellationToken _) => retiredAt = endUtc)
+            .ReturnsAsync(true);
+
+        await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        retiredAt.Should().Be(Period().StartUtc);
+        _published.Should().NotContain(document => document.ItemId == superseded.ItemId);
+    }
+
+    private static SubscriptionUsageCurrent OrphanRow() => new()
+    {
+        ItemId = "sub-1:retired-meter:M2026-09",
+        TenantId = TenantId,
+        OrganizationId = OrganizationId,
+        SubscriptionId = "sub-1",
+        MeterKey = "retired-meter",
+        PeriodKey = "M2026-09",
+        PeriodStartUtc = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+        PeriodEndUtc = new DateTime(2026, 10, 1, 0, 0, 0, DateTimeKind.Utc),
+        Included = 100,
+        Used = 42,
+        Remaining = 58,
+        CounterVersion = 5,
+        SubscriptionVersion = 3,
+        ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+    };
 
     private UsageProjectionPublisher Publisher() => new(
         _current.Object,

--- a/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
@@ -369,6 +369,36 @@ public sealed class UsageProjectionPublisherTests
         document.CounterVersion.Should().Be(orphan.CounterVersion);
     }
 
+    /// <summary>
+    /// A republish that would change nothing still runs the merge's insert fallback into a
+    /// guaranteed duplicate-key exception — skipped so a backfill does not throw once per orphaned
+    /// row, forever.
+    /// </summary>
+    [Fact]
+    public async Task An_orphaned_row_already_at_the_subscriptions_version_is_not_republished()
+    {
+        var subscription = Subscription();
+        subscription.Plan.Meters = [];
+        subscription.Version = 1;
+
+        var orphan = OrphanRow();
+        orphan.SubscriptionVersion = 1;
+
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[orphan]);
+
+        var written = await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        written.Should().Be(0);
+        _current.Verify(
+            repository => repository.TryPublishAsync(
+                It.IsAny<SubscriptionUsageCurrent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     /// <summary>The a00c2376 shape: a plan change re-anchored the window before this row was retired.</summary>
     [Fact]
     public async Task A_superseded_row_is_retired_at_the_current_windows_start_and_the_current_row_stands()
@@ -400,8 +430,10 @@ public sealed class UsageProjectionPublisherTests
         DateTime? retiredAt = null;
         _current
             .Setup(repository => repository.TryRetireAsync(
-                TenantId, superseded.ItemId, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .Callback((string _, string _, DateTime endUtc, CancellationToken _) => retiredAt = endUtc)
+                TenantId, superseded.ItemId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((string _, string _, DateTime endUtc, DateTime _, CancellationToken _) =>
+                retiredAt = endUtc)
             .ReturnsAsync(true);
 
         await Publisher().RefreshAsync(
@@ -409,6 +441,50 @@ public sealed class UsageProjectionPublisherTests
 
         retiredAt.Should().Be(Period().StartUtc);
         _published.Should().NotContain(document => document.ItemId == superseded.ItemId);
+    }
+
+    /// <summary>
+    /// A window that opens before every stored row — a meter's <c>ResetPolicy</c> moving from
+    /// <c>Periodic</c> to <c>Never</c> opens a lifetime window starting at the subscription's own
+    /// creation — must not be mistaken for having superseded a row that in fact starts later than it.
+    /// Retiring it would clamp <c>PeriodEndUtc</c> below <c>PeriodStartUtc</c> and hand the TTL index
+    /// a still-live row to delete.
+    /// </summary>
+    [Fact]
+    public async Task A_row_that_starts_after_the_current_window_is_not_retired()
+    {
+        var subscription = Subscription();
+
+        var futureDated = new SubscriptionUsageCurrent
+        {
+            ItemId = "sub-1:screening:M20261005",
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            SubscriptionId = "sub-1",
+            MeterKey = "screening",
+            PeriodKey = "M20261005",
+            // Starts after the current window's own start, so it has not been superseded by it —
+            // the inverse of the superseded-row shape above.
+            PeriodStartUtc = new DateTime(2026, 10, 5, 0, 0, 0, DateTimeKind.Utc),
+            PeriodEndUtc = new DateTime(2026, 11, 5, 0, 0, 0, DateTimeKind.Utc),
+            Included = 100,
+            Used = 1,
+            ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[futureDated]);
+
+        await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        _current.Verify(
+            repository => repository.TryRetireAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private static SubscriptionUsageCurrent OrphanRow() => new()
@@ -425,7 +501,9 @@ public sealed class UsageProjectionPublisherTests
         Used = 42,
         Remaining = 58,
         CounterVersion = 5,
-        SubscriptionVersion = 3,
+        // Below any Subscription() default (Version 1) and below the explicit 7 the second test
+        // below sets, so both exercise a subscription version that has genuinely moved past it.
+        SubscriptionVersion = 0,
         ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
     };
 

--- a/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
@@ -551,6 +551,58 @@ public sealed class UsageProjectionPublisherTests
             Times.Never);
     }
 
+    /// <summary>
+    /// The fb64f47d shape: a future-dated row the current window has not superseded, but whose
+    /// status is still stale. Republish is gated only on the version comparison, never on window
+    /// position, so it must fire here exactly as it would for a row the window has already passed —
+    /// proven directly rather than left to follow from the retire guard above, since scoping
+    /// republish to rows preceding the current window is the kind of change that would look like a
+    /// safe tightening and silently reopen this one.
+    /// </summary>
+    [Fact]
+    public async Task A_future_dated_row_with_a_stale_version_is_republished_but_not_retired()
+    {
+        var subscription = Subscription();
+        subscription.Status = SubscriptionStatus.Canceled;
+        subscription.Version = 14;
+
+        var futureDated = new SubscriptionUsageCurrent
+        {
+            ItemId = "sub-1:screening:M20261005",
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            SubscriptionId = "sub-1",
+            MeterKey = "screening",
+            PeriodKey = "M20261005",
+            PeriodStartUtc = new DateTime(2026, 10, 5, 0, 0, 0, DateTimeKind.Utc),
+            PeriodEndUtc = new DateTime(2026, 11, 5, 0, 0, 0, DateTimeKind.Utc),
+            Included = 100,
+            Used = 1,
+            SubscriptionStatus = SubscriptionStatus.Active,
+            SubscriptionVersion = 11,
+            ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[futureDated]);
+
+        await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        var republished = _published.Should()
+            .ContainSingle(document => document.ItemId == futureDated.ItemId).Subject;
+        republished.SubscriptionStatus.Should().Be(SubscriptionStatus.Canceled);
+        republished.SubscriptionVersion.Should().Be(14);
+        _current.Verify(
+            repository => repository.TryRetireAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the current window has not superseded a row that starts after it");
+    }
+
     private static SubscriptionUsageCurrent OrphanRow() => new()
     {
         ItemId = "sub-1:retired-meter:M2026-09",

--- a/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
@@ -399,7 +399,8 @@ public sealed class UsageProjectionPublisherTests
             Times.Never);
     }
 
-    /// <summary>The a00c2376 shape: a plan change re-anchored the window before this row was retired.</summary>
+    /// <summary>The a00c2376 shape, isolating the clamp: a row already at the subscription's own
+    /// version, so nothing about republishing muddies what the overlap clamp alone does.</summary>
     [Fact]
     public async Task A_superseded_row_is_retired_at_the_current_windows_start_and_the_current_row_stands()
     {
@@ -419,6 +420,10 @@ public sealed class UsageProjectionPublisherTests
             PeriodEndUtc = new DateTime(2026, 10, 15, 0, 0, 0, DateTimeKind.Utc),
             Included = 100,
             Used = 10,
+            // Already at the subscription's own version, so the republish half of reconciliation has
+            // nothing to do here and this test is purely about the clamp — the combined case, where a
+            // stale version drives both actions, is its own test below.
+            SubscriptionVersion = subscription.Version,
             ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         };
 
@@ -441,6 +446,62 @@ public sealed class UsageProjectionPublisherTests
 
         retiredAt.Should().Be(Period().StartUtc);
         _published.Should().NotContain(document => document.ItemId == superseded.ItemId);
+    }
+
+    /// <summary>
+    /// The a00c2376 shape as it actually occurs: a plan change re-anchored the window AND moved the
+    /// subscription's version, so the row is both superseded and carrying a stale status. Retiring it
+    /// alone would leave that stale status readable for the whole of CounterRetentionDays to a query
+    /// that filters on SubscriptionStatus with no window predicate — the gap the client's own query
+    /// exposed. Both actions must fire from the one row.
+    /// </summary>
+    [Fact]
+    public async Task A_superseded_row_with_a_stale_status_is_republished_and_retired_together()
+    {
+        var subscription = Subscription();
+        subscription.Status = SubscriptionStatus.Canceled;
+        subscription.Version = 11;
+
+        var superseded = new SubscriptionUsageCurrent
+        {
+            ItemId = "sub-1:screening:M2026-08",
+            TenantId = TenantId,
+            OrganizationId = OrganizationId,
+            SubscriptionId = "sub-1",
+            MeterKey = "screening",
+            PeriodKey = "M2026-08",
+            PeriodStartUtc = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            PeriodEndUtc = new DateTime(2026, 10, 15, 0, 0, 0, DateTimeKind.Utc),
+            Included = 100,
+            Used = 10,
+            SubscriptionStatus = SubscriptionStatus.Active,
+            SubscriptionVersion = 2,
+            ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        };
+
+        _current
+            .Setup(repository => repository.ListBySubscriptionAsync(
+                TenantId, "sub-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<SubscriptionUsageCurrent>)[superseded]);
+
+        DateTime? retiredAt = null;
+        _current
+            .Setup(repository => repository.TryRetireAsync(
+                TenantId, superseded.ItemId, It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .Callback((string _, string _, DateTime endUtc, DateTime _, CancellationToken _) =>
+                retiredAt = endUtc)
+            .ReturnsAsync(true);
+
+        await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        retiredAt.Should().Be(Period().StartUtc);
+        var republished = _published.Should()
+            .ContainSingle(document => document.ItemId == superseded.ItemId).Subject;
+        republished.SubscriptionStatus.Should().Be(SubscriptionStatus.Canceled);
+        republished.SubscriptionVersion.Should().Be(11);
+        republished.Used.Should().Be(10, "the balance is untouched by republishing status and plan");
     }
 
     /// <summary>
@@ -469,6 +530,9 @@ public sealed class UsageProjectionPublisherTests
             PeriodEndUtc = new DateTime(2026, 11, 5, 0, 0, 0, DateTimeKind.Utc),
             Included = 100,
             Used = 1,
+            // Already at the subscription's own version, so this test is purely about the retire
+            // guard and is not incidentally also exercising a republish.
+            SubscriptionVersion = subscription.Version,
             ExpiresAtUtc = new DateTime(2027, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         };
 

--- a/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
+++ b/server/XUnitTest/Subscription/UsageRecordingServiceTests.cs
@@ -624,6 +624,45 @@ public sealed class UsageRecordingServiceTests
     }
 
     /// <summary>
+    /// A structurally sound projection can still hold two live rows for one meter — a superseded row
+    /// the reconciliation sweep has not yet retired. The read must not hand a caller two contradictory
+    /// answers for the same meter, and must not report the projection as partial for a pair that
+    /// between them cover every meter.
+    /// </summary>
+    [Fact]
+    public async Task A_duplicate_live_row_for_one_meter_is_deduped_to_the_highest_subscription_version()
+    {
+        AddLifetimeMeter();
+
+        var stale = Projected("screening");
+        stale.ItemId = "sub-1:screening:M2026-08";
+        stale.SubscriptionVersion = 2;
+
+        var current = Projected("screening");
+        current.ItemId = "sub-1:screening:M2026-09";
+        current.SubscriptionVersion = 4;
+        current.Used = 10;
+
+        _current
+            .Setup(repository => repository.ListCurrentAsync(
+                TenantId,
+                OrganizationId,
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([stale, current, Projected("storage")]);
+
+        var read = await Service().ReadCurrentAsync(
+            null, UsageReadMode.Projection, "corr-1", CancellationToken.None);
+
+        read.Value!.Items.Should().HaveCount(2, "one entry per meter, not one per row");
+        read.Value.Diagnostics.Fallback.Should().Be(
+            UsageReadFallback.None, "a deduped pair still covers every meter the plan has");
+        read.Value.Items.Should().ContainSingle(item => item.MeterKey == "screening")
+            .Which.Used.Should().Be(10, "the higher SubscriptionVersion wins");
+    }
+
+    /// <summary>
     /// The default is unchanged, so no existing caller of this endpoint starts depending on a read
     /// model having been published.
     /// </summary>


### PR DESCRIPTION
## Summary

A client consuming `SubscriptionUsageCurrent` reported it "is not updating the values." Investigation against dev found three distinct defects behind the one symptom:

- **Converted trials stay capped at the trial grant.** `LimitSnapshot` is frozen when a window opens and never re-derived when the subscription later converts from trial to paid, so a customer inside their real allowance is billed overage against the trial's grant until the usage window rolls over naturally.
- **Superseded and orphaned rows are never retired.** `UsageProjectionPublisher.RefreshAsync` only republished the windows the *current* plan implies, never the documents that actually exist, so a meter that left the plan or a window a plan change re-anchored past stayed live indefinitely — and a meterless plan returned `0` before reconciling anything.
- **One meter could return two live rows.** `readMode=projection` had no dedup, so a superseded row and its replacement could both satisfy the "current window" filter.

## Changes

- `ISubscriptionUsageRepository.TryResnapshotAllowanceAsync` + implementation: guarded re-freeze of an open counter's `LimitSnapshot`, pruning `NotifiedThresholds` to those still crossed at the new allowance.
- `SubscriptionRenewalService.ApplySuccessAsync`: on a trial→paid conversion with no plan change riding along, resolves the current window's allowance as `Active` and re-snapshots it, then schedules one projection refresh — best-effort, guarded, never fails the renewal.
- `ISubscriptionUsageCurrentRepository`: `ListBySubscriptionAsync` (every stored row, no window filter) and `TryRetireAsync` (guarded shrink of a superseded row's `PeriodEndUtc`/`ExpiresAtUtc`).
- `UsageProjectionPublisher.RefreshAsync`: reconciles stored rows a plan-derived window no longer covers — retires superseded rows at the new window's start, republishes subscription-owned fields on orphaned rows (carrying `Used`/`CounterVersion` across unchanged). The `windows.Count == 0` early return now happens *after* this pass, so a meterless plan still reconciles what it left behind.
- `UsageRecordingService.ReadProjectionAsync`: dedupes to one row per meter (highest `SubscriptionVersion` wins) before the completeness check that drives `ProjectionPartial`.
- CI: widened `subscription-scheduling-integration.yml`'s trigger paths to the touched files, which previously would not have gated this change.

Not in scope (per the fix plan): retroactive correction of windows already rated against a trial grant, re-anchoring the usage window at trial end, and making the projection reachable for ended subscriptions predating the collection.

## Test plan

- [x] `dotnet build server/Blocks.slnx` — 0 errors
- [x] `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName~UsageProjection|FullyQualifiedName~MeterAllowance|FullyQualifiedName~UsageRecording|FullyQualifiedName~Entitlement"` — all pass
- [x] Full offline suite (`FullyQualifiedName!~Integration`) — no regressions; the two isolated failures seen under parallel load (`SubscriptionWorkDispatcherTests`, `FinancialDocumentRendererHealthMonitorTests`) are pre-existing timing flakiness unrelated to this change and pass individually
- [x] Added unit tests: trial-conversion resnapshot (+ threshold pruning, + skipped when a plan change rides along), meterless-plan reconciliation, orphaned-row republish, superseded-row retirement, projection dedup
- [ ] Mongo integration tests (`ListBySubscriptionAsync`/`TryRetireAsync` scoping) — need `BLOCKS_IT_MONGO`, not run locally
- [ ] End-to-end verification against dev using the known-bad rows as fixture, per the fix plan's verification section

🤖 Generated with [Claude Code](https://claude.com/claude-code)