### PR TITLE
Log unprovisioned tenants as one line, not a stack trace

### DIFF
--- a/server/Worker/SubscriptionReconciliationBackgroundService.cs
+++ b/server/Worker/SubscriptionReconciliationBackgroundService.cs
@@ -128,11 +128,24 @@ public sealed class SubscriptionReconciliationBackgroundService : BackgroundServ
                 // reach — one never provisioned a database, one mid-migration. Letting that
                 // escape would abort the loop at whatever position the bad tenant happens to
                 // occupy and silently stop billing every tenant ordered after it.
-                _logger.LogWarning(
-                    exception,
-                    "Subscription reconciliation skipped a tenant after an error " +
-                    "TenantHash={TenantHash}",
-                    PaymentLogValue.Hash(tenantId));
+                // An unprovisioned tenant is the expected half of that, and it repeats every
+                // pass for every such tenant — a stack trace per tenant per tick buries the
+                // failures worth reading, so it gets one line and anything else keeps its trace.
+                if (exception.GetBaseException() is KeyNotFoundException)
+                {
+                    _logger.LogWarning(
+                        "Subscription reconciliation skipped a tenant with no database " +
+                        "TenantHash={TenantHash}",
+                        PaymentLogValue.Hash(tenantId));
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        exception,
+                        "Subscription reconciliation skipped a tenant after an error " +
+                        "TenantHash={TenantHash}",
+                        PaymentLogValue.Hash(tenantId));
+                }
             }
         }
     }


### PR DESCRIPTION
The subscription repair sweep walks a roster it discovers rather than curates, so tenants with no provisioned database are expected and permanent. Every one of them produced a full stack-trace warning on every tick — that is the log spam.

Unprovisioned tenants (`KeyNotFoundException` at the base of the chain) now get a single warning line with the tenant hash. Anything else still logs with its stack trace, since that is a failure worth reading.

Not touched: the `[ERR] Failed to initialize database for tenant` line above ours comes from `Blocks.Genesis` (SeliseBlocks.Genesis.OS package), not this repo. Silencing it needs a Serilog `MinimumLevel.Override` on `Blocks.Genesis.MongoDbContextProvider`, which would also hide real database errors — say the word if you want that trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)