### PR TITLE
Pin the docker/* actions in ci-dev to commit SHAs

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -41,16 +41,16 @@ jobs:
           { cat .github/variables/vars.env; echo; } >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build & push ${{ matrix.component }} image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: ${{ env[matrix.dockerfile] }}
@@ -84,7 +84,7 @@ jobs:
       # here keeps the job self-contained instead of relying on whatever
       # credentials happen to sit in the runner user's ~/.docker/config.json.
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Clears the four `actions/unpinned-tag` alerts (CWE-829, medium) that code scanning raises on [#482](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/482):

| Alert | Line | Was | Now |
|---|---|---|---|
| [175](https://github.com/SELISEdigitalplatforms/blocks-utilities/security/code-scanning/175) | 44 | `docker/setup-buildx-action@v3` | `@8d2750c6` — v3.12.0 |
| [176](https://github.com/SELISEdigitalplatforms/blocks-utilities/security/code-scanning/176) | 47 | `docker/login-action@v3` | `@c94ce9fb` — v3.7.0 |
| [177](https://github.com/SELISEdigitalplatforms/blocks-utilities/security/code-scanning/177) | 53 | `docker/build-push-action@v6` | `@10e90e36` — v6.19.2 |
| [178](https://github.com/SELISEdigitalplatforms/blocks-utilities/security/code-scanning/178) | 87 | `docker/login-action@v3` | `@c94ce9fb` — v3.7.0 |

## Why it matters here

A tag like `v3` is a mutable ref — whoever controls the action's repository can repoint it at any commit, and every workflow using it then runs that code. These particular steps see `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in a job that builds and pushes our images, so a compromised action gets registry push credentials. This is the `tj-actions/changed-files` class of attack, and a full-length commit SHA is currently the only way to consume a mutable ref as an immutable one.

## What this is not

**Not a version bump.** Each SHA is the commit the tag already pointed at, so behaviour is unchanged. These majors *are* behind current (v4, v4, v7), but moving majors is a behavioural change and belongs in its own PR rather than riding along with a security fix.

**Not a repo-wide sweep.** Only `docker/*` is pinned. `actions/*` and `azure/*` are first-party immutable publishers and `SELISEdigitalplatforms/*` is this org's own — which is why code scanning flags neither, and why nothing else in `.github/workflows/` is in scope.

## Verification

SHAs were resolved from the GitHub API rather than written by hand, then mapped back to confirm each one is a real tagged release. The workflow was parsed with PyYAML afterwards: both jobs (`build-and-push`, `deploy`) intact, all four `uses:` resolving to the pinned SHAs. Whether the pins actually work end-to-end is proven by this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
