### PR TITLE
fix(simulation): read meter usage from GET /subscription-usage/current

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/usage-meter-row.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/usage-meter-row.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { MeterUsage } from "../models/subscription-simulation.model";
+import type { PlanMeter } from "../../subscription/models/subscription-plan.model";
+
+vi.mock("../hooks/use-record-usage", () => ({
+  useRecordUsage: () => ({ mutateAsync: vi.fn() }),
+}));
+
+import { UsageMeterRow } from "./usage-meter-row";
+
+const meter = {
+  meterKey: "screening",
+  displayName: "Screenings",
+  unitLabel: "screening",
+  aggregation: "Sum",
+  includedQuantity: 150,
+  overageAllowed: true,
+  thresholdPercents: [],
+} as PlanMeter;
+
+const usage: MeterUsage = {
+  allowed: true,
+  meterKey: "screening",
+  unitLabel: "screening",
+  periodKey: "2026-08",
+  periodStartUtc: "2026-08-01T00:00:00Z",
+  periodEndUtc: "2026-09-01T00:00:00Z",
+  included: 150,
+  used: 42,
+  remaining: 108,
+  overage: 0,
+  replayed: false,
+};
+
+describe("UsageMeterRow", () => {
+  it("shows the figures from the current-usage read, not the plan's included quantity", () => {
+    render(
+      <UsageMeterRow
+        meter={meter}
+        entitlementKey="screening.limit"
+        usage={usage}
+        organizationId={undefined}
+      />,
+    );
+
+    expect(screen.getByText(/42\/150 screenings used this period/)).toBeInTheDocument();
+  });
+
+  it("falls back to naming the entitlement when the meter has no usage row yet", () => {
+    render(
+      <UsageMeterRow
+        meter={meter}
+        entitlementKey="screening.limit"
+        usage={undefined}
+        organizationId={undefined}
+      />,
+    );
+
+    expect(screen.getByText("Entitlement: screening.limit")).toBeInTheDocument();
+  });
+});

--- a/client/app/cross-modules/utilities/subscription-simulation/components/usage-meter-row.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/usage-meter-row.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui-kits/button/button";
 import { Input } from "@/components/ui-kits/input/input";
 import { toast } from "@/hooks/use-toast";
 import { useRecordUsage } from "../hooks/use-record-usage";
-import type { EntitlementDecision } from "../models/subscription-simulation.model";
+import type { MeterUsage } from "../models/subscription-simulation.model";
 import { subscriptionSimulationService } from "../services/subscription-simulation.service";
 import type { PlanMeter } from "../../subscription/models/subscription-plan.model";
 
