### PR TITLE
Ship the Linux half of SkiaSharp so Aspose stops killing the worker

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -147,6 +147,17 @@ RUN mkdir -p /usr/share/color/icc/ghostscript \
     && test -e /usr/share/color/icc/ghostscript/srgb.icc
 
 COPY --from=publish /app/publish .
+
+# Aspose.Words renders through SkiaSharp, and SkiaSharp's own package brings native assets only
+# for Windows and macOS. A Linux publish that is missing SkiaSharp.NativeAssets.Linux.NoDependencies
+# still carries the managed SkiaSharp.dll, so nothing fails until Aspose lays out its first page --
+# at which point the worker takes a SIGSEGV and crashloops on the redelivered message, taking every
+# other queue this process serves down with it. That is what happened in production, so the presence
+# of the native library is asserted at build time rather than discovered from a pod's exit code.
+# Matched by glob rather than a fixed RID: the publish stage's platform is overridable via
+# DOTNET_PUBLISH_PLATFORM, so pinning linux-musl-x64 here would fail an arm64 build for the wrong reason.
+RUN test -n "$(find /app/runtimes -path '*linux-musl-*/native/libSkiaSharp.so' -print -quit)"
+
 COPY --from=pdfbox-build /opt/pdfbox /opt/pdfbox
 COPY tools/ghostscript/PDFA_def.ps /opt/pdfingestion/PDFA_def.ps
 

--- a/server/Directory.Packages.props
+++ b/server/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
@@ -29,6 +29,12 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageVersion Include="Aspose.Words" Version="25.6.0" />
+    <!-- Aspose.Words pulls SkiaSharp 3.119.0, whose only native-asset dependencies are Win32 and
+         macOS. Without this the published Linux image carries the managed SkiaSharp.dll and no
+         libSkiaSharp.so behind it, and Aspose segfaults the process the moment it renders a page.
+         Must stay pinned to the same version SkiaSharp resolves to: a managed binding and a native
+         library from different releases disagree about the ABI, which is its own crash. -->
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.0" />
     <PackageVersion Include="DotLiquid" Version="2.2.692" />
     <PackageVersion Include="iTextSharp.LGPLv2.Core" Version="1.7.5" />
     <PackageVersion Include="PdfPig" Version="0.1.16" />

--- a/server/Utility.DomainService/Utility.DomainService.csproj
+++ b/server/Utility.DomainService/Utility.DomainService.csproj
@@ -3,6 +3,13 @@
 
   <ItemGroup>
 	<PackageReference Include="Aspose.Words" />
+	<!-- The Linux native half of the SkiaSharp that Aspose.Words depends on. SkiaSharp itself only
+	     brings native assets for Windows and macOS, so a Linux publish ships the managed binding
+	     with nothing behind it and the process takes a SIGSEGV on the first page it renders.
+	     NoDependencies is the right variant for the Alpine worker image: it carries a linux-musl-x64
+	     RID and statically links freetype, so it needs no fontconfig and no extra apk packages.
+	     Aspose does its own font discovery through FolderFontSource, so nothing is lost by that. -->
+	<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
 	<PackageReference Include="DotLiquid" />
 	<PackageReference Include="FluentValidation" />
 	<PackageReference Include="iTextSharp.LGPLv2.Core" />

--- a/server/XUnitTest/PdfGenerator/AsposePdfEngineTests.cs
+++ b/server/XUnitTest/PdfGenerator/AsposePdfEngineTests.cs
@@ -179,7 +179,14 @@ namespace XUnitTest.PdfGenerator
 
         #region ConvertHtmlToPdfAsync
 
