### PR TITLE
fix(subscription): publish usage projection row on free/card-free subscribe

### DIFF
--- a/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
+++ b/server/Subscription.DomainService/Scheduling/SubscriptionRepairAnnouncer.cs
@@ -144,6 +144,25 @@ public sealed class SubscriptionRepairAnnouncer
                     repaired,
                     PaymentLogValue.Id(tenantId));
             }
+
+            // The sweep above compares rows that already exist, so it can never find a subscription
+            // whose row was never written -- exactly what an activation path that skips the
+            // publish (see StartWithoutPaymentAsync) leaves behind. Nothing else in this codebase
+            // ever schedules a tenant-wide UsageProjectionRefresh work item, so without this call
+            // the backfill this class's own remarks call "the durable path" never actually runs.
+            var backfilled = await _usageProjections.BackfillTenantAsync(
+                tenantId,
+                $"backfill:{tenantId}",
+                stoppingToken);
+
+            if (backfilled.Written > 0)
+            {
+                _logger.LogInformation(
+                    "Repair sweep backfilled missing usage projections " +
+                    "WrittenCount={WrittenCount} TenantId={TenantId}",
+                    backfilled.Written,
+                    PaymentLogValue.Id(tenantId));
+            }
         }
 
         var bucketMinutes = Math.Max(1, options.SchedulerSweepBucketMinutes);

--- a/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCheckoutService.cs
@@ -10,6 +10,7 @@ using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
 using Subscription.DomainService.Responses;
+using Subscription.DomainService.Scheduling;
 using Subscription.DomainService.Utilities;
 
 namespace Subscription.DomainService.Services;
@@ -52,7 +53,11 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         IBillingAccountRepository billingAccounts,
         ILogger<SubscriptionCheckoutService> logger,
         ISubscriptionFinancialDocumentAnnouncer? documents = null,
-        TimeProvider? time = null)
+        TimeProvider? time = null,
+        // Optional for the same reason documents already is: an existing caller or test that
+        // constructs this service unaware the usage projection exists must keep compiling and
+        // keep behaving as before.
+        IUsageProjectionReconciler? usageProjections = null)
     {
         _creation = creation;
         _subscriptions = subscriptions;
@@ -68,6 +73,7 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
         _logger = logger;
         _documents = documents;
         _time = time ?? TimeProvider.System;
+        _usageProjections = usageProjections;
     }
 
     /// <summary>
@@ -75,6 +81,13 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
     /// without announcing its document is one the repair sweep has to find, not one that failed.
     /// </summary>
     private readonly ISubscriptionFinancialDocumentAnnouncer? _documents;
+
+    /// <summary>
+    /// Optional for the same reason. Missing it means a free or card-free-trial subscription
+    /// waits for the repair sweep to publish its first usage projection row instead of getting
+    /// one immediately, not that the subscribe request should fail.
+    /// </summary>
+    private readonly IUsageProjectionReconciler? _usageProjections;
 
     public async Task<SubscriptionOperationResult<SubscriptionResponse>> SubscribeAsync(
         CreateSubscriptionRequest request,
@@ -1055,6 +1068,35 @@ public sealed class SubscriptionCheckoutService : ISubscriptionCheckoutService
                     context.UserId,
                     context.UserName,
                     context.UserEmail));
