### PR TITLE
chore(worker): sweep the client tenant on dev

### DIFF
--- a/server/Worker/appsettings.dev.json
+++ b/server/Worker/appsettings.dev.json
@@ -36,7 +36,7 @@
 
   "Subscription": {
     "FinancialDocumentRenderMaxConcurrency": 1,
-    "TenantIds": [ "T21223ef2472d47e08862329b03e814b7" ],
+    "TenantIds": [ "T21223ef2472d47e08862329b03e814b7", "T25a12bf38b3844f7b6d38b999bbeb366" ],
     "ReconciliationPollSeconds": 30
   }
 }


### PR DESCRIPTION
## Why

On dev, `Subscription.TenantIds` in `server/Worker/appsettings.dev.json` pins the subscription worker to `T21223ef2472d47e08862329b03e814b7`. `SubscriptionTenantDirectory` treats a configured list as authoritative — it "wins outright and never reaches the registry" — so the reconciliation sweep never visits any other tenant.

The usage-projection backfill added in #491 runs inside that sweep, so on dev it cannot repair tenant `T25a12bf38b3844f7b6d38b999bbeb366` (DB `0726e97176314aa7812f945ac34e7347`). Observed: subscription `18dbd502-33e2-450e-b679-19493b0e3502` (free plan `blocks-internal-unlimited`, created before #491 deployed) is `Active` with no `SubscriptionUsageCurrent` row, and the worker's last audit event for this tenant is 2026-09-09 02:37.

## Change

Add `T25a12bf38b3844f7b6d38b999bbeb366` to the dev `Subscription.TenantIds` list. One line, dev only.

- stg / prod have no pin and already discover every tenant — unaffected.
- `Payment.TenantIds` untouched.
- This also turns on the other subscription sweeps (renewals, dunning, cancellation-effective, repair) for this tenant on dev, which is what the pin already does for `T21223ef…`.

## Verify after deploy

Within one sweep (`ReconciliationPollSeconds: 30`), `18dbd502` should gain a `SubscriptionUsageCurrent` row for `ai-credits` with `SubscriptionStatus = 3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)