@@ -21,23 +21,33 @@ import type { PlanMeter } from "../../subscription/models/subscription-plan.mode
 export const UsageMeterRow = ({
   meter,
   entitlementKey,
-  initialDecision,
+  usage,
   organizationId,
 }: {
   meter: PlanMeter;
   /** The plan entitlement that gates this meter, if the plan defines one. */
   entitlementKey: string | undefined;
-  initialDecision: EntitlementDecision | undefined;
+  /** This meter's row from `GET /api/subscription-usage/current` — the authoritative figures. */
+  usage: MeterUsage | undefined;
   organizationId: string | undefined;
 }) => {
   const { mutateAsync: recordUsage } = useRecordUsage();
 
   const [quantity, setQuantity] = useState("1");
   const [phase, setPhase] = useState<"idle" | "checking" | "recording">("idle");
-  const [lastCheck, setLastCheck] = useState<EntitlementDecision | undefined>(initialDecision);
+  // A record answers with the balance including that call, so it is newer than any read. It is
+  // dropped as soon as a fresh read arrives for the same period.
+  const [recorded, setRecorded] = useState<MeterUsage | null>(null);
   const [lastResult, setLastResult] = useState<
     { message: string; tone: "success" | "blocked" | "error" } | null
   >(null);
+
+  // The record result wins while it is for the period the read describes; once the read catches
+  // up (or the period turns over) the server's own row takes back over.
+  const current =
+    recorded && (!usage || (usage.periodKey === recorded.periodKey && usage.used < recorded.used))
+      ? recorded
+      : usage;
 
   const consume = async () => {
     const parsedQuantity = Number(quantity);
@@ -56,8 +66,6 @@ export const UsageMeterRow = ({
           entitlementKey,
           organizationId,
         );
-        setLastCheck(checked);
-
         if (!checked.allowed) {
           setLastResult({
             message: `Blocked before recording — ${checked.reason}.`,
@@ -92,6 +100,8 @@ export const UsageMeterRow = ({
         organizationId,
       });
 
+      setRecorded(result);
+
       setLastResult({
         message: result.allowed
           ? `Recorded. ${result.used}/${result.included} ${result.unitLabel} used this period, ${result.remaining} remaining${result.overage ? `, ${result.overage} over` : ""}.`
@@ -121,8 +131,8 @@ export const UsageMeterRow = ({
       <div className="min-w-0">
         <p className="text-sm font-medium">{meter.displayName}</p>
         <p className="text-xs text-muted-foreground">
-          {lastCheck?.limitKind === "Count"
-            ? `${lastCheck.used ?? 0}/${lastCheck.limit ?? meter.includedQuantity} ${meter.unitLabel}${meter.includedQuantity === 1 ? "" : "s"} used this period`
+          {current
+            ? `${current.used}/${current.included} ${current.unitLabel || meter.unitLabel}${current.included === 1 ? "" : "s"} used this period${current.overage ? `, ${current.overage} over` : ""}`
             : entitlementKey
               ? `Entitlement: ${entitlementKey}`
               : `No entitlement gates this meter — recording goes straight through.`}

--- a/client/app/cross-modules/utilities/subscription-simulation/components/usage-section.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/usage-section.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui-kits/button/button";
 import { Card } from "@/components/ui-kits/card/card";
 import { Skeleton } from "@/components/ui-kits/skeleton/skeleton";
 import type { SubscriptionPlan } from "../../subscription/models/subscription-plan.model";
-import { useEntitlements } from "../hooks/use-entitlements";
+import { useCurrentUsage } from "../hooks/use-current-usage";
 import { UsageMeterRow } from "./usage-meter-row";
 
 export const UsageSection = ({
@@ -13,13 +13,10 @@ export const UsageSection = ({
   plan: SubscriptionPlan | undefined;
   organizationId: string | undefined;
 }) => {
-  const {
-    data: entitlements,
-    error,
-    isError,
-    isLoading,
-    refetch,
-  } = useEntitlements(organizationId);
+  // The figures shown come from here, not from the entitlement snapshot: this is per meter and
+  // exists whether or not an entitlement gates it. The per-consume entitlement check still runs
+  // inside each row, right before acting, which is the point of the two-step flow.
+  const { data: usage, error, isError, isLoading, refetch } = useCurrentUsage(organizationId);
 
   return (
     <Card className="rounded-xl p-0">
@@ -30,7 +27,8 @@ export const UsageSection = ({
           <code className="mx-1 rounded bg-muted px-1">GET /api/entitlements/{"{key}"}</code>{" "}
           first and decides from that answer, then records with{" "}
           <code className="mx-1 rounded bg-muted px-1">POST /api/subscription-usage</code>,
-          which is the call that actually enforces.
+          which is the call that actually enforces. The figures below are read from{" "}
+          <code className="mx-1 rounded bg-muted px-1">GET /api/subscription-usage/current</code>.
         </p>
       </div>
 
@@ -44,7 +42,7 @@ export const UsageSection = ({
           <div className="flex flex-col items-start gap-2">
             <div className="flex items-center gap-2 text-destructive">
               <AlertCircle className="h-4 w-4" />
-              <span className="font-medium">Entitlements could not be loaded</span>
+              <span className="font-medium">Current usage could not be loaded</span>
             </div>
             <p className="text-sm text-muted-foreground">
               {error instanceof Error ? error.message : "Try again in a moment."}
@@ -72,9 +70,7 @@ export const UsageSection = ({
                   key={meter.meterKey}
                   meter={meter}
                   entitlementKey={entitlementKey}
-                  initialDecision={entitlements?.entitlements.find(
-                    (decision) => decision.key === entitlementKey,
-                  )}
+                  usage={usage?.find((row) => row.meterKey === meter.meterKey)}
                   organizationId={organizationId}
                 />
               );

--- a/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/constants/subscription-simulation.constants.ts
@@ -2,6 +2,7 @@ export const SUBSCRIPTIONS_ENDPOINT = "/api/subscriptions";
 export const SUBSCRIPTIONS_CURRENT_ENDPOINT = "/api/subscriptions/current";
 export const ENTITLEMENTS_ENDPOINT = "/api/entitlements";
 export const SUBSCRIPTION_USAGE_ENDPOINT = "/api/subscription-usage";
+export const SUBSCRIPTION_USAGE_CURRENT_ENDPOINT = "/api/subscription-usage/current";
 export const SUBSCRIPTION_USAGE_OVERAGE_PREVIEW_ENDPOINT =
   "/api/subscription-usage/overage/preview";
 

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-current-usage.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-current-usage.ts
@@ -1,0 +1,19 @@
+import { useProjectStore } from "@seliseblocks/genesis-os";
+import { useQuery } from "@tanstack/react-query";
+import { subscriptionSimulationService } from "../services/subscription-simulation.service";
+
+/**
+ * Every meter's current allowance, read from the counters.
+ *
+ * Keyed under "subscription-usage" so the invalidations the seat-count paths already fire
+ * (use-people, use-user) refresh this too — a quantity change moves the included allowance.
+ */
+export const useCurrentUsage = (organizationId?: string) => {
+  const tenantId = useProjectStore()?.selectedProject?.tenantId || "";
+
+  return useQuery({
+    queryKey: ["subscription-usage", tenantId, organizationId ?? null],
+    queryFn: () => subscriptionSimulationService.getCurrentUsage(organizationId),
+    staleTime: 5_000,
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-record-usage.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-record-usage.ts
@@ -8,9 +8,11 @@ export const useRecordUsage = () => {
   return useMutation({
     mutationFn: (request: RecordUsageRequest) =>
       subscriptionSimulationService.recordUsage(request),
-    onSuccess: () =>
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["subscription-simulation-entitlements"],
-      }),
+      });
+      queryClient.invalidateQueries({ queryKey: ["subscription-usage"] });
+    },
   });
 };

--- a/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/models/subscription-simulation.model.ts
@@ -595,6 +595,13 @@ export interface RecordUsageResult {
  * A hypothetical slice of additional metered usage to price. Writes nothing and charges nothing —
  * see {@link UsageOveragePreviewResult}.
  */
+/**
+ * One meter's state as `GET /api/subscription-usage/current` reports it — the same body a record
+ * call returns, so the two are read the same way. `allowed` and `replayed` describe a recording
+ * and mean nothing on a read.
+ */
+export type MeterUsage = RecordUsageResult;
+
 export interface PreviewUsageOverageRequest {
   meterKey: string;
   /** Cannot be zero or negative — a preview of no additional usage answers nothing. */

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -3,6 +3,7 @@ import { serviceInstances } from "@/lib/http-client";
 import {
   AUDIT_TRAIL_DEFAULT_LIMIT,
   ENTITLEMENTS_ENDPOINT,
+  SUBSCRIPTION_USAGE_CURRENT_ENDPOINT,
   SUBSCRIPTION_USAGE_ENDPOINT,
   SUBSCRIPTION_USAGE_OVERAGE_PREVIEW_ENDPOINT,
   SUBSCRIPTIONS_CURRENT_ENDPOINT,
@@ -16,6 +17,7 @@ import type {
   QuantityChangeQuote,
   EntitlementDecision,
   EntitlementsSnapshot,
+  MeterUsage,
   PreviewUsageOverageRequest,
   RecordUsageRequest,
   RecordUsageResult,
@@ -485,6 +487,29 @@ class SubscriptionSimulationService {
 
       throw error;
     }
+  }
+
+  /**
+   * Where every meter's allowance actually stands, straight from the counters.
+   *
+   * The entitlement snapshot is not this: it answers "may they act", per entitlement, and a meter
+   * with no entitlement gating it has no row there at all. Read here instead so the figures shown
+   * are the meter's own.
+   */
+  async getCurrentUsage(organizationId?: string): Promise<MeterUsage[]> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+
+    const response = await serviceInstances.utitlitiesService.get<
+      SimulationApiResponse<MeterUsage[]>
+    >(`${SUBSCRIPTION_USAGE_CURRENT_ENDPOINT}${query}`);
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "Current usage could not be loaded.");
+    }
+
+    return response.data;
   }
 
   /** The authoritative gate — the figures returned include this call. */


### PR DESCRIPTION
## The bug

In the subscription simulation, the Usage section's per-meter line ("X/Y used this period") was derived from the **entitlement** decision returned by `GET /api/entitlements`, and `GET /api/subscription-usage/current` was never called at all.

That endpoint answers a different question — "may they act", per entitlement — so:

- the figures shown were the entitlement's counter and limit, not the meter's `used`/`included`;
- a meter with no entitlement linked to it showed no figures at all;
- nothing refreshed after a record — the record response's authoritative balance only reached the status line, never the meter's own line.

## The fix

- `subscriptionSimulationService.getCurrentUsage()` + a `useCurrentUsage` hook calling `GET /api/subscription-usage/current`, which returns one `UsageResponse` row per meter, read from the counters.
- `UsageSection` takes its data, loading and error state from that read. The entitlement *snapshot* query is gone from the section; the per-consume `GET /api/entitlements/{key}` check inside each row is untouched, since watching that advisory check diverge from the enforcing record is the point of the two-step flow.
- `UsageMeterRow` renders `used`/`included` (plus overage) from the read, with the record response taking over until the read catches up — a record answers with the balance *including* that call, so it is the newer figure.
- Query key is `["subscription-usage", …]`, so the invalidations the seat-count paths (`use-people`, `use-user`) already fire refresh it too: a quantity change moves the included allowance.

## Verification

`tsc --noEmit` clean, eslint clean, `vitest run` over the module green (82 tests, including two new ones covering the meter row's display source).

Not included: a `readMode=projection` toggle and the `X-Usage-Read-*` diagnostics headers — worth adding if the simulation should also demo the projection read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
