### PR TITLE
feat(pdf): port PDF ingestion (inspect + qpdf/PDFBox/veraPDF/Ghostscript remediation)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -23,6 +23,26 @@ RUN dotnet publish server/Worker/Worker.csproj \
     -p:DebugType=None
 
 # -----------------------------------------------------------------------------
+# Stage: pdfbox-build — compiles the two PDFBox ingestion tools against the
+# real pdfbox-app jar. glibc image (matches l3-net-signature-pdfengine's own
+# build stage); only the compiled classes are copied into the Alpine runtime
+# stage below, so this stage's libc never reaches the shipped image.
+# -----------------------------------------------------------------------------
+FROM eclipse-temurin:17-jdk AS pdfbox-build
+ARG PDFBOX_VERSION=3.0.8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tools/pdfbox/*.java /tmp/pdfbox-src/
+RUN mkdir -p /opt/pdfbox \
+    && curl -fsSL "https://repo1.maven.org/maven2/org/apache/pdfbox/pdfbox-app/${PDFBOX_VERSION}/pdfbox-app-${PDFBOX_VERSION}.jar" -o /opt/pdfbox/pdfbox-app.jar \
+    && javac -cp /opt/pdfbox/pdfbox-app.jar -d /opt/pdfbox /tmp/pdfbox-src/*.java \
+    && java -cp "/opt/pdfbox/pdfbox-app.jar:/opt/pdfbox" PdfBoxFlatten --version \
+    && java -cp "/opt/pdfbox/pdfbox-app.jar:/opt/pdfbox" PdfBoxNormalizeGeometry --version
+
+# -----------------------------------------------------------------------------
 # Stage: runtime — ASP.NET Core runtime on Alpine (Worker targets shared
 # Microsoft.AspNetCore.App via the Worker SDK / dependencies.)
 # -----------------------------------------------------------------------------
@@ -74,8 +94,82 @@ RUN apk add --no-cache \
 # key is unset, so a set path means no runtime download is ever attempted.
 ENV PuppeteerSharp__ExecutablePath=/usr/local/bin/chromium-browser
 
+# PDF ingestion toolchain (ported from l3-net-signature-pdfengine, ARM: it cannot be called over
+# HTTP from here, so its capability is compiled straight into this image instead). qpdf repairs
+# unreadable PDFs; openjdk17-jre-headless + the pdfbox-build stage's classes normalize page
+# geometry and flatten forms; ghostscript repairs PDF/A; bash backs the veraPDF installer, which
+# is a shell script, and its generated launcher.
+ARG VERAPDF_INSTALLER_URL=https://software.verapdf.org/releases/verapdf-installer.zip
+# In-build assertions (qpdf --version, verapdf --version below) so a broken tool install fails
+# the image build rather than surfacing at runtime the first time a document needs repair.
+RUN apk add --no-cache \
+        qpdf \
+        openjdk17-jre-headless \
+        ghostscript \
+        bash \
+        unzip \
+        curl \
+    && mkdir -p /tmp/verapdf-installer /opt/verapdf \
+    && curl -fsSL "${VERAPDF_INSTALLER_URL}" -o /tmp/verapdf-installer/verapdf-installer.zip \
+    && unzip -q /tmp/verapdf-installer/verapdf-installer.zip -d /tmp/verapdf-installer \
+    && printf '%s\n' \
+        '<AutomatedInstallation langpack="eng">' \
+        '  <com.izforge.izpack.panels.htmlhello.HTMLHelloPanel id="welcome"/>' \
+        '  <com.izforge.izpack.panels.target.TargetPanel id="install_dir">' \
+        '    <installpath>/opt/verapdf</installpath>' \
+        '  </com.izforge.izpack.panels.target.TargetPanel>' \
+        '  <com.izforge.izpack.panels.packs.PacksPanel id="sdk_pack_select">' \
+        '    <pack index="0" name="veraPDF GUI" selected="true"/>' \
+        '    <pack index="1" name="veraPDF Mac and *nix Scripts" selected="true"/>' \
+        '    <pack index="2" name="veraPDF Validation model" selected="true"/>' \
+        '    <pack index="3" name="veraPDF Documentation" selected="false"/>' \
+        '    <pack index="4" name="veraPDF Sample Plugins" selected="false"/>' \
+        '  </com.izforge.izpack.panels.packs.PacksPanel>' \
+        '  <com.izforge.izpack.panels.install.InstallPanel id="install"/>' \
+        '  <com.izforge.izpack.panels.finish.FinishPanel id="finish"/>' \
+        '</AutomatedInstallation>' \
+        > /tmp/verapdf-installer/auto-install.xml \
+    && installer_script="$(find /tmp/verapdf-installer -maxdepth 2 -type f \( -name 'verapdf-install' -o -name 'vera-install' \) -print -quit)" \
+    && test -n "${installer_script}" \
+    && chmod +x "${installer_script}" \
+    && "${installer_script}" /tmp/verapdf-installer/auto-install.xml \
+    && test -x /opt/verapdf/verapdf \
+    && qpdf --version \
+    && /opt/verapdf/verapdf --version \
+    && rm -rf /tmp/verapdf-installer
+
+# PDFA_def.ps hardcodes the Debian ICC profile path; Alpine installs the sRGB profile under
+# /usr/share/ghostscript/<version>/iccprofiles/ instead. Symlinking keeps PDFA_def.ps
+# byte-identical to upstream rather than forking it, and `test -e` fails the build on a miss
+# instead of silently producing broken PDF/A output at runtime.
+RUN mkdir -p /usr/share/color/icc/ghostscript \
+    && ln -sf "$(find /usr/share/ghostscript -name srgb.icc -print -quit)" /usr/share/color/icc/ghostscript/srgb.icc \
+    && test -e /usr/share/color/icc/ghostscript/srgb.icc
+
 COPY --from=publish /app/publish .
-RUN chown -R app:app /app
+COPY --from=pdfbox-build /opt/pdfbox /opt/pdfbox
+COPY tools/ghostscript/PDFA_def.ps /opt/pdfingestion/PDFA_def.ps
+
+# Every deployed environment runs Direct - the image carries all four binaries. Docker mode exists
+# only so a developer can run the Worker without installing qpdf/Java/veraPDF locally; selecting
+# it in a container would require the Worker to spawn sibling containers via a Docker socket
+# mounted into the pod, which this deployment does not do. Pinning here means a stray config value
+# cannot put a deployed pod onto that path.
+ENV PdfIngestion__QpdfExecutionMode=Direct \
+    PdfIngestion__QpdfPath=/usr/bin/qpdf \
+    PdfIngestion__VeraPdfExecutionMode=Direct \
+    PdfIngestion__VeraPdfPath=/opt/verapdf/verapdf \
+    PdfIngestion__PdfBoxExecutionMode=Direct \
+    PdfIngestion__JavaPath=/usr/bin/java \
+    PdfIngestion__PdfBoxJarPath=/opt/pdfbox/pdfbox-app.jar \
+    PdfIngestion__PdfBoxClassPath=/opt/pdfbox \
+    PdfIngestion__GhostscriptPath=/usr/bin/gs \
+    PdfIngestion__GhostscriptPdfADefinitionPath=/opt/pdfingestion/PDFA_def.ps \
+    PdfIngestion__GhostscriptIccProfilePath=/usr/share/color/icc/ghostscript/srgb.icc \
+    PdfIngestion__TempDirectory=/tmp/pdf-ingestion
+
+RUN mkdir -p /tmp/pdf-ingestion \
+    && chown -R app:app /app /tmp/pdf-ingestion /opt/pdfbox /opt/pdfingestion
 
 USER app
 

--- a/docker/pdfbox/Dockerfile
+++ b/docker/pdfbox/Dockerfile
@@ -1,0 +1,24 @@
+# Build context is the REPOSITORY ROOT, not this directory, so the Java sources stay in one place
+# (tools/pdfbox) instead of being duplicated here:
+#   docker build -t blocks-pdfbox:dev -f docker/pdfbox/Dockerfile .
+#
+# Local-dev image for PdfToolingOptions.PdfBoxExecutionMode=Docker only. Every deployed environment
+# runs Direct (PDFBox compiled straight into Dockerfile.worker) - this lets a developer run the
+# Worker without installing a JDK locally.
+FROM eclipse-temurin:17-jdk AS build
+ARG PDFBOX_VERSION=3.0.8
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY tools/pdfbox/*.java /tmp/pdfbox-src/
+RUN mkdir -p /opt/pdfbox \
+    && curl -fsSL "https://repo1.maven.org/maven2/org/apache/pdfbox/pdfbox-app/${PDFBOX_VERSION}/pdfbox-app-${PDFBOX_VERSION}.jar" -o /opt/pdfbox/pdfbox-app.jar \
+    && javac -cp /opt/pdfbox/pdfbox-app.jar -d /opt/pdfbox /tmp/pdfbox-src/*.java
+
+FROM eclipse-temurin:17-jre
+COPY --from=build /opt/pdfbox /opt/pdfbox
+WORKDIR /work
+# The main class is passed as the first container argument so one image serves every PDFBox tool.
+ENTRYPOINT ["java", "-cp", "/opt/pdfbox/pdfbox-app.jar:/opt/pdfbox"]

--- a/docker/qpdf/Dockerfile
+++ b/docker/qpdf/Dockerfile
@@ -1,0 +1,11 @@
+# Local-dev image for PdfToolingOptions.QpdfExecutionMode=Docker only. Every deployed environment
+# runs Direct (qpdf installed straight into Dockerfile.worker) - this lets a developer run the
+# Worker without installing qpdf locally.
+#   docker build -t blocks-qpdf:dev ./docker/qpdf
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends qpdf \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /work

--- a/server/Api/Controllers/PdfIngestionsController.cs
+++ b/server/Api/Controllers/PdfIngestionsController.cs
@@ -1,0 +1,103 @@
+using Api.Utilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Utility.DomainService.PdfIngestion;
+using Utility.DomainService.PdfIngestion.service;
+
+namespace Api.Controllers;
+
+/// <summary>
+/// Inspecting PDFs already in storage and remediating whatever the inspection finds - unreadable
+/// files, indirect page geometry, a claimed but non-compliant PDF/A profile.
+/// </summary>
+/// <remarks>
+/// Its own controller rather than another action on <c>PdfGeneratorController</c>, for the same
+/// reason <c>DocumentConversionsController</c> is: ingestion is a resource with a lifetime, not a
+/// fire-and-forget queue push, and needs a status endpoint to match.
+/// <para>
+/// Both endpoints take a list of file IDs and answer with one outcome per file. Remediation happens
+/// in place, so a file's own storage ID is the only thing supplied for it and the only thing needed
+/// to poll status afterwards.
+/// </para>
+/// </remarks>
+[ApiController]
+[Authorize]
+[Route("pdf-ingestions")]
+public sealed class PdfIngestionsController : ControllerBase
+{
+    private readonly IPdfIngestionService _ingestions;
+
+    public PdfIngestionsController(IPdfIngestionService ingestions) =>
+        _ingestions = ingestions;
+
+    /// <summary>
+    /// Queues one or more PDFs for ingestion.
+    /// </summary>
+    /// <remarks>
+    /// Returns 202 as soon as the batch is recorded and queued - no file in it has been inspected
+    /// yet. Each file in <c>fileIds</c> is accepted or rejected independently: one blank or duplicate
+    /// ID does not stop the rest of the batch, and the response's <c>results</c> array says which is
+    /// which.
+    /// <para>
+    /// Supplying <c>messageCoRelationId</c> also gets a completion notification per file as each one
+    /// finishes. Setting <c>dryRun</c> records and reports each file's verdict without uploading any
+    /// remediated bytes back to storage - useful for the first production rollout of an otherwise
+    /// destructive in-place feature.
+    /// </para>
+    /// </remarks>
+    [HttpPost]
+    [ProducesResponseType(
+        typeof(ApiResponse<IngestPdfsBatchResponse>),
+        StatusCodes.Status202Accepted)]
+    [ProducesResponseType(
+        typeof(ApiResponse<IngestPdfsBatchResponse>),
+        StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(
+        typeof(ApiResponse<IngestPdfsBatchResponse>),
+        StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> Ingest(
+        [FromBody] IngestPdfsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _ingestions.RequestIngestionsAsync(request, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId, StatusCodes.Status202Accepted);
+    }
+
+    /// <summary>
+    /// Reads the ingestion outcome of one or more files, including each one's full verdict once its
+    /// pipeline run has completed.
+    /// </summary>
+    /// <remarks>
+    /// The fallback for a completion notification that never arrived. A file still running answers
+    /// with <c>status</c> of <c>Queued</c> or <c>Processing</c> and <c>isComplete: false</c>. A file
+    /// never submitted for ingestion answers with <c>found: false</c> rather than dropping out of the
+    /// response, so the caller can match every ID they asked about against exactly one result.
+    /// <para>
+    /// The request as a whole is 400 only when it is structurally invalid - an empty or oversized
+    /// <c>fileIds</c> list. A per-file outcome is carried in that file's own result entry, not the
+    /// HTTP status, because one response can only carry one status code for the whole batch.
+    /// </para>
+    /// </remarks>
+    [HttpPost("status")]
+    [ProducesResponseType(
+        typeof(ApiResponse<PdfIngestionStatusBatchResponse>),
+        StatusCodes.Status200OK)]
+    [ProducesResponseType(
+        typeof(ApiResponse<PdfIngestionStatusBatchResponse>),
+        StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetStatus(
+        [FromBody] GetPdfIngestionStatusRequest request,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+        var result = await _ingestions.GetStatusAsync(request, correlationId, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+}

--- a/server/Api/Utilities/PdfIngestionApiResults.cs
+++ b/server/Api/Utilities/PdfIngestionApiResults.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Utility.DomainService.PdfIngestion;
+
+namespace Api.Utilities;
+
+/// <summary>
+/// Maps a PDF-ingestion result onto an HTTP response.
+/// </summary>
+/// <remarks>
+/// The same shape as <see cref="DocumentConversionApiResults"/>, and deliberately the same status
+/// codes for the same kinds of failure.
+/// </remarks>
+public static class PdfIngestionApiResults
+{
+    public static IActionResult ToActionResult<TValue>(
+        this PdfIngestionResult<TValue> result,
+        string correlationId,
+        int successStatusCode = StatusCodes.Status200OK)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (result.IsSuccess)
+        {
+            return new ObjectResult(ApiResponse<TValue>.Ok(result.Value!, correlationId))
+            {
+                // Accepting an ingestion is a 202, not a 200: the batch has been recorded and
+                // queued, not inspected yet.
+                StatusCode = successStatusCode
+            };
+        }
+
+        var response = ApiResponse<TValue>.Fail(
+            result.ErrorCode ?? "pdf_ingestion_failed",
+            result.ErrorMessage ?? "The PDF ingestion request failed.",
+            correlationId,
+            result.ValidationErrors?.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value,
+                StringComparer.Ordinal));
+
+        return new ObjectResult(response) { StatusCode = StatusCodeFor(result.FailureKind) };
+    }
+
+    private static int StatusCodeFor(PdfIngestionFailureKind kind) => kind switch
+    {
+        PdfIngestionFailureKind.Validation => StatusCodes.Status400BadRequest,
+        PdfIngestionFailureKind.NotFound => StatusCodes.Status404NotFound,
+        PdfIngestionFailureKind.Unavailable => StatusCodes.Status503ServiceUnavailable,
+        _ => StatusCodes.Status500InternalServerError
+    };
+}

--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Aspose.Words" Version="25.6.0" />
     <PackageVersion Include="DotLiquid" Version="2.2.692" />
     <PackageVersion Include="iTextSharp.LGPLv2.Core" Version="1.7.5" />
-    <PackageVersion Include="PdfPig" Version="0.1.5" />
+    <PackageVersion Include="PdfPig" Version="0.1.16" />
     <PackageVersion Include="PdfSharp" Version="6.2.4" />
     <PackageVersion Include="PuppeteerSharp" Version="20.2.5" />
     <PackageVersion Include="Shark.PdfConvert" Version="1.0.5" />

--- a/server/Utility.DomainService/PdfGenerator/README.md
+++ b/server/Utility.DomainService/PdfGenerator/README.md
@@ -268,6 +268,15 @@ mounted into its own pod to spawn sibling containers. `Dockerfile.worker` pins
 `PdfIngestion__QpdfExecutionMode`, `PdfIngestion__VeraPdfExecutionMode` and
 `PdfIngestion__PdfBoxExecutionMode` to `Direct` explicitly for exactly this reason.
 
+Ghostscript has no Docker mode, so testing PDF/A repair on a Windows dev machine means running a
+real Windows Ghostscript build. `PDFA_def.ps` hardcodes its ICC profile path as the rootless,
+Debian-shaped `/usr/share/color/icc/ghostscript/srgb.icc` (unambiguous on Linux). On Windows,
+Ghostscript's `-dSAFER` sandbox resolves that rootless path differently at `--permit-file-read`
+registration time than at actual open time, so the two never match and every PDF/A repair fails
+with `invalidfileaccess` — confirmed live, not something Linux/Docker deployments hit. Work around
+it locally with `--permit-file-read=*` (or point `GhostscriptIccProfilePath`/`PDFA_def.ps` at a
+matching drive-letter path); don't change the production default over this.
+
 ### Configuration
 
 Bound from the `PdfIngestion` section (`PdfToolingOptions`), by `RegisterPdfIngestionToolchain` —

--- a/server/Utility.DomainService/PdfGenerator/README.md
+++ b/server/Utility.DomainService/PdfGenerator/README.md
@@ -226,6 +226,65 @@ Content-Type: application/json
 }
 ```
 
+## PDF Ingestion
+
+A sibling feature (`Utility.DomainService.PdfIngestion`, alongside this module rather than inside
+it) that inspects a PDF already in storage and remediates whatever the inspection finds — an
+unreadable file, indirect page geometry, a claimed but non-compliant PDF/A profile — replacing the
+file in place when a stage actually changes its bytes. Ported from `l3-net-signature-pdfengine`,
+which cannot be called over HTTP from here, so its capability is compiled straight into the Worker
+image instead (`server/Utility.DomainService/PdfGenerator/Tooling/`).
+
+### Endpoints
+
+| Method | Path | Returns | Purpose |
+|---|---|---|---|
+| `POST` | `/pdf-ingestions` | 202 | Queue one or more file IDs for ingestion. Accepts `dryRun: true` to inspect and record a verdict without uploading any remediated bytes back to storage. |
+| `POST` | `/pdf-ingestions/status` | 200 | Read the ingestion state — and, once complete, the full verdict — of one or more files. |
+
+Both mirror `/document-conversions` and `/document-conversions/status` exactly: a batch of file IDs
+in, one outcome per file back, `found: false` for a file never submitted rather than dropping it
+from the response, and a fresh `downloadUrl` resolved per request rather than stored.
+
+### Pipeline order
+
+Inspect → qpdf repair (if unreadable) → PDFBox geometry normalize (if geometry unreadable; a
+`SIGNED_DOCUMENT` exit is recorded as a skip, not a failure) → record signature → veraPDF confirm
+(if a PDF/A claim was found) → flatten + Ghostscript + re-validate + standard-PDF fallback (if
+non-compliant or PDF/A-1). Every stage's outcome is recorded on the verdict's provenance list.
+
+### Tool matrix
+
+| Tool | Used for | Execution mode in every deployed environment | Docker mode (local dev only) |
+|---|---|---|---|
+| qpdf | Repairing a file PdfPig/PdfSharp cannot open at all | Direct (`/usr/bin/qpdf`, installed in `Dockerfile.worker`) | `docker/qpdf/Dockerfile` — no JDK/qpdf install needed locally |
+| Apache PDFBox | Normalizing page geometry; flattening forms before PDF/A repair; the standard-PDF fallback | Direct (compiled into the image from `tools/pdfbox/*.java` against the real `pdfbox-app` jar) | `docker/pdfbox/Dockerfile` |
+| veraPDF | Confirming or refuting a PDF/A claim | Direct (`/opt/verapdf/verapdf`, via its own upstream installer) | Official `ghcr.io/verapdf/cli:latest` |
+| Ghostscript | Converting a non-compliant or PDF/A-1 file up to PDF/A-2B | Direct only — no Docker mode exists for it | n/a |
+
+Docker mode exists only so a developer can run the Worker without installing these binaries
+locally; it must never be selected in a container, since the Worker would then need a Docker socket
+mounted into its own pod to spawn sibling containers. `Dockerfile.worker` pins
+`PdfIngestion__QpdfExecutionMode`, `PdfIngestion__VeraPdfExecutionMode` and
+`PdfIngestion__PdfBoxExecutionMode` to `Direct` explicitly for exactly this reason.
+
+### Configuration
+
+Bound from the `PdfIngestion` section (`PdfToolingOptions`), by `RegisterPdfIngestionToolchain` —
+called only from the Worker, never the Api:
+
+| Key | Purpose |
+|---|---|
+| `QpdfPath`, `VeraPdfPath`, `JavaPath`, `PdfBoxJarPath`, `PdfBoxClassPath`, `GhostscriptPath` | Where each tool's binary/jar lives inside the Worker image |
+| `GhostscriptPdfADefinitionPath` | `PDFA_def.ps`, the Ghostscript output-intent definition |
+| `GhostscriptIccProfilePath` | The sRGB ICC profile Ghostscript reads for PDF/A repair — Alpine's real path, symlinked in `Dockerfile.worker` to the Debian-shaped path `PDFA_def.ps` was written against |
+| `QpdfExecutionMode`, `VeraPdfExecutionMode`, `PdfBoxExecutionMode` | `Direct` or `Docker` per tool (Ghostscript has no equivalent — Direct-only) |
+| `DockerPath`, `DockerContainerWorkspacePath`, `QpdfDockerImage`, `VeraPdfDockerImage`, `PdfBoxDockerImage` | Docker-mode settings, local development only |
+| `TempDirectory` | Per-operation workspace root (`/tmp/pdf-ingestion` in the image) |
+| `DefaultTimeoutSeconds` | Per-tool-call timeout |
+| `MaxFileSizeMb` | Defined (default 50) but not yet enforced by any stage — reserved for a future request-time size check |
+| `MaxParallelExternalProcesses` | Default 2 — Ghostscript and a JVM may run alongside the Worker's resident Chromium instance |
+
 ## Summary
 
 ✅ **Completed:**

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Ghostscript/GhostscriptCommandFactory.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Ghostscript/GhostscriptCommandFactory.cs
@@ -1,0 +1,33 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Ghostscript;
+
+/// <summary>
+/// Direct-only: unlike qpdf, veraPDF and PdfBox, Ghostscript has no Docker execution mode here (the
+/// source it was ported from never gave it one). A developer using Docker mode for the other three
+/// still needs <c>gs</c> installed locally to exercise PDF/A repair.
+/// </summary>
+public sealed class GhostscriptCommandFactory
+{
+    public ProcessCommand CreatePdfA2BCommand(string inputPath, string outputPath, int timeoutSeconds, PdfToolingOptions options) => new()
+    {
+        FileName = options.GhostscriptPath,
+        Arguments =
+        [
+            "-dPDFA=2",
+            "-dBATCH",
+            "-dNOPAUSE",
+            "-dSAFER",
+            $"--permit-file-read={options.GhostscriptIccProfilePath}",
+            "-sDEVICE=pdfwrite",
+            "-dPDFACompatibilityPolicy=1",
+            "-sColorConversionStrategy=RGB",
+            $"-sOutputFile={outputPath}",
+            options.GhostscriptPdfADefinitionPath,
+            inputPath
+        ],
+        WorkingDirectory = Path.GetDirectoryName(inputPath),
+        TimeoutSeconds = timeoutSeconds
+    };
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Ghostscript/GhostscriptPdfAConverter.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Ghostscript/GhostscriptPdfAConverter.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Ghostscript;
+
+public sealed class GhostscriptPdfAConverter : IPdfAConverter
+{
+    private readonly IProcessRunner _runner;
+    private readonly IOptions<PdfToolingOptions> _options;
+    private readonly GhostscriptCommandFactory _commands;
+
+    public GhostscriptPdfAConverter(IProcessRunner runner, IOptions<PdfToolingOptions> options, GhostscriptCommandFactory commands)
+    {
+        _runner = runner;
+        _options = options;
+        _commands = commands;
+    }
+
+    public async Task<PdfTransformationResult> ConvertToPdfA2BAsync(string inputPath, string outputPath, int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        var result = await _runner.RunAsync(_commands.CreatePdfA2BCommand(inputPath, outputPath, timeoutSeconds, _options.Value), cancellationToken);
+        if (result.TimedOut) return Failure(PdfToolErrorCodes.ProcessTimeout);
+        if (!result.Success || !File.Exists(outputPath) || new FileInfo(outputPath).Length == 0) return Failure(FirstLine(result.StandardError) ?? PdfToolErrorCodes.GhostscriptFailed);
+        return new PdfTransformationResult { Success = true };
+    }
+
+    private static PdfTransformationResult Failure(string error) => new() { Success = false, Errors = [error] };
+    private static string? FirstLine(string text) => text.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/IPdfIngestionPipeline.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/IPdfIngestionPipeline.cs
@@ -1,0 +1,14 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling;
+
+public interface IPdfIngestionPipeline
+{
+    /// <summary>
+    /// Runs inspection and whatever remediation it calls for over one file's bytes. Never throws
+    /// for a malformed or unrepairable input - a bad file is reported in the returned outcome
+    /// (<see cref="PdfIngestionOutcome.ErrorCode"/>/<see cref="PdfIngestionOutcome.ErrorMessage"/>),
+    /// not thrown, so one bad file in a batch cannot abort the files after it.
+    /// </summary>
+    Task<PdfIngestionOutcome> ProcessAsync(byte[] inputBytes, CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/IPdfInspector.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/IPdfInspector.cs
@@ -1,0 +1,10 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Inspection;
+
+public interface IPdfInspector
+{
+    /// <summary>
+    /// Synchronous: both underlying libraries parse the given bytes entirely in memory, so there is
+    /// no I/O to make asynchronous.
+    /// </summary>
+    PdfInspectionResult Inspect(byte[] pdfBytes);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/PdfAMetadataClaim.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/PdfAMetadataClaim.cs
@@ -1,0 +1,18 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Inspection;
+
+/// <summary>
+/// What the document's own XMP metadata says about PDF/A conformance. This is a claim, not a
+/// verdict - <see cref="PdfInspectionResult.ClaimedProfile"/> is only ever confirmed or refuted by
+/// veraPDF later in the pipeline.
+/// </summary>
+public enum PdfAMetadataClaim
+{
+    /// <summary>No XMP metadata, or XMP with no pdfaid:part/pdfaid:conformance entry.</summary>
+    Missing,
+
+    /// <summary>A parseable pdfaid:part/pdfaid:conformance pair was found.</summary>
+    Claimed,
+
+    /// <summary>XMP metadata is present but is not well-formed XML, or its pdfaid values are not parseable.</summary>
+    Malformed
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/PdfInspectionResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/PdfInspectionResult.cs
@@ -1,0 +1,31 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Inspection;
+
+public sealed class PdfInspectionResult
+{
+    /// <summary>Both UglyToad.PdfPig and PdfSharp opened the file without throwing.</summary>
+    public required bool Readable { get; init; }
+
+    /// <summary>
+    /// A guarded read of every page's MediaBox/CropBox/Width/Height did not throw. On the PdfSharp
+    /// (not PdfSharpCore) version this repo carries, indirect page-box references and inheritance
+    /// from an ancestor /Pages node are both already resolved transparently by the typed
+    /// accessors - there is no structural signal left to inspect by the time a page's Elements are
+    /// reachable, so this guarded read is the only detection mechanism, not a backstop for one.
+    /// </summary>
+    public bool GeometryReadable { get; init; } = true;
+
+    /// <summary>0 when the file could not be opened at all.</summary>
+    public int PageCount { get; init; }
+
+    public bool HasSignature { get; init; }
+
+    public int SignatureCount { get; init; }
+
+    public PdfAMetadataClaim MetadataClaim { get; init; } = PdfAMetadataClaim.Missing;
+
+    /// <summary>e.g. "PDF/A-2B". Set only when <see cref="MetadataClaim"/> is <see cref="PdfAMetadataClaim.Claimed"/>.</summary>
+    public string? ClaimedProfile { get; init; }
+
+    /// <summary>Set when <see cref="Readable"/> or <see cref="GeometryReadable"/> is false.</summary>
+    public string? FailureReason { get; init; }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/PdfInspector.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Inspection/PdfInspector.cs
@@ -1,0 +1,156 @@
+using System.Xml.Linq;
+using PdfSharp.Pdf.IO;
+using UglyToad.PdfPig.AcroForms.Fields;
+using UglyToad.PdfPig.Tokens;
+using PdfPigDocument = UglyToad.PdfPig.PdfDocument;
+using PdfSharpDocument = PdfSharp.Pdf.PdfDocument;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Inspection;
+
+/// <summary>
+/// Managed, in-process first look at an ingested file - runs before any external tool is invoked,
+/// since most files need no remediation at all.
+/// </summary>
+public sealed class PdfInspector : IPdfInspector
+{
+    private static readonly XNamespace PdfAIdNamespace = "http://www.aiim.org/pdfa/ns/id/";
+
+    public PdfInspectionResult Inspect(byte[] pdfBytes)
+    {
+        ArgumentNullException.ThrowIfNull(pdfBytes);
+
+        PdfPigDocument? pigDocument;
+        try
+        {
+            pigDocument = PdfPigDocument.Open(pdfBytes);
+        }
+        catch (Exception ex)
+        {
+            return Unreadable($"PdfPig: {ex.Message}");
+        }
+
+        using (pigDocument)
+        {
+            PdfSharpDocument sharpDocument;
+            try
+            {
+                using var stream = new MemoryStream(pdfBytes, writable: false);
+                sharpDocument = PdfReader.Open(stream, PdfDocumentOpenMode.Modify);
+            }
+            catch (Exception ex)
+            {
+                return Unreadable($"PdfSharp: {ex.Message}");
+            }
+
+            using (sharpDocument)
+            {
+                var geometryReadable = TryReadGeometry(sharpDocument, out var geometryFailure);
+                var (hasSignature, signatureCount) = InspectSignatures(pigDocument);
+                var (claim, profile) = InspectPdfAClaim(pigDocument);
+
+                return new PdfInspectionResult
+                {
+                    Readable = true,
+                    GeometryReadable = geometryReadable,
+                    PageCount = pigDocument.NumberOfPages,
+                    HasSignature = hasSignature,
+                    SignatureCount = signatureCount,
+                    MetadataClaim = claim,
+                    ClaimedProfile = profile,
+                    FailureReason = geometryReadable ? null : geometryFailure
+                };
+            }
+        }
+    }
+
+    private static PdfInspectionResult Unreadable(string reason)
+    {
+        return new PdfInspectionResult
+        {
+            Readable = false,
+            GeometryReadable = false,
+            FailureReason = reason
+        };
+    }
+
+    /// <summary>
+    /// The only geometry detection this inspector can perform: PdfSharp (unlike PdfSharpCore, which
+    /// the e-signature reference this pipeline was ported from relies on) already resolves indirect
+    /// page-box references - both directly and inherited from an ancestor /Pages node - before they
+    /// ever reach a typed accessor, so there is no structural signal left to inspect. A guarded read
+    /// is therefore the whole check, not a backstop for one.
+    /// </summary>
+    private static bool TryReadGeometry(PdfSharpDocument document, out string? failureReason)
+    {
+        try
+        {
+            for (var i = 0; i < document.PageCount; i++)
+            {
+                var page = document.Pages[i];
+                _ = page.MediaBox;
+                _ = page.CropBox;
+                _ = page.Width;
+                _ = page.Height;
+            }
+
+            failureReason = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            failureReason = $"Geometry: {ex.Message}";
+            return false;
+        }
+    }
+
+    private static (bool HasSignature, int SignatureCount) InspectSignatures(PdfPigDocument document)
+    {
+        if (!document.TryGetForm(out var form))
+        {
+            return (false, 0);
+        }
+
+        var signatureCount = form.Fields
+            .OfType<AcroSignatureField>()
+            .Count(field => field.Dictionary.TryGet(NameToken.V, out var value) && value is not NullToken);
+
+        return (signatureCount > 0, signatureCount);
+    }
+
+    private static (PdfAMetadataClaim Claim, string? Profile) InspectPdfAClaim(PdfPigDocument document)
+    {
+        if (!document.TryGetXmpMetadata(out var xmp))
+        {
+            return (PdfAMetadataClaim.Missing, null);
+        }
+
+        XDocument xDocument;
+        try
+        {
+            xDocument = xmp.GetXDocument();
+        }
+        catch (Exception)
+        {
+            return (PdfAMetadataClaim.Malformed, null);
+        }
+
+        var partValue = xDocument.Descendants(PdfAIdNamespace + "part").FirstOrDefault()?.Value;
+        var conformanceValue = xDocument.Descendants(PdfAIdNamespace + "conformance").FirstOrDefault()?.Value;
+
+        if (string.IsNullOrWhiteSpace(partValue) && string.IsNullOrWhiteSpace(conformanceValue))
+        {
+            return (PdfAMetadataClaim.Missing, null);
+        }
+
+        if (string.IsNullOrWhiteSpace(partValue) || !int.TryParse(partValue, out _))
+        {
+            return (PdfAMetadataClaim.Malformed, null);
+        }
+
+        var profile = string.IsNullOrWhiteSpace(conformanceValue)
+            ? $"PDF/A-{partValue}"
+            : $"PDF/A-{partValue}{conformanceValue.ToUpperInvariant()}";
+
+        return (PdfAMetadataClaim.Claimed, profile);
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IExternalProcessConcurrencyLimiter.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IExternalProcessConcurrencyLimiter.cs
@@ -1,0 +1,6 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IExternalProcessConcurrencyLimiter
+{
+    Task<IDisposable> AcquireAsync(CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfAConverter.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfAConverter.cs
@@ -1,0 +1,8 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IPdfAConverter
+{
+    Task<PdfTransformationResult> ConvertToPdfA2BAsync(string inputPath, string outputPath, int timeoutSeconds, CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfAValidator.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfAValidator.cs
@@ -1,0 +1,13 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IPdfAValidator
+{
+    Task<PdfAValidationResult> ValidateAsync(
+        string inputPath,
+        string reportPath,
+        CancellationToken cancellationToken);
+
+    Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfFlattener.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfFlattener.cs
@@ -1,0 +1,14 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IPdfFlattener
+{
+    Task<PdfFlattenResult> FlattenAsync(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        CancellationToken cancellationToken);
+
+    Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfGeometryNormalizer.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfGeometryNormalizer.cs
@@ -1,0 +1,14 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IPdfGeometryNormalizer
+{
+    Task<PdfGeometryNormalizeResult> NormalizeGeometryAsync(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        CancellationToken cancellationToken);
+
+    Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfNormalizer.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfNormalizer.cs
@@ -1,0 +1,14 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IPdfNormalizer
+{
+    Task<PdfNormalizeResult> NormalizeAsync(
+        string inputPath,
+        string outputPath,
+        PdfNormalizeOptions options,
+        CancellationToken cancellationToken);
+
+    Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfWorkspaceService.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IPdfWorkspaceService.cs
@@ -1,0 +1,11 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IPdfWorkspaceService
+{
+    Task<PdfWorkspace> CreateWorkspaceAsync(
+        string operationId,
+        Stream inputStream,
+        CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IProcessRunner.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IProcessRunner.cs
@@ -1,0 +1,8 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IProcessRunner
+{
+    Task<ProcessResult> RunAsync(ProcessCommand command, CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IStandardPdfConverter.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Interfaces/IStandardPdfConverter.cs
@@ -1,0 +1,8 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+
+public interface IStandardPdfConverter
+{
+    Task<PdfTransformationResult> ConvertAsync(string inputPath, string outputPath, int timeoutSeconds, CancellationToken cancellationToken);
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfAValidationResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfAValidationResult.cs
@@ -1,0 +1,13 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class PdfAValidationResult
+{
+    public bool Success { get; init; }
+    public string Engine { get; init; } = "veraPDF";
+    public bool IsPdfA { get; init; }
+    public bool IsCompliant { get; init; }
+    public string? ProfileName { get; init; }
+    public string RawReport { get; init; } = string.Empty;
+    public IReadOnlyList<string> Errors { get; init; } = [];
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfFlattenResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfFlattenResult.cs
@@ -1,0 +1,9 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class PdfFlattenResult
+{
+    public bool Success { get; init; }
+    public string Engine { get; init; } = "pdfbox";
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public IReadOnlyList<string> Errors { get; init; } = [];
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfGeometryNormalizeResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfGeometryNormalizeResult.cs
@@ -1,0 +1,13 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class PdfGeometryNormalizeResult
+{
+    public bool Success { get; init; }
+    public string Engine { get; init; } = "pdfbox";
+    public int PageCount { get; init; }
+    public bool Signed { get; init; }
+    public bool GeometryChanged { get; init; }
+    public IReadOnlyList<PdfPageGeometry> Pages { get; init; } = [];
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public IReadOnlyList<string> Errors { get; init; } = [];
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfIngestionOutcome.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfIngestionOutcome.cs
@@ -1,0 +1,52 @@
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+/// <summary>
+/// Everything the ingestion pipeline determined about one file. Deliberately carries no identity
+/// or job-tracking fields (file id, timestamps, status) - those belong to the caller, which knows
+/// about jobs; this is what running the pipeline over some bytes produced.
+/// </summary>
+public sealed class PdfIngestionOutcome
+{
+    public required int PageCount { get; init; }
+
+    // Readability
+    public required bool WasReadable { get; init; }
+    public required bool IsReadable { get; init; }
+    public bool RepairedWithQpdf { get; init; }
+
+    // Geometry
+    public bool GeometryWasReadable { get; init; } = true;
+    public bool GeometryIsReadable { get; init; } = true;
+    public bool GeometryNormalized { get; init; }
+    public IReadOnlyList<PdfPageGeometry> PageGeometry { get; init; } = [];
+    public string? GeometrySkippedReason { get; init; }
+
+    // Signature
+    public bool HasSignature { get; init; }
+    public int SignatureCount { get; init; }
+
+    // PDF/A
+    public PdfAMetadataClaim MetadataClaim { get; init; } = PdfAMetadataClaim.Missing;
+    public string? ClaimedProfile { get; init; }
+    public string? ValidatedProfile { get; init; }
+    public bool IsPdfA { get; init; }
+    public bool IsCompliant { get; init; }
+
+    /// <summary>Capped at 25 entries by <c>VeraPdfXmlParser</c> - never the full raw veraPDF report.</summary>
+    public IReadOnlyList<string> PdfAFailedChecks { get; init; } = [];
+
+    public bool PdfARepairAttempted { get; init; }
+    public bool? PdfARepairSucceeded { get; init; }
+    public string? FinalProfile { get; init; }
+
+    // Result
+    public required bool ContentChanged { get; init; }
+    public required byte[] FinalBytes { get; init; }
+    public IReadOnlyList<PdfIngestionStageRecord> Stages { get; init; } = [];
+
+    /// <summary>Set only when the file could not be read at all, even after qpdf repair.</summary>
+    public string? ErrorCode { get; init; }
+    public string? ErrorMessage { get; init; }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfIngestionStageName.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfIngestionStageName.cs
@@ -1,0 +1,13 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public enum PdfIngestionStageName
+{
+    Inspect,
+    QpdfNormalize,
+    PdfBoxGeometryNormalize,
+    VeraPdfValidate,
+    PdfARepairFlatten,
+    PdfARepairGhostscript,
+    PdfARepairRevalidate,
+    PdfARepairStandardFallback
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfIngestionStageRecord.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfIngestionStageRecord.cs
@@ -1,0 +1,19 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+/// <summary>One entry in a file's provenance: a stage the pipeline actually ran, and what happened.</summary>
+public sealed class PdfIngestionStageRecord
+{
+    public required PdfIngestionStageName Stage { get; init; }
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// True when the stage did not run to completion by design rather than failure - PDFBox's
+    /// geometry tool exiting 3 SIGNED_DOCUMENT is the case this exists for: re-saving would
+    /// invalidate an existing signature, so the pipeline treats it as a skip, not a failure.
+    /// </summary>
+    public bool Skipped { get; init; }
+
+    public string? SkipReason { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public IReadOnlyList<string> Errors { get; init; } = [];
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfNormalizeOptions.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfNormalizeOptions.cs
@@ -1,0 +1,8 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class PdfNormalizeOptions
+{
+    public bool DisableObjectStreams { get; init; } = true;
+    public bool Linearize { get; init; } = false;
+    public int TimeoutSeconds { get; init; } = 60;
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfNormalizeResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfNormalizeResult.cs
@@ -1,0 +1,9 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class PdfNormalizeResult
+{
+    public bool Success { get; init; }
+    public string Engine { get; init; } = "qpdf";
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+    public IReadOnlyList<string> Errors { get; init; } = [];
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfPageGeometry.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfPageGeometry.cs
@@ -1,0 +1,27 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+/// <summary>
+/// Geometry PDFBox read for a single page. Reported back to the caller so it can verify that
+/// normalization did not shift page placement.
+/// </summary>
+public sealed class PdfPageGeometry
+{
+    public int Index { get; init; }
+
+    public int Rotate { get; init; }
+
+    /// <summary>Effective CropBox width - what a viewer shows, and what stamps are placed against.</summary>
+    public double Width { get; init; }
+
+    public double Height { get; init; }
+
+    public IReadOnlyList<double> MediaBox { get; init; } = [];
+
+    public IReadOnlyList<double> CropBox { get; init; } = [];
+
+    /// <summary>Box keys rewritten as direct arrays on this page.</summary>
+    public IReadOnlyList<string> RewrittenBoxes { get; init; } = [];
+
+    /// <summary>Box keys that were stored as, or contained, indirect references before the rewrite.</summary>
+    public IReadOnlyList<string> IndirectBoxes { get; init; } = [];
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfTransformationResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfTransformationResult.cs
@@ -1,0 +1,8 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class PdfTransformationResult
+{
+    public required bool Success { get; init; }
+    public List<string> Errors { get; init; } = [];
+    public List<string> Warnings { get; init; } = [];
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfWorkspace.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/PdfWorkspace.cs
@@ -1,0 +1,24 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class PdfWorkspace : IAsyncDisposable
+{
+    private readonly Func<ValueTask> _cleanupAsync;
+
+    public PdfWorkspace(string operationId, string directoryPath, string inputPath, Func<ValueTask> cleanupAsync)
+    {
+        OperationId = operationId;
+        DirectoryPath = directoryPath;
+        InputPath = inputPath;
+        OutputPath = Path.Combine(directoryPath, "output.pdf");
+        ReportPath = Path.Combine(directoryPath, "verapdf-report.xml");
+        _cleanupAsync = cleanupAsync;
+    }
+
+    public string OperationId { get; }
+    public string DirectoryPath { get; }
+    public string InputPath { get; }
+    public string OutputPath { get; }
+    public string ReportPath { get; }
+
+    public ValueTask DisposeAsync() => _cleanupAsync();
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/ProcessCommand.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/ProcessCommand.cs
@@ -1,0 +1,9 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class ProcessCommand
+{
+    public required string FileName { get; init; }
+    public IReadOnlyList<string> Arguments { get; init; } = [];
+    public string? WorkingDirectory { get; init; }
+    public int TimeoutSeconds { get; init; } = 60;
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/ProcessResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/ProcessResult.cs
@@ -1,0 +1,11 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class ProcessResult
+{
+    public required int ExitCode { get; init; }
+    public string StandardOutput { get; init; } = string.Empty;
+    public string StandardError { get; init; } = string.Empty;
+    public TimeSpan Duration { get; init; }
+    public bool TimedOut { get; init; }
+    public bool Success => ExitCode == 0 && !TimedOut;
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Models/ToolHealthResult.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Models/ToolHealthResult.cs
@@ -1,0 +1,8 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Models;
+
+public sealed class ToolHealthResult
+{
+    public bool Available { get; init; }
+    public string? Version { get; init; }
+    public string? Error { get; init; }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Options/PdfBoxExecutionMode.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Options/PdfBoxExecutionMode.cs
@@ -1,0 +1,7 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Options;
+
+public enum PdfBoxExecutionMode
+{
+    Direct,
+    Docker
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Options/PdfToolingOptions.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Options/PdfToolingOptions.cs
@@ -1,0 +1,51 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Options;
+
+/// <summary>
+/// Ported from l3-net-signature-pdfengine's <c>PdfEngineOptions</c>, minus every storage/identity
+/// key (<see cref="Utility.DomainService.PdfGenerator.service.PdfStorageHelper"/> owns that here)
+/// and <c>StoreRawVeraPdfReportByDefault</c>, since the raw veraPDF report is never persisted.
+/// </summary>
+public sealed class PdfToolingOptions
+{
+    public const string SectionName = "PdfIngestion";
+
+    public string TempDirectory { get; set; } = "/tmp/pdf-ingestion";
+
+    public QpdfExecutionMode QpdfExecutionMode { get; set; } = QpdfExecutionMode.Direct;
+    public string QpdfPath { get; set; } = "/usr/bin/qpdf";
+    public string QpdfDockerImage { get; set; } = "blocks-qpdf:dev";
+
+    public string DockerPath { get; set; } = "docker";
+    public string DockerContainerWorkspacePath { get; set; } = "/work";
+
+    public VeraPdfExecutionMode VeraPdfExecutionMode { get; set; } = VeraPdfExecutionMode.Direct;
+    public string VeraPdfPath { get; set; } = "/opt/verapdf/verapdf";
+    public string VeraPdfDockerImage { get; set; } = "ghcr.io/verapdf/cli:latest";
+
+    public PdfBoxExecutionMode PdfBoxExecutionMode { get; set; } = PdfBoxExecutionMode.Direct;
+    public string PdfBoxDockerImage { get; set; } = "blocks-pdfbox:dev";
+    public string JavaPath { get; set; } = "java";
+    public string PdfBoxJarPath { get; set; } = "/opt/pdfbox/pdfbox-app.jar";
+    public string PdfBoxClassPath { get; set; } = "/opt/pdfbox";
+
+    public string GhostscriptPath { get; set; } = "/usr/bin/gs";
+    public string GhostscriptPdfADefinitionPath { get; set; } = "/opt/pdfingestion/PDFA_def.ps";
+
+    /// <summary>
+    /// Alpine installs ICC profiles under <c>/usr/share/ghostscript/&lt;version&gt;/iccprofiles/</c>,
+    /// not Debian's <c>/usr/share/color/icc/ghostscript/</c> that <c>GhostscriptCommandFactory</c> and
+    /// <c>PDFA_def.ps</c> were both written against. The image symlinks Alpine's real profile to the
+    /// Debian-shaped path so <c>PDFA_def.ps</c> can stay byte-identical to upstream; this option lets
+    /// the argument follow config instead of repeating the literal path a second time in code.
+    /// </summary>
+    public string GhostscriptIccProfilePath { get; set; } = "/usr/share/color/icc/ghostscript/srgb.icc";
+
+    public int DefaultTimeoutSeconds { get; set; } = 60;
+    public int MaxFileSizeMb { get; set; } = 50;
+
+    /// <summary>
+    /// Ghostscript and a JVM (PDFBox) may run alongside the Worker's resident Chromium instance,
+    /// so the default is deliberately lower than PdfEngine's standalone default of 4.
+    /// </summary>
+    public int MaxParallelExternalProcesses { get; set; } = 2;
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Options/QpdfExecutionMode.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Options/QpdfExecutionMode.cs
@@ -1,0 +1,7 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Options;
+
+public enum QpdfExecutionMode
+{
+    Direct,
+    Docker
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Options/VeraPdfExecutionMode.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Options/VeraPdfExecutionMode.cs
@@ -1,0 +1,7 @@
+namespace Utility.DomainService.PdfGenerator.Tooling.Options;
+
+public enum VeraPdfExecutionMode
+{
+    Direct,
+    Docker
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxCommandFactory.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxCommandFactory.cs
@@ -1,0 +1,204 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+public sealed class PdfBoxCommandFactory
+{
+    public const string FlattenMainClass = "PdfBoxFlatten";
+    public const string NormalizeGeometryMainClass = "PdfBoxNormalizeGeometry";
+
+    public ProcessCommand CreateFlattenCommand(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        PdfToolingOptions options)
+    {
+        return CreateToolCommand(FlattenMainClass, inputPath, outputPath, timeoutSeconds, options);
+    }
+
+    public ProcessCommand CreateNormalizeGeometryCommand(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        PdfToolingOptions options)
+    {
+        return CreateToolCommand(NormalizeGeometryMainClass, inputPath, outputPath, timeoutSeconds, options);
+    }
+
+    public ProcessCommand CreateVersionCommand(PdfToolingOptions options)
+    {
+        if (options.PdfBoxExecutionMode == PdfBoxExecutionMode.Docker)
+        {
+            return new ProcessCommand
+            {
+                FileName = options.DockerPath,
+                Arguments =
+                [
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    options.PdfBoxDockerImage,
+                    FlattenMainClass,
+                    "--version"
+                ],
+                TimeoutSeconds = 10
+            };
+        }
+
+        return new ProcessCommand
+        {
+            FileName = options.JavaPath,
+            Arguments =
+            [
+                "-cp",
+                $"{options.PdfBoxJarPath}{Path.PathSeparator}{options.PdfBoxClassPath}",
+                FlattenMainClass,
+                "--version"
+            ],
+            TimeoutSeconds = 10
+        };
+    }
+
+    private static ProcessCommand CreateToolCommand(
+        string mainClass,
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        PdfToolingOptions options)
+    {
+        if (options.PdfBoxExecutionMode == PdfBoxExecutionMode.Docker)
+        {
+            return CreateDockerCommand(mainClass, inputPath, outputPath, timeoutSeconds, options);
+        }
+
+        return new ProcessCommand
+        {
+            FileName = options.JavaPath,
+            Arguments =
+            [
+                "-cp",
+                $"{options.PdfBoxJarPath}{Path.PathSeparator}{options.PdfBoxClassPath}",
+                mainClass,
+                inputPath,
+                outputPath
+            ],
+            WorkingDirectory = Path.GetDirectoryName(inputPath),
+            TimeoutSeconds = timeoutSeconds
+        };
+    }
+
+    public ProcessCommand CreateStandardizeCommand(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        PdfToolingOptions options)
+    {
+        if (options.PdfBoxExecutionMode == PdfBoxExecutionMode.Docker)
+        {
+            return CreateDockerStandardizeCommand(inputPath, outputPath, timeoutSeconds, options);
+        }
+
+        return new ProcessCommand
+        {
+            FileName = options.JavaPath,
+            Arguments =
+            [
+                "-cp",
+                $"{options.PdfBoxJarPath}{Path.PathSeparator}{options.PdfBoxClassPath}",
+                FlattenMainClass,
+                "--standardize",
+                inputPath,
+                outputPath
+            ],
+            WorkingDirectory = Path.GetDirectoryName(inputPath),
+            TimeoutSeconds = timeoutSeconds
+        };
+    }
+
+    private static ProcessCommand CreateDockerCommand(
+        string mainClass,
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        PdfToolingOptions options)
+    {
+        var hostWorkspacePath = Path.GetDirectoryName(inputPath)
+            ?? throw new InvalidOperationException("Input path must include a workspace directory.");
+        var outputWorkspacePath = Path.GetDirectoryName(outputPath)
+            ?? throw new InvalidOperationException("Output path must include a workspace directory.");
+
+        if (!Path.GetFullPath(hostWorkspacePath).Equals(
+                Path.GetFullPath(outputWorkspacePath),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                "Docker PDFBox mode requires input and output files to be in the same operation workspace.");
+        }
+
+        var containerWorkspacePath = NormalizeContainerPath(options.DockerContainerWorkspacePath);
+        var containerInputPath = $"{containerWorkspacePath}/{Path.GetFileName(inputPath)}";
+        var containerOutputPath = $"{containerWorkspacePath}/{Path.GetFileName(outputPath)}";
+
+        return new ProcessCommand
+        {
+            FileName = options.DockerPath,
+            Arguments =
+            [
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "-v",
+                $"{hostWorkspacePath}:{containerWorkspacePath}",
+                options.PdfBoxDockerImage,
+                mainClass,
+                containerInputPath,
+                containerOutputPath
+            ],
+            WorkingDirectory = hostWorkspacePath,
+            TimeoutSeconds = timeoutSeconds
+        };
+    }
+
+    private static string NormalizeContainerPath(string path)
+    {
+        var normalized = string.IsNullOrWhiteSpace(path) ? "/work" : path.Trim();
+        return normalized.TrimEnd('/');
+    }
+
+    private static ProcessCommand CreateDockerStandardizeCommand(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        PdfToolingOptions options)
+    {
+        var hostWorkspacePath = Path.GetDirectoryName(inputPath)
+            ?? throw new InvalidOperationException("Input path must include a workspace directory.");
+        var outputWorkspacePath = Path.GetDirectoryName(outputPath)
+            ?? throw new InvalidOperationException("Output path must include a workspace directory.");
+
+        if (!Path.GetFullPath(hostWorkspacePath).Equals(Path.GetFullPath(outputWorkspacePath), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Docker PDFBox mode requires input and output files to be in the same operation workspace.");
+        }
+
+        var containerWorkspacePath = NormalizeContainerPath(options.DockerContainerWorkspacePath);
+        return new ProcessCommand
+        {
+            FileName = options.DockerPath,
+            Arguments =
+            [
+                "run", "--rm", "--network", "none", "-v",
+                $"{hostWorkspacePath}:{containerWorkspacePath}", options.PdfBoxDockerImage,
+                FlattenMainClass,
+                "--standardize",
+                $"{containerWorkspacePath}/{Path.GetFileName(inputPath)}",
+                $"{containerWorkspacePath}/{Path.GetFileName(outputPath)}"
+            ],
+            WorkingDirectory = hostWorkspacePath,
+            TimeoutSeconds = timeoutSeconds
+        };
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxGeometryNormalizer.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxGeometryNormalizer.cs
@@ -1,0 +1,121 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+public sealed class PdfBoxGeometryNormalizer : IPdfGeometryNormalizer
+{
+    private readonly IProcessRunner _processRunner;
+    private readonly IOptions<PdfToolingOptions> _options;
+    private readonly PdfBoxCommandFactory _commandFactory;
+    private readonly PdfBoxGeometryReportParser _reportParser;
+
+    public PdfBoxGeometryNormalizer(
+        IProcessRunner processRunner,
+        IOptions<PdfToolingOptions> options,
+        PdfBoxCommandFactory commandFactory,
+        PdfBoxGeometryReportParser reportParser)
+    {
+        _processRunner = processRunner;
+        _options = options;
+        _commandFactory = commandFactory;
+        _reportParser = reportParser;
+    }
+
+    public async Task<PdfGeometryNormalizeResult> NormalizeGeometryAsync(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var processResult = await _processRunner.RunAsync(
+            _commandFactory.CreateNormalizeGeometryCommand(
+                inputPath,
+                outputPath,
+                timeoutSeconds,
+                _options.Value),
+            cancellationToken);
+
+        if (processResult.TimedOut)
+        {
+            return Failure(PdfToolErrorCodes.ProcessTimeout);
+        }
+
+        // The tool exits 3 with SIGNED_DOCUMENT on stderr when the file already carries a
+        // signature: a full re-save would invalidate it, so the caller keeps its own path.
+        if (!processResult.Success)
+        {
+            return Failure(
+                PdfBoxProcessOutput.FirstLine(processResult.StandardError) ?? PdfToolErrorCodes.PdfBoxGeometryFailed);
+        }
+
+        if (!File.Exists(outputPath) || new FileInfo(outputPath).Length == 0)
+        {
+            return Failure(PdfToolErrorCodes.OutputNotCreated);
+        }
+
+        var payload = PdfBoxGeometryReportParser.ExtractPayload(processResult.StandardOutput);
+        if (payload is null)
+        {
+            return Failure(PdfToolErrorCodes.GeometryReportUnreadable);
+        }
+
+        try
+        {
+            // The per-page report is part of this operation's contract - the caller needs it to
+            // verify placement did not shift - so an unreadable report fails the operation even
+            // though the output file itself is fine.
+            return _reportParser.Parse(payload, CollectProcessWarnings(processResult));
+        }
+        catch (JsonException ex)
+        {
+            return Failure(PdfToolErrorCodes.GeometryReportUnreadable, ex.Message);
+        }
+    }
+
+    public async Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _processRunner.RunAsync(
+                _commandFactory.CreateVersionCommand(_options.Value),
+                cancellationToken);
+
+            return new ToolHealthResult
+            {
+                Available = result.Success,
+                Version = PdfBoxProcessOutput.FirstLine(result.StandardOutput),
+                Error = result.Success ? null : PdfBoxProcessOutput.FirstLine(result.StandardError)
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ToolHealthResult { Available = false, Error = ex.Message };
+        }
+    }
+
+    /// <summary>
+    /// Drops the report line before scanning for warnings: it carries a "warnings" key, so the
+    /// generic substring match would otherwise report the whole JSON blob as a warning.
+    /// </summary>
+    private static IReadOnlyList<string> CollectProcessWarnings(ProcessResult result)
+    {
+        return
+        [
+            .. PdfBoxProcessOutput.CollectWarnings(result)
+                .Where(line => !line.StartsWith(PdfBoxGeometryReportParser.Marker, StringComparison.Ordinal))
+        ];
+    }
+
+    private static PdfGeometryNormalizeResult Failure(params string[] errors)
+    {
+        return new PdfGeometryNormalizeResult
+        {
+            Success = false,
+            Errors = errors
+        };
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxGeometryReportParser.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxGeometryReportParser.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+/// <summary>
+/// Parses the single marker-prefixed JSON line PdfBoxNormalizeGeometry writes to stdout.
+/// </summary>
+public sealed class PdfBoxGeometryReportParser
+{
+    public const string Marker = "##PDFBOX_GEOMETRY##";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Returns the payload of the LAST marker line, so log4j status output or any other stdout
+    /// noise preceding the report is tolerated. Null when the tool emitted no report.
+    /// </summary>
+    public static string? ExtractPayload(string standardOutput)
+    {
+        if (string.IsNullOrWhiteSpace(standardOutput))
+        {
+            return null;
+        }
+
+        var lines = standardOutput.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        for (var i = lines.Length - 1; i >= 0; i--)
+        {
+            if (lines[i].StartsWith(Marker, StringComparison.Ordinal))
+            {
+                return lines[i][Marker.Length..];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Throws <see cref="JsonException"/> when the payload is malformed.</summary>
+    public PdfGeometryNormalizeResult Parse(string payload, IReadOnlyList<string> processWarnings)
+    {
+        var report = JsonSerializer.Deserialize<GeometryReport>(payload, SerializerOptions)
+            ?? throw new JsonException("PDFBox geometry report deserialized to null.");
+
+        return new PdfGeometryNormalizeResult
+        {
+            Success = true,
+            Engine = string.IsNullOrWhiteSpace(report.Engine) ? "pdfbox" : report.Engine,
+            PageCount = report.PageCount,
+            Signed = report.Signed,
+            GeometryChanged = report.Changed,
+            Pages = [.. report.Pages.Select(ToPageGeometry)],
+            Warnings = [.. report.Warnings.Concat(processWarnings).Distinct()]
+        };
+    }
+
+    private static PdfPageGeometry ToPageGeometry(GeometryReportPage page)
+    {
+        return new PdfPageGeometry
+        {
+            Index = page.Index,
+            Rotate = page.Rotate,
+            Width = page.Width,
+            Height = page.Height,
+            MediaBox = page.MediaBox,
+            CropBox = page.CropBox,
+            RewrittenBoxes = page.RewrittenBoxes,
+            IndirectBoxes = page.IndirectBoxes
+        };
+    }
+
+    private sealed class GeometryReport
+    {
+        public string Engine { get; set; } = string.Empty;
+        public int PageCount { get; set; }
+        public bool Signed { get; set; }
+        public bool Changed { get; set; }
+        public List<GeometryReportPage> Pages { get; set; } = [];
+        public List<string> Warnings { get; set; } = [];
+    }
+
+    private sealed class GeometryReportPage
+    {
+        public int Index { get; set; }
+        public int Rotate { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+        public List<double> MediaBox { get; set; } = [];
+        public List<double> CropBox { get; set; } = [];
+        public List<string> RewrittenBoxes { get; set; } = [];
+        public List<string> IndirectBoxes { get; set; } = [];
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxPdfFlattener.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxPdfFlattener.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+public sealed class PdfBoxPdfFlattener : IPdfFlattener
+{
+    private readonly IProcessRunner _processRunner;
+    private readonly IOptions<PdfToolingOptions> _options;
+    private readonly PdfBoxCommandFactory _commandFactory;
+
+    public PdfBoxPdfFlattener(
+        IProcessRunner processRunner,
+        IOptions<PdfToolingOptions> options,
+        PdfBoxCommandFactory commandFactory)
+    {
+        _processRunner = processRunner;
+        _options = options;
+        _commandFactory = commandFactory;
+    }
+
+    public async Task<PdfFlattenResult> FlattenAsync(
+        string inputPath,
+        string outputPath,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var processResult = await _processRunner.RunAsync(
+            _commandFactory.CreateFlattenCommand(
+                inputPath,
+                outputPath,
+                timeoutSeconds,
+                _options.Value),
+            cancellationToken);
+
+        if (processResult.TimedOut)
+        {
+            return Failure(PdfToolErrorCodes.ProcessTimeout);
+        }
+
+        if (!processResult.Success)
+        {
+            return Failure(FirstLine(processResult.StandardError) ?? PdfToolErrorCodes.PdfBoxFailed);
+        }
+
+        if (!File.Exists(outputPath) || new FileInfo(outputPath).Length == 0)
+        {
+            return Failure(PdfToolErrorCodes.OutputNotCreated);
+        }
+
+        return new PdfFlattenResult
+        {
+            Success = true,
+            Warnings = CollectWarnings(processResult)
+        };
+    }
+
+    public async Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _processRunner.RunAsync(
+                _commandFactory.CreateVersionCommand(_options.Value),
+                cancellationToken);
+
+            return new ToolHealthResult
+            {
+                Available = result.Success,
+                Version = FirstLine(result.StandardOutput),
+                Error = result.Success ? null : FirstLine(result.StandardError)
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ToolHealthResult { Available = false, Error = ex.Message };
+        }
+    }
+
+    private static PdfFlattenResult Failure(string error)
+    {
+        return new PdfFlattenResult
+        {
+            Success = false,
+            Errors = [error]
+        };
+    }
+
+    private static string? FirstLine(string text)
+    {
+        return PdfBoxProcessOutput.FirstLine(text);
+    }
+
+    private static IReadOnlyList<string> CollectWarnings(ProcessResult result)
+    {
+        return PdfBoxProcessOutput.CollectWarnings(result);
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxProcessOutput.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxProcessOutput.cs
@@ -1,0 +1,28 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+/// <summary>Stdout/stderr handling shared by the PDFBox tool wrappers.</summary>
+internal static class PdfBoxProcessOutput
+{
+    public static string? FirstLine(string text)
+    {
+        return SplitLines(text).FirstOrDefault();
+    }
+
+    public static IReadOnlyList<string> CollectWarnings(ProcessResult result)
+    {
+        return SplitLines(result.StandardError)
+            .Concat(SplitLines(result.StandardOutput))
+            .Where(line => line.Contains("warning", StringComparison.OrdinalIgnoreCase))
+            .Distinct()
+            .ToList();
+    }
+
+    public static IReadOnlyList<string> SplitLines(string text)
+    {
+        return text.Split(
+            ["\r\n", "\n"],
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxStandardPdfConverter.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfBox/PdfBoxStandardPdfConverter.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+public sealed class PdfBoxStandardPdfConverter : IStandardPdfConverter
+{
+    private readonly IProcessRunner _runner;
+    private readonly IOptions<PdfToolingOptions> _options;
+    private readonly PdfBoxCommandFactory _commands;
+
+    public PdfBoxStandardPdfConverter(IProcessRunner runner, IOptions<PdfToolingOptions> options, PdfBoxCommandFactory commands)
+    {
+        _runner = runner;
+        _options = options;
+        _commands = commands;
+    }
+
+    public async Task<PdfTransformationResult> ConvertAsync(string inputPath, string outputPath, int timeoutSeconds, CancellationToken cancellationToken)
+    {
+        var result = await _runner.RunAsync(_commands.CreateStandardizeCommand(inputPath, outputPath, timeoutSeconds, _options.Value), cancellationToken);
+        if (result.TimedOut) return Failure(PdfToolErrorCodes.ProcessTimeout);
+        if (!result.Success || !File.Exists(outputPath) || new FileInfo(outputPath).Length == 0) return Failure(FirstLine(result.StandardError) ?? PdfToolErrorCodes.StandardPdfConversionFailed);
+        return new PdfTransformationResult { Success = true };
+    }
+
+    private static PdfTransformationResult Failure(string error) => new() { Success = false, Errors = [error] };
+    private static string? FirstLine(string text) => text.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfIngestionPipeline.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfIngestionPipeline.cs
@@ -1,0 +1,345 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+using Utility.DomainService.Shared.Utilities;
+
+namespace Utility.DomainService.PdfGenerator.Tooling;
+
+/// <summary>
+/// Mirrors l3-net-signature-pdfengine's <c>ProcessPdfIngestionAsync</c> ordering, but per-file and
+/// non-throwing: that reference throws and abandons its whole batch on one bad file, which is
+/// deliberately not carried over here (see <see cref="ProcessAsync"/>).
+/// </summary>
+public sealed class PdfIngestionPipeline : IPdfIngestionPipeline
+{
+    private readonly IPdfInspector _inspector;
+    private readonly IPdfWorkspaceService _workspaceService;
+    private readonly IPdfNormalizer _qpdfNormalizer;
+    private readonly IPdfGeometryNormalizer _geometryNormalizer;
+    private readonly IPdfAValidator _pdfAValidator;
+    private readonly IPdfFlattener _flattener;
+    private readonly IPdfAConverter _pdfAConverter;
+    private readonly IStandardPdfConverter _standardConverter;
+    private readonly IOptions<PdfToolingOptions> _options;
+    private readonly ILogger<PdfIngestionPipeline> _logger;
+
+    public PdfIngestionPipeline(
+        IPdfInspector inspector,
+        IPdfWorkspaceService workspaceService,
+        IPdfNormalizer qpdfNormalizer,
+        IPdfGeometryNormalizer geometryNormalizer,
+        IPdfAValidator pdfAValidator,
+        IPdfFlattener flattener,
+        IPdfAConverter pdfAConverter,
+        IStandardPdfConverter standardConverter,
+        IOptions<PdfToolingOptions> options,
+        ILogger<PdfIngestionPipeline> logger)
+    {
+        _inspector = inspector;
+        _workspaceService = workspaceService;
+        _qpdfNormalizer = qpdfNormalizer;
+        _geometryNormalizer = geometryNormalizer;
+        _pdfAValidator = pdfAValidator;
+        _flattener = flattener;
+        _pdfAConverter = pdfAConverter;
+        _standardConverter = standardConverter;
+        _options = options;
+        _logger = logger;
+    }
+
+    public async Task<PdfIngestionOutcome> ProcessAsync(byte[] inputBytes, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(inputBytes);
+
+        var operationId = Guid.NewGuid().ToString("N");
+        var timeoutSeconds = _options.Value.DefaultTimeoutSeconds;
+        var stages = new List<PdfIngestionStageRecord>();
+
+        try
+        {
+            await using var workspace = await CreateWorkspaceAsync(operationId, inputBytes, cancellationToken);
+            var currentPath = workspace.InputPath;
+            var currentBytes = inputBytes;
+            var contentChanged = false;
+
+            var inspection = _inspector.Inspect(currentBytes);
+            var wasReadable = inspection.Readable;
+            var repairedWithQpdf = false;
+
+            if (!inspection.Readable)
+            {
+                _logger.LogInformation("PdfIngestion[{OperationId}]: unreadable, attempting qpdf repair", operationId);
+
+                var qpdfOutputPath = Path.Combine(workspace.DirectoryPath, "qpdf-repaired.pdf");
+                var qpdfResult = await _qpdfNormalizer.NormalizeAsync(
+                    currentPath,
+                    qpdfOutputPath,
+                    new PdfNormalizeOptions { TimeoutSeconds = timeoutSeconds },
+                    cancellationToken);
+
+                stages.Add(new PdfIngestionStageRecord
+                {
+                    Stage = PdfIngestionStageName.QpdfNormalize,
+                    Success = qpdfResult.Success,
+                    Warnings = qpdfResult.Warnings,
+                    Errors = qpdfResult.Errors
+                });
+
+                if (qpdfResult.Success)
+                {
+                    currentPath = qpdfOutputPath;
+                    currentBytes = await File.ReadAllBytesAsync(currentPath, cancellationToken);
+                    contentChanged = true;
+                    repairedWithQpdf = true;
+                    inspection = _inspector.Inspect(currentBytes);
+                }
+            }
+
+            if (!inspection.Readable)
+            {
+                _logger.LogWarning("PdfIngestion[{OperationId}]: still unreadable after qpdf repair", operationId);
+
+                return new PdfIngestionOutcome
+                {
+                    PageCount = 0,
+                    WasReadable = wasReadable,
+                    IsReadable = false,
+                    RepairedWithQpdf = repairedWithQpdf,
+                    GeometryWasReadable = false,
+                    GeometryIsReadable = false,
+                    ContentChanged = contentChanged,
+                    FinalBytes = currentBytes,
+                    Stages = stages,
+                    ErrorCode = PdfToolErrorCodes.InvalidRequest,
+                    ErrorMessage = LogSanitizer.Scrub(inspection.FailureReason)
+                };
+            }
+
+            var geometryWasReadable = inspection.GeometryReadable;
+            var geometryNormalized = false;
+            string? geometrySkippedReason = null;
+
+            if (!inspection.GeometryReadable)
+            {
+                _logger.LogInformation("PdfIngestion[{OperationId}]: geometry unreadable, normalizing with PDFBox", operationId);
+
+                var geometryOutputPath = Path.Combine(workspace.DirectoryPath, "geometry-normalized.pdf");
+                var geometryResult = await _geometryNormalizer.NormalizeGeometryAsync(
+                    currentPath, geometryOutputPath, timeoutSeconds, cancellationToken);
+
+                var signed = geometryResult.Errors.Contains(PdfToolErrorCodes.SignedDocument);
+                stages.Add(new PdfIngestionStageRecord
+                {
+                    Stage = PdfIngestionStageName.PdfBoxGeometryNormalize,
+                    Success = geometryResult.Success,
+                    Skipped = signed,
+                    SkipReason = signed ? PdfToolErrorCodes.SignedDocument : null,
+                    Warnings = geometryResult.Warnings,
+                    Errors = signed ? [] : geometryResult.Errors
+                });
+
+                if (signed)
+                {
+                    // A full re-save would invalidate the existing signature - the reference this
+                    // was ported from treats this as non-fatal, and so does this pipeline.
+                    geometrySkippedReason = PdfToolErrorCodes.SignedDocument;
+                }
+                else if (geometryResult.Success)
+                {
+                    currentPath = geometryOutputPath;
+                    currentBytes = await File.ReadAllBytesAsync(currentPath, cancellationToken);
+                    contentChanged = true;
+                    geometryNormalized = true;
+                    inspection = _inspector.Inspect(currentBytes);
+                }
+            }
+
+            var pdfARepairAttempted = false;
+            bool? pdfARepairSucceeded = null;
+            string? finalProfile = null;
+            var validatedProfile = inspection.ClaimedProfile;
+            var isPdfA = false;
+            var isCompliant = false;
+            IReadOnlyList<string> failedChecks = [];
+
+            if (inspection.MetadataClaim != PdfAMetadataClaim.Missing)
+            {
+                var veraPdfResult = await _pdfAValidator.ValidateAsync(currentPath, workspace.ReportPath, cancellationToken);
+                stages.Add(new PdfIngestionStageRecord
+                {
+                    Stage = PdfIngestionStageName.VeraPdfValidate,
+                    Success = veraPdfResult.Success,
+                    Warnings = veraPdfResult.Warnings,
+                    Errors = veraPdfResult.Errors
+                });
+
+                validatedProfile = veraPdfResult.ProfileName;
+                isPdfA = veraPdfResult.IsPdfA;
+                isCompliant = veraPdfResult.IsCompliant;
+                failedChecks = veraPdfResult.Errors;
+                finalProfile = validatedProfile;
+
+                var isPdfA1 = validatedProfile is not null && validatedProfile.TrimStart().StartsWith('1');
+                var needsRepair = veraPdfResult.Success && (!isCompliant || isPdfA1);
+
+                if (needsRepair)
+                {
+                    pdfARepairAttempted = true;
+                    (pdfARepairSucceeded, finalProfile, isPdfA, isCompliant, failedChecks) = await RepairPdfAAsync(
+                        workspace.DirectoryPath,
+                        workspace.ReportPath,
+                        currentPath,
+                        timeoutSeconds,
+                        stages,
+                        operationId,
+                        cancellationToken,
+                        UpdateCurrent);
+
+                    void UpdateCurrent(string path, byte[] bytes)
+                    {
+                        currentPath = path;
+                        currentBytes = bytes;
+                        contentChanged = true;
+                    }
+                }
+            }
+
+            return new PdfIngestionOutcome
+            {
+                PageCount = inspection.PageCount,
+                WasReadable = wasReadable,
+                IsReadable = true,
+                RepairedWithQpdf = repairedWithQpdf,
+                GeometryWasReadable = geometryWasReadable,
+                GeometryIsReadable = inspection.GeometryReadable,
+                GeometryNormalized = geometryNormalized,
+                GeometrySkippedReason = geometrySkippedReason,
+                HasSignature = inspection.HasSignature,
+                SignatureCount = inspection.SignatureCount,
+                MetadataClaim = inspection.MetadataClaim,
+                ClaimedProfile = inspection.ClaimedProfile,
+                ValidatedProfile = validatedProfile,
+                IsPdfA = isPdfA,
+                IsCompliant = isCompliant,
+                PdfAFailedChecks = failedChecks,
+                PdfARepairAttempted = pdfARepairAttempted,
+                PdfARepairSucceeded = pdfARepairSucceeded,
+                FinalProfile = finalProfile,
+                ContentChanged = contentChanged,
+                FinalBytes = currentBytes,
+                Stages = stages
+            };
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A tool crashing, a workspace directory failing to create, or any other unexpected
+            // failure must not abort the batch - this file is reported as failed, siblings still run.
+            _logger.LogError(ex, "PdfIngestion[{OperationId}]: unhandled failure", operationId);
+
+            return new PdfIngestionOutcome
+            {
+                PageCount = 0,
+                WasReadable = false,
+                IsReadable = false,
+                ContentChanged = false,
+                FinalBytes = inputBytes,
+                Stages = stages,
+                ErrorCode = PdfToolErrorCodes.InternalError,
+                ErrorMessage = LogSanitizer.Scrub(ex.Message)
+            };
+        }
+    }
+
+    private async Task<PdfWorkspace> CreateWorkspaceAsync(string operationId, byte[] inputBytes, CancellationToken cancellationToken)
+    {
+        await using var inputStream = new MemoryStream(inputBytes, writable: false);
+        return await _workspaceService.CreateWorkspaceAsync(operationId, inputStream, cancellationToken);
+    }
+
+    /// <summary>
+    /// Flatten -&gt; Ghostscript -&gt; re-validate -&gt; standard-PDF fallback. Runs only when veraPDF
+    /// reported the file claims PDF/A but is not compliant, or is compliant only at PDF/A-1 (which
+    /// this pipeline treats as needing an upgrade to PDF/A-2B, matching the reference's own target).
+    /// </summary>
+    private async Task<(bool Succeeded, string? Profile, bool IsPdfA, bool IsCompliant, IReadOnlyList<string> FailedChecks)> RepairPdfAAsync(
+        string workspaceDirectory,
+        string reportPath,
+        string inputPath,
+        int timeoutSeconds,
+        List<PdfIngestionStageRecord> stages,
+        string operationId,
+        CancellationToken cancellationToken,
+        Action<string, byte[]> adoptOutput)
+    {
+        _logger.LogInformation("PdfIngestion[{OperationId}]: repairing non-compliant PDF/A", operationId);
+
+        var flattenOutputPath = Path.Combine(workspaceDirectory, "flattened.pdf");
+        var flattenResult = await _flattener.FlattenAsync(inputPath, flattenOutputPath, timeoutSeconds, cancellationToken);
+        stages.Add(new PdfIngestionStageRecord
+        {
+            Stage = PdfIngestionStageName.PdfARepairFlatten,
+            Success = flattenResult.Success,
+            Warnings = flattenResult.Warnings,
+            Errors = flattenResult.Errors
+        });
+
+        var flattenedPath = inputPath;
+        if (flattenResult.Success)
+        {
+            flattenedPath = flattenOutputPath;
+            adoptOutput(flattenedPath, await File.ReadAllBytesAsync(flattenedPath, cancellationToken));
+        }
+
+        var gsOutputPath = Path.Combine(workspaceDirectory, "pdfa-repaired.pdf");
+        var gsResult = await _pdfAConverter.ConvertToPdfA2BAsync(flattenedPath, gsOutputPath, timeoutSeconds, cancellationToken);
+        stages.Add(new PdfIngestionStageRecord
+        {
+            Stage = PdfIngestionStageName.PdfARepairGhostscript,
+            Success = gsResult.Success,
+            Warnings = gsResult.Warnings,
+            Errors = gsResult.Errors
+        });
+
+        if (gsResult.Success)
+        {
+            var gsBytes = await File.ReadAllBytesAsync(gsOutputPath, cancellationToken);
+            adoptOutput(gsOutputPath, gsBytes);
+
+            var revalidateResult = await _pdfAValidator.ValidateAsync(gsOutputPath, reportPath, cancellationToken);
+            stages.Add(new PdfIngestionStageRecord
+            {
+                Stage = PdfIngestionStageName.PdfARepairRevalidate,
+                Success = revalidateResult.Success,
+                Warnings = revalidateResult.Warnings,
+                Errors = revalidateResult.Errors
+            });
+
+            if (revalidateResult.Success && revalidateResult.IsCompliant)
+            {
+                return (true, revalidateResult.ProfileName, true, true, revalidateResult.Errors);
+            }
+        }
+
+        // Ghostscript repair did not produce a compliant PDF/A: fall back to a plain standard PDF
+        // rather than shipping a file that still falsely claims PDF/A conformance.
+        var standardOutputPath = Path.Combine(workspaceDirectory, "standard.pdf");
+        var standardResult = await _standardConverter.ConvertAsync(flattenedPath, standardOutputPath, timeoutSeconds, cancellationToken);
+        stages.Add(new PdfIngestionStageRecord
+        {
+            Stage = PdfIngestionStageName.PdfARepairStandardFallback,
+            Success = standardResult.Success,
+            Warnings = standardResult.Warnings,
+            Errors = standardResult.Errors
+        });
+
+        if (standardResult.Success)
+        {
+            adoptOutput(standardOutputPath, await File.ReadAllBytesAsync(standardOutputPath, cancellationToken));
+        }
+
+        return (false, null, false, false, []);
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfIngestionPipeline.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfIngestionPipeline.cs
@@ -182,7 +182,10 @@ public sealed class PdfIngestionPipeline : IPdfIngestionPipeline
                 failedChecks = veraPdfResult.Errors;
                 finalProfile = validatedProfile;
 
-                var isPdfA1 = validatedProfile is not null && validatedProfile.TrimStart().StartsWith('1');
+                // Real veraPDF output puts a full descriptive string here - "PDF/A-1b validation
+                // profile" - not a short code, so a StartsWith('1') check (which would never match)
+                // was verified wrong against an actual captured report before being fixed to this.
+                var isPdfA1 = validatedProfile is not null && validatedProfile.Contains("PDF/A-1", StringComparison.OrdinalIgnoreCase);
                 var needsRepair = veraPdfResult.Success && (!isCompliant || isPdfA1);
 
                 if (needsRepair)

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfIngestionToolchainServiceCollectionExtensions.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfIngestionToolchainServiceCollectionExtensions.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Utility.DomainService.PdfGenerator.Tooling.Ghostscript;
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+using Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+using Utility.DomainService.PdfGenerator.Tooling.ProcessExecution;
+using Utility.DomainService.PdfGenerator.Tooling.Qpdf;
+using Utility.DomainService.PdfGenerator.Tooling.VeraPdf;
+using Utility.DomainService.PdfGenerator.Tooling.Workspace;
+
+namespace Utility.DomainService.PdfGenerator.Tooling
+{
+    /// <summary>
+    /// Registers the external-tool wrappers the PDF ingestion pipeline drives (qpdf, veraPDF,
+    /// PDFBox, Ghostscript) plus the pipeline and inspector that sit on top of them.
+    /// </summary>
+    /// <remarks>
+    /// Called only from <c>Worker/Program.cs</c>. The Api host answers requests and serves polling;
+    /// it must never resolve a graph that expects <c>qpdf</c>, Java or Ghostscript on <c>PATH</c>,
+    /// which is exactly what registering these singletons there would set it up to need. The
+    /// request/status surface (<c>IPdfIngestionRepository</c>, <c>IPdfIngestionService</c>) is
+    /// registered separately in <c>RegisterUtilityServices</c>, which both hosts call, because both
+    /// need to accept requests and answer status polls.
+    /// </remarks>
+    public static class PdfIngestionToolchainServiceCollectionExtensions
+    {
+        public static IServiceCollection RegisterPdfIngestionToolchain(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(configuration);
+
+            services.Configure<PdfToolingOptions>(configuration.GetSection(PdfToolingOptions.SectionName));
+
+            services.AddSingleton<IProcessRunner, ProcessRunner>();
+
+            // Must be singleton: a scoped or transient lifetime would give each resolution its own
+            // semaphore, so nothing would actually be limited across concurrent ingestions.
+            services.AddSingleton<IExternalProcessConcurrencyLimiter, ExternalProcessConcurrencyLimiter>();
+
+            services.AddSingleton<IPdfWorkspaceService, PdfWorkspaceService>();
+
+            services.AddSingleton<QpdfCommandFactory>();
+            services.AddSingleton<IPdfNormalizer, QpdfPdfNormalizer>();
+
+            services.AddSingleton<VeraPdfCommandFactory>();
+            services.AddSingleton<VeraPdfXmlParser>();
+            services.AddSingleton<IPdfAValidator, VeraPdfAValidator>();
+
+            services.AddSingleton<PdfBoxCommandFactory>();
+            services.AddSingleton<PdfBoxGeometryReportParser>();
+            services.AddSingleton<IPdfGeometryNormalizer, PdfBoxGeometryNormalizer>();
+            services.AddSingleton<IPdfFlattener, PdfBoxPdfFlattener>();
+            services.AddSingleton<IStandardPdfConverter, PdfBoxStandardPdfConverter>();
+
+            services.AddSingleton<GhostscriptCommandFactory>();
+            services.AddSingleton<IPdfAConverter, GhostscriptPdfAConverter>();
+
+            services.AddSingleton<IPdfInspector, PdfInspector>();
+            services.AddSingleton<IPdfIngestionPipeline, PdfIngestionPipeline>();
+
+            return services;
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/PdfToolErrorCodes.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/PdfToolErrorCodes.cs
@@ -1,0 +1,17 @@
+namespace Utility.DomainService.PdfGenerator.Tooling;
+
+public static class PdfToolErrorCodes
+{
+    public const string InvalidRequest = "INVALID_REQUEST";
+    public const string QpdfFailed = "QPDF_FAILED";
+    public const string VeraPdfFailed = "VERAPDF_FAILED";
+    public const string PdfBoxFailed = "PDFBOX_FAILED";
+    public const string PdfBoxGeometryFailed = "PDFBOX_GEOMETRY_FAILED";
+    public const string SignedDocument = "SIGNED_DOCUMENT";
+    public const string GeometryReportUnreadable = "GEOMETRY_REPORT_UNREADABLE";
+    public const string GhostscriptFailed = "GHOSTSCRIPT_FAILED";
+    public const string StandardPdfConversionFailed = "STANDARD_PDF_CONVERSION_FAILED";
+    public const string ProcessTimeout = "PROCESS_TIMEOUT";
+    public const string OutputNotCreated = "OUTPUT_NOT_CREATED";
+    public const string InternalError = "INTERNAL_ERROR";
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/ProcessExecution/ExternalProcessConcurrencyLimiter.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/ProcessExecution/ExternalProcessConcurrencyLimiter.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.ProcessExecution;
+
+/// <summary>
+/// Must be registered as a singleton: a scoped or transient lifetime would give each resolution
+/// its own semaphore, so nothing would actually be limited across concurrent requests.
+/// </summary>
+public sealed class ExternalProcessConcurrencyLimiter : IExternalProcessConcurrencyLimiter, IDisposable
+{
+    private readonly SemaphoreSlim _semaphore;
+
+    public ExternalProcessConcurrencyLimiter(IOptions<PdfToolingOptions> options)
+    {
+        var maxParallel = Math.Max(1, options.Value.MaxParallelExternalProcesses);
+        _semaphore = new SemaphoreSlim(maxParallel, maxParallel);
+    }
+
+    public async Task<IDisposable> AcquireAsync(CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken);
+        return new Releaser(_semaphore);
+    }
+
+    public void Dispose() => _semaphore.Dispose();
+
+    private sealed class Releaser : IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore;
+        private bool _disposed;
+
+        public Releaser(SemaphoreSlim semaphore)
+        {
+            _semaphore = semaphore;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _semaphore.Release();
+            _disposed = true;
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/ProcessExecution/ProcessRunner.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/ProcessExecution/ProcessRunner.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.ProcessExecution;
+
+public sealed class ProcessRunner : IProcessRunner
+{
+    private readonly IExternalProcessConcurrencyLimiter _concurrencyLimiter;
+
+    public ProcessRunner(IExternalProcessConcurrencyLimiter concurrencyLimiter)
+    {
+        _concurrencyLimiter = concurrencyLimiter;
+    }
+
+    public async Task<ProcessResult> RunAsync(ProcessCommand command, CancellationToken cancellationToken)
+    {
+        using var lease = await _concurrencyLimiter.AcquireAsync(cancellationToken);
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, command.TimeoutSeconds)));
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = command.FileName,
+            WorkingDirectory = command.WorkingDirectory ?? Environment.CurrentDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        foreach (var argument in command.Arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        PrependExecutableDirectoryToPath(startInfo, command.FileName);
+
+        using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            process.Start();
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutCts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(timeoutCts.Token);
+            await process.WaitForExitAsync(timeoutCts.Token);
+
+            stopwatch.Stop();
+            return new ProcessResult
+            {
+                ExitCode = process.ExitCode,
+                StandardOutput = await stdoutTask,
+                StandardError = await stderrTask,
+                Duration = stopwatch.Elapsed
+            };
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            KillProcessTree(process);
+            stopwatch.Stop();
+            return new ProcessResult
+            {
+                ExitCode = -1,
+                StandardError = "Process timed out.",
+                Duration = stopwatch.Elapsed,
+                TimedOut = true
+            };
+        }
+    }
+
+    private static void PrependExecutableDirectoryToPath(ProcessStartInfo startInfo, string fileName)
+    {
+        if (!Path.IsPathRooted(fileName))
+        {
+            return;
+        }
+
+        var executableDirectory = Path.GetDirectoryName(fileName);
+        if (string.IsNullOrWhiteSpace(executableDirectory))
+        {
+            return;
+        }
+
+        const string pathKey = "PATH";
+        var currentPath = startInfo.Environment.TryGetValue(pathKey, out var configuredPath)
+            ? configuredPath
+            : Environment.GetEnvironmentVariable(pathKey);
+
+        startInfo.Environment[pathKey] = string.IsNullOrWhiteSpace(currentPath)
+            ? executableDirectory
+            : $"{executableDirectory}{Path.PathSeparator}{currentPath}";
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/ProcessExecution/ProcessRunner.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/ProcessExecution/ProcessRunner.cs
@@ -67,6 +67,25 @@ public sealed class ProcessRunner : IProcessRunner
                 TimedOut = true
             };
         }
+        catch (Exception ex) when (ex is System.ComponentModel.Win32Exception or IOException)
+        {
+            // The executable could not even be started - a missing binary, an invalid working
+            // directory, a permission error. Every tool wrapper (QpdfPdfNormalizer,
+            // VeraPdfAValidator, PdfBoxGeometryNormalizer/PdfFlattener/StandardPdfConverter,
+            // GhostscriptPdfAConverter) already treats a non-zero-exit ProcessResult as an
+            // ordinary, graceful failure - reporting this the same way means a misconfigured or
+            // missing tool surfaces through those existing fallback paths instead of throwing past
+            // all of them and erasing whatever the pipeline had already legitimately determined
+            // about the file (verified live: a missing Ghostscript binary during PDF/A repair used
+            // to make the whole verdict falsely report the file as completely unreadable).
+            stopwatch.Stop();
+            return new ProcessResult
+            {
+                ExitCode = -1,
+                StandardError = ex.Message,
+                Duration = stopwatch.Elapsed
+            };
+        }
     }
 
     private static void PrependExecutableDirectoryToPath(ProcessStartInfo startInfo, string fileName)

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Qpdf/QpdfCommandFactory.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Qpdf/QpdfCommandFactory.cs
@@ -1,0 +1,177 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Qpdf;
+
+public sealed class QpdfCommandFactory
+{
+    public ProcessCommand CreateNormalizeCommand(
+        string inputPath,
+        string outputPath,
+        PdfNormalizeOptions normalizeOptions,
+        PdfToolingOptions toolingOptions)
+    {
+        var qpdfArguments = CreateQpdfArguments(inputPath, outputPath, normalizeOptions);
+
+        if (toolingOptions.QpdfExecutionMode == QpdfExecutionMode.Docker)
+        {
+            return CreateDockerNormalizeCommand(inputPath, outputPath, normalizeOptions, toolingOptions);
+        }
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.QpdfPath,
+            Arguments = qpdfArguments,
+            WorkingDirectory = Path.GetDirectoryName(inputPath),
+            TimeoutSeconds = normalizeOptions.TimeoutSeconds
+        };
+    }
+
+    public ProcessCommand CreateVersionCommand(PdfToolingOptions toolingOptions)
+    {
+        if (toolingOptions.QpdfExecutionMode == QpdfExecutionMode.Docker)
+        {
+            return new ProcessCommand
+            {
+                FileName = toolingOptions.DockerPath,
+                Arguments =
+                [
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    toolingOptions.QpdfDockerImage,
+                    "qpdf",
+                    "--version"
+                ],
+                TimeoutSeconds = 10
+            };
+        }
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.QpdfPath,
+            Arguments = ["--version"],
+            TimeoutSeconds = 10
+        };
+    }
+
+    public ProcessCommand CreateCheckCommand(
+        string outputPath,
+        PdfToolingOptions toolingOptions,
+        int timeoutSeconds)
+    {
+        if (toolingOptions.QpdfExecutionMode == QpdfExecutionMode.Docker)
+        {
+            return CreateDockerCheckCommand(outputPath, toolingOptions, timeoutSeconds);
+        }
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.QpdfPath,
+            Arguments = ["--check", outputPath],
+            WorkingDirectory = Path.GetDirectoryName(outputPath),
+            TimeoutSeconds = timeoutSeconds
+        };
+    }
+
+    private static ProcessCommand CreateDockerNormalizeCommand(
+        string inputPath,
+        string outputPath,
+        PdfNormalizeOptions normalizeOptions,
+        PdfToolingOptions toolingOptions)
+    {
+        var hostWorkspacePath = Path.GetDirectoryName(inputPath)
+            ?? throw new InvalidOperationException("Input path must include a workspace directory.");
+
+        var outputWorkspacePath = Path.GetDirectoryName(outputPath)
+            ?? throw new InvalidOperationException("Output path must include a workspace directory.");
+
+        if (!Path.GetFullPath(hostWorkspacePath).Equals(Path.GetFullPath(outputWorkspacePath), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("Docker qpdf mode requires input and output files to be in the same operation workspace.");
+        }
+
+        var containerWorkspacePath = NormalizeContainerPath(toolingOptions.DockerContainerWorkspacePath);
+        var containerInputPath = $"{containerWorkspacePath}/{Path.GetFileName(inputPath)}";
+        var containerOutputPath = $"{containerWorkspacePath}/{Path.GetFileName(outputPath)}";
+        var qpdfArguments = CreateQpdfArguments(containerInputPath, containerOutputPath, normalizeOptions);
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.DockerPath,
+            Arguments =
+            [
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "-v",
+                $"{hostWorkspacePath}:{containerWorkspacePath}",
+                toolingOptions.QpdfDockerImage,
+                "qpdf",
+                .. qpdfArguments
+            ],
+            WorkingDirectory = hostWorkspacePath,
+            TimeoutSeconds = normalizeOptions.TimeoutSeconds
+        };
+    }
+
+    private static ProcessCommand CreateDockerCheckCommand(
+        string outputPath,
+        PdfToolingOptions toolingOptions,
+        int timeoutSeconds)
+    {
+        var hostWorkspacePath = Path.GetDirectoryName(outputPath)
+            ?? throw new InvalidOperationException("Output path must include a workspace directory.");
+
+        var containerWorkspacePath = NormalizeContainerPath(toolingOptions.DockerContainerWorkspacePath);
+        var containerOutputPath = $"{containerWorkspacePath}/{Path.GetFileName(outputPath)}";
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.DockerPath,
+            Arguments =
+            [
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "-v",
+                $"{hostWorkspacePath}:{containerWorkspacePath}",
+                toolingOptions.QpdfDockerImage,
+                "qpdf",
+                "--check",
+                containerOutputPath
+            ],
+            WorkingDirectory = hostWorkspacePath,
+            TimeoutSeconds = timeoutSeconds
+        };
+    }
+
+    private static List<string> CreateQpdfArguments(
+        string inputPath,
+        string outputPath,
+        PdfNormalizeOptions options)
+    {
+        var arguments = new List<string>();
+        if (options.Linearize)
+        {
+            arguments.Add("--linearize");
+        }
+        else if (options.DisableObjectStreams)
+        {
+            arguments.Add("--object-streams=disable");
+        }
+
+        arguments.Add(inputPath);
+        arguments.Add(outputPath);
+        return arguments;
+    }
+
+    private static string NormalizeContainerPath(string path)
+    {
+        var normalized = string.IsNullOrWhiteSpace(path) ? "/work" : path.Trim();
+        return normalized.TrimEnd('/');
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Qpdf/QpdfPdfNormalizer.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Qpdf/QpdfPdfNormalizer.cs
@@ -1,0 +1,149 @@
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Qpdf;
+
+public sealed class QpdfPdfNormalizer : IPdfNormalizer
+{
+    private readonly IProcessRunner _processRunner;
+    private readonly IOptions<PdfToolingOptions> _options;
+    private readonly QpdfCommandFactory _commandFactory;
+
+    public QpdfPdfNormalizer(
+        IProcessRunner processRunner,
+        IOptions<PdfToolingOptions> options,
+        QpdfCommandFactory commandFactory)
+    {
+        _processRunner = processRunner;
+        _options = options;
+        _commandFactory = commandFactory;
+    }
+
+    public async Task<PdfNormalizeResult> NormalizeAsync(
+        string inputPath,
+        string outputPath,
+        PdfNormalizeOptions options,
+        CancellationToken cancellationToken)
+    {
+        var normalizeResult = await _processRunner.RunAsync(
+            _commandFactory.CreateNormalizeCommand(inputPath, outputPath, options, _options.Value),
+            cancellationToken);
+
+        if (normalizeResult.TimedOut)
+        {
+            return Failure(
+                PdfToolErrorCodes.ProcessTimeout,
+                CollectErrors("normalize", normalizeResult),
+                CollectWarnings(normalizeResult));
+        }
+
+        if (!File.Exists(outputPath) || new FileInfo(outputPath).Length == 0)
+        {
+            return Failure(
+                PdfToolErrorCodes.OutputNotCreated,
+                CollectErrors("normalize", normalizeResult),
+                CollectWarnings(normalizeResult));
+        }
+
+        var checkResult = await _processRunner.RunAsync(
+            _commandFactory.CreateCheckCommand(outputPath, _options.Value, options.TimeoutSeconds),
+            cancellationToken);
+
+        if (checkResult.TimedOut)
+        {
+            return Failure(
+                PdfToolErrorCodes.ProcessTimeout,
+                CollectErrors("check", checkResult),
+                CollectWarnings(normalizeResult, checkResult));
+        }
+
+        if (!checkResult.Success)
+        {
+            return Failure(
+                PdfToolErrorCodes.QpdfFailed,
+                CollectErrors("check", checkResult),
+                CollectWarnings(normalizeResult, checkResult));
+        }
+
+        return new PdfNormalizeResult
+        {
+            Success = true,
+            Warnings = CollectWarnings(normalizeResult, checkResult)
+        };
+    }
+
+    public async Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _processRunner.RunAsync(
+                _commandFactory.CreateVersionCommand(_options.Value),
+                cancellationToken);
+
+            return new ToolHealthResult
+            {
+                Available = result.Success,
+                Version = FirstLine(result.StandardOutput),
+                Error = result.Success ? null : FirstLine(result.StandardError)
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ToolHealthResult { Available = false, Error = ex.Message };
+        }
+    }
+
+    private static PdfNormalizeResult Failure(
+        string errorCode,
+        IReadOnlyList<string>? errors = null,
+        IReadOnlyList<string>? warnings = null)
+    {
+        return new PdfNormalizeResult
+        {
+            Success = false,
+            Errors = errors is { Count: > 0 }
+                ? [errorCode, .. errors.Where(error => !string.Equals(error, errorCode, StringComparison.OrdinalIgnoreCase))]
+                : [errorCode],
+            Warnings = warnings ?? []
+        };
+    }
+
+    private static IReadOnlyList<string> SplitLines(string text)
+    {
+        return text.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string? FirstLine(string text) => SplitLines(text).FirstOrDefault();
+
+    private static IReadOnlyList<string> CollectWarnings(params ProcessResult[] results)
+    {
+        return results
+            .SelectMany(result => SplitLines(result.StandardError).Concat(SplitLines(result.StandardOutput)))
+            .Where(line => line.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("warning", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("succeeded with warnings", StringComparison.OrdinalIgnoreCase))
+            .Distinct()
+            .ToList();
+    }
+
+    private static IReadOnlyList<string> CollectErrors(string stage, ProcessResult result)
+    {
+        var diagnostics = SplitLines(result.StandardError)
+            .Concat(SplitLines(result.StandardOutput))
+            .Where(line => !IsWarning(line))
+            .Distinct()
+            .ToList();
+
+        diagnostics.Insert(0, $"qpdf {stage} exited with code {result.ExitCode}.");
+        return diagnostics;
+    }
+
+    private static bool IsWarning(string line)
+    {
+        return line.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("warning", StringComparison.OrdinalIgnoreCase)
+            || line.Contains("succeeded with warnings", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfAValidator.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfAValidator.cs
@@ -1,0 +1,135 @@
+using System.Text;
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.VeraPdf;
+
+public sealed class VeraPdfAValidator : IPdfAValidator
+{
+    private readonly IProcessRunner _processRunner;
+    private readonly IOptions<PdfToolingOptions> _options;
+    private readonly VeraPdfCommandFactory _commandFactory;
+    private readonly VeraPdfXmlParser _xmlParser;
+
+    public VeraPdfAValidator(
+        IProcessRunner processRunner,
+        IOptions<PdfToolingOptions> options,
+        VeraPdfCommandFactory commandFactory,
+        VeraPdfXmlParser xmlParser)
+    {
+        _processRunner = processRunner;
+        _options = options;
+        _commandFactory = commandFactory;
+        _xmlParser = xmlParser;
+    }
+
+    public async Task<PdfAValidationResult> ValidateAsync(
+        string inputPath,
+        string reportPath,
+        CancellationToken cancellationToken)
+    {
+        var result = await _processRunner.RunAsync(
+            _commandFactory.CreateValidateCommand(inputPath, _options.Value),
+            cancellationToken);
+
+        if (result.TimedOut)
+        {
+            return Failure(PdfToolErrorCodes.ProcessTimeout, result.StandardOutput);
+        }
+
+        var rawReport = result.StandardOutput;
+        if (!string.IsNullOrWhiteSpace(rawReport))
+        {
+            await File.WriteAllTextAsync(reportPath, rawReport, cancellationToken);
+        }
+
+        if (string.IsNullOrWhiteSpace(rawReport))
+        {
+            return Failure(PdfToolErrorCodes.VeraPdfFailed, rawReport, FirstLine(result.StandardError));
+        }
+
+        try
+        {
+            var parsedResult = _xmlParser.Parse(rawReport, result.Success, FirstLine(result.StandardError));
+            return WithResolvedPdfAClaim(inputPath, parsedResult);
+        }
+        catch (Exception ex)
+        {
+            return Failure(PdfToolErrorCodes.VeraPdfFailed, rawReport, ex.Message);
+        }
+    }
+
+    public async Task<ToolHealthResult> CheckHealthAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _processRunner.RunAsync(
+                _commandFactory.CreateVersionCommand(_options.Value),
+                cancellationToken);
+
+            return new ToolHealthResult
+            {
+                Available = result.Success,
+                Version = FirstLine(result.StandardOutput),
+                Error = result.Success ? null : FirstLine(result.StandardError)
+            };
+        }
+        catch (Exception ex)
+        {
+            return new ToolHealthResult { Available = false, Error = ex.Message };
+        }
+    }
+
+    private static PdfAValidationResult Failure(string error, string rawReport, string? detail = null)
+    {
+        return new PdfAValidationResult
+        {
+            Success = false,
+            RawReport = rawReport,
+            Errors = string.IsNullOrWhiteSpace(detail) ? [error] : [error, detail]
+        };
+    }
+
+    private static string? FirstLine(string text)
+    {
+        return text.Split(Environment.NewLine, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault();
+    }
+
+    private static PdfAValidationResult WithResolvedPdfAClaim(string inputPath, PdfAValidationResult result)
+    {
+        var isPdfA = result.IsCompliant || IsPdfAClaimed(inputPath);
+        if (!File.Exists(inputPath))
+        {
+            isPdfA = result.IsPdfA;
+        }
+
+        return new PdfAValidationResult
+        {
+            Success = result.Success,
+            Engine = result.Engine,
+            IsPdfA = isPdfA,
+            IsCompliant = result.IsCompliant,
+            ProfileName = result.ProfileName,
+            RawReport = result.RawReport,
+            Errors = result.Errors,
+            Warnings = result.Warnings
+        };
+    }
+
+    private static bool IsPdfAClaimed(string inputPath)
+    {
+        if (!File.Exists(inputPath))
+        {
+            return false;
+        }
+
+        var content = Encoding.Latin1.GetString(File.ReadAllBytes(inputPath));
+        return content.Contains("pdfaid:part", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("pdfaid:conformance", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("www.aiim.org/pdfa/ns/id", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("/GTS_PDFA", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfCommandFactory.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfCommandFactory.cs
@@ -1,0 +1,92 @@
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.VeraPdf;
+
+public sealed class VeraPdfCommandFactory
+{
+    public ProcessCommand CreateValidateCommand(
+        string inputPath,
+        PdfToolingOptions toolingOptions)
+    {
+        if (toolingOptions.VeraPdfExecutionMode == VeraPdfExecutionMode.Docker)
+        {
+            return CreateDockerValidateCommand(inputPath, toolingOptions);
+        }
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.VeraPdfPath,
+            Arguments = ["--format", "xml", inputPath],
+            WorkingDirectory = Path.GetDirectoryName(inputPath),
+            TimeoutSeconds = toolingOptions.DefaultTimeoutSeconds
+        };
+    }
+
+    public ProcessCommand CreateVersionCommand(PdfToolingOptions toolingOptions)
+    {
+        var timeoutSeconds = Math.Max(1, toolingOptions.DefaultTimeoutSeconds);
+
+        if (toolingOptions.VeraPdfExecutionMode == VeraPdfExecutionMode.Docker)
+        {
+            return new ProcessCommand
+            {
+                FileName = toolingOptions.DockerPath,
+                Arguments =
+                [
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    toolingOptions.VeraPdfDockerImage,
+                    "--version"
+                ],
+                TimeoutSeconds = timeoutSeconds
+            };
+        }
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.VeraPdfPath,
+            Arguments = ["--version"],
+            TimeoutSeconds = timeoutSeconds
+        };
+    }
+
+    private static ProcessCommand CreateDockerValidateCommand(
+        string inputPath,
+        PdfToolingOptions toolingOptions)
+    {
+        var hostWorkspacePath = Path.GetDirectoryName(inputPath)
+            ?? throw new InvalidOperationException("Input path must include a workspace directory.");
+
+        var containerWorkspacePath = NormalizeContainerPath(toolingOptions.DockerContainerWorkspacePath);
+        var containerInputPath = $"{containerWorkspacePath}/{Path.GetFileName(inputPath)}";
+
+        return new ProcessCommand
+        {
+            FileName = toolingOptions.DockerPath,
+            Arguments =
+            [
+                "run",
+                "--rm",
+                "--network",
+                "none",
+                "-v",
+                $"{hostWorkspacePath}:{containerWorkspacePath}",
+                toolingOptions.VeraPdfDockerImage,
+                "--format",
+                "xml",
+                containerInputPath
+            ],
+            WorkingDirectory = hostWorkspacePath,
+            TimeoutSeconds = toolingOptions.DefaultTimeoutSeconds
+        };
+    }
+
+    private static string NormalizeContainerPath(string path)
+    {
+        var normalized = string.IsNullOrWhiteSpace(path) ? "/work" : path.Trim();
+        return normalized.TrimEnd('/');
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfXmlParser.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfXmlParser.cs
@@ -53,9 +53,23 @@ public sealed class VeraPdfXmlParser
 
     private static bool IsFailedCheckNode(XElement element)
     {
-        if (!element.Name.LocalName.Equals("rule", StringComparison.OrdinalIgnoreCase)
-            && !element.Name.LocalName.Equals("test", StringComparison.OrdinalIgnoreCase)
-            && !element.Name.LocalName.Equals("check", StringComparison.OrdinalIgnoreCase))
+        var name = element.Name.LocalName;
+        var isRule = name.Equals("rule", StringComparison.OrdinalIgnoreCase);
+
+        if (!isRule
+            && !name.Equals("test", StringComparison.OrdinalIgnoreCase)
+            && !name.Equals("check", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        // A real captured veraPDF report nests <check status="failed"> inside <rule status="failed">
+        // as that rule's own supporting detail (one per failing location), not a second independent
+        // failure - counting both produced duplicate entries, and collapsed distinct rules into one
+        // generic string once DescribeFailure's old priority order is applied to both. Only a
+        // check/test with no rule ancestor - a different report shape this parser also tolerates -
+        // is counted on its own.
+        if (!isRule && element.Ancestors().Any(a => a.Name.LocalName.Equals("rule", StringComparison.OrdinalIgnoreCase)))
         {
             return false;
         }
@@ -70,11 +84,22 @@ public sealed class VeraPdfXmlParser
 
     private static string? DescribeFailure(XElement element)
     {
-        return ReadAttribute(element, "specification")
-            ?? ReadAttribute(element, "clause")
+        // clause+description first: against a real captured report, "specification" alone is the
+        // ISO document name shared by every rule in it (e.g. "ISO 19005-1:2005"), so putting it
+        // first made every distinct rule collapse into one identical, uninformative string once
+        // deduplicated.
+        var clause = ReadAttribute(element, "clause");
+        var description = ReadElementValue(element, "description");
+
+        if (!string.IsNullOrWhiteSpace(clause) && !string.IsNullOrWhiteSpace(description))
+        {
+            return $"{clause}: {description}";
+        }
+
+        return description
+            ?? ReadAttribute(element, "specification")
             ?? ReadAttribute(element, "testNumber")
             ?? ReadElementValue(element, "message")
-            ?? ReadElementValue(element, "description")
             ?? CompactText(element.Value);
     }
 

--- a/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfXmlParser.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/VeraPdf/VeraPdfXmlParser.cs
@@ -1,0 +1,128 @@
+using System.Xml.Linq;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.VeraPdf;
+
+public sealed class VeraPdfXmlParser
+{
+    public PdfAValidationResult Parse(string rawReport, bool processSuccess, string? processError)
+    {
+        var document = XDocument.Parse(rawReport);
+        var report = document.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName.Equals("validationReport", StringComparison.OrdinalIgnoreCase));
+
+        var isCompliant = ReadBool(report, "isCompliant")
+            ?? ReadBool(document.Root, "isCompliant")
+            ?? false;
+
+        var profileName = ReadAttribute(report, "profileName")
+            ?? ReadAttribute(report, "flavour")
+            ?? ReadElementValue(report, "profileName")
+            ?? ReadElementValue(report, "flavour")
+            ?? ReadElementValue(document.Root, "profileName")
+            ?? ReadElementValue(document.Root, "flavour");
+
+        var failedChecks = document
+            .Descendants()
+            .Where(IsFailedCheckNode)
+            .Select(DescribeFailure)
+            .OfType<string>()
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(25)
+            .ToList();
+
+        var errors = new List<string>();
+        if (!processSuccess && !string.IsNullOrWhiteSpace(processError))
+        {
+            errors.Add(processError);
+        }
+
+        errors.AddRange(failedChecks);
+
+        return new PdfAValidationResult
+        {
+            Success = true,
+            IsPdfA = !string.IsNullOrWhiteSpace(profileName),
+            IsCompliant = isCompliant,
+            ProfileName = profileName,
+            RawReport = rawReport,
+            Errors = errors
+        };
+    }
+
+    private static bool IsFailedCheckNode(XElement element)
+    {
+        if (!element.Name.LocalName.Equals("rule", StringComparison.OrdinalIgnoreCase)
+            && !element.Name.LocalName.Equals("test", StringComparison.OrdinalIgnoreCase)
+            && !element.Name.LocalName.Equals("check", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return IsFailureValue(ReadAttribute(element, "status"))
+            || IsFailureValue(ReadAttribute(element, "result"))
+            || IsFailureValue(ReadElementValue(element, "status"))
+            || IsFailureValue(ReadElementValue(element, "result"))
+            || IsPassedFalse(ReadAttribute(element, "passed"))
+            || IsPassedFalse(ReadElementValue(element, "passed"));
+    }
+
+    private static string? DescribeFailure(XElement element)
+    {
+        return ReadAttribute(element, "specification")
+            ?? ReadAttribute(element, "clause")
+            ?? ReadAttribute(element, "testNumber")
+            ?? ReadElementValue(element, "message")
+            ?? ReadElementValue(element, "description")
+            ?? CompactText(element.Value);
+    }
+
+    private static bool IsFailureValue(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return value.Equals("failed", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("fail", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("false", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsPassedFalse(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return value.Equals("false", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool? ReadBool(XElement? element, string name)
+    {
+        var value = ReadAttribute(element, name) ?? ReadElementValue(element, name);
+        return bool.TryParse(value, out var parsed) ? parsed : null;
+    }
+
+    private static string? ReadAttribute(XElement? element, string name)
+    {
+        return element?.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
+    }
+
+    private static string? ReadElementValue(XElement? element, string name)
+    {
+        return element?.Elements().FirstOrDefault(e => e.Name.LocalName == name)?.Value;
+    }
+
+    private static string? CompactText(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return string.Join(' ', value.Split(default(char[]), StringSplitOptions.RemoveEmptyEntries));
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/Tooling/Workspace/PdfWorkspaceService.cs
+++ b/server/Utility.DomainService/PdfGenerator/Tooling/Workspace/PdfWorkspaceService.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace Utility.DomainService.PdfGenerator.Tooling.Workspace;
+
+public sealed class PdfWorkspaceService : IPdfWorkspaceService
+{
+    private readonly IOptions<PdfToolingOptions> _options;
+
+    public PdfWorkspaceService(IOptions<PdfToolingOptions> options)
+    {
+        _options = options;
+    }
+
+    public async Task<PdfWorkspace> CreateWorkspaceAsync(
+        string operationId,
+        Stream inputStream,
+        CancellationToken cancellationToken)
+    {
+        var directoryPath = Path.Combine(_options.Value.TempDirectory, operationId);
+        Directory.CreateDirectory(directoryPath);
+
+        var inputPath = Path.Combine(directoryPath, "input.pdf");
+        await using (var fileStream = File.Create(inputPath))
+        {
+            await inputStream.CopyToAsync(fileStream, cancellationToken);
+        }
+
+        return new PdfWorkspace(operationId, directoryPath, inputPath, () =>
+        {
+            if (Directory.Exists(directoryPath))
+            {
+                Directory.Delete(directoryPath, recursive: true);
+            }
+
+            return ValueTask.CompletedTask;
+        });
+    }
+}

--- a/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorNotificationService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/IPdfGeneratorNotificationService.cs
@@ -15,6 +15,13 @@
         Task NotifyStampTextToPdfEvent(bool success, string outputPdfFileId, string messageCoRelationId, string? projectKey);
         Task NotifyStampIntoPdfEvent(bool success, string outputPdfFileId, string messageCoRelationId, string? projectKey);
         Task NotifyConvertDocumentToPdfEvent(bool success, string fileId, string messageCoRelationId, string? projectKey);
+
+        /// <summary>
+        /// Notifies the requesting user that one file's ingestion finished. Unlike
+        /// <see cref="NotifyConvertDocumentToPdfEvent"/>, the user is supplied explicitly rather than
+        /// read from ambient <c>BlocksContext</c> - see <c>IngestPdfEvent.UserId</c> for why.
+        /// </summary>
+        Task NotifyIngestPdfEvent(bool success, string fileId, string messageCoRelationId, string? userId, string? projectKey);
     }
 }
 

--- a/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
+++ b/server/Utility.DomainService/PdfGenerator/service/PdfGeneratorNotificationService.cs
@@ -148,6 +148,18 @@ namespace Utility.DomainService.PdfGenerator.service
             });
         }
 
+        public async Task NotifyIngestPdfEvent(bool success, string fileId, string messageCoRelationId, string? userId, string? projectKey)
+        {
+            _logger.LogInformation("NotifyIngestPdfEvent: Sending notification for fileId={FileId}, success={Success}", LogSanitizer.Scrub(fileId), success);
+
+            await SendUserNotificationAsync(success, messageCoRelationId, new
+            {
+                FileId = fileId,
+                MessageCoRelationId = messageCoRelationId,
+                Success = success
+            }, userId);
+        }
+
         /// <summary>
         /// Sends a document-conversion notification to <c>POST /api/Notifier/Notify</c>, targeted
         /// at the requesting user rather than a push connection.
@@ -170,12 +182,17 @@ namespace Utility.DomainService.PdfGenerator.service
         /// notification type, not something derived from configuration.
         /// </para>
         /// </remarks>
-        private async Task SendUserNotificationAsync(bool success, string? messageCoRelationId, object payload)
+        private Task SendUserNotificationAsync(bool success, string? messageCoRelationId, object payload) =>
+            SendUserNotificationAsync(success, messageCoRelationId, payload, BlocksContext.GetContext()?.UserId);
+
+        /// <summary>
+        /// Overload taking the target user explicitly, for callers such as
+        /// <see cref="NotifyIngestPdfEvent"/> whose event carries the requesting user rather than
+        /// relying on ambient <see cref="BlocksContext"/> still being correct by the time a queued
+        /// message is consumed.
+        /// </summary>
+        private async Task SendUserNotificationAsync(bool success, string? messageCoRelationId, object payload, string? userId)
         {
-            // Read once and kept in scope for the catch block too, so a failure log can still say
-            // who the notification was for even when the exception happens after this point (e.g.
-            // serializing the payload, hashing the secret, or the HTTP call itself).
-            var userId = BlocksContext.GetContext()?.UserId;
 
             try
             {

--- a/server/Utility.DomainService/PdfIngestion/Entities/PdfIngestionJob.cs
+++ b/server/Utility.DomainService/PdfIngestion/Entities/PdfIngestionJob.cs
@@ -1,0 +1,149 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfIngestion.Entities
+{
+    /// <summary>
+    /// Where the ingestion of one file has got to.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <c>DocumentConversionJob</c>: ingestion is queued and answered immediately, so this
+    /// record is written when the request is accepted and updated as the worker moves through it,
+    /// giving the status endpoint something truthful to answer with even if the completion
+    /// notification is missed.
+    /// <para>
+    /// Keyed by the file's own storage ID, for the same reason: remediation replaces the file in
+    /// place, so that ID is stable across the operation and is what the caller already holds.
+    /// </para>
+    /// </remarks>
+    [BsonIgnoreExtraElements]
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class PdfIngestionJob
+    {
+        /// <summary>The file's storage ID, and this record's key.</summary>
+        [BsonId]
+        [BsonRepresentation(BsonType.String)]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>The caller's own correlation ID, used to address the completion notification.</summary>
+        public string? MessageCoRelationId { get; set; }
+
+        /// <summary>
+        /// Serialized as a string, unlike <c>DocumentConversionJob.Status</c> whose doc comment
+        /// claims the same but omits the attribute - so a stored record stays readable and adding a
+        /// state later cannot renumber the ones already written.
+        /// </summary>
+        [BsonRepresentation(BsonType.String)]
+        public PdfIngestionStatus Status { get; set; } = PdfIngestionStatus.Queued;
+
+        public string? FileName { get; set; }
+
+        /// <summary>
+        /// The requesting user, captured at accept time and carried on the queued event rather than
+        /// read from ambient <c>BlocksContext</c> when the worker later sends the completion
+        /// notification - a queue hop is not guaranteed to preserve that context.
+        /// </summary>
+        public string? UserId { get; set; }
+
+        /// <summary>Why the job itself failed to produce a verdict. Null unless <see cref="Status"/> is <see cref="PdfIngestionStatus.Failed"/>.</summary>
+        public string? ErrorCode { get; set; }
+
+        public string? ErrorMessage { get; set; }
+
+        public string TenantId { get; set; } = string.Empty;
+
+        public string? CreatedBy { get; set; }
+
+        public DateTime CreateDate { get; set; }
+
+        public DateTime LastUpdateDate { get; set; }
+
+        /// <summary>When the job reached a terminal state. Null while still queued or running.</summary>
+        public DateTime? CompletedDate { get; set; }
+
+        /// <summary>
+        /// True when this run asked the pipeline to inspect and report only, uploading nothing back
+        /// to storage - the de-risking switch for the first production rollout of an otherwise
+        /// destructive in-place feature.
+        /// </summary>
+        public bool DryRun { get; set; }
+
+        /// <summary>The pipeline's verdict, once <see cref="Status"/> reaches <see cref="PdfIngestionStatus.Completed"/>.</summary>
+        public PdfIngestionVerdict? Verdict { get; set; }
+    }
+
+    /// <summary>
+    /// The stored shape of a pipeline run's outcome.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not the same type <c>PdfIngestionPipeline</c> returns
+    /// (<see cref="PdfIngestionOutcome"/>): that type carries <c>FinalBytes</c>, the file's full
+    /// content, which must never end up written into a Mongo document alongside every other job's -
+    /// exactly the bloat risk this feature's own risk register calls out for the veraPDF raw report.
+    /// <see cref="FromOutcome"/> is the one place that gap is bridged.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public sealed class PdfIngestionVerdict
+    {
+        public int PageCount { get; set; }
+
+        public bool WasReadable { get; set; }
+        public bool IsReadable { get; set; }
+        public bool RepairedWithQpdf { get; set; }
+
+        public bool GeometryWasReadable { get; set; } = true;
+        public bool GeometryIsReadable { get; set; } = true;
+        public bool GeometryNormalized { get; set; }
+        public List<PdfPageGeometry> PageGeometry { get; set; } = [];
+        public string? GeometrySkippedReason { get; set; }
+
+        public bool HasSignature { get; set; }
+        public int SignatureCount { get; set; }
+
+        public PdfAMetadataClaim MetadataClaim { get; set; } = PdfAMetadataClaim.Missing;
+        public string? ClaimedProfile { get; set; }
+        public string? ValidatedProfile { get; set; }
+        public bool IsPdfA { get; set; }
+        public bool IsCompliant { get; set; }
+        public List<string> PdfAFailedChecks { get; set; } = [];
+        public bool PdfARepairAttempted { get; set; }
+        public bool? PdfARepairSucceeded { get; set; }
+        public string? FinalProfile { get; set; }
+
+        public bool ContentChanged { get; set; }
+        public List<PdfIngestionStageRecord> Stages { get; set; } = [];
+
+        public static PdfIngestionVerdict FromOutcome(PdfIngestionOutcome outcome)
+        {
+            ArgumentNullException.ThrowIfNull(outcome);
+
+            return new PdfIngestionVerdict
+            {
+                PageCount = outcome.PageCount,
+                WasReadable = outcome.WasReadable,
+                IsReadable = outcome.IsReadable,
+                RepairedWithQpdf = outcome.RepairedWithQpdf,
+                GeometryWasReadable = outcome.GeometryWasReadable,
+                GeometryIsReadable = outcome.GeometryIsReadable,
+                GeometryNormalized = outcome.GeometryNormalized,
+                PageGeometry = [.. outcome.PageGeometry],
+                GeometrySkippedReason = outcome.GeometrySkippedReason,
+                HasSignature = outcome.HasSignature,
+                SignatureCount = outcome.SignatureCount,
+                MetadataClaim = outcome.MetadataClaim,
+                ClaimedProfile = outcome.ClaimedProfile,
+                ValidatedProfile = outcome.ValidatedProfile,
+                IsPdfA = outcome.IsPdfA,
+                IsCompliant = outcome.IsCompliant,
+                PdfAFailedChecks = [.. outcome.PdfAFailedChecks],
+                PdfARepairAttempted = outcome.PdfARepairAttempted,
+                PdfARepairSucceeded = outcome.PdfARepairSucceeded,
+                FinalProfile = outcome.FinalProfile,
+                ContentChanged = outcome.ContentChanged,
+                Stages = [.. outcome.Stages]
+            };
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/Events/PdfIngestionEvents.cs
+++ b/server/Utility.DomainService/PdfIngestion/Events/PdfIngestionEvents.cs
@@ -1,0 +1,30 @@
+namespace Utility.DomainService.PdfIngestion.Events
+{
+    /// <summary>
+    /// Event for ingesting one PDF: inspecting it and remediating whatever the inspection calls for.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <c>ConvertDocumentToPdfEvent</c>, this carries <see cref="UserId"/> explicitly rather
+    /// than leaving the completion notification to read it from ambient <c>BlocksContext</c> at
+    /// consume time. A queue hop is not guaranteed to preserve that context, so a value captured at
+    /// accept time - when it is known to be correct - is carried on the event instead.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public record IngestPdfEvent
+    {
+        /// <summary>
+        /// The file to ingest, and the key of the ingestion record the worker updates as it goes -
+        /// the record the status endpoint reads.
+        /// </summary>
+        public string FileId { get; set; } = string.Empty;
+
+        public string? MessageCoRelationId { get; set; }
+
+        public string? ProjectKey { get; set; }
+
+        public string? UserId { get; set; }
+
+        /// <summary>See <c>PdfIngestionJob.DryRun</c>.</summary>
+        public bool DryRun { get; set; }
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/PdfIngestionContracts.cs
+++ b/server/Utility.DomainService/PdfIngestion/PdfIngestionContracts.cs
@@ -1,0 +1,111 @@
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+
+namespace Utility.DomainService.PdfIngestion
+{
+    /// <summary>
+    /// Request to read the ingestion state of one or more files.
+    /// </summary>
+    /// <remarks>
+    /// A POST rather than a GET, even though this only reads: the query needs to carry a list of
+    /// file IDs, and a body on a GET is inconsistently supported by clients, proxies and framework
+    /// model binding. The same trade the document conversion status endpoint already makes.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class GetPdfIngestionStatusRequest
+    {
+        public List<string> FileIds { get; set; } = [];
+    }
+
+    /// <summary>
+    /// One file's ingestion state and, once the pipeline has run, its full verdict: what shape the
+    /// file arrived in, what was repaired, and what still needs attention.
+    /// </summary>
+    /// <remarks>
+    /// Every field below <see cref="Status"/> is null when <see cref="Found"/> is false or the job
+    /// has not reached <see cref="PdfIngestionStatus.Completed"/> yet - there is no verdict for them
+    /// to describe before the pipeline has actually run.
+    /// </remarks>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class PdfIngestionStatusResult
+    {
+        /// <summary>
+        /// The file this is about. Remediation happens in place, so this is both what was queried
+        /// and where the (possibly rewritten) PDF now lives.
+        /// </summary>
+        public string FileId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// False when this file was never submitted for ingestion. <see cref="Status"/> and every
+        /// verdict field below are meaningless in that case and are left null.
+        /// </summary>
+        public bool Found { get; set; }
+
+        public string? FileName { get; set; }
+
+        public string? MessageCoRelationId { get; set; }
+
+        public PdfIngestionStatus? Status { get; set; }
+
+        /// <summary>
+        /// True once <see cref="Status"/> can no longer change, so a poller knows to stop asking
+        /// about this file.
+        /// </summary>
+        public bool IsComplete { get; set; }
+
+        /// <summary>
+        /// A time-limited URL the current file can be downloaded from. Resolved fresh on each
+        /// request rather than stored, because it expires.
+        /// </summary>
+        public string? DownloadUrl { get; set; }
+
+        public string? ErrorCode { get; set; }
+
+        public string? ErrorMessage { get; set; }
+
+        public DateTime? RequestedAtUtc { get; set; }
+
+        public DateTime? CompletedAtUtc { get; set; }
+
+        public int? PageCount { get; set; }
+
+        // Readability
+        public bool? WasReadable { get; set; }
+        public bool? IsReadable { get; set; }
+        public bool? RepairedWithQpdf { get; set; }
+
+        // Geometry
+        public bool? GeometryWasReadable { get; set; }
+        public bool? GeometryIsReadable { get; set; }
+        public bool? GeometryNormalized { get; set; }
+        public IReadOnlyList<PdfPageGeometry>? PageGeometry { get; set; }
+        public string? GeometrySkippedReason { get; set; }
+
+        // Signature
+        public bool? HasSignature { get; set; }
+        public int? SignatureCount { get; set; }
+
+        // PDF/A
+        public PdfAMetadataClaim? MetadataClaim { get; set; }
+        public string? ClaimedProfile { get; set; }
+        public string? ValidatedProfile { get; set; }
+        public bool? IsPdfA { get; set; }
+        public bool? IsCompliant { get; set; }
+        public IReadOnlyList<string>? PdfAFailedChecks { get; set; }
+        public bool? PdfARepairAttempted { get; set; }
+        public bool? PdfARepairSucceeded { get; set; }
+        public string? FinalProfile { get; set; }
+
+        /// <summary>Whether any pipeline stage actually rewrote the file's bytes.</summary>
+        public bool? ContentChanged { get; set; }
+
+        /// <summary>Which stages ran and what each one's outcome was, in the order they ran.</summary>
+        public IReadOnlyList<PdfIngestionStageRecord>? Stages { get; set; }
+    }
+
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class PdfIngestionStatusBatchResponse
+    {
+        public List<PdfIngestionStatusResult> Results { get; set; } = [];
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/PdfIngestionContracts.cs
+++ b/server/Utility.DomainService/PdfIngestion/PdfIngestionContracts.cs
@@ -4,6 +4,80 @@ using Utility.DomainService.PdfGenerator.Tooling.Models;
 namespace Utility.DomainService.PdfIngestion
 {
     /// <summary>
+    /// Request to inspect and, if needed, remediate one or more PDFs already in storage.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class IngestPdfsRequest
+    {
+        /// <summary>
+        /// Storage file IDs of the PDFs to ingest. Remediated output overwrites its own ID, so
+        /// anything already referencing an ID keeps working, and that same ID is what the status
+        /// endpoint is queried with. A duplicate ID is treated as one request for that file, not two.
+        /// </summary>
+        public List<string> FileIds { get; set; } = [];
+
+        /// <summary>
+        /// Optional. Identifies the request so the caller is notified as each file's ingestion
+        /// finishes. Leaving it empty skips the notification; ingestion still runs and its outcome is
+        /// still readable from the status endpoint.
+        /// </summary>
+        public string? MessageCoRelationId { get; set; }
+
+        /// <summary>
+        /// When true, every file is inspected and its verdict recorded, but nothing is uploaded back
+        /// to storage even when a remediation stage would otherwise have changed the file's bytes.
+        /// Meant for the first production rollout of an otherwise destructive in-place feature.
+        /// </summary>
+        public bool DryRun { get; set; }
+    }
+
+    /// <summary>
+    /// Whether one file's ingestion was queued, and if not, why.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class PdfIngestionAcceptance
+    {
+        /// <summary>
+        /// The file this outcome is about - the same ID that was sent in, and the one to query
+        /// status with.
+        /// </summary>
+        public string FileId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// True once the ingestion has been recorded and queued. False means it never started -
+        /// <see cref="ErrorCode"/> says why, and there is nothing to poll for this file.
+        /// </summary>
+        public bool Accepted { get; set; }
+
+        public PdfIngestionStatus? Status { get; set; }
+
+        public string? ErrorCode { get; set; }
+
+        public string? ErrorMessage { get; set; }
+    }
+
+    /// <summary>
+    /// The acknowledgement returned when a batch of ingestions is accepted.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class IngestPdfsBatchResponse
+    {
+        public string? MessageCoRelationId { get; set; }
+
+        /// <summary>
+        /// Where to check on the files in this batch - a POST, because the query needs to name the
+        /// files it is asking about and a URL alone cannot carry a list.
+        /// </summary>
+        public string StatusUrl { get; set; } = "/pdf-ingestions/status";
+
+        public List<PdfIngestionAcceptance> Results { get; set; } = [];
+
+        public int AcceptedCount { get; set; }
+
+        public int RejectedCount { get; set; }
+    }
+
+    /// <summary>
     /// Request to read the ingestion state of one or more files.
     /// </summary>
     /// <remarks>

--- a/server/Utility.DomainService/PdfIngestion/PdfIngestionResult.cs
+++ b/server/Utility.DomainService/PdfIngestion/PdfIngestionResult.cs
@@ -1,0 +1,72 @@
+namespace Utility.DomainService.PdfIngestion
+{
+    /// <summary>
+    /// What a PDF-ingestion operation returns, whether or not it worked.
+    /// </summary>
+    /// <remarks>
+    /// The same shape as <c>DocumentConversionResult&lt;TValue&gt;</c>, and deliberately its own type
+    /// rather than a reuse of it: <c>PdfIngestion</c> is a sibling feature of <c>PdfGenerator</c>, not
+    /// a consumer of it, and should not inherit PdfGenerator's failure vocabulary just because the
+    /// shape happens to match.
+    /// </remarks>
+    public sealed class PdfIngestionResult<TValue>
+    {
+        private PdfIngestionResult()
+        {
+        }
+
+        public bool IsSuccess { get; private init; }
+
+        public TValue? Value { get; private init; }
+
+        public PdfIngestionFailureKind FailureKind { get; private init; }
+
+        public string? ErrorCode { get; private init; }
+
+        public string? ErrorMessage { get; private init; }
+
+        public IReadOnlyDictionary<string, string[]>? ValidationErrors { get; private init; }
+
+        public string CorrelationId { get; private init; } = string.Empty;
+
+        public static PdfIngestionResult<TValue> Success(TValue value, string correlationId) =>
+            new()
+            {
+                IsSuccess = true,
+                Value = value,
+                CorrelationId = correlationId
+            };
+
+        public static PdfIngestionResult<TValue> Failure(
+            PdfIngestionFailureKind kind,
+            string errorCode,
+            string errorMessage,
+            string correlationId,
+            IReadOnlyDictionary<string, string[]>? validationErrors = null) =>
+            new()
+            {
+                IsSuccess = false,
+                FailureKind = kind,
+                ErrorCode = errorCode,
+                ErrorMessage = errorMessage,
+                CorrelationId = correlationId,
+                ValidationErrors = validationErrors
+            };
+    }
+
+    /// <summary>The shape of a failure, independent of HTTP. The API layer maps these to status codes.</summary>
+    public enum PdfIngestionFailureKind
+    {
+        /// <summary>The request itself is wrong - a missing or malformed field.</summary>
+        Validation,
+
+        /// <summary>The ingestion job or the file being asked about does not exist.</summary>
+        NotFound,
+
+        /// <summary>A dependency was unreachable - storage, or the message broker.</summary>
+        Unavailable,
+
+        /// <summary>Anything else.</summary>
+        Internal
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/PdfIngestionStatus.cs
+++ b/server/Utility.DomainService/PdfIngestion/PdfIngestionStatus.cs
@@ -1,0 +1,23 @@
+namespace Utility.DomainService.PdfIngestion;
+
+/// <summary>
+/// The states an ingestion job moves through. Deliberately coarser than the verdict it produces:
+/// a file can complete with an incomplete or non-compliant result (geometry still unreadable, a
+/// PDF/A repair that fell back to a standard PDF) and still be <see cref="Completed"/> - this
+/// tracks the job's own lifecycle, not how good the outcome was. <see cref="Failed"/> is reserved
+/// for the job itself never producing a verdict (an unhandled exception, a crashed worker).
+/// </summary>
+public enum PdfIngestionStatus
+{
+    /// <summary>Accepted and waiting for a worker.</summary>
+    Queued,
+
+    /// <summary>A worker has picked it up.</summary>
+    Processing,
+
+    /// <summary>The pipeline ran and produced a verdict, whatever that verdict says.</summary>
+    Completed,
+
+    /// <summary>The job itself never produced a verdict. <c>ErrorCode</c> says why.</summary>
+    Failed
+}

--- a/server/Utility.DomainService/PdfIngestion/Utilities/PdfIngestionConstants.cs
+++ b/server/Utility.DomainService/PdfIngestion/Utilities/PdfIngestionConstants.cs
@@ -1,0 +1,23 @@
+using Blocks.Genesis;
+using Utility.DomainService.Messaging;
+
+namespace Utility.DomainService.PdfIngestion.Utilities
+{
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public static class PdfIngestionConstants
+    {
+        public const string IngestPdfQueue = "blocks_pdf_ingestion_listener";
+
+        /// <summary>
+        /// Must be spread into <c>GetCombinedMessageConfiguration</c> in <c>Worker/Program.cs</c>
+        /// (both the RabbitMq and Azure Service Bus branches) - a separate constants class is not
+        /// picked up automatically the way an entry added to <c>PdfGeneratorConstants</c> would be.
+        /// </summary>
+        public static MessageConfiguration GetMessageConfiguration(string messageConnectionString)
+        {
+            return MessageConfigurationHelper.GetMessageConfiguration(
+                messageConnectionString,
+                IngestPdfQueue);
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/service/IPdfIngestionRepository.cs
+++ b/server/Utility.DomainService/PdfIngestion/service/IPdfIngestionRepository.cs
@@ -1,0 +1,30 @@
+using Utility.DomainService.PdfIngestion.Entities;
+
+namespace Utility.DomainService.PdfIngestion.service
+{
+    /// <summary>
+    /// Repository for PDF ingestion job records.
+    /// </summary>
+    /// <remarks>
+    /// Not appended to <c>IPdfGeneratorRepository</c>, which already carries profiles, extract dumps
+    /// and conversion jobs for an unrelated feature - ingestion gets its own repository the same way
+    /// it gets its own collection.
+    /// </remarks>
+    public interface IPdfIngestionRepository
+    {
+        /// <summary>Records an ingestion, replacing any earlier one for the same file.</summary>
+        Task<bool> SaveJobAsync(PdfIngestionJob job, string? tenantId = null);
+
+        /// <summary>
+        /// Reads the ingestion state of a file. Null when that file has never been submitted for
+        /// ingestion.
+        /// </summary>
+        Task<PdfIngestionJob?> GetJobAsync(string fileId, string? tenantId = null);
+
+        /// <summary>Reads several ingestion records in one round trip via an $in filter.</summary>
+        Task<List<PdfIngestionJob>> GetJobsAsync(IEnumerable<string> fileIds, string? tenantId = null);
+
+        /// <summary>Writes an ingestion's new state.</summary>
+        Task<bool> UpdateJobAsync(PdfIngestionJob job, string? tenantId = null);
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/service/IPdfIngestionService.cs
+++ b/server/Utility.DomainService/PdfIngestion/service/IPdfIngestionService.cs
@@ -1,0 +1,27 @@
+namespace Utility.DomainService.PdfIngestion.service
+{
+    /// <summary>
+    /// Accepts batches of PDF ingestions and reports what became of them.
+    /// </summary>
+    public interface IPdfIngestionService
+    {
+        /// <summary>
+        /// Records and queues a batch of ingestions. Returns as soon as the batch is accepted, not
+        /// when any file has actually been inspected. Each file in the batch succeeds or fails
+        /// independently - one bad ID does not stop the rest of the batch.
+        /// </summary>
+        Task<PdfIngestionResult<IngestPdfsBatchResponse>> RequestIngestionsAsync(
+            IngestPdfsRequest request,
+            string correlationId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Reads the current state of a batch of files, including each one's verdict once its
+        /// ingestion has completed.
+        /// </summary>
+        Task<PdfIngestionResult<PdfIngestionStatusBatchResponse>> GetStatusAsync(
+            GetPdfIngestionStatusRequest request,
+            string correlationId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/service/PdfIngestionRepository.cs
+++ b/server/Utility.DomainService/PdfIngestion/service/PdfIngestionRepository.cs
@@ -1,0 +1,135 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using MongoDB.Driver;
+using Utility.DomainService.PdfIngestion.Entities;
+using Utility.DomainService.Shared.Utilities;
+
+namespace Utility.DomainService.PdfIngestion.service
+{
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class PdfIngestionRepository : IPdfIngestionRepository
+    {
+        private const string PdfIngestionJobs = "PdfIngestionJobs";
+
+        private readonly ILogger<PdfIngestionRepository> _logger;
+        private readonly IDbContextProvider _dbContextProvider;
+
+        public PdfIngestionRepository(
+            ILogger<PdfIngestionRepository> logger,
+            IDbContextProvider dbContextProvider)
+        {
+            _logger = logger;
+            _dbContextProvider = dbContextProvider;
+        }
+
+        /// <remarks>
+        /// An upsert rather than an insert: the record is keyed by the file, and ingesting a file
+        /// again is a new attempt on the same file, not a second thing to track.
+        /// </remarks>
+        public async Task<bool> SaveJobAsync(PdfIngestionJob job, string? tenantId = null)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+
+            try
+            {
+                var tid = tenantId ?? BlocksContext.GetContext()?.TenantId ?? string.Empty;
+                var database = _dbContextProvider.GetDatabase(tid);
+                var collection = database.GetCollection<PdfIngestionJob>(PdfIngestionJobs);
+                var filter = Builders<PdfIngestionJob>.Filter.Eq(j => j.Id, job.Id);
+
+                await collection.ReplaceOneAsync(filter, job, new ReplaceOptions { IsUpsert = true });
+
+                _logger.LogInformation("SaveJobAsync: Recorded ingestion of file {FileId}", LogSanitizer.Scrub(job.Id));
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in SaveJobAsync for file {FileId}", LogSanitizer.Scrub(job.Id));
+                return false;
+            }
+        }
+
+        public async Task<PdfIngestionJob?> GetJobAsync(string fileId, string? tenantId = null)
+        {
+            try
+            {
+                var tid = tenantId ?? BlocksContext.GetContext()?.TenantId ?? string.Empty;
+                var database = _dbContextProvider.GetDatabase(tid);
+                var collection = database.GetCollection<PdfIngestionJob>(PdfIngestionJobs);
+                var filter = Builders<PdfIngestionJob>.Filter.Eq(j => j.Id, fileId);
+
+                return await collection.Find(filter).FirstOrDefaultAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in GetJobAsync for file {FileId}", LogSanitizer.Scrub(fileId));
+                return null;
+            }
+        }
+
+        /// <remarks>
+        /// Reads several ingestion records in one round trip via an $in filter, rather than the batch
+        /// status endpoint issuing one query per file.
+        /// </remarks>
+        public async Task<List<PdfIngestionJob>> GetJobsAsync(IEnumerable<string> fileIds, string? tenantId = null)
+        {
+            ArgumentNullException.ThrowIfNull(fileIds);
+            var ids = fileIds.ToList();
+
+            if (ids.Count == 0)
+            {
+                return [];
+            }
+
+            try
+            {
+                var tid = tenantId ?? BlocksContext.GetContext()?.TenantId ?? string.Empty;
+                var database = _dbContextProvider.GetDatabase(tid);
+                var collection = database.GetCollection<PdfIngestionJob>(PdfIngestionJobs);
+                var filter = Builders<PdfIngestionJob>.Filter.In(j => j.Id, ids);
+
+                return await collection.Find(filter).ToListAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in GetJobsAsync for {Count} file(s)", ids.Count);
+                return [];
+            }
+        }
+
+        /// <remarks>
+        /// A failure here is logged and swallowed rather than thrown. The ingestion itself may have
+        /// succeeded; losing the status write should leave the caller polling a stale record, not
+        /// abandon a file that was already remediated.
+        /// </remarks>
+        public async Task<bool> UpdateJobAsync(PdfIngestionJob job, string? tenantId = null)
+        {
+            ArgumentNullException.ThrowIfNull(job);
+
+            try
+            {
+                var tid = tenantId ?? BlocksContext.GetContext()?.TenantId ?? string.Empty;
+                var database = _dbContextProvider.GetDatabase(tid);
+                var collection = database.GetCollection<PdfIngestionJob>(PdfIngestionJobs);
+                var filter = Builders<PdfIngestionJob>.Filter.Eq(j => j.Id, job.Id);
+
+                job.LastUpdateDate = DateTime.UtcNow;
+
+                var result = await collection.ReplaceOneAsync(filter, job);
+
+                if (result.MatchedCount == 0)
+                {
+                    _logger.LogWarning("UpdateJobAsync: No ingestion record for file {FileId}", LogSanitizer.Scrub(job.Id));
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in UpdateJobAsync for file {FileId}", LogSanitizer.Scrub(job.Id));
+                return false;
+            }
+        }
+    }
+}

--- a/server/Utility.DomainService/PdfIngestion/service/PdfIngestionService.cs
+++ b/server/Utility.DomainService/PdfIngestion/service/PdfIngestionService.cs
@@ -1,0 +1,338 @@
+using Blocks.Genesis;
+using Microsoft.Extensions.Logging;
+using Utility.DomainService.PdfGenerator.service;
+using Utility.DomainService.PdfIngestion.Entities;
+using Utility.DomainService.PdfIngestion.Events;
+using Utility.DomainService.PdfIngestion.Utilities;
+using Utility.DomainService.Shared.Utilities;
+
+namespace Utility.DomainService.PdfIngestion.service
+{
+    /// <inheritdoc />
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+    public class PdfIngestionService : IPdfIngestionService
+    {
+        /// <summary>
+        /// The most files one request may name. See <c>DocumentConversionService.MaxBatchSize</c>
+        /// for why this is bounded rather than left open.
+        /// </summary>
+        internal const int MaxBatchSize = 50;
+
+        private readonly ILogger<PdfIngestionService> _logger;
+        private readonly IMessageClient _messageClient;
+        private readonly IPdfIngestionRepository _repository;
+        private readonly PdfStorageHelper _storageHelper;
+
+        public PdfIngestionService(
+            ILogger<PdfIngestionService> logger,
+            IMessageClient messageClient,
+            IPdfIngestionRepository repository,
+            PdfStorageHelper storageHelper)
+        {
+            _logger = logger;
+            _messageClient = messageClient;
+            _repository = repository;
+            _storageHelper = storageHelper;
+        }
+
+        /// <inheritdoc />
+        public async Task<PdfIngestionResult<IngestPdfsBatchResponse>> RequestIngestionsAsync(
+            IngestPdfsRequest request,
+            string correlationId,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            // A duplicate ID is one request for that file, not two, so queuing it twice would just
+            // race two workers over the same replacement.
+            var fileIds = (request.FileIds ?? [])
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            if (fileIds.Count == 0)
+            {
+                return PdfIngestionResult<IngestPdfsBatchResponse>.Failure(
+                    PdfIngestionFailureKind.Validation,
+                    "file_ids_required",
+                    "fileIds must contain at least one file ID.",
+                    correlationId,
+                    new Dictionary<string, string[]>(StringComparer.Ordinal)
+                    {
+                        ["fileIds"] = ["fileIds must contain at least one file ID."]
+                    });
+            }
+
+            if (fileIds.Count > MaxBatchSize)
+            {
+                return PdfIngestionResult<IngestPdfsBatchResponse>.Failure(
+                    PdfIngestionFailureKind.Validation,
+                    "too_many_files",
+                    $"A single request can ingest at most {MaxBatchSize} files; {fileIds.Count} were sent.",
+                    correlationId,
+                    new Dictionary<string, string[]>(StringComparer.Ordinal)
+                    {
+                        ["fileIds"] = [$"A single request can ingest at most {MaxBatchSize} files."]
+                    });
+            }
+
+            var tenantId = BlocksContext.GetContext()?.TenantId ?? string.Empty;
+            var userId = BlocksContext.GetContext()?.UserId;
+            var results = new List<PdfIngestionAcceptance>(fileIds.Count);
+
+            // Sequential rather than fanned out with Task.WhenAll: each file writes to the same
+            // tenant database and publishes to the same queue, so nothing here benefits from
+            // concurrency the way the read side's storage lookups do, and staying sequential keeps
+            // the per-file logging in request order.
+            foreach (var fileId in fileIds)
+            {
+                results.Add(await RequestOneIngestion(fileId, request.MessageCoRelationId, request.DryRun, tenantId, userId));
+            }
+
+            var accepted = results.Count(r => r.Accepted);
+
+            return PdfIngestionResult<IngestPdfsBatchResponse>.Success(
+                new IngestPdfsBatchResponse
+                {
+                    MessageCoRelationId = request.MessageCoRelationId,
+                    Results = results,
+                    AcceptedCount = accepted,
+                    RejectedCount = results.Count - accepted
+                },
+                correlationId);
+        }
+
+        /// <summary>
+        /// Records and queues the ingestion of one file. Never throws - any failure becomes a
+        /// rejected <see cref="PdfIngestionAcceptance"/>, so one bad file cannot abort the rest of
+        /// the batch the caller is waiting on.
+        /// </summary>
+        private async Task<PdfIngestionAcceptance> RequestOneIngestion(
+            string fileId,
+            string? messageCoRelationId,
+            bool dryRun,
+            string tenantId,
+            string? userId)
+        {
+            if (string.IsNullOrWhiteSpace(fileId))
+            {
+                return new PdfIngestionAcceptance
+                {
+                    FileId = fileId ?? string.Empty,
+                    Accepted = false,
+                    ErrorCode = "input_file_id_required",
+                    ErrorMessage = "A file ID in the list was blank."
+                };
+            }
+
+            var now = DateTime.UtcNow;
+
+            var job = new PdfIngestionJob
+            {
+                Id = fileId,
+                MessageCoRelationId = messageCoRelationId,
+                Status = PdfIngestionStatus.Queued,
+                TenantId = tenantId,
+                UserId = userId,
+                CreatedBy = userId,
+                DryRun = dryRun,
+                CreateDate = now,
+                LastUpdateDate = now
+            };
+
+            // The record is written before the event is published, deliberately - see
+            // DocumentConversionService.RequestOneConversion for why.
+            if (!await _repository.SaveJobAsync(job))
+            {
+                return new PdfIngestionAcceptance
+                {
+                    FileId = fileId,
+                    Accepted = false,
+                    ErrorCode = "ingestion_not_recorded",
+                    ErrorMessage = "The ingestion could not be recorded and was not started."
+                };
+            }
+
+            try
+            {
+                await _messageClient.SendToConsumerAsync(
+                    new ConsumerMessage<IngestPdfEvent>
+                    {
+                        ConsumerName = PdfIngestionConstants.IngestPdfQueue,
+                        Payload = new IngestPdfEvent
+                        {
+                            FileId = fileId,
+                            MessageCoRelationId = messageCoRelationId,
+                            ProjectKey = tenantId,
+                            UserId = userId,
+                            DryRun = dryRun
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                // The record exists but nothing will ever pick it up, so it is failed here rather
+                // than left Queued forever - a poller deserves an answer, not a permanent maybe.
+                _logger.LogError(
+                    ex,
+                    "RequestIngestionsAsync: Failed to queue ingestion of file {FileId}",
+                    LogSanitizer.Scrub(fileId));
+
+                job.Status = PdfIngestionStatus.Failed;
+                job.ErrorCode = "ingestion_not_queued";
+                job.ErrorMessage = "The ingestion could not be queued.";
+                job.CompletedDate = DateTime.UtcNow;
+                await _repository.UpdateJobAsync(job);
+
+                return new PdfIngestionAcceptance
+                {
+                    FileId = fileId,
+                    Accepted = false,
+                    ErrorCode = "ingestion_not_queued",
+                    ErrorMessage = "The ingestion could not be queued."
+                };
+            }
+
+            _logger.LogInformation(
+                "RequestIngestionsAsync: Queued ingestion of file {FileId}",
+                LogSanitizer.Scrub(fileId));
+
+            return new PdfIngestionAcceptance
+            {
+                FileId = fileId,
+                Accepted = true,
+                Status = job.Status
+            };
+        }
+
+        /// <inheritdoc />
+        public async Task<PdfIngestionResult<PdfIngestionStatusBatchResponse>> GetStatusAsync(
+            GetPdfIngestionStatusRequest request,
+            string correlationId,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            var fileIds = (request.FileIds ?? [])
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            if (fileIds.Count == 0)
+            {
+                return PdfIngestionResult<PdfIngestionStatusBatchResponse>.Failure(
+                    PdfIngestionFailureKind.Validation,
+                    "file_ids_required",
+                    "fileIds must contain at least one file ID.",
+                    correlationId,
+                    new Dictionary<string, string[]>(StringComparer.Ordinal)
+                    {
+                        ["fileIds"] = ["fileIds must contain at least one file ID."]
+                    });
+            }
+
+            if (fileIds.Count > MaxBatchSize)
+            {
+                return PdfIngestionResult<PdfIngestionStatusBatchResponse>.Failure(
+                    PdfIngestionFailureKind.Validation,
+                    "too_many_files",
+                    $"A single request can query at most {MaxBatchSize} files; {fileIds.Count} were sent.",
+                    correlationId,
+                    new Dictionary<string, string[]>(StringComparer.Ordinal)
+                    {
+                        ["fileIds"] = [$"A single request can query at most {MaxBatchSize} files."]
+                    });
+            }
+
+            var jobs = await _repository.GetJobsAsync(fileIds);
+            var jobsById = jobs.ToDictionary(j => j.Id, StringComparer.Ordinal);
+
+            // Storage is consulted once per completed file, and those lookups are independent of
+            // one another, so they run concurrently rather than serially the way the write side does.
+            var resolutions = await Task.WhenAll(fileIds.Select(fileId => BuildStatus(fileId, jobsById)));
+
+            return PdfIngestionResult<PdfIngestionStatusBatchResponse>.Success(
+                new PdfIngestionStatusBatchResponse { Results = [.. resolutions] },
+                correlationId);
+        }
+
+        private async Task<PdfIngestionStatusResult> BuildStatus(
+            string fileId,
+            IReadOnlyDictionary<string, PdfIngestionJob> jobsById)
+        {
+            if (!jobsById.TryGetValue(fileId, out var job))
+            {
+                return new PdfIngestionStatusResult
+                {
+                    FileId = fileId,
+                    Found = false,
+                    ErrorCode = "ingestion_not_found",
+                    ErrorMessage = "That file has not been submitted for ingestion."
+                };
+            }
+
+            var isComplete = job.Status is PdfIngestionStatus.Completed or PdfIngestionStatus.Failed;
+
+            var result = new PdfIngestionStatusResult
+            {
+                FileId = job.Id,
+                Found = true,
+                FileName = job.FileName,
+                MessageCoRelationId = job.MessageCoRelationId,
+                Status = job.Status,
+                IsComplete = isComplete,
+                ErrorCode = job.ErrorCode,
+                ErrorMessage = job.ErrorMessage,
+                RequestedAtUtc = job.CreateDate,
+                CompletedAtUtc = job.CompletedDate
+            };
+
+            var verdict = job.Verdict;
+            if (verdict != null)
+            {
+                result.PageCount = verdict.PageCount;
+                result.WasReadable = verdict.WasReadable;
+                result.IsReadable = verdict.IsReadable;
+                result.RepairedWithQpdf = verdict.RepairedWithQpdf;
+                result.GeometryWasReadable = verdict.GeometryWasReadable;
+                result.GeometryIsReadable = verdict.GeometryIsReadable;
+                result.GeometryNormalized = verdict.GeometryNormalized;
+                result.PageGeometry = verdict.PageGeometry;
+                result.GeometrySkippedReason = verdict.GeometrySkippedReason;
+                result.HasSignature = verdict.HasSignature;
+                result.SignatureCount = verdict.SignatureCount;
+                result.MetadataClaim = verdict.MetadataClaim;
+                result.ClaimedProfile = verdict.ClaimedProfile;
+                result.ValidatedProfile = verdict.ValidatedProfile;
+                result.IsPdfA = verdict.IsPdfA;
+                result.IsCompliant = verdict.IsCompliant;
+                result.PdfAFailedChecks = verdict.PdfAFailedChecks;
+                result.PdfARepairAttempted = verdict.PdfARepairAttempted;
+                result.PdfARepairSucceeded = verdict.PdfARepairSucceeded;
+                result.FinalProfile = verdict.FinalProfile;
+                result.ContentChanged = verdict.ContentChanged;
+                result.Stages = verdict.Stages;
+            }
+
+            if (job.Status == PdfIngestionStatus.Completed)
+            {
+                // Resolved per request rather than stored: a storage URL is time-limited, so one
+                // written at completion time would be expired by the time a poller asked for it.
+                var record = await _storageHelper.GetFileRecord(job.Id);
+
+                if (record == null)
+                {
+                    _logger.LogWarning(
+                        "GetStatusAsync: Ingestion of file {FileId} completed but the file could not be resolved",
+                        LogSanitizer.Scrub(job.Id));
+                }
+                else
+                {
+                    result.DownloadUrl = record.Url;
+                    result.FileName ??= record.Name;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/server/Utility.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Utility.DomainService/Shared/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Utility.DomainService.Geolocation.service;
 using Utility.DomainService.TemplateEngine.service;
 using Utility.DomainService.Shared.Services;
 using Utility.DomainService.PdfGenerator.service;
+using Utility.DomainService.PdfIngestion.service;
 using Utility.DomainService.MagicLink.Service;
 using Utility.DomainService.MagicLink;
 using DomainService.Storage;
@@ -72,6 +73,15 @@ namespace DomainService.Utilities
             // Word formats, so there is nothing to select between.
             services.TryAddSingleton<IDocumentToPdfConverter, AsposeDocumentToPdfConverter>();
             services.TryAddSingleton<IDocumentConversionService, DocumentConversionService>();
+
+            // PDF Ingestion request/status surface. Registered here, for both hosts, because both
+            // the Api (accepting requests, serving polls) and the Worker (the consumer that resolves
+            // IPdfIngestionRepository too) need it. The tool-execution graph these depend on
+            // downstream (qpdf, veraPDF, PDFBox, Ghostscript) is registered separately by
+            // RegisterPdfIngestionToolchain, called only from the Worker - the Api must never need
+            // those binaries on PATH.
+            services.TryAddSingleton<IPdfIngestionRepository, PdfIngestionRepository>();
+            services.TryAddSingleton<IPdfIngestionService, PdfIngestionService>();
 
             // Magic Link Services
             services.AddSingleton<IMagicLinkService, MagicLinkService>();

--- a/server/Worker/Consumers/PdfIngestion/IngestPdfConsumer.cs
+++ b/server/Worker/Consumers/PdfIngestion/IngestPdfConsumer.cs
@@ -1,0 +1,198 @@
+using Blocks.Genesis;
+using System.Diagnostics.CodeAnalysis;
+using Utility.DomainService.PdfGenerator.service;
+using Utility.DomainService.PdfGenerator.Tooling;
+using Utility.DomainService.PdfIngestion;
+using Utility.DomainService.PdfIngestion.Entities;
+using Utility.DomainService.PdfIngestion.Events;
+using Utility.DomainService.PdfIngestion.service;
+using Utility.DomainService.Shared.Utilities;
+
+namespace Worker.Consumers.PdfIngestion
+{
+    /// <summary>
+    /// Inspects one PDF held in storage and remediates whatever the inspection calls for, replacing
+    /// the file in place when a stage actually changed its bytes.
+    /// </summary>
+    /// <remarks>
+    /// Every exit path writes the ingestion record, the same discipline
+    /// <c>ConvertDocumentToPdfConsumer</c> follows: the completion notification can be missed, and
+    /// the record is the only thing the status endpoint can answer from.
+    /// <para>
+    /// A file the pipeline could not make sense of at all is still a <c>Completed</c> job with a
+    /// verdict attached (<c>IsReadable: false</c>) - the pipeline ran and answered the question it
+    /// exists to answer. <c>Failed</c> is reserved for this consumer itself never reaching a verdict:
+    /// storage unreachable, an unhandled exception, or a repaired file that could not be saved back.
+    /// </para>
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    public class IngestPdfConsumer : IConsumer<IngestPdfEvent>
+    {
+        private readonly ILogger<IngestPdfConsumer> _logger;
+        private readonly PdfStorageHelper _storageHelper;
+        private readonly IPdfIngestionPipeline _pipeline;
+        private readonly IPdfIngestionRepository _repository;
+        private readonly IPdfGeneratorNotificationService _notificationService;
+
+        public IngestPdfConsumer(
+            ILogger<IngestPdfConsumer> logger,
+            PdfStorageHelper storageHelper,
+            IPdfIngestionPipeline pipeline,
+            IPdfIngestionRepository repository,
+            IPdfGeneratorNotificationService notificationService)
+        {
+            _logger = logger;
+            _storageHelper = storageHelper;
+            _pipeline = pipeline;
+            _repository = repository;
+            _notificationService = notificationService;
+        }
+
+        public async Task Consume(IngestPdfEvent @event)
+        {
+            var tenantId = @event.ProjectKey ?? BlocksContext.GetContext()?.TenantId ?? string.Empty;
+
+            _logger.LogInformation(
+                "IngestPdfConsumer: Processing ingestion of file {FileId}, TenantId={TenantId}",
+                LogSanitizer.Scrub(@event.FileId),
+                LogSanitizer.Scrub(tenantId));
+
+            var job = await _repository.GetJobAsync(@event.FileId, @event.ProjectKey);
+
+            if (job == null)
+            {
+                // Nothing to report progress against, and no caller can be polling for it. Running
+                // the pipeline anyway would produce a verdict with nowhere to record it.
+                _logger.LogError(
+                    "IngestPdfConsumer: No ingestion record for file {FileId}; skipping",
+                    LogSanitizer.Scrub(@event.FileId));
+
+                return;
+            }
+
+            try
+            {
+                job.Status = PdfIngestionStatus.Processing;
+                await _repository.UpdateJobAsync(job, @event.ProjectKey);
+
+                await IngestAsync(job, @event);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "IngestPdfConsumer: Ingestion of file {FileId} threw",
+                    LogSanitizer.Scrub(@event.FileId));
+
+                await Fail(job, @event, "ingestion_error", "The ingestion failed unexpectedly.");
+            }
+        }
+
+        private async Task IngestAsync(PdfIngestionJob job, IngestPdfEvent @event)
+        {
+            var record = await _storageHelper.GetFileRecord(job.Id, @event.ProjectKey);
+
+            if (record == null)
+            {
+                await Fail(job, @event, "input_file_not_found", "The file could not be found in storage.");
+                return;
+            }
+
+            job.FileName = record.Name;
+
+            using var fileStream = await _storageHelper.GetStreamForRecord(record);
+
+            if (fileStream == null)
+            {
+                await Fail(job, @event, "input_file_unreadable", "The file could not be downloaded.");
+                return;
+            }
+
+            using var buffer = new MemoryStream();
+            await fileStream.CopyToAsync(buffer);
+            var inputBytes = buffer.ToArray();
+
+            var outcome = await _pipeline.ProcessAsync(inputBytes, CancellationToken.None);
+
+            if (outcome.ContentChanged && !@event.DryRun)
+            {
+                var metadata = new Dictionary<string, string>
+                {
+                    { "IngestedFileId", job.Id },
+                    { "IngestedDate", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ") },
+                    { "FileType", "IngestedPDF" }
+                };
+
+                var saved = await _storageHelper.SavePdfToStorage(
+                    new MemoryStream(outcome.FinalBytes),
+                    job.Id,
+                    job.FileName ?? $"{job.Id}.pdf",
+                    metadata,
+                    record.ParentDirectoryID ?? string.Empty,
+                    @event.ProjectKey);
+
+                if (!saved)
+                {
+                    // The verdict describes bytes that were never actually written back, so the
+                    // stored record would disagree with the file a caller downloads next - a real
+                    // job failure, not merely a note on an otherwise-completed verdict.
+                    await Fail(job, @event, "output_not_saved", "The remediated PDF could not be written back to storage.");
+                    return;
+                }
+            }
+
+            job.Status = PdfIngestionStatus.Completed;
+            job.Verdict = PdfIngestionVerdict.FromOutcome(outcome);
+            job.CompletedDate = DateTime.UtcNow;
+            await _repository.UpdateJobAsync(job, @event.ProjectKey);
+
+            _logger.LogInformation(
+                "IngestPdfConsumer: Completed ingestion of file {FileId}, contentChanged={ContentChanged}",
+                LogSanitizer.Scrub(job.Id),
+                outcome.ContentChanged);
+
+            await Notify(job, @event, success: outcome.IsReadable);
+        }
+
+        private async Task Fail(PdfIngestionJob job, IngestPdfEvent @event, string errorCode, string errorMessage)
+        {
+            _logger.LogError(
+                "IngestPdfConsumer: Ingestion of file {FileId} failed: {ErrorCode}",
+                LogSanitizer.Scrub(job.Id),
+                errorCode);
+
+            job.Status = PdfIngestionStatus.Failed;
+            job.ErrorCode = errorCode;
+            job.ErrorMessage = errorMessage;
+            job.CompletedDate = DateTime.UtcNow;
+
+            await _repository.UpdateJobAsync(job, @event.ProjectKey);
+            await Notify(job, @event, success: false);
+        }
+
+        /// <summary>
+        /// Sends the completion notification. Never lets a notification failure change the recorded
+        /// outcome - the record is already written, and the status endpoint exists precisely because
+        /// this call cannot be relied on.
+        /// </summary>
+        private async Task Notify(PdfIngestionJob job, IngestPdfEvent @event, bool success)
+        {
+            try
+            {
+                await _notificationService.NotifyIngestPdfEvent(
+                    success,
+                    job.Id,
+                    job.MessageCoRelationId ?? string.Empty,
+                    job.UserId,
+                    @event.ProjectKey);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "IngestPdfConsumer: Could not notify for file {FileId}; status endpoint still has the outcome",
+                    LogSanitizer.Scrub(job.Id));
+            }
+        }
+    }
+}

--- a/server/Worker/Consumers/PdfIngestion/PdfIngestionConsumerRegistration.cs
+++ b/server/Worker/Consumers/PdfIngestion/PdfIngestionConsumerRegistration.cs
@@ -1,0 +1,28 @@
+using Blocks.Genesis;
+using System.Diagnostics.CodeAnalysis;
+using Utility.DomainService.PdfIngestion.Events;
+
+namespace Worker.Consumers.PdfIngestion
+{
+    /// <summary>
+    /// Registers the PDF ingestion message consumer with the worker's container.
+    /// </summary>
+    /// <remarks>
+    /// The worker subscribes to the ingestion queue through
+    /// <c>PdfIngestionConstants.GetMessageConfiguration</c>, but subscribing only creates the
+    /// listener - the dispatcher still has to resolve an <c>IConsumer&lt;TEvent&gt;</c> to hand the
+    /// message to. Omitting this registration means every ingestion message is accepted onto the
+    /// queue and then silently dropped, exactly the failure
+    /// <c>PdfGeneratorConsumerRegistration</c> exists to prevent for its own events.
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    public static class PdfIngestionConsumerRegistration
+    {
+        public static IServiceCollection RegisterPdfIngestionConsumers(this IServiceCollection services)
+        {
+            services.AddSingleton<IConsumer<IngestPdfEvent>, IngestPdfConsumer>();
+
+            return services;
+        }
+    }
+}

--- a/server/Worker/Program.cs
+++ b/server/Worker/Program.cs
@@ -5,7 +5,9 @@ using Payment.DomainService.Services;
 using Payment.DomainService.Utilities;
 using Utility.DomainService.MagicLink.Utilities;
 using Utility.DomainService.Messaging;
+using Utility.DomainService.PdfGenerator.Tooling;
 using Utility.DomainService.PdfGenerator.Utilities;
+using Utility.DomainService.PdfIngestion.Utilities;
 using Utility.DomainService.TemplateEngine.Utilities;
 using SeliseBlocks.ConfigurationDriver;
 using Subscription.DomainService.Services;
@@ -13,6 +15,7 @@ using Subscription.DomainService.Utilities;
 using Worker;
 using Worker.Configuration;
 using Worker.Consumers.PdfGenerator;
+using Worker.Consumers.PdfIngestion;
 using Worker.Consumers.Payment;
 using Worker.Consumers.Subscription;
 using Subscription.DomainService.Entities;
@@ -77,6 +80,10 @@ IHostBuilder CreateHostBuilder(string[] args) =>
             // Register the test consumer
             services.RegisterUtilityServices();
             services.RegisterPdfGeneratorConsumers();
+            services.RegisterPdfIngestionConsumers();
+            // Worker-only: the Api answers requests and serves polling, and must never resolve a
+            // graph that expects qpdf, Java or Ghostscript on PATH.
+            services.RegisterPdfIngestionToolchain(context.Configuration);
             services.AddSingleton<IVault>(_ => paymentVault);
             services.RegisterPaymentDomainServices(context.Configuration);
             services.RegisterSubscriptionDomainServices(
@@ -131,6 +138,7 @@ static MessageConfiguration GetCombinedMessageConfiguration(string connectionStr
     var magicLink = MagicLinkConstants.GetMessageConfiguration(connectionString);
     var helper = MessageConfigurationHelper.GetMessageConfiguration(connectionString);
     var pdfGenerator = PdfGeneratorConstants.GetMessageConfiguration(connectionString);
+    var pdfIngestion = PdfIngestionConstants.GetMessageConfiguration(connectionString);
     var templateEngine = TemplateEngineConstants.GetMessageConfiguration(connectionString);
 
     if (MagicLinkConstants.GetProvider(connectionString) == MagicLinkConstants.RabbitMqProvider)
@@ -145,6 +153,7 @@ static MessageConfiguration GetCombinedMessageConfiguration(string connectionStr
                     ..magicLink.RabbitMqConfiguration?.ConsumerSubscriptions ?? [],
                     ..helper.RabbitMqConfiguration?.ConsumerSubscriptions ?? [],
                     ..pdfGenerator.RabbitMqConfiguration?.ConsumerSubscriptions ?? [],
+                    ..pdfIngestion.RabbitMqConfiguration?.ConsumerSubscriptions ?? [],
                     ..templateEngine.RabbitMqConfiguration?.ConsumerSubscriptions ?? [],
                     ConsumerSubscription.BindToQueue(
                         PaymentConstants.PaymentWorkQueue),
@@ -165,6 +174,7 @@ static MessageConfiguration GetCombinedMessageConfiguration(string connectionStr
                 ..magicLink.AzureServiceBusConfiguration?.Queues ?? [],
                 ..helper.AzureServiceBusConfiguration?.Queues ?? [],
                 ..pdfGenerator.AzureServiceBusConfiguration?.Queues ?? [],
+                ..pdfIngestion.AzureServiceBusConfiguration?.Queues ?? [],
                 ..templateEngine.AzureServiceBusConfiguration?.Queues ?? [],
                 PaymentConstants.PaymentWorkQueue
             ],
@@ -173,6 +183,7 @@ static MessageConfiguration GetCombinedMessageConfiguration(string connectionStr
                 ..magicLink.AzureServiceBusConfiguration?.Topics ?? [],
                 ..helper.AzureServiceBusConfiguration?.Topics ?? [],
                 ..pdfGenerator.AzureServiceBusConfiguration?.Topics ?? [],
+                ..pdfIngestion.AzureServiceBusConfiguration?.Topics ?? [],
                 ..templateEngine.AzureServiceBusConfiguration?.Topics ?? [],
                 PaymentConstants.LifecycleTopic,
                 SubscriptionConstants.LifecycleTopic

--- a/server/XUnitTest/PdfGenerator/PdfGeneratorNotificationServiceTests.cs
+++ b/server/XUnitTest/PdfGenerator/PdfGeneratorNotificationServiceTests.cs
@@ -336,6 +336,38 @@ namespace XUnitTest.PdfGenerator
                 DateTime.UtcNow.AddHours(1), null, null, null, null, null, null, null));
 
         [Fact]
+        public async Task NotifyIngestPdfEvent_Sends_ToTheUserSuppliedExplicitly_EvenWithNoAmbientContext()
+        {
+            // The whole point of the explicit-userId overload: it must not depend on BlocksContext
+            // being populated correctly by the time a queued message is consumed.
+            BlocksContext.ClearContext();
+
+            await _service.NotifyIngestPdfEvent(true, "file-1", "corr-1", "user-99", "p1");
+
+            _httpHelper.Verify(h => h.MakeHttpPostRequest<NotificationResponse>(
+                It.Is<object>(payload => JsonSerializer.Serialize(payload).Contains("user-99")),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task NotifyIngestPdfEvent_Skips_WhenTheSuppliedUserIdIsNull()
+        {
+            BlocksContext.ClearContext();
+
+            await _service.NotifyIngestPdfEvent(true, "file-1", "corr-1", null, "p1");
+
+            _httpHelper.Verify(h => h.MakeHttpPostRequest<NotificationResponse>(
+                It.IsAny<object>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
         public async Task SendNotification_ShouldHandleExceptions_WithoutThrowing()
         {
             _httpHelper.Setup(h => h.MakeHttpPostRequest<NotificationResponse>(

--- a/server/XUnitTest/PdfIngestion/GhostscriptCommandFactoryTests.cs
+++ b/server/XUnitTest/PdfIngestion/GhostscriptCommandFactoryTests.cs
@@ -1,0 +1,60 @@
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.Ghostscript;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Pins the fix this port made over the source it was ported from: the ICC profile path must come
+/// from <see cref="PdfToolingOptions.GhostscriptIccProfilePath"/>, not a hardcoded Debian literal -
+/// the source's own hardcoded path does not exist on the Alpine image this runs in and would
+/// silently produce broken PDF/A output.
+/// </remarks>
+public sealed class GhostscriptCommandFactoryTests
+{
+    private readonly GhostscriptCommandFactory _factory = new();
+
+    [Fact]
+    public void The_permit_file_read_argument_follows_the_configured_icc_path()
+    {
+        var options = new PdfToolingOptions
+        {
+            GhostscriptIccProfilePath = "/usr/share/color/icc/ghostscript/srgb.icc"
+        };
+
+        var command = _factory.CreatePdfA2BCommand("/work/input.pdf", "/work/output.pdf", 60, options);
+
+        command.Arguments.Should().Contain("--permit-file-read=/usr/share/color/icc/ghostscript/srgb.icc");
+    }
+
+    [Fact]
+    public void A_different_configured_icc_path_changes_the_argument_rather_than_being_ignored()
+    {
+        var options = new PdfToolingOptions
+        {
+            GhostscriptIccProfilePath = "/some/other/profile.icc"
+        };
+
+        var command = _factory.CreatePdfA2BCommand("/work/input.pdf", "/work/output.pdf", 60, options);
+
+        command.Arguments.Should().Contain("--permit-file-read=/some/other/profile.icc");
+        command.Arguments.Should().NotContain(a => a.Contains("/usr/share/color/icc/ghostscript/srgb.icc"));
+    }
+
+    [Fact]
+    public void The_command_targets_pdfa2_and_the_configured_definition_file()
+    {
+        var options = new PdfToolingOptions
+        {
+            GhostscriptPath = "/usr/bin/gs",
+            GhostscriptPdfADefinitionPath = "/opt/pdfingestion/PDFA_def.ps"
+        };
+
+        var command = _factory.CreatePdfA2BCommand("/work/input.pdf", "/work/output.pdf", 60, options);
+
+        command.FileName.Should().Be("/usr/bin/gs");
+        command.Arguments.Should().Contain("-dPDFA=2");
+        command.Arguments.Should().Contain("-sOutputFile=/work/output.pdf");
+        command.Arguments.Should().ContainInOrder("/opt/pdfingestion/PDFA_def.ps", "/work/input.pdf");
+    }
+}

--- a/server/XUnitTest/PdfIngestion/IngestPdfConsumerTests.cs
+++ b/server/XUnitTest/PdfIngestion/IngestPdfConsumerTests.cs
@@ -1,0 +1,218 @@
+using System.Net;
+using DomainService.Storage;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StorageDriver;
+using Utility.DomainService.PdfGenerator.service;
+using Utility.DomainService.PdfGenerator.Tooling;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfIngestion;
+using Utility.DomainService.PdfIngestion.Entities;
+using Utility.DomainService.PdfIngestion.Events;
+using Utility.DomainService.PdfIngestion.service;
+using Worker.Consumers.PdfIngestion;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Closes the same test gap as <see cref="PdfIngestionServiceTests"/>, on the consume side: every
+/// exit path must leave the job record in a state the status endpoint can answer truthfully from,
+/// and a repaired file that fails to save back must be reported as failed rather than as a
+/// completed verdict describing bytes nobody actually wrote.
+/// </remarks>
+public sealed class IngestPdfConsumerTests
+{
+    private sealed class RoutingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public RoutingHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) => _handler = handler;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(_handler(request));
+    }
+
+    private readonly Mock<IPdfIngestionPipeline> _pipeline = new();
+    private readonly Mock<IPdfIngestionRepository> _repository = new();
+    private readonly Mock<IPdfGeneratorNotificationService> _notificationService = new();
+    private readonly Mock<IStorageDriverService> _storageDriver = new();
+
+    private IngestPdfConsumer CreateConsumer(HttpMessageHandler? handler = null)
+    {
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler ?? new RoutingHttpMessageHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)), disposeHandler: false));
+
+        var storageHelper = new PdfStorageHelper(
+            new Mock<ILogger<PdfStorageHelper>>().Object,
+            _storageDriver.Object,
+            factory.Object);
+
+        return new IngestPdfConsumer(
+            new Mock<ILogger<IngestPdfConsumer>>().Object,
+            storageHelper,
+            _pipeline.Object,
+            _repository.Object,
+            _notificationService.Object);
+    }
+
+    private static PdfIngestionJob QueuedJob(bool dryRun = false) => new()
+    {
+        Id = "file-1",
+        Status = PdfIngestionStatus.Queued,
+        UserId = "user-1"
+    };
+
+    private void SetUpDownload(byte[] content)
+    {
+        _storageDriver
+            .Setup(x => x.GetUrlForDownloadFileAsync(It.IsAny<GetFileRequest>()))
+            .ReturnsAsync(new FileResponse { Url = "https://storage.example/file-1", Name = "file-1.pdf", ParentDirectoryID = "dir-1" });
+    }
+
+    private static PdfIngestionOutcome Outcome(bool contentChanged, bool isReadable = true) => new()
+    {
+        PageCount = 1,
+        WasReadable = true,
+        IsReadable = isReadable,
+        ContentChanged = contentChanged,
+        FinalBytes = contentChanged ? [9, 9, 9] : [1, 2, 3]
+    };
+
+    [Fact]
+    public async Task No_job_record_means_the_pipeline_never_runs()
+    {
+        _repository.Setup(x => x.GetJobAsync("file-1", null)).ReturnsAsync((PdfIngestionJob?)null);
+        var consumer = CreateConsumer();
+
+        await consumer.Consume(new IngestPdfEvent { FileId = "file-1" });
+
+        _pipeline.Verify(x => x.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A_missing_storage_record_fails_the_job_without_running_the_pipeline()
+    {
+        _repository.Setup(x => x.GetJobAsync("file-1", null)).ReturnsAsync(QueuedJob());
+        _repository.Setup(x => x.UpdateJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        _storageDriver.Setup(x => x.GetUrlForDownloadFileAsync(It.IsAny<GetFileRequest>())).ReturnsAsync((FileResponse?)null);
+        var consumer = CreateConsumer();
+
+        await consumer.Consume(new IngestPdfEvent { FileId = "file-1" });
+
+        _pipeline.Verify(x => x.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repository.Verify(x => x.UpdateJobAsync(
+            It.Is<PdfIngestionJob>(j => j.Status == PdfIngestionStatus.Failed && j.ErrorCode == "input_file_not_found"),
+            null), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task An_unchanged_file_completes_without_ever_uploading()
+    {
+        SetUpDownload([1, 2, 3]);
+        _repository.Setup(x => x.GetJobAsync("file-1", null)).ReturnsAsync(QueuedJob());
+        _repository.Setup(x => x.UpdateJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        _pipeline.Setup(x => x.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>())).ReturnsAsync(Outcome(contentChanged: false));
+
+        var uploadAttempted = false;
+        var handler = new RoutingHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Put)
+            {
+                uploadAttempted = true;
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3])
+            };
+        });
+
+        await CreateConsumer(handler).Consume(new IngestPdfEvent { FileId = "file-1" });
+
+        uploadAttempted.Should().BeFalse();
+        _repository.Verify(x => x.UpdateJobAsync(
+            It.Is<PdfIngestionJob>(j => j.Status == PdfIngestionStatus.Completed && j.Verdict != null),
+            null), Times.AtLeastOnce);
+        _notificationService.Verify(x => x.NotifyIngestPdfEvent(true, "file-1", It.IsAny<string>(), "user-1", null), Times.Once);
+    }
+
+    [Fact]
+    public async Task A_changed_file_is_uploaded_back_and_the_job_completes()
+    {
+        SetUpDownload([1, 2, 3]);
+        _repository.Setup(x => x.GetJobAsync("file-1", null)).ReturnsAsync(QueuedJob());
+        _repository.Setup(x => x.UpdateJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        _storageDriver
+            .Setup(x => x.GetPerSignedUrlForUploadAsync(It.IsAny<GetPreSignedUrlForUploadRequest>()))
+            .ReturnsAsync(new GetPreSignedUrlForUploadResponse { UploadUrl = "https://storage.example/upload" });
+        _pipeline.Setup(x => x.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>())).ReturnsAsync(Outcome(contentChanged: true));
+
+        var uploadAttempted = false;
+        var handler = new RoutingHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Put)
+            {
+                uploadAttempted = true;
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3])
+            };
+        });
+
+        await CreateConsumer(handler).Consume(new IngestPdfEvent { FileId = "file-1" });
+
+        uploadAttempted.Should().BeTrue();
+        _repository.Verify(x => x.UpdateJobAsync(
+            It.Is<PdfIngestionJob>(j => j.Status == PdfIngestionStatus.Completed),
+            null), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task A_dry_run_never_uploads_even_when_content_changed()
+    {
+        SetUpDownload([1, 2, 3]);
+        _repository.Setup(x => x.GetJobAsync("file-1", null)).ReturnsAsync(QueuedJob());
+        _repository.Setup(x => x.UpdateJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        _pipeline.Setup(x => x.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>())).ReturnsAsync(Outcome(contentChanged: true));
+
+        var uploadAttempted = false;
+        var handler = new RoutingHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Put)
+            {
+                uploadAttempted = true;
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3])
+            };
+        });
+
+        await CreateConsumer(handler).Consume(new IngestPdfEvent { FileId = "file-1", DryRun = true });
+
+        uploadAttempted.Should().BeFalse();
+        _repository.Verify(x => x.UpdateJobAsync(
+            It.Is<PdfIngestionJob>(j => j.Status == PdfIngestionStatus.Completed),
+            null), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task A_failed_upload_of_changed_bytes_fails_the_job_rather_than_reporting_a_verdict_for_bytes_nobody_wrote()
+    {
+        SetUpDownload([1, 2, 3]);
+        _repository.Setup(x => x.GetJobAsync("file-1", null)).ReturnsAsync(QueuedJob());
+        _repository.Setup(x => x.UpdateJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        _storageDriver
+            .Setup(x => x.GetPerSignedUrlForUploadAsync(It.IsAny<GetPreSignedUrlForUploadRequest>()))
+            .ReturnsAsync((GetPreSignedUrlForUploadResponse?)null);
+        _pipeline.Setup(x => x.ProcessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>())).ReturnsAsync(Outcome(contentChanged: true));
+
+        await CreateConsumer().Consume(new IngestPdfEvent { FileId = "file-1" });
+
+        _repository.Verify(x => x.UpdateJobAsync(
+            It.Is<PdfIngestionJob>(j => j.Status == PdfIngestionStatus.Failed && j.ErrorCode == "output_not_saved"),
+            null), Times.AtLeastOnce);
+    }
+}

--- a/server/XUnitTest/PdfIngestion/PdfBoxCommandFactoryTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfBoxCommandFactoryTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+using Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+namespace XUnitTest.PdfIngestion;
+
+public sealed class PdfBoxCommandFactoryTests
+{
+    private readonly PdfBoxCommandFactory _factory = new();
+
+    [Fact]
+    public void Direct_flatten_runs_the_flatten_main_class_with_the_configured_classpath()
+    {
+        var options = new PdfToolingOptions
+        {
+            JavaPath = "/usr/bin/java",
+            PdfBoxJarPath = "/opt/pdfbox/pdfbox-app.jar",
+            PdfBoxClassPath = "/opt/pdfbox"
+        };
+
+        var command = _factory.CreateFlattenCommand("/work/input.pdf", "/work/output.pdf", 60, options);
+
+        command.FileName.Should().Be("/usr/bin/java");
+        command.Arguments.Should().ContainInOrder(
+            "-cp", $"/opt/pdfbox/pdfbox-app.jar{Path.PathSeparator}/opt/pdfbox",
+            PdfBoxCommandFactory.FlattenMainClass,
+            "/work/input.pdf", "/work/output.pdf");
+    }
+
+    [Fact]
+    public void Direct_normalize_geometry_runs_the_geometry_main_class()
+    {
+        var command = _factory.CreateNormalizeGeometryCommand("/work/input.pdf", "/work/output.pdf", 60, new PdfToolingOptions());
+
+        command.Arguments.Should().Contain(PdfBoxCommandFactory.NormalizeGeometryMainClass);
+    }
+
+    [Fact]
+    public void Direct_standardize_passes_the_standardize_flag_to_the_flatten_class()
+    {
+        // There is no separate "standardize" main class - PdfBoxFlatten itself handles
+        // --standardize, per tools/pdfbox/PdfBoxFlatten.java.
+        var command = _factory.CreateStandardizeCommand("/work/input.pdf", "/work/output.pdf", 60, new PdfToolingOptions());
+
+        command.Arguments.Should().ContainInOrder(PdfBoxCommandFactory.FlattenMainClass, "--standardize", "/work/input.pdf", "/work/output.pdf");
+    }
+
+    [Fact]
+    public void Docker_flatten_mounts_the_workspace_and_uses_container_paths()
+    {
+        var options = new PdfToolingOptions
+        {
+            PdfBoxExecutionMode = PdfBoxExecutionMode.Docker,
+            PdfBoxDockerImage = "blocks-pdfbox:dev"
+        };
+
+        var workspaceDir = Path.Combine(Path.GetTempPath(), "op-1");
+        var inputPath = Path.Combine(workspaceDir, "input.pdf");
+        var outputPath = Path.Combine(workspaceDir, "output.pdf");
+
+        var command = _factory.CreateFlattenCommand(inputPath, outputPath, 60, options);
+
+        command.FileName.Should().Be("docker");
+        command.Arguments.Should().ContainInOrder(
+            "-v", $"{workspaceDir}:/work", "blocks-pdfbox:dev",
+            PdfBoxCommandFactory.FlattenMainClass, "/work/input.pdf", "/work/output.pdf");
+    }
+
+    [Fact]
+    public void Docker_flatten_refuses_input_and_output_in_different_workspaces()
+    {
+        var options = new PdfToolingOptions { PdfBoxExecutionMode = PdfBoxExecutionMode.Docker };
+
+        var act = () => _factory.CreateFlattenCommand("/host/op-1/input.pdf", "/host/op-2/output.pdf", 60, options);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Docker_standardize_refuses_input_and_output_in_different_workspaces()
+    {
+        var options = new PdfToolingOptions { PdfBoxExecutionMode = PdfBoxExecutionMode.Docker };
+
+        var act = () => _factory.CreateStandardizeCommand("/host/op-1/input.pdf", "/host/op-2/output.pdf", 60, options);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Direct_version_command_asks_the_flatten_class_for_its_own_version()
+    {
+        var command = _factory.CreateVersionCommand(new PdfToolingOptions());
+
+        command.Arguments.Should().Contain(PdfBoxCommandFactory.FlattenMainClass);
+        command.Arguments.Should().Contain("--version");
+    }
+}

--- a/server/XUnitTest/PdfIngestion/PdfBoxGeometryReportParserTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfBoxGeometryReportParserTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.PdfBox;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Parses reports genuinely produced by running the actual tools/pdfbox/PdfBoxNormalizeGeometry.java
+/// tool (compiled for real, via the docker/pdfbox dev image) against real PDFs - not a hand-written
+/// guess at the report shape.
+/// </remarks>
+public sealed class PdfBoxGeometryReportParserTests
+{
+    private readonly PdfBoxGeometryReportParser _parser = new();
+
+    // Captured verbatim from:
+    //   docker run --rm --network none -v <dir>:/work blocks-pdfbox:dev PdfBoxNormalizeGeometry /work/plain.pdf /work/out.pdf
+    // against a one-page PDF written by PdfSharp with a direct (not indirect) /MediaBox.
+    private const string RealReportOnADirectMediaBox =
+        """##PDFBOX_GEOMETRY##{"engine":"pdfbox","version":"3.0.8","pageCount":1,"signed":false,"changed":true,"pages":[{"index":0,"rotate":0,"mediaBox":[0.0000,0.0000,595.0000,842.0000],"cropBox":[0.0000,0.0000,595.0000,842.0000],"width":595.0000,"height":842.0000,"rewrittenBoxes":["MediaBox"],"indirectBoxes":[]}],"warnings":[]}""";
+
+    // Same tool, same run shape, against a hand-built raw PDF whose /MediaBox is a genuine indirect
+    // reference (/MediaBox 4 0 R, with object 4 the array [0 0 595 842]) - the exact pattern the
+    // e-signature reference's PdfSharpCore throws on.
+    private const string RealReportOnAnIndirectMediaBox =
+        """##PDFBOX_GEOMETRY##{"engine":"pdfbox","version":"3.0.8","pageCount":1,"signed":false,"changed":true,"pages":[{"index":0,"rotate":0,"mediaBox":[0.0000,0.0000,595.0000,842.0000],"cropBox":[0.0000,0.0000,595.0000,842.0000],"width":595.0000,"height":842.0000,"rewrittenBoxes":["MediaBox"],"indirectBoxes":["MediaBox"]}],"warnings":[]}""";
+
+    [Fact]
+    public void ExtractPayload_finds_the_marker_line_and_strips_the_marker_itself()
+    {
+        var output = "some noise\n" + RealReportOnADirectMediaBox + "\ntrailing noise";
+
+        var payload = PdfBoxGeometryReportParser.ExtractPayload(output);
+
+        payload.Should().NotBeNull();
+        payload.Should().NotContain("##PDFBOX_GEOMETRY##");
+        payload.Should().StartWith("{\"engine\"");
+    }
+
+    [Fact]
+    public void ExtractPayload_returns_null_when_the_tool_emitted_no_report()
+    {
+        PdfBoxGeometryReportParser.ExtractPayload("just some log noise, no marker anywhere").Should().BeNull();
+    }
+
+    [Fact]
+    public void A_direct_mediabox_reports_no_indirect_boxes_even_though_it_was_still_rewritten()
+    {
+        var payload = PdfBoxGeometryReportParser.ExtractPayload(RealReportOnADirectMediaBox)!;
+
+        var result = _parser.Parse(payload, processWarnings: []);
+
+        result.Success.Should().BeTrue();
+        result.PageCount.Should().Be(1);
+        result.Signed.Should().BeFalse();
+        result.GeometryChanged.Should().BeTrue(because: "MediaBox is always materialised at page level regardless of whether it needed it");
+        result.Pages.Should().ContainSingle();
+        result.Pages[0].IndirectBoxes.Should().BeEmpty();
+        result.Pages[0].RewrittenBoxes.Should().Contain("MediaBox");
+    }
+
+    [Fact]
+    public void A_genuinely_indirect_mediabox_is_reported_as_such()
+    {
+        var payload = PdfBoxGeometryReportParser.ExtractPayload(RealReportOnAnIndirectMediaBox)!;
+
+        var result = _parser.Parse(payload, processWarnings: []);
+
+        result.Pages[0].IndirectBoxes.Should().Contain("MediaBox");
+        result.Pages[0].Width.Should().Be(595.0);
+        result.Pages[0].Height.Should().Be(842.0);
+    }
+
+    [Fact]
+    public void Process_warnings_are_merged_in_and_deduplicated_against_the_reports_own_warnings()
+    {
+        var payload = PdfBoxGeometryReportParser.ExtractPayload(RealReportOnADirectMediaBox)!;
+
+        var result = _parser.Parse(payload, processWarnings: ["a stray stderr warning"]);
+
+        result.Warnings.Should().Contain("a stray stderr warning");
+    }
+}

--- a/server/XUnitTest/PdfIngestion/PdfIngestionApiResultsTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfIngestionApiResultsTests.cs
@@ -1,0 +1,140 @@
+using Api.Utilities;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Payment.DomainService.Responses;
+using Utility.DomainService.PdfIngestion;
+
+namespace XUnitTest.PdfIngestion
+{
+    public class PdfIngestionApiResultsTests
+    {
+        [Fact]
+        public void AcceptedBatch_Is202NotOk()
+        {
+            // The files are queued, not inspected yet. A 200 would tell a client the verdict is in.
+            var result = PdfIngestionResult<IngestPdfsBatchResponse>.Success(
+                new IngestPdfsBatchResponse
+                {
+                    Results =
+                    [
+                        new() { FileId = "file-1", Accepted = true, Status = PdfIngestionStatus.Queued }
+                    ],
+                    AcceptedCount = 1,
+                    RejectedCount = 0
+                },
+                "trace-1");
+
+            var action = result.ToActionResult("trace-1", StatusCodes.Status202Accepted) as ObjectResult;
+
+            action.Should().NotBeNull();
+            action!.StatusCode.Should().Be(StatusCodes.Status202Accepted);
+
+            var body = action.Value.Should().BeOfType<ApiResponse<IngestPdfsBatchResponse>>().Subject;
+            body.Success.Should().BeTrue();
+            body.Data!.Results.Should().ContainSingle().Which.FileId.Should().Be("file-1");
+            body.Data.AcceptedCount.Should().Be(1);
+            body.Error.Should().BeNull();
+            body.Meta.CorrelationId.Should().Be("trace-1");
+        }
+
+        [Fact]
+        public void StatusBatchRead_Is200()
+        {
+            var result = PdfIngestionResult<PdfIngestionStatusBatchResponse>.Success(
+                new PdfIngestionStatusBatchResponse
+                {
+                    Results =
+                    [
+                        new() { FileId = "file-1", Found = true, Status = PdfIngestionStatus.Completed }
+                    ]
+                },
+                "trace-1");
+
+            var action = result.ToActionResult("trace-1") as ObjectResult;
+
+            action!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Fact]
+        public void StatusBatch_PerFileOutcomesDoNotChangeTheOverallStatusCode()
+        {
+            // A file that was never submitted, or whose ingestion failed outright, is still a
+            // successful read of the batch as a whole. Only a structurally invalid request (an
+            // empty fileIds list) is a 4xx.
+            var result = PdfIngestionResult<PdfIngestionStatusBatchResponse>.Success(
+                new PdfIngestionStatusBatchResponse
+                {
+                    Results =
+                    [
+                        new() { FileId = "file-1", Found = true, Status = PdfIngestionStatus.Failed, ErrorCode = "ingestion_error" },
+                        new() { FileId = "file-2", Found = false, ErrorCode = "ingestion_not_found" }
+                    ]
+                },
+                "trace-1");
+
+            var action = result.ToActionResult("trace-1") as ObjectResult;
+
+            action!.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Theory]
+        [InlineData(PdfIngestionFailureKind.Validation, StatusCodes.Status400BadRequest)]
+        [InlineData(PdfIngestionFailureKind.NotFound, StatusCodes.Status404NotFound)]
+        [InlineData(PdfIngestionFailureKind.Unavailable, StatusCodes.Status503ServiceUnavailable)]
+        [InlineData(PdfIngestionFailureKind.Internal, StatusCodes.Status500InternalServerError)]
+        public void FailureKind_MapsToTheSameCodesTheRestOfTheApiUses(
+            PdfIngestionFailureKind kind,
+            int expectedStatusCode)
+        {
+            var result = PdfIngestionResult<PdfIngestionStatusBatchResponse>.Failure(
+                kind,
+                "some_code",
+                "Something went wrong.",
+                "trace-1");
+
+            var action = result.ToActionResult("trace-1") as ObjectResult;
+
+            action!.StatusCode.Should().Be(expectedStatusCode);
+        }
+
+        [Fact]
+        public void Failure_CarriesCodeMessageAndTraceInTheStandardEnvelope()
+        {
+            var result = PdfIngestionResult<IngestPdfsBatchResponse>.Failure(
+                PdfIngestionFailureKind.Validation,
+                "file_ids_required",
+                "fileIds must contain at least one file ID.",
+                "trace-9",
+                new Dictionary<string, string[]>(StringComparer.Ordinal)
+                {
+                    ["fileIds"] = ["fileIds must contain at least one file ID."]
+                });
+
+            var action = result.ToActionResult("trace-9") as ObjectResult;
+            var body = action!.Value.Should().BeOfType<ApiResponse<IngestPdfsBatchResponse>>().Subject;
+
+            body.Success.Should().BeFalse();
+            body.Data.Should().BeNull();
+            body.Error!.Code.Should().Be("file_ids_required");
+            body.Error.Message.Should().Be("fileIds must contain at least one file ID.");
+            body.Error.TraceId.Should().Be("trace-9");
+            body.Error.Fields.Should().ContainKey("fileIds");
+        }
+
+        [Fact]
+        public void SuccessStatusCodeOverride_DoesNotLeakIntoFailures()
+        {
+            // Asking for 202 on success must not turn a validation failure into a 202.
+            var result = PdfIngestionResult<IngestPdfsBatchResponse>.Failure(
+                PdfIngestionFailureKind.Validation,
+                "file_ids_required",
+                "fileIds must contain at least one file ID.",
+                "trace-1");
+
+            var action = result.ToActionResult("trace-1", StatusCodes.Status202Accepted) as ObjectResult;
+
+            action!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        }
+    }
+}

--- a/server/XUnitTest/PdfIngestion/PdfIngestionContractsTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfIngestionContractsTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+using Utility.DomainService.PdfIngestion;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Guards the "not found" shape callers actually depend on: a caller checks Found before reading
+/// any verdict field, and every one of those fields must default to null so a poller cannot
+/// mistake an empty status for a real (if falsy) verdict.
+/// </remarks>
+public sealed class PdfIngestionContractsTests
+{
+    [Fact]
+    public void A_not_found_result_leaves_every_verdict_field_null()
+    {
+        var result = new PdfIngestionStatusResult { FileId = "f1", Found = false };
+
+        result.Status.Should().BeNull();
+        result.DownloadUrl.Should().BeNull();
+        result.WasReadable.Should().BeNull();
+        result.IsReadable.Should().BeNull();
+        result.GeometryWasReadable.Should().BeNull();
+        result.MetadataClaim.Should().BeNull();
+        result.PdfAFailedChecks.Should().BeNull();
+        result.Stages.Should().BeNull();
+        result.ContentChanged.Should().BeNull();
+    }
+
+    [Fact]
+    public void A_completed_result_carries_the_full_verdict()
+    {
+        var result = new PdfIngestionStatusResult
+        {
+            FileId = "f1",
+            Found = true,
+            Status = PdfIngestionStatus.Completed,
+            IsComplete = true,
+            DownloadUrl = "https://example/download",
+            WasReadable = false,
+            IsReadable = true,
+            RepairedWithQpdf = true,
+            GeometryWasReadable = true,
+            GeometryIsReadable = true,
+            HasSignature = true,
+            SignatureCount = 1,
+            MetadataClaim = PdfAMetadataClaim.Claimed,
+            ClaimedProfile = "PDF/A-2B",
+            IsPdfA = true,
+            IsCompliant = true,
+            ContentChanged = true
+        };
+
+        result.Status.Should().Be(PdfIngestionStatus.Completed);
+        result.IsComplete.Should().BeTrue();
+        result.RepairedWithQpdf.Should().BeTrue();
+        result.ClaimedProfile.Should().Be("PDF/A-2B");
+        result.ContentChanged.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_batch_response_defaults_to_an_empty_result_list()
+    {
+        var response = new PdfIngestionStatusBatchResponse();
+
+        response.Results.Should().BeEmpty();
+    }
+}

--- a/server/XUnitTest/PdfIngestion/PdfIngestionPipelineTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfIngestionPipelineTests.cs
@@ -1,0 +1,279 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Utility.DomainService.PdfGenerator.Tooling;
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Workspace;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Guards two things a customer would actually notice: that the pipeline runs only the remediation
+/// stages a file's own inspection calls for (an unnecessary Ghostscript pass on a healthy file is a
+/// silent cost regression), and that one file's failure - however it fails - never throws out of
+/// ProcessAsync, since a caller processing a batch depends on that to keep every other file's
+/// result.
+/// </remarks>
+public sealed class PdfIngestionPipelineTests : IDisposable
+{
+    private readonly string _tempDirectory;
+    private readonly Mock<IPdfInspector> _inspector = new();
+    private readonly Mock<IPdfNormalizer> _qpdfNormalizer = new();
+    private readonly Mock<IPdfGeometryNormalizer> _geometryNormalizer = new();
+    private readonly Mock<IPdfAValidator> _pdfAValidator = new();
+    private readonly Mock<IPdfFlattener> _flattener = new();
+    private readonly Mock<IPdfAConverter> _pdfAConverter = new();
+    private readonly Mock<IStandardPdfConverter> _standardConverter = new();
+    private readonly IPdfWorkspaceService _workspaceService;
+
+    public PdfIngestionPipelineTests()
+    {
+        _tempDirectory = Directory.CreateTempSubdirectory("pdf-ingestion-tests-").FullName;
+        _workspaceService = new PdfWorkspaceService(
+            Options.Create(new PdfToolingOptions { TempDirectory = _tempDirectory }));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private PdfIngestionPipeline CreatePipeline()
+    {
+        return new PdfIngestionPipeline(
+            _inspector.Object,
+            _workspaceService,
+            _qpdfNormalizer.Object,
+            _geometryNormalizer.Object,
+            _pdfAValidator.Object,
+            _flattener.Object,
+            _pdfAConverter.Object,
+            _standardConverter.Object,
+            Options.Create(new PdfToolingOptions()),
+            new Mock<ILogger<PdfIngestionPipeline>>().Object);
+    }
+
+    private static PdfInspectionResult HealthyInspection(PdfAMetadataClaim claim = PdfAMetadataClaim.Missing, string? claimedProfile = null)
+    {
+        return new PdfInspectionResult
+        {
+            Readable = true,
+            GeometryReadable = true,
+            PageCount = 1,
+            MetadataClaim = claim,
+            ClaimedProfile = claimedProfile
+        };
+    }
+
+    private static Task<PdfNormalizeResult> WriteFileAndSucceed(string outputPath, byte[] content)
+    {
+        File.WriteAllBytes(outputPath, content);
+        return Task.FromResult(new PdfNormalizeResult { Success = true });
+    }
+
+    [Fact]
+    public async Task A_healthy_file_runs_no_remediation_stage_at_all()
+    {
+        _inspector.Setup(x => x.Inspect(It.IsAny<byte[]>())).Returns(HealthyInspection());
+
+        var outcome = await CreatePipeline().ProcessAsync([1, 2, 3], CancellationToken.None);
+
+        outcome.IsReadable.Should().BeTrue();
+        outcome.ContentChanged.Should().BeFalse();
+        outcome.Stages.Should().BeEmpty(because: "nothing about this file called for a remediation stage");
+        _qpdfNormalizer.Verify(x => x.NormalizeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PdfNormalizeOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+        _geometryNormalizer.Verify(x => x.NormalizeGeometryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+        _pdfAValidator.Verify(x => x.ValidateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task An_unreadable_file_that_qpdf_repairs_becomes_readable()
+    {
+        var repairedBytes = new byte[] { 9, 9, 9 };
+        _inspector.SetupSequence(x => x.Inspect(It.IsAny<byte[]>()))
+            .Returns(new PdfInspectionResult { Readable = false, GeometryReadable = false, FailureReason = "broken" })
+            .Returns(HealthyInspection());
+
+        _qpdfNormalizer
+            .Setup(x => x.NormalizeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PdfNormalizeOptions>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, string output, PdfNormalizeOptions _, CancellationToken _) => WriteFileAndSucceed(output, repairedBytes));
+
+        var outcome = await CreatePipeline().ProcessAsync([0xDE, 0xAD], CancellationToken.None);
+
+        outcome.WasReadable.Should().BeFalse();
+        outcome.IsReadable.Should().BeTrue();
+        outcome.RepairedWithQpdf.Should().BeTrue();
+        outcome.ContentChanged.Should().BeTrue();
+        outcome.FinalBytes.Should().Equal(repairedBytes);
+    }
+
+    [Fact]
+    public async Task A_file_qpdf_cannot_repair_is_reported_not_thrown()
+    {
+        _inspector.Setup(x => x.Inspect(It.IsAny<byte[]>()))
+            .Returns(new PdfInspectionResult { Readable = false, GeometryReadable = false, FailureReason = "beyond repair" });
+
+        _qpdfNormalizer
+            .Setup(x => x.NormalizeAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PdfNormalizeOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfNormalizeResult { Success = false, Errors = ["QPDF_FAILED"] });
+
+        var outcome = await CreatePipeline().ProcessAsync([0xDE, 0xAD], CancellationToken.None);
+
+        outcome.IsReadable.Should().BeFalse();
+        outcome.ErrorCode.Should().NotBeNullOrEmpty();
+        outcome.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Geometry_normalization_runs_only_when_the_inspector_reports_it_unreadable()
+    {
+        var normalizedBytes = new byte[] { 5, 5, 5 };
+        _inspector.SetupSequence(x => x.Inspect(It.IsAny<byte[]>()))
+            .Returns(new PdfInspectionResult { Readable = true, GeometryReadable = false, PageCount = 1 })
+            .Returns(HealthyInspection());
+
+        _geometryNormalizer
+            .Setup(x => x.NormalizeGeometryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, string output, int _, CancellationToken _) =>
+            {
+                File.WriteAllBytes(output, normalizedBytes);
+                return Task.FromResult(new PdfGeometryNormalizeResult { Success = true, GeometryChanged = true });
+            });
+
+        var outcome = await CreatePipeline().ProcessAsync([1], CancellationToken.None);
+
+        outcome.GeometryWasReadable.Should().BeFalse();
+        outcome.GeometryIsReadable.Should().BeTrue();
+        outcome.GeometryNormalized.Should().BeTrue();
+        outcome.FinalBytes.Should().Equal(normalizedBytes);
+    }
+
+    [Fact]
+    public async Task A_signed_document_that_pdfbox_refuses_to_touch_is_recorded_as_skipped_not_failed()
+    {
+        _inspector.Setup(x => x.Inspect(It.IsAny<byte[]>()))
+            .Returns(new PdfInspectionResult { Readable = true, GeometryReadable = false, PageCount = 1, HasSignature = true, SignatureCount = 1 });
+
+        _geometryNormalizer
+            .Setup(x => x.NormalizeGeometryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfGeometryNormalizeResult { Success = false, Errors = [PdfToolErrorCodes.SignedDocument] });
+
+        var outcome = await CreatePipeline().ProcessAsync([1], CancellationToken.None);
+
+        outcome.GeometryNormalized.Should().BeFalse();
+        outcome.GeometrySkippedReason.Should().Be(PdfToolErrorCodes.SignedDocument);
+        outcome.ContentChanged.Should().BeFalse(because: "a skip must not be treated as a byte-changing repair");
+    }
+
+    [Fact]
+    public async Task A_pdfa_claim_that_verapdf_confirms_compliant_needs_no_repair()
+    {
+        _inspector.Setup(x => x.Inspect(It.IsAny<byte[]>()))
+            .Returns(HealthyInspection(PdfAMetadataClaim.Claimed, "PDF/A-2B"));
+
+        _pdfAValidator
+            .Setup(x => x.ValidateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfAValidationResult { Success = true, IsPdfA = true, IsCompliant = true, ProfileName = "2B" });
+
+        var outcome = await CreatePipeline().ProcessAsync([1], CancellationToken.None);
+
+        outcome.IsCompliant.Should().BeTrue();
+        outcome.PdfARepairAttempted.Should().BeFalse();
+        _flattener.Verify(x => x.FlattenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A_noncompliant_pdfa_claim_is_repaired_via_flatten_then_ghostscript_then_revalidated()
+    {
+        _inspector.Setup(x => x.Inspect(It.IsAny<byte[]>()))
+            .Returns(HealthyInspection(PdfAMetadataClaim.Claimed, "PDF/A-2B"));
+
+        _pdfAValidator
+            .SetupSequence(x => x.ValidateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfAValidationResult { Success = true, IsPdfA = true, IsCompliant = false, ProfileName = "2B", Errors = ["some check failed"] })
+            .ReturnsAsync(new PdfAValidationResult { Success = true, IsPdfA = true, IsCompliant = true, ProfileName = "2B" });
+
+        _flattener
+            .Setup(x => x.FlattenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, string output, int _, CancellationToken _) =>
+            {
+                File.WriteAllBytes(output, [1]);
+                return Task.FromResult(new PdfFlattenResult { Success = true });
+            });
+
+        _pdfAConverter
+            .Setup(x => x.ConvertToPdfA2BAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, string output, int _, CancellationToken _) =>
+            {
+                File.WriteAllBytes(output, [2]);
+                return Task.FromResult(new PdfTransformationResult { Success = true });
+            });
+
+        var outcome = await CreatePipeline().ProcessAsync([1], CancellationToken.None);
+
+        outcome.PdfARepairAttempted.Should().BeTrue();
+        outcome.PdfARepairSucceeded.Should().BeTrue();
+        outcome.IsCompliant.Should().BeTrue();
+        outcome.FinalProfile.Should().Be("2B");
+        outcome.ContentChanged.Should().BeTrue();
+        _standardConverter.Verify(x => x.ConvertAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A_pdfa_repair_ghostscript_cannot_fix_falls_back_to_a_standard_pdf()
+    {
+        _inspector.Setup(x => x.Inspect(It.IsAny<byte[]>()))
+            .Returns(HealthyInspection(PdfAMetadataClaim.Claimed, "PDF/A-1B"));
+
+        _pdfAValidator
+            .Setup(x => x.ValidateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfAValidationResult { Success = true, IsPdfA = true, IsCompliant = true, ProfileName = "1B" });
+
+        _flattener
+            .Setup(x => x.FlattenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, string output, int _, CancellationToken _) =>
+            {
+                File.WriteAllBytes(output, [1]);
+                return Task.FromResult(new PdfFlattenResult { Success = true });
+            });
+
+        _pdfAConverter
+            .Setup(x => x.ConvertToPdfA2BAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfTransformationResult { Success = false, Errors = ["GHOSTSCRIPT_FAILED"] });
+
+        _standardConverter
+            .Setup(x => x.ConvertAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns((string _, string output, int _, CancellationToken _) =>
+            {
+                File.WriteAllBytes(output, [3]);
+                return Task.FromResult(new PdfTransformationResult { Success = true });
+            });
+
+        var outcome = await CreatePipeline().ProcessAsync([1], CancellationToken.None);
+
+        outcome.PdfARepairAttempted.Should().BeTrue();
+        outcome.PdfARepairSucceeded.Should().BeFalse();
+        outcome.IsPdfA.Should().BeFalse(because: "a document that could not be made compliant must not still claim PDF/A");
+        outcome.IsCompliant.Should().BeFalse();
+        outcome.FinalBytes.Should().Equal(new byte[] { 3 });
+    }
+
+    [Fact]
+    public async Task An_unexpected_exception_is_reported_on_the_outcome_never_thrown()
+    {
+        _inspector.Setup(x => x.Inspect(It.IsAny<byte[]>())).Throws(new InvalidOperationException("boom"));
+
+        var act = async () => await CreatePipeline().ProcessAsync([1], CancellationToken.None);
+
+        var outcome = await act.Should().NotThrowAsync(because: "one file's failure must never abort a batch");
+        outcome.Subject.IsReadable.Should().BeFalse();
+        outcome.Subject.ErrorCode.Should().NotBeNullOrEmpty();
+    }
+}

--- a/server/XUnitTest/PdfIngestion/PdfIngestionPipelineTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfIngestionPipelineTests.cs
@@ -234,7 +234,9 @@ public sealed class PdfIngestionPipelineTests : IDisposable
 
         _pdfAValidator
             .Setup(x => x.ValidateAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new PdfAValidationResult { Success = true, IsPdfA = true, IsCompliant = true, ProfileName = "1B" });
+            // The real veraPDF shape, captured against an actual PDF via its Docker CLI: a full
+            // descriptive string, not a short code - profileName="PDF/A-1b validation profile".
+            .ReturnsAsync(new PdfAValidationResult { Success = true, IsPdfA = true, IsCompliant = true, ProfileName = "PDF/A-1b validation profile" });
 
         _flattener
             .Setup(x => x.FlattenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))

--- a/server/XUnitTest/PdfIngestion/PdfIngestionServiceTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfIngestionServiceTests.cs
@@ -1,0 +1,196 @@
+using Blocks.Genesis;
+using DomainService.Storage;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StorageDriver;
+using Utility.DomainService.PdfGenerator.service;
+using Utility.DomainService.PdfIngestion;
+using Utility.DomainService.PdfIngestion.Entities;
+using Utility.DomainService.PdfIngestion.Events;
+using Utility.DomainService.PdfIngestion.service;
+using Utility.DomainService.PdfIngestion.Utilities;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Closes a gap the document-conversion feature this was modelled on left open: neither its
+/// service nor its consumer had tests. Covers the batch validation rules, that one bad file id
+/// does not stop the rest of a batch from being accepted, that a queue-publish failure marks the
+/// job Failed rather than leaving it stuck Queued forever, and that a completed job's stored
+/// verdict is the one the status endpoint actually reports back.
+/// </remarks>
+public sealed class PdfIngestionServiceTests
+{
+    private readonly Mock<ILogger<PdfIngestionService>> _logger = new();
+    private readonly Mock<IMessageClient> _messageClient = new();
+    private readonly Mock<IPdfIngestionRepository> _repository = new();
+    private readonly Mock<IStorageDriverService> _storageDriver = new();
+
+    private PdfIngestionService CreateService()
+    {
+        var storageHelper = new PdfStorageHelper(
+            new Mock<ILogger<PdfStorageHelper>>().Object,
+            _storageDriver.Object,
+            new Mock<IHttpClientFactory>(MockBehavior.Strict).Object);
+
+        return new PdfIngestionService(_logger.Object, _messageClient.Object, _repository.Object, storageHelper);
+    }
+
+    [Fact]
+    public async Task An_empty_file_list_is_a_validation_failure()
+    {
+        var service = CreateService();
+
+        var result = await service.RequestIngestionsAsync(new IngestPdfsRequest(), "corr-1");
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PdfIngestionFailureKind.Validation);
+    }
+
+    [Fact]
+    public async Task More_files_than_the_batch_limit_is_a_validation_failure()
+    {
+        var request = new IngestPdfsRequest
+        {
+            FileIds = [.. Enumerable.Range(0, 51).Select(i => $"file-{i}")]
+        };
+        var service = CreateService();
+
+        var result = await service.RequestIngestionsAsync(request, "corr-1");
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PdfIngestionFailureKind.Validation);
+    }
+
+    [Fact]
+    public async Task A_blank_id_is_rejected_without_stopping_the_rest_of_the_batch()
+    {
+        _repository.Setup(x => x.SaveJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        var request = new IngestPdfsRequest { FileIds = ["", "file-1"] };
+        var service = CreateService();
+
+        var result = await service.RequestIngestionsAsync(request, "corr-1");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Results.Should().HaveCount(2);
+        result.Value.Results[0].Accepted.Should().BeFalse();
+        result.Value.Results[1].Accepted.Should().BeTrue();
+        result.Value.AcceptedCount.Should().Be(1);
+        result.Value.RejectedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task A_duplicate_id_is_queued_only_once()
+    {
+        _repository.Setup(x => x.SaveJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        var request = new IngestPdfsRequest { FileIds = ["file-1", "file-1"] };
+        var service = CreateService();
+
+        var result = await service.RequestIngestionsAsync(request, "corr-1");
+
+        result.Value!.Results.Should().ContainSingle();
+        _messageClient.Verify(
+            x => x.SendToConsumerAsync(It.IsAny<ConsumerMessage<IngestPdfEvent>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task A_file_the_repository_cannot_record_is_never_queued()
+    {
+        _repository.Setup(x => x.SaveJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(false);
+        var request = new IngestPdfsRequest { FileIds = ["file-1"] };
+        var service = CreateService();
+
+        var result = await service.RequestIngestionsAsync(request, "corr-1");
+
+        result.Value!.Results[0].Accepted.Should().BeFalse();
+        _messageClient.Verify(x => x.SendToConsumerAsync(It.IsAny<ConsumerMessage<IngestPdfEvent>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task A_publish_failure_marks_the_already_recorded_job_failed_rather_than_leaving_it_queued_forever()
+    {
+        _repository.Setup(x => x.SaveJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        _messageClient
+            .Setup(x => x.SendToConsumerAsync(It.IsAny<ConsumerMessage<IngestPdfEvent>>()))
+            .ThrowsAsync(new InvalidOperationException("broker unreachable"));
+        var request = new IngestPdfsRequest { FileIds = ["file-1"] };
+        var service = CreateService();
+
+        var result = await service.RequestIngestionsAsync(request, "corr-1");
+
+        result.Value!.Results[0].Accepted.Should().BeFalse();
+        _repository.Verify(
+            x => x.UpdateJobAsync(
+                It.Is<PdfIngestionJob>(j => j.Status == PdfIngestionStatus.Failed),
+                null),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task The_published_event_carries_the_dry_run_flag_and_project_key()
+    {
+        _repository.Setup(x => x.SaveJobAsync(It.IsAny<PdfIngestionJob>(), null)).ReturnsAsync(true);
+        ConsumerMessage<IngestPdfEvent>? captured = null;
+        _messageClient
+            .Setup(x => x.SendToConsumerAsync(It.IsAny<ConsumerMessage<IngestPdfEvent>>()))
+            .Callback<ConsumerMessage<IngestPdfEvent>>(m => captured = m)
+            .Returns(Task.CompletedTask);
+
+        var request = new IngestPdfsRequest { FileIds = ["file-1"], DryRun = true };
+        var service = CreateService();
+
+        await service.RequestIngestionsAsync(request, "corr-1");
+
+        captured.Should().NotBeNull();
+        captured!.Payload.FileId.Should().Be("file-1");
+        captured.Payload.DryRun.Should().BeTrue();
+        captured.ConsumerName.Should().Be(PdfIngestionConstants.IngestPdfQueue);
+    }
+
+    [Fact]
+    public async Task GetStatus_reports_not_found_for_a_file_never_submitted()
+    {
+        _repository.Setup(x => x.GetJobsAsync(It.IsAny<IEnumerable<string>>(), null)).ReturnsAsync([]);
+        var service = CreateService();
+
+        var result = await service.GetStatusAsync(new GetPdfIngestionStatusRequest { FileIds = ["missing"] }, "corr-1");
+
+        result.Value!.Results.Should().ContainSingle();
+        result.Value.Results[0].Found.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetStatus_reports_the_stored_verdict_and_resolves_a_fresh_download_url()
+    {
+        var job = new PdfIngestionJob
+        {
+            Id = "file-1",
+            Status = PdfIngestionStatus.Completed,
+            CompletedDate = DateTime.UtcNow,
+            Verdict = new PdfIngestionVerdict
+            {
+                IsReadable = true,
+                IsPdfA = true,
+                IsCompliant = true,
+                ContentChanged = true
+            }
+        };
+        _repository.Setup(x => x.GetJobsAsync(It.IsAny<IEnumerable<string>>(), null)).ReturnsAsync([job]);
+        _storageDriver
+            .Setup(x => x.GetUrlForDownloadFileAsync(It.IsAny<GetFileRequest>()))
+            .ReturnsAsync(new FileResponse { Url = "https://storage.example/file-1", Name = "file-1.pdf" });
+
+        var service = CreateService();
+
+        var result = await service.GetStatusAsync(new GetPdfIngestionStatusRequest { FileIds = ["file-1"] }, "corr-1");
+
+        var status = result.Value!.Results[0];
+        status.Found.Should().BeTrue();
+        status.IsComplete.Should().BeTrue();
+        status.DownloadUrl.Should().Be("https://storage.example/file-1");
+        status.IsPdfA.Should().BeTrue();
+        status.ContentChanged.Should().BeTrue();
+    }
+}

--- a/server/XUnitTest/PdfIngestion/PdfInspectorTests.cs
+++ b/server/XUnitTest/PdfIngestion/PdfInspectorTests.cs
@@ -1,0 +1,133 @@
+using System.Text;
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.Inspection;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Guards the per-file verdict a caller polls for: a wrong readable/geometry/signature/PDF-A
+/// classification here means blocks-utilities either skips remediation a file actually needed, or
+/// runs a remediation stage (qpdf/PDFBox/Ghostscript) against a file that never needed one.
+/// </remarks>
+public sealed class PdfInspectorTests
+{
+    private readonly PdfInspector _inspector = new();
+
+    [Fact]
+    public void A_pdf_produced_by_pdfsharp_reads_as_fully_healthy()
+    {
+        using var document = new PdfSharp.Pdf.PdfDocument();
+        document.AddPage();
+        using var stream = new MemoryStream();
+        document.Save(stream, closeStream: false);
+
+        var result = _inspector.Inspect(stream.ToArray());
+
+        result.Readable.Should().BeTrue(because: "PdfSharp writes documents PdfPig and PdfSharp can both re-open");
+        result.GeometryReadable.Should().BeTrue();
+        result.PageCount.Should().Be(1);
+        result.HasSignature.Should().BeFalse();
+        result.MetadataClaim.Should().Be(PdfAMetadataClaim.Missing);
+    }
+
+    [Fact]
+    public void Garbage_bytes_are_reported_as_unreadable_with_a_reason()
+    {
+        var bytes = Encoding.ASCII.GetBytes("this is not a pdf at all, just garbage bytes");
+
+        var result = _inspector.Inspect(bytes);
+
+        result.Readable.Should().BeFalse();
+        result.GeometryReadable.Should().BeFalse();
+        result.FailureReason.Should().NotBeNullOrWhiteSpace(because: "a caller needs to know why, not just that it failed");
+    }
+
+    [Fact]
+    public void An_indirect_mediabox_reference_still_reads_fine_under_pdfsharp()
+    {
+        // This is the exact failure mode the PDFBox geometry-normalize tool exists to fix on
+        // PdfSharpCore (the e-signature reference this pipeline was ported from): a producer may
+        // legally emit /MediaBox as an indirect reference, and PdfSharpCore throws
+        // InvalidCastException reading it. The PdfSharp (not Core) package this repo actually
+        // carries already resolves indirect page-box references - and inheritance from an
+        // ancestor /Pages node - transparently. This test pins that behavior down: if a future
+        // PdfSharp upgrade or downgrade regresses it, GeometryReadable flipping to false here is
+        // the signal, not a customer-reported broken stamp placement.
+        var pdf = RawPdfFixtures.BuildPdf(
+            rootObjectNumber: 1,
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox 4 0 R /Resources << >> >>",
+            "[0 0 200 300]");
+
+        var result = _inspector.Inspect(pdf);
+
+        result.Readable.Should().BeTrue();
+        result.GeometryReadable.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_signature_field_with_a_value_is_detected()
+    {
+        var pdf = RawPdfFixtures.BuildPdf(
+            rootObjectNumber: 1,
+            "<< /Type /Catalog /Pages 2 0 R /AcroForm 4 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 300] /Annots [5 0 R] /Resources << >> >>",
+            "<< /Fields [5 0 R] /SigFlags 3 >>",
+            "<< /FT /Sig /Type /Annot /Subtype /Widget /Rect [0 0 0 0] /T (Signature1) /V 6 0 R /P 3 0 R >>",
+            "<< /Type /Sig /Filter /Adobe.PPKLite /SubFilter /adbe.pkcs7.detached /ByteRange [0 1 2 3] /Contents <00> >>");
+
+        var result = _inspector.Inspect(pdf);
+
+        result.HasSignature.Should().BeTrue();
+        result.SignatureCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Xmp_metadata_with_a_parseable_pdfaid_part_and_conformance_is_claimed()
+    {
+        var pdf = RawPdfFixtures.BuildPdf(
+            rootObjectNumber: 1,
+            "<< /Type /Catalog /Pages 2 0 R /Metadata 4 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 300] /Resources << >> >>",
+            RawPdfFixtures.MetadataStream(RawPdfFixtures.PdfAXmpPacket(part: "2", conformance: "B")));
+
+        var result = _inspector.Inspect(pdf);
+
+        result.MetadataClaim.Should().Be(PdfAMetadataClaim.Claimed);
+        result.ClaimedProfile.Should().Be("PDF/A-2B");
+    }
+
+    [Fact]
+    public void Xmp_metadata_with_an_unparseable_pdfaid_part_is_malformed_not_missing()
+    {
+        var pdf = RawPdfFixtures.BuildPdf(
+            rootObjectNumber: 1,
+            "<< /Type /Catalog /Pages 2 0 R /Metadata 4 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 300] /Resources << >> >>",
+            RawPdfFixtures.MetadataStream(RawPdfFixtures.PdfAXmpPacket(part: "notanumber", conformance: null)));
+
+        var result = _inspector.Inspect(pdf);
+
+        result.MetadataClaim.Should().Be(
+            PdfAMetadataClaim.Malformed,
+            because: "a document that names a pdfaid:part it cannot parse is claiming PDF/A badly, not declining to claim it");
+    }
+
+    [Fact]
+    public void A_document_with_no_xmp_metadata_at_all_reports_missing()
+    {
+        using var document = new PdfSharp.Pdf.PdfDocument();
+        document.AddPage();
+        using var stream = new MemoryStream();
+        document.Save(stream, closeStream: false);
+
+        var result = _inspector.Inspect(stream.ToArray());
+
+        result.MetadataClaim.Should().Be(PdfAMetadataClaim.Missing);
+        result.ClaimedProfile.Should().BeNull();
+    }
+}

--- a/server/XUnitTest/PdfIngestion/ProcessRunnerTests.cs
+++ b/server/XUnitTest/PdfIngestion/ProcessRunnerTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Moq;
+using Utility.DomainService.PdfGenerator.Tooling.Interfaces;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.ProcessExecution;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Found live: with Ghostscript not installed locally, a real ingestion run against a
+/// non-compliant PDF/A file threw System.ComponentModel.Win32Exception ("cannot find the file
+/// specified") out of Process.Start(), past every tool wrapper's own graceful-failure handling,
+/// all the way to PdfIngestionPipeline's outer catch - which discards everything the pipeline had
+/// already legitimately determined (the file was perfectly readable) and reports the verdict as
+/// completely unreadable with zero pages instead. This pins the fix: a process that cannot even
+/// start must come back as an ordinary failed ProcessResult, the same as a process that starts and
+/// exits non-zero, not as an exception - the same fix a Docker daemon hiccup or a bad working
+/// directory needs, not just a missing binary.
+/// </remarks>
+public sealed class ProcessRunnerTests
+{
+    private static IExternalProcessConcurrencyLimiter UnlimitedConcurrency()
+    {
+        var limiter = new Mock<IExternalProcessConcurrencyLimiter>();
+        limiter.Setup(x => x.AcquireAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<IDisposable>());
+        return limiter.Object;
+    }
+
+    [Fact]
+    public async Task A_missing_executable_is_reported_as_a_failed_result_not_thrown()
+    {
+        var runner = new ProcessRunner(UnlimitedConcurrency());
+        var command = new ProcessCommand
+        {
+            FileName = @"C:\this\path\definitely\does\not\exist\nonexistent-tool.exe",
+            Arguments = ["--version"]
+        };
+
+        var result = await runner.RunAsync(command, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.TimedOut.Should().BeFalse(because: "this is a start failure, not a timeout");
+        result.StandardError.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task An_invalid_working_directory_is_reported_as_a_failed_result_not_thrown()
+    {
+        var runner = new ProcessRunner(UnlimitedConcurrency());
+        var command = new ProcessCommand
+        {
+            FileName = "cmd",
+            Arguments = ["/c", "echo", "hi"],
+            WorkingDirectory = @"C:\this\directory\definitely\does\not\exist\at\all"
+        };
+
+        var act = async () => await runner.RunAsync(command, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/server/XUnitTest/PdfIngestion/QpdfCommandFactoryTests.cs
+++ b/server/XUnitTest/PdfIngestion/QpdfCommandFactoryTests.cs
@@ -1,0 +1,109 @@
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.Models;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+using Utility.DomainService.PdfGenerator.Tooling.Qpdf;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Pure argument-construction logic - the highest-value tests in the toolchain, since a wrong flag
+/// here silently changes what qpdf actually does to a customer's file, with no compiler or runtime
+/// signal that anything is wrong.
+/// </remarks>
+public sealed class QpdfCommandFactoryTests
+{
+    private readonly QpdfCommandFactory _factory = new();
+
+    [Fact]
+    public void Direct_normalize_disables_object_streams_by_default()
+    {
+        var command = _factory.CreateNormalizeCommand(
+            "/work/input.pdf", "/work/output.pdf", new PdfNormalizeOptions(), new PdfToolingOptions());
+
+        command.FileName.Should().Be("/usr/bin/qpdf");
+        command.Arguments.Should().ContainInOrder("--object-streams=disable", "/work/input.pdf", "/work/output.pdf");
+    }
+
+    [Fact]
+    public void Direct_normalize_linearizes_instead_when_asked()
+    {
+        var options = new PdfNormalizeOptions { Linearize = true, DisableObjectStreams = true };
+
+        var command = _factory.CreateNormalizeCommand("/work/in.pdf", "/work/out.pdf", options, new PdfToolingOptions());
+
+        command.Arguments.Should().Contain("--linearize");
+        command.Arguments.Should().NotContain("--object-streams=disable");
+    }
+
+    [Fact]
+    public void Direct_check_command_targets_the_output_file()
+    {
+        var command = _factory.CreateCheckCommand("/work/out.pdf", new PdfToolingOptions(), timeoutSeconds: 30);
+
+        command.FileName.Should().Be("/usr/bin/qpdf");
+        command.Arguments.Should().Equal("--check", "/work/out.pdf");
+        command.TimeoutSeconds.Should().Be(30);
+    }
+
+    [Fact]
+    public void Direct_version_command_is_just_version()
+    {
+        var command = _factory.CreateVersionCommand(new PdfToolingOptions());
+
+        command.FileName.Should().Be("/usr/bin/qpdf");
+        command.Arguments.Should().Equal("--version");
+    }
+
+    [Fact]
+    public void Docker_normalize_runs_the_configured_image_with_a_mounted_workspace()
+    {
+        var options = new PdfToolingOptions
+        {
+            QpdfExecutionMode = QpdfExecutionMode.Docker,
+            DockerPath = "docker",
+            DockerContainerWorkspacePath = "/work",
+            QpdfDockerImage = "blocks-qpdf:dev"
+        };
+
+        // Built via Path.Combine, the same way PdfWorkspaceService builds real workspace paths,
+        // so the assertion below matches on every OS rather than assuming forward slashes.
+        var workspaceDir = Path.Combine(Path.GetTempPath(), "op-1");
+        var inputPath = Path.Combine(workspaceDir, "input.pdf");
+        var outputPath = Path.Combine(workspaceDir, "output.pdf");
+
+        var command = _factory.CreateNormalizeCommand(inputPath, outputPath, new PdfNormalizeOptions(), options);
+
+        command.FileName.Should().Be("docker");
+        command.Arguments.Should().ContainInOrder("run", "--rm", "--network", "none", "-v", $"{workspaceDir}:/work", "blocks-qpdf:dev", "qpdf");
+        command.Arguments.Should().Contain("/work/input.pdf");
+        command.Arguments.Should().Contain("/work/output.pdf");
+    }
+
+    [Fact]
+    public void Docker_normalize_refuses_input_and_output_in_different_workspaces()
+    {
+        var options = new PdfToolingOptions { QpdfExecutionMode = QpdfExecutionMode.Docker };
+
+        var act = () => _factory.CreateNormalizeCommand(
+            "/host/op-1/input.pdf", "/host/op-2/output.pdf", new PdfNormalizeOptions(), options);
+
+        // Docker mode volume-mounts exactly one directory; an input/output pair split across two
+        // workspaces would silently write nowhere the container can see.
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Docker_version_command_runs_qpdf_inside_the_image_rather_than_on_path()
+    {
+        var options = new PdfToolingOptions
+        {
+            QpdfExecutionMode = QpdfExecutionMode.Docker,
+            QpdfDockerImage = "blocks-qpdf:dev"
+        };
+
+        var command = _factory.CreateVersionCommand(options);
+
+        command.FileName.Should().Be("docker");
+        command.Arguments.Should().ContainInOrder("blocks-qpdf:dev", "qpdf", "--version");
+    }
+}

--- a/server/XUnitTest/PdfIngestion/RawPdfFixtures.cs
+++ b/server/XUnitTest/PdfIngestion/RawPdfFixtures.cs
@@ -1,0 +1,60 @@
+using System.Text;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <summary>
+/// Builds minimal, hand-crafted PDF byte sequences for cases a normal PDF writer will not produce
+/// on its own (an indirect /MediaBox, a bare signature dictionary) - every offset in the resulting
+/// xref table is computed from the actual bytes written, so the fixture is a real parseable PDF,
+/// not a recorded sample.
+/// </summary>
+internal static class RawPdfFixtures
+{
+    public static byte[] BuildPdf(int rootObjectNumber, params string[] objectBodies)
+    {
+        var header = "%PDF-1.7\n%âãÏÓ\n";
+        var builder = new StringBuilder(header);
+        var offsets = new List<int>();
+
+        for (var i = 0; i < objectBodies.Length; i++)
+        {
+            offsets.Add(Encoding.Latin1.GetByteCount(builder.ToString()));
+            builder.Append(i + 1).Append(" 0 obj\n").Append(objectBodies[i]).Append("\nendobj\n");
+        }
+
+        var xrefOffset = Encoding.Latin1.GetByteCount(builder.ToString());
+        builder.Append("xref\n0 ").Append(objectBodies.Length + 1).Append("\n0000000000 65535 f \n");
+        foreach (var offset in offsets)
+        {
+            builder.Append(offset.ToString("D10")).Append(" 00000 n \n");
+        }
+
+        builder.Append("trailer\n<< /Size ").Append(objectBodies.Length + 1)
+            .Append(" /Root ").Append(rootObjectNumber).Append(" 0 R >>\nstartxref\n")
+            .Append(xrefOffset).Append("\n%%EOF");
+
+        return Encoding.Latin1.GetBytes(builder.ToString());
+    }
+
+    /// <summary>Wraps XMP content as a /Metadata stream object body, with /Length computed for real.</summary>
+    public static string MetadataStream(string xmpPacket)
+    {
+        var length = Encoding.Latin1.GetByteCount(xmpPacket);
+        return $"<< /Type /Metadata /Subtype /XML /Length {length} >>\nstream\n{xmpPacket}\nendstream";
+    }
+
+    public static string PdfAXmpPacket(string part, string? conformance)
+    {
+        var conformanceElement = conformance is null ? string.Empty : $"   <pdfaid:conformance>{conformance}</pdfaid:conformance>\n";
+        return "<?xpacket begin=\"\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n" +
+               "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n" +
+               " <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +
+               "  <rdf:Description rdf:about=\"\" xmlns:pdfaid=\"http://www.aiim.org/pdfa/ns/id/\">\n" +
+               $"   <pdfaid:part>{part}</pdfaid:part>\n" +
+               conformanceElement +
+               "  </rdf:Description>\n" +
+               " </rdf:RDF>\n" +
+               "</x:xmpmeta>\n" +
+               "<?xpacket end=\"w\"?>";
+    }
+}

--- a/server/XUnitTest/PdfIngestion/VeraPdfCommandFactoryTests.cs
+++ b/server/XUnitTest/PdfIngestion/VeraPdfCommandFactoryTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.Options;
+using Utility.DomainService.PdfGenerator.Tooling.VeraPdf;
+
+namespace XUnitTest.PdfIngestion;
+
+public sealed class VeraPdfCommandFactoryTests
+{
+    private readonly VeraPdfCommandFactory _factory = new();
+
+    [Fact]
+    public void Direct_validate_requests_xml_output()
+    {
+        var command = _factory.CreateValidateCommand("/work/input.pdf", new PdfToolingOptions());
+
+        command.FileName.Should().Be("/opt/verapdf/verapdf");
+        command.Arguments.Should().Equal("--format", "xml", "/work/input.pdf");
+    }
+
+    [Fact]
+    public void Docker_validate_mounts_the_workspace_and_still_requests_xml()
+    {
+        var options = new PdfToolingOptions
+        {
+            VeraPdfExecutionMode = VeraPdfExecutionMode.Docker,
+            VeraPdfDockerImage = "ghcr.io/verapdf/cli:latest"
+        };
+
+        var workspaceDir = Path.Combine(Path.GetTempPath(), "op-1");
+        var inputPath = Path.Combine(workspaceDir, "input.pdf");
+
+        var command = _factory.CreateValidateCommand(inputPath, options);
+
+        command.FileName.Should().Be("docker");
+        command.Arguments.Should().ContainInOrder("-v", $"{workspaceDir}:/work", "ghcr.io/verapdf/cli:latest", "--format", "xml", "/work/input.pdf");
+    }
+
+    [Fact]
+    public void Direct_version_command_is_just_version()
+    {
+        var command = _factory.CreateVersionCommand(new PdfToolingOptions());
+
+        command.FileName.Should().Be("/opt/verapdf/verapdf");
+        command.Arguments.Should().Equal("--version");
+    }
+}

--- a/server/XUnitTest/PdfIngestion/VeraPdfXmlParserTests.cs
+++ b/server/XUnitTest/PdfIngestion/VeraPdfXmlParserTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Utility.DomainService.PdfGenerator.Tooling.VeraPdf;
+
+namespace XUnitTest.PdfIngestion;
+
+/// <remarks>
+/// Parses a real report captured by actually running veraPDF's own CLI Docker image
+/// (ghcr.io/verapdf/cli:latest) against a genuine PdfSharp-produced PDF - not a hand-written sample
+/// guessing at the schema. That real report is what first showed <c>&lt;check&gt;</c> nested inside
+/// <c>&lt;rule&gt;</c>, both carrying <c>status="failed"</c>, which the parser originally
+/// double-counted and then collapsed into one generic string per the earlier priority order - the
+/// exact bug these tests now guard against regressing.
+/// </remarks>
+public sealed class VeraPdfXmlParserTests
+{
+    private readonly VeraPdfXmlParser _parser = new();
+
+    // Captured verbatim (stdout only - stderr, where veraPDF's own Java logging goes, was
+    // redirected separately, matching how ProcessRunner reads them) from:
+    //   docker run --rm --network none -v <dir>:/work ghcr.io/verapdf/cli:latest --format xml /work/plain.pdf
+    // against a one-page PDF written by PdfSharp with no PDF/A metadata at all.
+    private const string RealNonCompliantReport = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <report>
+          <buildInformation>
+            <releaseDetails id="core" version="1.31.37" buildDate="2026-08-26T09:26:00Z"></releaseDetails>
+            <releaseDetails id="validation-model" version="1.31.169" buildDate="2026-08-31T10:21:00Z"></releaseDetails>
+            <releaseDetails id="apps" version="1.31.167" buildDate="2026-08-31T10:27:00Z"></releaseDetails>
+          </buildInformation>
+          <jobs>
+            <job>
+              <item size="2146">
+                <name>/work/plain.pdf</name>
+              </item>
+              <validationReport jobEndStatus="normal" profileName="PDF/A-1b validation profile" statement="PDF file is not compliant with Validation Profile requirements." isCompliant="false">
+                <details passedRules="126" failedRules="3" passedChecks="143" failedChecks="3">
+                  <rule specification="ISO 19005-1:2005" clause="6.2.3.3" testNumber="1" status="failed" failedChecks="1">
+                    <description>DeviceRGB may be used only if the file has a PDF/A-1 OutputIntent that uses an RGB colour space</description>
+                    <object>PDDeviceRGB</object>
+                    <test>gOutputCS != null &amp;&amp; gOutputCS == "RGB "</test>
+                    <check status="failed">
+                      <context>root/document[0]/pages[0](4 0 obj PDPage)/Group[0]/colorSpace[0]</context>
+                      <errorMessage>DeviceRGB colour space is used without RGB output intent profile</errorMessage>
+                    </check>
+                  </rule>
+                  <rule specification="ISO 19005-1:2005" clause="6.7.11" testNumber="1" status="failed" failedChecks="1">
+                    <description>The PDF/A version and conformance level of a file shall be specified using the PDF/A Identification extension schema</description>
+                    <object>MainXMPPackage</object>
+                    <test>containsPDFAIdentification == true</test>
+                    <check status="failed">
+                      <context>root/document[0]/metadata[0](5 0 obj PDMetadata)/XMPPackage[0]</context>
+                      <errorMessage>The document metadata stream doesn't contain PDF/A Identification Schema</errorMessage>
+                    </check>
+                  </rule>
+                  <rule specification="ISO 19005-1:2005" clause="6.4" testNumber="3" status="failed" failedChecks="1">
+                    <description>A Group object with an S key with a value of Transparency shall not be included in a form XObject. A Group object with an S key with a value of Transparency shall not be included in a page dictionary</description>
+                    <object>PDGroup</object>
+                    <test>S != "Transparency"</test>
+                    <check status="failed">
+                      <context>root/document[0]/pages[0](4 0 obj PDPage)/Group[0]</context>
+                      <errorMessage>A transparency group is present in a form XObject or page dictionary</errorMessage>
+                    </check>
+                  </rule>
+                </details>
+              </validationReport>
+              <duration start="1788868145754" finish="1788868156951">00:00:11.197</duration>
+            </job>
+          </jobs>
+          <batchSummary totalJobs="1" failedToParse="0" encrypted="0" outOfMemory="0" veraExceptions="0">
+            <validationReports compliant="0" nonCompliant="1" failedJobs="0">1</validationReports>
+            <featureReports failedJobs="0">0</featureReports>
+            <repairReports failedJobs="0">0</repairReports>
+            <duration start="1788868145640" finish="1788868157093">00:00:11.453</duration>
+          </batchSummary>
+        </report>
+        """;
+
+    [Fact]
+    public void The_real_report_parses_as_not_compliant_with_the_full_profile_name()
+    {
+        var result = _parser.Parse(RealNonCompliantReport, processSuccess: true, processError: null);
+
+        result.Success.Should().BeTrue();
+        result.IsCompliant.Should().BeFalse();
+        result.ProfileName.Should().Be("PDF/A-1b validation profile");
+    }
+
+    [Fact]
+    public void Each_of_the_three_distinct_rule_failures_is_reported_once_not_collapsed_or_duplicated()
+    {
+        var result = _parser.Parse(RealNonCompliantReport, processSuccess: true, processError: null);
+
+        // Three failedRules in the report. The nested <check status="failed"> under each <rule>
+        // must not add three more, and "ISO 19005-1:2005" (the specification every rule shares)
+        // must not be the string that survives deduplication for all three.
+        result.Errors.Should().HaveCount(3);
+        result.Errors.Should().OnlyHaveUniqueItems();
+        result.Errors.Should().Contain(e => e.Contains("6.2.3.3") && e.Contains("DeviceRGB"));
+        result.Errors.Should().Contain(e => e.Contains("6.7.11") && e.Contains("PDF/A Identification"));
+        result.Errors.Should().Contain(e => e.Contains("6.4") && e.Contains("Transparency"));
+    }
+}

--- a/tools/ghostscript/PDFA_def.ps
+++ b/tools/ghostscript/PDFA_def.ps
@@ -1,0 +1,13 @@
+% Ghostscript PDF/A-2 output intent definition.
+/ICCProfile (/usr/share/color/icc/ghostscript/srgb.icc) def
+[/_objdef {icc_PDFA} /type /stream /OBJ pdfmark
+[{icc_PDFA} << /N 3 >> /PUT pdfmark
+[{icc_PDFA} ICCProfile (r) file /PUT pdfmark
+[/_objdef {OutputIntent_PDFA} /type /dict /OBJ pdfmark
+[{OutputIntent_PDFA} <<
+  /Type /OutputIntent
+  /S /GTS_PDFA1
+  /DestOutputProfile {icc_PDFA}
+  /OutputConditionIdentifier (sRGB IEC61966-2.1)
+>> /PUT pdfmark
+[{Catalog} <</OutputIntents [ {OutputIntent_PDFA} ]>> /PUT pdfmark

--- a/tools/pdfbox/PdfBoxFlatten.java
+++ b/tools/pdfbox/PdfBoxFlatten.java
@@ -1,0 +1,52 @@
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+import org.apache.pdfbox.pdmodel.interactive.form.PDField;
+
+public final class PdfBoxFlatten {
+    private PdfBoxFlatten() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length == 1 && "--version".equals(args[0])) {
+            System.out.println("Apache PDFBox " + org.apache.pdfbox.util.Version.getVersion());
+            return;
+        }
+
+        boolean standardize = args.length == 3 && "--standardize".equals(args[0]);
+        int inputIndex = standardize ? 1 : 0;
+        int outputIndex = standardize ? 2 : 1;
+        if ((!standardize && args.length != 2) || (standardize && args.length != 3)) {
+            System.err.println("USAGE: PdfBoxFlatten [--standardize] <input.pdf> <output.pdf>");
+            System.exit(1);
+        }
+
+        try (PDDocument document = Loader.loadPDF(new File(args[inputIndex]))) {
+            PDAcroForm acroForm = document.getDocumentCatalog().getAcroForm();
+            if (acroForm != null) {
+                List<PDField> fields = new ArrayList<>();
+                for (PDField field : acroForm.getFieldTree()) {
+                    fields.add(field);
+                }
+
+                if (!fields.isEmpty()) {
+                    acroForm.flatten(fields, true);
+                }
+            }
+
+            if (standardize) {
+                document.getDocumentCatalog().getCOSObject().removeItem(COSName.METADATA);
+                document.getDocumentCatalog().getCOSObject().removeItem(COSName.OUTPUT_INTENTS);
+            }
+
+            document.save(args[outputIndex]);
+        } catch (Exception exception) {
+            System.err.println(exception.getClass().getSimpleName() + ": " + exception.getMessage());
+            System.exit(1);
+        }
+    }
+}

--- a/tools/pdfbox/PdfBoxNormalizeGeometry.java
+++ b/tools/pdfbox/PdfBoxNormalizeGeometry.java
@@ -1,0 +1,330 @@
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSFloat;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSObject;
+import org.apache.pdfbox.pdfwriter.compress.CompressParameters;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageTree;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.interactive.digitalsignature.PDSignature;
+
+/**
+ * Rewrites every page's box entries as DIRECT number arrays.
+ *
+ * <p>PDF 32000-1 7.3.6 allows any array element to be an indirect reference, so a producer may
+ * legally emit {@code /MediaBox [715 0 R 715 0 R 596.52 843]}. PdfSharpCore's value accessors are
+ * reference-blind and throw {@code InvalidCastException: GetReal: Object is not a number} on such a
+ * file. PDFBox resolves both indirect references and page-tree inheritance, so reading each box
+ * through the PD model and writing it straight back materialises direct values that PdfSharpCore
+ * can read. Nothing else in the document is touched.
+ *
+ * <p>Emits a one-line JSON report on stdout prefixed with {@link #REPORT_MARKER} so the caller can
+ * verify that page geometry did not shift.
+ */
+public final class PdfBoxNormalizeGeometry {
+
+    static final String REPORT_MARKER = "##PDFBOX_GEOMETRY##";
+
+    private static final COSName[] NON_INHERITABLE_BOXES = {
+        COSName.BLEED_BOX, COSName.TRIM_BOX, COSName.ART_BOX
+    };
+
+    private PdfBoxNormalizeGeometry() {
+    }
+
+    public static void main(String[] args) {
+        if (args.length == 1 && "--version".equals(args[0])) {
+            System.out.println("Apache PDFBox " + org.apache.pdfbox.util.Version.getVersion());
+            return;
+        }
+
+        if (args.length != 2) {
+            System.err.println("USAGE: PdfBoxNormalizeGeometry <input.pdf> <output.pdf>");
+            System.exit(1);
+        }
+
+        try (PDDocument document = Loader.loadPDF(new File(args[0]))) {
+            List<PageReport> pages = new ArrayList<>();
+            boolean changed = false;
+
+            for (PDPage page : document.getPages()) {
+                PageReport report = normalizePage(page, pages.size());
+                pages.add(report);
+                changed |= !report.rewrittenBoxes.isEmpty();
+            }
+
+            // Materialising the boxes on the page is not enough on its own: PdfSharpCore pushes
+            // inheritable attributes down from the /Pages nodes, so an indirect box left on an
+            // ancestor overwrites the direct one we just wrote and the file still fails to read.
+            changed |= normalizePageTreeNodes(document);
+
+            // A full re-save rewrites every object, so byte offsets move and any /ByteRange in an
+            // existing signature stops matching. Refuse rather than silently invalidate: the caller
+            // keeps such documents on its own (iText) path.
+            List<PDSignature> signatures = document.getSignatureDictionaries();
+            boolean signed = signatures != null && !signatures.isEmpty();
+            if (signed) {
+                System.out.println(buildReport(pages, signed, false));
+                System.err.println("SIGNED_DOCUMENT");
+                System.exit(3);
+            }
+
+            // NO_COMPRESSION keeps the page dictionaries out of /ObjStm, matching the deliberate
+            // --object-streams=disable on the sibling qpdf path and leaving the result verifiable
+            // by inspection.
+            document.save(new File(args[1]), CompressParameters.NO_COMPRESSION);
+
+            System.out.println(buildReport(pages, signed, changed));
+        } catch (Exception exception) {
+            System.err.println(exception.getClass().getSimpleName() + ": " + exception.getMessage());
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Rewrites inheritable box entries on the /Pages nodes as direct values. Walks up each page's
+     * /Parent chain rather than down from the catalog, so only nodes that actually govern a page
+     * are touched.
+     */
+    private static boolean normalizePageTreeNodes(PDDocument document) {
+        List<COSDictionary> visited = new ArrayList<>();
+        boolean changed = false;
+
+        for (PDPage page : document.getPages()) {
+            COSBase parent = page.getCOSObject().getDictionaryObject(COSName.PARENT);
+
+            while (parent instanceof COSDictionary) {
+                COSDictionary node = (COSDictionary) parent;
+
+                boolean seen = false;
+                for (COSDictionary candidate : visited) {
+                    if (candidate == node) {
+                        seen = true;
+                        break;
+                    }
+                }
+                if (seen) {
+                    break;
+                }
+                visited.add(node);
+
+                for (COSName key : new COSName[] {COSName.MEDIA_BOX, COSName.CROP_BOX}) {
+                    if (node.getItem(key) == null || !isIndirect(node, key)) {
+                        continue;
+                    }
+
+                    COSBase resolved = node.getDictionaryObject(key);
+                    if (resolved instanceof COSArray) {
+                        node.setItem(key, toDirectArray(new PDRectangle((COSArray) resolved)));
+                        changed = true;
+                    }
+                }
+
+                if (node.getItem(COSName.ROTATE) != null && isIndirect(node, COSName.ROTATE)) {
+                    node.setInt(COSName.ROTATE, node.getInt(COSName.ROTATE, 0));
+                    changed = true;
+                }
+
+                parent = node.getDictionaryObject(COSName.PARENT);
+            }
+        }
+
+        return changed;
+    }
+
+    private static PageReport normalizePage(PDPage page, int index) {
+        COSDictionary dict = page.getCOSObject();
+        PageReport report = new PageReport();
+        report.index = index;
+
+        // Read every value through the PD model BEFORE overwriting the dictionary: PDPage caches
+        // mediaBox/cropBox in fields, and the getters are what resolve references and inheritance.
+        if (isIndirect(dict, COSName.MEDIA_BOX)) {
+            report.indirectBoxes.add("MediaBox");
+        }
+        PDRectangle media = page.getMediaBox();
+        if (PDPageTree.getInheritableAttribute(dict, COSName.MEDIA_BOX) == null) {
+            report.warnings.add("PAGE_" + index + "_MEDIABOX_MISSING_DEFAULTED");
+        }
+
+        boolean hasCropBox = PDPageTree.getInheritableAttribute(dict, COSName.CROP_BOX) != null;
+        if (isIndirect(dict, COSName.CROP_BOX)) {
+            report.indirectBoxes.add("CropBox");
+        }
+        PDRectangle crop = hasCropBox ? page.getCropBox() : media;
+
+        if (isIndirect(dict, COSName.ROTATE)) {
+            report.indirectBoxes.add("Rotate");
+        }
+        int rotate = page.getRotation();
+
+        // MediaBox is required; always materialise it at page level so nothing downstream depends
+        // on inheritance resolution either.
+        dict.setItem(COSName.MEDIA_BOX, toDirectArray(media));
+        report.rewrittenBoxes.add("MediaBox");
+
+        if (hasCropBox) {
+            dict.setItem(COSName.CROP_BOX, toDirectArray(crop));
+            report.rewrittenBoxes.add("CropBox");
+        }
+
+        // Bleed/Trim/Art are not inheritable and default to CropBox, so only rewrite them when the
+        // key is physically present on this page.
+        for (COSName key : NON_INHERITABLE_BOXES) {
+            if (dict.getItem(key) == null) {
+                continue;
+            }
+
+            if (isIndirect(dict, key)) {
+                report.indirectBoxes.add(key.getName());
+            }
+
+            COSBase resolved = dict.getDictionaryObject(key);
+            if (resolved instanceof COSArray) {
+                dict.setItem(key, toDirectArray(new PDRectangle((COSArray) resolved)));
+                report.rewrittenBoxes.add(key.getName());
+            }
+        }
+
+        page.setRotation(rotate);
+
+        report.rotate = rotate;
+        report.mediaBox = media;
+        report.cropBox = crop;
+        return report;
+    }
+
+    /**
+     * True when the stored value is itself an indirect reference, or an array holding one. Uses
+     * {@code getItem} rather than {@code getDictionaryObject} precisely because the latter
+     * dereferences and would hide what we are looking for.
+     */
+    private static boolean isIndirect(COSDictionary pageDictionary, COSName key) {
+        COSBase raw = pageDictionary.getItem(key);
+        if (raw == null) {
+            return false;
+        }
+
+        if (raw instanceof COSObject) {
+            return true;
+        }
+
+        if (raw instanceof COSArray) {
+            COSArray array = (COSArray) raw;
+            for (int i = 0; i < array.size(); i++) {
+                if (array.get(i) instanceof COSObject) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static COSArray toDirectArray(PDRectangle rectangle) {
+        COSArray array = new COSArray();
+        array.add(new COSFloat(rectangle.getLowerLeftX()));
+        array.add(new COSFloat(rectangle.getLowerLeftY()));
+        array.add(new COSFloat(rectangle.getUpperRightX()));
+        array.add(new COSFloat(rectangle.getUpperRightY()));
+        array.setDirect(true);
+        return array;
+    }
+
+    private static String buildReport(List<PageReport> pages, boolean signed, boolean changed) {
+        StringBuilder builder = new StringBuilder(REPORT_MARKER);
+        builder.append("{\"engine\":\"pdfbox\",\"version\":\"")
+            .append(escape(org.apache.pdfbox.util.Version.getVersion()))
+            .append("\",\"pageCount\":").append(pages.size())
+            .append(",\"signed\":").append(signed)
+            .append(",\"changed\":").append(changed)
+            .append(",\"pages\":[");
+
+        List<String> warnings = new ArrayList<>();
+        for (int i = 0; i < pages.size(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            pages.get(i).appendTo(builder);
+            warnings.addAll(pages.get(i).warnings);
+        }
+
+        builder.append("],\"warnings\":[");
+        for (int i = 0; i < warnings.size(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append('"').append(escape(warnings.get(i))).append('"');
+        }
+        builder.append("]}");
+        return builder.toString();
+    }
+
+    /** Always Locale.ROOT: a comma-decimal container would otherwise emit 596,52 and break JSON. */
+    private static String number(float value) {
+        return String.format(Locale.ROOT, "%.4f", value);
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static final class PageReport {
+        private int index;
+        private int rotate;
+        private PDRectangle mediaBox;
+        private PDRectangle cropBox;
+        private final List<String> rewrittenBoxes = new ArrayList<>();
+        private final List<String> indirectBoxes = new ArrayList<>();
+        private final List<String> warnings = new ArrayList<>();
+
+        private void appendTo(StringBuilder builder) {
+            builder.append("{\"index\":").append(index)
+                .append(",\"rotate\":").append(rotate)
+                .append(",\"mediaBox\":");
+            appendRectangle(builder, mediaBox);
+            builder.append(",\"cropBox\":");
+            appendRectangle(builder, cropBox);
+
+            // Effective CropBox dimensions: that is what a viewer shows, and therefore what the
+            // caller places stamps against.
+            builder.append(",\"width\":").append(number(cropBox.getWidth()))
+                .append(",\"height\":").append(number(cropBox.getHeight()))
+                .append(",\"rewrittenBoxes\":");
+            appendStrings(builder, rewrittenBoxes);
+            builder.append(",\"indirectBoxes\":");
+            appendStrings(builder, indirectBoxes);
+            builder.append('}');
+        }
+
+        private static void appendRectangle(StringBuilder builder, PDRectangle rectangle) {
+            builder.append('[').append(number(rectangle.getLowerLeftX()))
+                .append(',').append(number(rectangle.getLowerLeftY()))
+                .append(',').append(number(rectangle.getUpperRightX()))
+                .append(',').append(number(rectangle.getUpperRightY()))
+                .append(']');
+        }
+
+        private static void appendStrings(StringBuilder builder, List<String> values) {
+            builder.append('[');
+            for (int i = 0; i < values.size(); i++) {
+                if (i > 0) {
+                    builder.append(',');
+                }
+                builder.append('"').append(escape(values.get(i))).append('"');
+            }
+            builder.append(']');
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the e-signature service's PDF ingestion capability
(`l3-net-signature-pdfengine`, which cannot be called over HTTP from
blocks-utilities) into this repo directly: an API that accepts a
batch of storage file IDs, offloads inspection and remediation to the
Worker, and reports an elaborate per-file verdict (readable,
geometry, signature, PDF/A) that a caller can poll for, plus a
notification when each file finishes.

- **Tool-execution layer** (`PdfGenerator/Tooling/`): qpdf, veraPDF,
  PDFBox and Ghostscript wrappers, both Direct and Docker execution
  modes, `IExternalProcessConcurrencyLimiter`. Fixes a real
  Alpine-vs-Debian ICC profile path bug in the Ghostscript command
  (made configurable via `GhostscriptIccProfilePath` instead of a
  hardcoded literal that would have silently produced broken PDF/A
  output).
- **`Dockerfile.worker`**: new JDK build stage compiling the two
  PDFBox tools, plus qpdf/ghostscript/veraPDF installed into the
  Alpine runtime stage. Verified end to end with a real `docker
  build` — qpdf, veraPDF (its IzPack installer on musl was the
  biggest risk in the plan; it just works), Ghostscript and both
  PDFBox tools all run correctly inside the built image.
- **`PdfInspector`**: readability, geometry, signature and PDF/A-claim
  detection. Empirically disproved one of the plan's own assumptions
  before writing this: PdfSharp 6 (unlike PdfSharpCore, which the
  e-signature reference relies on) already resolves indirect page-box
  references transparently, so the geometry check is a guarded read,
  not a structural `PdfReference` check with a fallback.
- **`PdfIngestionPipeline`**: per-file, non-throwing orchestration —
  inspect → qpdf repair → geometry normalize → signature record →
  veraPDF confirm → PDF/A repair (flatten → Ghostscript → re-validate
  → standard-PDF fallback). One bad file never aborts a batch.
- **Full feature surface**: entity, queue, repository, service,
  consumer, controller, DI — mirroring `DocumentConversionJob`'s shape
  throughout, with two deliberate fixes: `[BsonRepresentation(BsonType.String)]`
  actually applied to the status enum (the original's doc comment
  claims this but omits the attribute), and the completion
  notification's user id carried explicitly on the event rather than
  trusted from ambient `BlocksContext` after a queue hop.
- **Tests against real captured tool output**: ran veraPDF's actual
  Docker CLI and a compiled `PdfBoxNormalizeGeometry` against real
  PDFs to get genuine report fixtures rather than hand-written
  guesses. That caught two real bugs before they shipped further — a
  PDF/A-1 detection check that would never have fired against real
  veraPDF output, and a failure-list parser that double-counted and
  collapsed distinct rule violations into duplicate strings. Both
  fixed.
- **README**: new PDF Ingestion section — endpoints, pipeline order,
  tool matrix, config keys.

Sequenced as 8 commits, each independently buildable and tested, in
dependency order.

## Test plan

- [x] `dotnet build server/Blocks.slnx` — 0 errors
- [x] `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName!~Integration"` — 3799 passed, 0 failed, 1 pre-existing skip (unrelated `AsposePdfEngineTests` skip)
- [x] `docker build -f Dockerfile.worker .` + inside the built image: `qpdf --version`, `verapdf --version`, `gs --version`, both PDFBox tools, ICC symlink resolution — all verified working
- [x] Existing Chromium PDF-render path confirmed unaffected by the Alpine image changes
- [ ] End-to-end against a real broker/storage/Mongo — **not possible in this environment**; flagging explicitly rather than implying it was verified
- [ ] A fresh `docker build -f Dockerfile.worker .` re-run against the final commit (the build was last verified in an earlier commit, before later commits landed) — worth doing once more before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)