+        }
+
+        if (_usageProjections is not null)
+        {
+            // Same reason ActivateAsync refreshes right after its own transition commits: this is
+            // what lets a reader discover the subscription's meters and allowances before any usage
+            // exists. The paid path gets this from the activation processor; this one never goes
+            // through it, so nothing else publishes the row. Best-effort -- the subscription is
+            // already active, and failing the subscribe response over a read-model publish would
+            // turn a successful subscription into an apparent failure the subscriber would retry.
+            try
+            {
+                await _usageProjections.RefreshSubscriptionAsync(
+                    subscription.TenantId,
+                    subscription.ItemId,
+                    correlationId,
+                    cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to publish the initial usage projection for a subscription started " +
+                    "without payment; the repair sweep will catch it TenantHash={TenantHash} " +
+                    "SubscriptionHash={SubscriptionHash} CorrelationId={CorrelationId}",
+                    PaymentLogValue.Hash(subscription.TenantId),
+                    PaymentLogValue.Hash(subscription.ItemId),
+                    correlationId);
+            }
         }
 
         _logger.LogInformation(

--- a/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCheckoutServiceTests.cs
@@ -13,6 +13,7 @@ using Subscription.DomainService.Enums;
 using Subscription.DomainService.Outbox;
 using Subscription.DomainService.Repositories;
 using Subscription.DomainService.Requests;
+using Subscription.DomainService.Scheduling;
 using Subscription.DomainService.Services;
 using Subscription.DomainService.Utilities;
 
@@ -36,6 +37,7 @@ public sealed class SubscriptionCheckoutServiceTests
     private readonly Mock<IPaymentRepository> _paymentRepository = new();
     private readonly Mock<ICurrencyMinorUnitResolver> _currency = new();
     private readonly Mock<IBillingAccountRepository> _billingAccounts = new();
+    private readonly Mock<IUsageProjectionReconciler> _usageProjections = new();
 
     private SubscriptionDetail _subscription = NewSubscription();
     private MakePaymentRequest? _paymentRequest;
@@ -653,6 +655,32 @@ public sealed class SubscriptionCheckoutServiceTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
+
+        _usageProjections.Verify(
+            reconciler => reconciler.RefreshSubscriptionAsync(
+                TenantId, _subscription.ItemId, "corr-1", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the paid path publishes this from SubscriptionActivationProcessor.ActivateAsync, " +
+            "but a fully-discounted subscription never reaches that processor -- without this " +
+            "call SubscriptionUsageCurrent gets no row until cancellation writes one with a " +
+            "Canceled status that was never true while the subscription was live");
+    }
+
+    [Fact]
+    public async Task A_failed_usage_projection_publish_does_not_fail_a_free_subscribe()
+    {
+        _usageProjections
+            .Setup(reconciler => reconciler.RefreshSubscriptionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("projection store unavailable"));
+
+        var result = await Service().SubscribeAsync(
+            new CreateSubscriptionRequest(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(
+            "the subscription is already active; a read-model publish failing must not turn a " +
+            "successful subscribe into an apparent failure the subscriber would retry");
     }
 
     [Fact]
@@ -974,7 +1002,8 @@ public sealed class SubscriptionCheckoutServiceTests
         _paymentRepository.Object,
         _currency.Object,
         _billingAccounts.Object,
-        NullLogger<SubscriptionCheckoutService>.Instance);
+        NullLogger<SubscriptionCheckoutService>.Instance,
+        usageProjections: _usageProjections.Object);
 
     private void ArrangePendingCheckout()
     {


### PR DESCRIPTION
## Summary
- A plan costing 0 CHF (or a card-free trial) activates through `StartWithoutPaymentAsync`, which never published a `SubscriptionUsageCurrent` row — unlike the paid path, where `SubscriptionActivationProcessor.ActivateAsync` calls `IUsageProjectionReconciler.RefreshSubscriptionAsync` right after activation. The row only ever appeared when cancellation's own refresh created one, stamped with whatever status was current at that moment (`Canceled`), which is what the client observed.
- `StartWithoutPaymentAsync` now calls the same reconciler after its transition to `Active`/`Trialing` commits, via a new optional `IUsageProjectionReconciler` constructor parameter (mirrors how `documents` is already threaded through). Wrapped in try/catch and logged — the subscription is already active by that point, so a projection-publish failure must not fail the subscribe response.
- `SubscriptionRepairAnnouncer` now also calls `BackfillTenantAsync` next to `SweepTenantAsync`. Nothing in the codebase ever scheduled a tenant-wide `UsageProjectionRefresh` work item, so the backfill — the only pass that can find a row that was never written at all, as opposed to one that's merely behind its counter — never actually ran.

## Test plan
- [x] Added a test asserting the free-plan subscribe path calls `RefreshSubscriptionAsync` once
- [x] Added a test asserting a reconciler failure doesn't fail the subscribe call
- [x] `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName~SubscriptionCheckoutServiceTests"` — 45/45 passed
- [x] `dotnet build server/Subscription.DomainService/Subscription.DomainService.csproj` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)