-        [Fact(Skip = "Aspose HTML to PDF crashes in Linux CI (.NET 9)")]
+        // Was skipped as "Aspose HTML to PDF crashes in Linux CI (.NET 9)". The crash was not
+        // Aspose and not .NET 9: Aspose renders through SkiaSharp, and no Linux native asset for
+        // SkiaSharp was ever referenced, so libSkiaSharp.so was absent from every Linux publish and
+        // the process took a SIGSEGV on the first page it laid out. It reached production the same
+        // way, killing the worker (exit 139) on each redelivery of a document-conversion message.
+        // Re-enabled with SkiaSharp.NativeAssets.Linux.NoDependencies in place: this test is the
+        // regression guard, and skipping it again would hide exactly the failure it exists to catch.
+        [Fact]
         public async Task ConvertHtmlToPdfAsync_ValidHtml_ReturnsPdf()
         {
             // Minimal valid HTML and options


### PR DESCRIPTION
## What broke

`blocks-utilities-worker` in **production** dies with **SIGSEGV (exit code 139)** four seconds after a document→PDF conversion message reaches it, then crashloops on the redelivery until Service Bus dead-letters the message.

From the prod pod `prod-blocks-utilities-worker-utilities-worker-6b888b9fd5-4dx9v`:

| | |
|---|---|
| Last Status | `terminated — Reason: Error - exit code: 139` |
| Started / Finished | `10:38:56` / `10:39:21` UTC |
| API queued the message at | `10:39:17` UTC |
| Limits | `cpu 830m, memory 1250Mi` |

139 is a native fault, not an OOM kill (that would be 137), so the memory limit is not involved. While it looped it was consuming nothing from **any** of its queues — payments, subscriptions, magic links and template rendering all share that process.

## Why

`Aspose.Words 25.6.0` depends on `SkiaSharp 3.119.0`, and SkiaSharp's only native-asset dependencies are Win32 and macOS:

```json
"SkiaSharp/3.119.0": {
  "dependencies": {
    "SkiaSharp.NativeAssets.Win32": "3.119.0",
    "SkiaSharp.NativeAssets.macOS": "3.119.0"
  },
  "runtime": { "lib/net8.0/SkiaSharp.dll": {} }
}
```

Nothing referenced a Linux one, so every Linux publish shipped the managed binding with no `libSkiaSharp.so` behind it. Aspose reaches Skia the moment it lays out a page.

The failure is not clean, and that is the part worth reading. `SKObject`'s static constructor throws when the native library is missing; the finalizer for a half-built `SKBitmap` then re-enters that dead type initializer:

```
at SkiaSharp.SkiaSharpVersion.CheckNativeLibraryCompatible(Boolean)
at SkiaSharp.SKObject..cctor()
--- End of inner exception stack trace ---
at SkiaSharp.SKObject.DeregisterHandle(IntPtr, SKObject)
at SkiaSharp.SKNativeObject.Dispose(Boolean)
at SkiaSharp.SKBitmap.Dispose(Boolean)
at SkiaSharp.SKNativeObject.Finalize()
at System.GC.RunFinalizers()
```

An exception escaping a finalizer takes the process down. `AsposeDocumentToPdfConverter` already wraps its work in a catch-all — that guard was never going to help, because the fault is on the GC finalizer thread, not the thread doing the conversion.

## The change

- `SkiaSharp.NativeAssets.Linux.NoDependencies` `3.119.0`, referenced from `Utility.DomainService`.
  - **`NoDependencies`**, because it ships a `linux-musl-x64` RID for the Alpine base image and statically links freetype — no fontconfig, no new `apk` packages. Plain `SkiaSharp.NativeAssets.Linux` is a glibc build that also wants fontconfig and would not load on musl. Losing fontconfig costs nothing: `AsposeDocumentToPdfConverter.ConfigureFontSources()` already does its own discovery through `FolderFontSource`.
  - Pinned to the version SkiaSharp resolves to. A managed binding and a native library from different releases disagree about the ABI, which is its own crash.
- `Dockerfile.worker` asserts the library is present in the image. A missing native asset is exactly the kind of defect that survives review and reappears as a pod exit code. Globbed rather than pinned to a fixed RID, so an arm64 build (`DOTNET_PUBLISH_PLATFORM`) does not fail for the wrong reason.
- Re-enabled `AsposePdfEngineTests.ConvertHtmlToPdfAsync_ValidHtml_ReturnsPdf`, which was skipped as *"Aspose HTML to PDF crashes in Linux CI (.NET 9)"*. That was this bug — seen in CI, worked around instead of fixed. It is the regression guard for it.

## Verification

- `dotnet build` clean; **3822 passed, 0 failed, 0 skipped** (previously 3821 + 1 skipped).
- `docker build -f Dockerfile.worker .` succeeds and the new assertion passes.
- Inside the built image, the library is a real musl binary with every dependency resolved:
  ```
  ldd /app/runtimes/linux-musl-x64/native/libSkiaSharp.so
      /lib/ld-musl-x86_64.so.1
      libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1
  ```
- Ran `AsposePdfEngineTests` on Alpine/musl in `mcr.microsoft.com/dotnet/sdk:10.0-alpine`: **14/14 pass**.
- Negative control — reverting *only* the package change and re-running the same tests in the same container reproduces the crash: `Test Run Aborted` after 4 of 14 tests, with the finalizer stack above. That is what confirms the package is the fix rather than a coincidence.

**Not verified:** an end-to-end conversion needs a broker, storage and Mongo, none of which are reachable from here.

## Before redeploying

Nothing in-process can catch this, so containment was at the queue: prod only recovered because ASB exhausted the delivery count. Worth draining the dead-letter queue for `blocks_pdf_convert_document_listener` — any message redelivered before this ships will crashloop the worker again and stall every other queue it serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
