### PR TITLE
Restore the client lockfile stg's merge from main corrupted

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3638,17 +3638,34 @@
         }
       }
     },
-    "node_modules/@vitest/mocker": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
-      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.31",
-        "@vitest/spy": "5.0.0",
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
-        "magic-string": "^1.2.3"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -5138,9 +5155,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
-      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7523,9 +7540,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
-      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8125,6 +8142,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -9701,19 +9725,16 @@
       "license": "MIT"
     },
     "node_modules/tinybench": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
-      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10291,7 +10312,7 @@
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -10308,7 +10329,7 @@
         "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -10350,9 +10371,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
-      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Unblocks `build-client` on [#484](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/484).

## The failure

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Missing: pathe@2.0.3 from lock file
npm error Missing: magic-string@0.30.21 from lock file
npm error Missing: @vitest/expect@4.1.11 from lock file
npm error Missing: @vitest/mocker@4.1.11 from lock file
npm error Missing: tinybench@2.9.0 from lock file
```

`build-worker` passed; only `build-client` failed.

## Where it came from

`client/package.json` is byte-identical on `dev`, `stg` and `main`. `dev` and `main` both have a lockfile that satisfies it — **only `stg`'s is broken**:

| branch | lock has `pathe` | lock has `@vitest/expect` |
|---|---|---|
| `dev` | yes | yes |
| `stg` | **no** | **no** |
| `main` | yes | yes |

`stg`'s lockfile was last touched by `560169e6 Merge branch 'main' into stg`, which landed on top of `2c1cfa33 fix(deps): bump vitest to 4.1.11 to patch @vitest/mocker path traversal` and partially undid that commit's lock entries while leaving `package.json` asking for `^4.1.11`.

The tell: the broken lock pins `@vitest/mocker` at **5.0.0** beside `vitest` **4.1.11**. Nothing can resolve to that — `package.json` pins `^4.1.11`, so vitest 5's mocker is unreachable, which is why npm reports 4.1.11 as *missing* rather than as a conflict. Merge debris, not a dependency decision.

## Why taken from `dev` rather than regenerated

`dev` is upstream of `stg`, so this is the lockfile `stg` receives anyway when [#482](https://github.com/SELISEdigitalplatforms/blocks-utilities/pull/482) merges. Regenerating here would produce a third variant and a conflict later.

**Not a downgrade of the security fix.** The restored file is self-consistent at `vitest` 4.1.11 with `@vitest/mocker` 4.1.11 — the patched line `2c1cfa33` was moving to. The 5.0.0 entry it replaces was never reachable.

## Verification

Ran the failing command against the image the Dockerfile actually uses:

- `npm ci --no-audit --no-fund` under `node:22-alpine` → **added 681 packages**, clean exit.
- `docker build -f Dockerfile --target client` → completes both `npm ci` and the Vite `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
