### PR TITLE
fix(subscription): refuse plan/quantity changes while cancellation is scheduled

### DIFF
--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/hooks/use-toast", () => ({ toast: (...args: unknown[]) => toast(...ar
 
 const previewPlanChange = vi.fn();
 const changePlan = vi.fn();
+const withdrawCancellation = vi.fn();
 
 vi.mock("../services/subscription-simulation.service", async () => {
   const actual = await vi.importActual<
@@ -23,6 +24,7 @@ vi.mock("../services/subscription-simulation.service", async () => {
     subscriptionSimulationService: {
       previewPlanChange: (...args: unknown[]) => previewPlanChange(...args),
       changePlan: (...args: unknown[]) => changePlan(...args),
+      withdrawCancellation: (...args: unknown[]) => withdrawCancellation(...args),
     },
   };
 });
@@ -141,13 +143,13 @@ const quote: SubscriptionPlanChangePreview = {
   quotedAtUtc: "2026-08-16T00:00:00Z",
 };
 
-const renderDialog = () => {
+const renderDialog = (subscriptionOverride: SimulatedSubscription = subscription) => {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
   return render(
     <QueryClientProvider client={client}>
       <ChangePlanDialog
-        subscription={subscription}
+        subscription={subscriptionOverride}
         currentPlan={currentPlan}
         plans={[currentPlan, premiumPlan]}
         organizationId="org-1"
@@ -341,6 +343,40 @@ describe("ChangePlanDialog", () => {
 
     expect(screen.getByRole("button", { name: /^Confirm change$/ })).toBeDisabled();
     expect(changePlan).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChangePlanDialog scheduled cancellation", () => {
+  const cancelling: SimulatedSubscription = { ...subscription, cancelAtPeriodEnd: true };
+
+  it("shows the notice and the undo button, and keeps preview disabled", () => {
+    renderDialog(cancelling);
+
+    expect(screen.getByTestId("change-plan-cancellation-notice")).toHaveTextContent(
+      /scheduled to cancel/i,
+    );
+    expect(screen.getByRole("button", { name: /undo cancellation/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Preview$/ })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^Confirm change$/ })).toBeDisabled();
+  });
+
+  it("undoes the cancellation from the dialog", async () => {
+    withdrawCancellation.mockResolvedValue({ ...subscription, cancelAtPeriodEnd: false });
+
+    renderDialog(cancelling);
+    click(/undo cancellation/i);
+
+    await waitFor(() => {
+      expect(withdrawCancellation).toHaveBeenCalledWith("sub-1", "org-1");
+    });
+  });
+
+  it("shows nothing when no cancellation is scheduled", () => {
+    renderDialog();
+
+    expect(
+      screen.queryByTestId("change-plan-cancellation-notice"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-plan-dialog.tsx
@@ -28,6 +28,7 @@ import {
   type BillingProfileGap,
 } from "../../subscription/utilities/subscription-api-failure";
 import { BillingProfileIncompleteNotice } from "./billing-profile-incomplete-notice";
+import { useWithdrawCancellation } from "../hooks/use-cancel-subscription";
 import { useChangeSubscriptionPlan } from "../hooks/use-change-subscription-plan";
 import { usePreviewPlanChange } from "../hooks/use-preview-plan-change";
 import type {
@@ -63,6 +64,7 @@ export const ChangePlanDialog = ({
 }) => {
   const preview = usePreviewPlanChange();
   const apply = useChangeSubscriptionPlan();
+  const withdrawCancellation = useWithdrawCancellation();
 
   const [targetPlanId, setTargetPlanId] = useState(currentPlan?.planId ?? "");
   const [priceId, setPriceId] = useState("");
@@ -72,7 +74,7 @@ export const ChangePlanDialog = ({
   const [confirmationProfileGap, setConfirmationProfileGap] =
     useState<BillingProfileGap | null>(null);
 
-  const busy = preview.isPending || apply.isPending;
+  const busy = preview.isPending || apply.isPending || withdrawCancellation.isPending;
 
   const targetPlan = useMemo(
     () => plans.find((plan) => plan.planId === targetPlanId),
@@ -230,7 +232,28 @@ export const ChangePlanDialog = ({
     }
   };
 
-  const blocked = (quote?.blockers.length ?? 0) > 0;
+  const undoCancellation = async () => {
+    try {
+      await withdrawCancellation.mutateAsync({
+        subscriptionId: subscription.subscriptionId,
+        organizationId,
+      });
+      toast({
+        variant: "success",
+        title: "Cancellation undone",
+        description: "This subscription keeps renewing as before.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Could not undo the cancellation",
+        description:
+          error instanceof Error ? error.message : "The cancellation could not be undone.",
+      });
+    }
+  };
+
+  const blocked = (quote?.blockers.length ?? 0) > 0 || subscription.cancelAtPeriodEnd;
   const previewProfileGap = quote?.blockers
     .map((blocker) =>
       billingProfileGapOf({
@@ -260,6 +283,28 @@ export const ChangePlanDialog = ({
         </DialogHeader>
 
         <div className="space-y-4">
+          {subscription.cancelAtPeriodEnd && (
+            <div
+              className="flex items-start justify-between gap-2 rounded-md border border-warning-300 bg-warning-50 p-2.5 text-xs text-warning-900"
+              data-testid="change-plan-cancellation-notice"
+            >
+              <span className="flex items-start gap-1.5">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                This subscription is scheduled to cancel on{" "}
+                {formatDate(subscription.currentPeriodEndUtc)}. Undo the cancellation to change
+                plan.
+              </span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={undoCancellation}
+                disabled={busy}
+              >
+                Undo cancellation
+              </Button>
+            </div>
+          )}
+
           <div className="space-y-1.5">
             <Label htmlFor="change-plan-target">Target plan</Label>
             <Select value={targetPlanId} onValueChange={selectTargetPlan}>
@@ -428,7 +473,11 @@ export const ChangePlanDialog = ({
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button variant="outline" onClick={runPreview} disabled={busy}>
+          <Button
+            variant="outline"
+            onClick={runPreview}
+            disabled={busy || subscription.cancelAtPeriodEnd}
+          >
             {preview.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
             Preview
           </Button>
@@ -453,6 +502,9 @@ const formatDate = (isoDate: string) => new Date(isoDate).toLocaleString();
  */
 const describePlanChangeRefusal = (code: string | undefined): string | null => {
   switch (code) {
+    case "subscription_cancellation_scheduled":
+      return "This subscription is scheduled to cancel. Undo the cancellation before changing " +
+        "plan.";
     case "subscription_pending_quantity_change_exists":
       return "A quantity change is already scheduled for the end of this period. Cancel it on the " +
         "subscription first — only one change can be waiting at a time.";

--- a/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/change-quantity-dialog.tsx
@@ -420,6 +420,9 @@ const explain = (code: string, error: unknown): string => {
       return "An increase has to be charged, and there is no saved card to charge. Add a payment method first.";
     case "subscription_quantity_change_not_allowed":
       return "This subscription cannot change quantity in its current state.";
+    case "subscription_cancellation_scheduled":
+      return "This subscription is scheduled to cancel. Undo the cancellation before changing " +
+        "quantity.";
     case "subscription_quantity_item_unknown":
       return "This plan does not sell that item.";
     case "subscription_quantity_unchanged":

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.test.tsx
@@ -56,6 +56,8 @@ const renderCard = (subscription: SimulatedSubscription) =>
       onCancelPendingPlanChange={noop}
       isCancelingPendingPlanChange={false}
       isCancelingPendingQuantityChange={false}
+      onWithdrawCancellation={noop}
+      isWithdrawingCancellation={false}
       onViewAuditTrail={noop}
       onAddPaymentMethod={noop}
       isStartingPaymentMethodSetup={false}
@@ -165,6 +167,8 @@ describe("CurrentSubscriptionCard payment-method actions", () => {
         onCancelPendingPlanChange={noop}
         isCancelingPendingPlanChange={false}
         isCancelingPendingQuantityChange={false}
+        onWithdrawCancellation={noop}
+        isWithdrawingCancellation={false}
         onViewAuditTrail={noop}
         onAddPaymentMethod={onAddPaymentMethod}
         isStartingPaymentMethodSetup={false}
@@ -192,6 +196,8 @@ describe("CurrentSubscriptionCard payment-method actions", () => {
         onCancelPendingPlanChange={noop}
         isCancelingPendingPlanChange={false}
         isCancelingPendingQuantityChange={false}
+        onWithdrawCancellation={noop}
+        isWithdrawingCancellation={false}
         onViewAuditTrail={noop}
         onAddPaymentMethod={noop}
         isStartingPaymentMethodSetup
@@ -249,6 +255,8 @@ describe("CurrentSubscriptionCard scheduled plan change", () => {
         isCancelingPendingQuantityChange={false}
         onCancelPendingPlanChange={onCancelPendingPlanChange}
         isCancelingPendingPlanChange={false}
+        onWithdrawCancellation={noop}
+        isWithdrawingCancellation={false}
         onViewAuditTrail={noop}
         onAddPaymentMethod={noop}
         isStartingPaymentMethodSetup={false}
@@ -264,6 +272,53 @@ describe("CurrentSubscriptionCard scheduled plan change", () => {
     renderCard(baseSubscription);
 
     expect(screen.queryByTestId("pending-plan-change")).not.toBeInTheDocument();
+  });
+});
+
+describe("CurrentSubscriptionCard scheduled cancellation", () => {
+  const scheduled: SimulatedSubscription = {
+    ...baseSubscription,
+    cancelAtPeriodEnd: true,
+  };
+
+  it("shows the scheduled cancellation and offers to keep the subscription", () => {
+    const onWithdrawCancellation = vi.fn();
+
+    render(
+      <CurrentSubscriptionCard
+        subscription={scheduled}
+        isLoading={false}
+        isError={false}
+        error={null}
+        scopeLabel="Acme"
+        onRetry={noop}
+        onCancel={noop}
+        onChangePlan={noop}
+        onChangeQuantity={noop}
+        onCancelPendingQuantityChange={noop}
+        isCancelingPendingQuantityChange={false}
+        onCancelPendingPlanChange={noop}
+        isCancelingPendingPlanChange={false}
+        onWithdrawCancellation={onWithdrawCancellation}
+        isWithdrawingCancellation={false}
+        onViewAuditTrail={noop}
+        onAddPaymentMethod={noop}
+        isStartingPaymentMethodSetup={false}
+      />,
+    );
+
+    const banner = screen.getByTestId("scheduled-cancellation");
+    expect(banner).toHaveTextContent(/Cancellation scheduled/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /keep subscription/i }));
+
+    expect(onWithdrawCancellation).toHaveBeenCalledOnce();
+  });
+
+  it("shows nothing when no cancellation is scheduled", () => {
+    renderCard(baseSubscription);
+
+    expect(screen.queryByTestId("scheduled-cancellation")).not.toBeInTheDocument();
   });
 });
 

--- a/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/components/current-subscription-card.tsx
@@ -56,6 +56,8 @@ export const CurrentSubscriptionCard = ({
   isCancelingPendingQuantityChange,
   onCancelPendingPlanChange,
   isCancelingPendingPlanChange,
+  onWithdrawCancellation,
+  isWithdrawingCancellation,
   onViewAuditTrail,
   onAddPaymentMethod,
   isStartingPaymentMethodSetup,
@@ -73,6 +75,8 @@ export const CurrentSubscriptionCard = ({
   isCancelingPendingQuantityChange: boolean;
   onCancelPendingPlanChange: () => void;
   isCancelingPendingPlanChange: boolean;
+  onWithdrawCancellation: () => void;
+  isWithdrawingCancellation: boolean;
   onViewAuditTrail: () => void;
   /** Opens a card-collection session. Never a payment -- see the button labels below. */
   onAddPaymentMethod: () => void;
@@ -224,9 +228,6 @@ export const CurrentSubscriptionCard = ({
         {subscription.trialEndsAtUtc && (
           <span>Trial ends {formatDate(subscription.trialEndsAtUtc)}</span>
         )}
-        {subscription.cancelAtPeriodEnd && (
-          <span className="text-warning-800">Cancels at period end</span>
-        )}
         {subscription.quantities.length > 0 && (
           <span>
             {subscription.quantities
@@ -240,6 +241,31 @@ export const CurrentSubscriptionCard = ({
           <span>{describeTier(subscription.currentTier)}</span>
         )}
       </div>
+
+      {/* A cancellation already scheduled. The subscription stays Active and keeps granting until
+          the period ends, so this is the one place that says so and offers the one clear way
+          back: undo it. Change plan is refused server-side while this is showing -- see the
+          dialog's own notice. */}
+      {subscription.cancelAtPeriodEnd && (
+        <div
+          className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-warning-300 bg-warning-50 p-2.5 text-xs"
+          data-testid="scheduled-cancellation"
+        >
+          <span className="flex items-center gap-1.5 text-warning-900">
+            <CalendarClock className="h-3.5 w-3.5 shrink-0" />
+            Cancellation scheduled for {formatDate(subscription.currentPeriodEndUtc)}. You keep{" "}
+            {subscription.planName} until then.
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onWithdrawCancellation}
+            disabled={isWithdrawingCancellation}
+          >
+            Keep subscription
+          </Button>
+        </div>
+      )}
 
       {/* A plan change already booked, shown for the same reason the reduction below is: without
           it a reload shows the current plan with nothing to say a different one is coming, and no

--- a/client/app/cross-modules/utilities/subscription-simulation/hooks/use-cancel-subscription.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/hooks/use-cancel-subscription.ts
@@ -12,3 +12,27 @@ export const useCancelSubscription = () => {
       queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] }),
   });
 };
+
+/**
+ * Undoes a cancellation scheduled for the end of the paid period, restoring the renewal it
+ * cleared. Invalidates the same two queries a plan change does: what is granted today has not
+ * moved, but the current subscription and its entitlements both read differently once the
+ * schedule is gone.
+ */
+export const useWithdrawCancellation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      subscriptionId,
+      organizationId,
+    }: {
+      subscriptionId: string;
+      organizationId?: string;
+    }) => subscriptionSimulationService.withdrawCancellation(subscriptionId, organizationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-current"] });
+      queryClient.invalidateQueries({ queryKey: ["subscription-simulation-entitlements"] });
+    },
+  });
+};

--- a/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
+++ b/client/app/cross-modules/utilities/subscription-simulation/pages/subscription-simulation-page.tsx
@@ -31,6 +31,7 @@ import { CloseUsagePeriodDialog } from "../components/close-usage-period-dialog"
 import { DataConsoleDialog } from "../components/data-console-dialog";
 import { useCancelPendingQuantityChange } from "../hooks/use-quantity-change";
 import { useCancelPendingPlanChange } from "../hooks/use-change-subscription-plan";
+import { useWithdrawCancellation } from "../hooks/use-cancel-subscription";
 import { useStartPaymentMethodSetup } from "../hooks/use-start-payment-method-setup";
 import { CurrentSubscriptionCard } from "../components/current-subscription-card";
 import { OverageTermsSection } from "../components/overage-terms-section";
@@ -125,6 +126,7 @@ export const SubscriptionSimulationPage = () => {
 
   const cancelPendingQuantity = useCancelPendingQuantityChange();
   const cancelPendingPlan = useCancelPendingPlanChange();
+  const withdrawCancellation = useWithdrawCancellation();
   const startPaymentMethodSetup = useStartPaymentMethodSetup();
 
   /**
@@ -220,6 +222,37 @@ export const SubscriptionSimulationPage = () => {
     }
   };
 
+  /**
+   * Undoes a cancellation scheduled for the end of the paid period. Reported as a toast for the
+   * same reason the reduction and plan-change withdrawals above are: the control that raised it
+   * disappears the moment the subscription is re-read without a scheduled cancellation.
+   */
+  const withdrawScheduledCancellation = async () => {
+    if (!currentSubscription) {
+      return;
+    }
+
+    try {
+      await withdrawCancellation.mutateAsync({
+        subscriptionId: currentSubscription.subscriptionId,
+        organizationId: organizationScope,
+      });
+
+      toast({
+        variant: "success",
+        title: "Cancellation undone",
+        description: "This subscription keeps renewing as before.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "The cancellation could not be undone",
+        description:
+          error instanceof Error ? error.message : "Reload and try again.",
+      });
+    }
+  };
+
   return (
     <main className="min-w-0 space-y-5 p-4 sm:p-6 lg:p-8">
       <SubscriptionPlanPageHeader
@@ -291,6 +324,8 @@ export const SubscriptionSimulationPage = () => {
             isCancelingPendingQuantityChange={cancelPendingQuantity.isPending}
             onCancelPendingPlanChange={withdrawScheduledPlanChange}
             isCancelingPendingPlanChange={cancelPendingPlan.isPending}
+            onWithdrawCancellation={withdrawScheduledCancellation}
+            isWithdrawingCancellation={withdrawCancellation.isPending}
             onViewAuditTrail={() => setIsViewingAuditTrail(true)}
             onAddPaymentMethod={addPaymentMethod}
             isStartingPaymentMethodSetup={startPaymentMethodSetup.isPending}

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -219,6 +219,35 @@ class SubscriptionSimulationService {
   }
 
   /**
+   * Undoes a cancellation scheduled for the end of the paid period, restoring the renewal it
+   * cleared. A copy of {@link cancelPendingPlanChange} pointed at the cancellation endpoint.
+   */
+  async withdrawCancellation(
+    subscriptionId: string,
+    organizationId?: string,
+  ): Promise<SimulatedSubscription> {
+    const query = organizationId
+      ? `?organizationId=${encodeURIComponent(organizationId)}`
+      : "";
+
+    try {
+      const response = await serviceInstances.utitlitiesService.delete<
+        SimulationApiResponse<SimulatedSubscription>
+      >(
+        `${SUBSCRIPTIONS_ENDPOINT}/${encodeURIComponent(subscriptionId)}/cancellation${query}`,
+      );
+
+      if (!response.success || !response.data) {
+        throw operationError(response, "The cancellation could not be undone.");
+      }
+
+      return response.data;
+    } catch (error) {
+      throw operationError(error, "The cancellation could not be undone.");
+    }
+  }
+
+  /**
    * Moves an existing subscription to another price. The whole request is body-bound
    * (`[FromBody]` on the server), so — unlike the GET/DELETE endpoints — `organizationId` has to
    * travel as a field on `request`, not as a query parameter.
@@ -615,6 +644,7 @@ const PLAN_CHANGE_ERROR_CODES = [
   "subscription_plan_change_invalid",
   "subscription_not_found",
   "subscription_plan_change_not_eligible",
+  "subscription_cancellation_scheduled",
   "subscription_quantity_change_in_flight",
   // A prepaid opening stub no longer refuses a compatible plan change outright — see
   // change-plan-dialog's own remarks on the retired _prepaid code. Only an unpaid stub still

--- a/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
+++ b/client/app/cross-modules/utilities/subscription-simulation/services/subscription-simulation.service.ts
@@ -588,6 +588,7 @@ const QUANTITY_ERROR_CODES = [
   "subscription_quantity_charge_unresolved",
   "subscription_quantity_charge_failed",
   "subscription_quantity_change_in_flight",
+  "subscription_cancellation_scheduled",
   "subscription_version_conflict",
   "subscription_payment_method_missing",
   "subscription_quantity_change_not_allowed",

--- a/server/Api/Api.xml
+++ b/server/Api/Api.xml
@@ -896,6 +896,16 @@
             simply swaps with no charge or credit either way.
             </remarks>
         </member>
+        <member name="M:Api.Controllers.SubscriptionsController.WithdrawCancellation(System.String,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Undoes a cancellation scheduled for the end of the paid period.
+            </summary>
+            <remarks>
+            The subscription keeps renewing exactly as before. <c>404</c> when nothing is scheduled —
+            including once the promised period end has already passed — <c>409</c> when the
+            subscription moved underneath the request.
+            </remarks>
+        </member>
         <member name="M:Api.Controllers.SubscriptionsController.CancelPendingPlanChange(System.String,System.String,System.Threading.CancellationToken)">
             <summary>
             Withdraws a plan change scheduled for the end of the paid period.

--- a/server/Api/Controllers/SubscriptionsController.cs
+++ b/server/Api/Controllers/SubscriptionsController.cs
@@ -287,6 +287,40 @@ public sealed class SubscriptionsController : ControllerBase
     }
 
     /// <summary>
+    /// Undoes a cancellation scheduled for the end of the paid period.
+    /// </summary>
+    /// <remarks>
+    /// The subscription keeps renewing exactly as before. <c>404</c> when nothing is scheduled —
+    /// including once the promised period end has already passed — <c>409</c> when the
+    /// subscription moved underneath the request.
+    /// </remarks>
+    [HttpDelete("{subscriptionId}/cancellation")]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ApiResponse<SubscriptionResponse>), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProtectedEndPoint("blocks-utilities::subscription::manage")]
+    public async Task<IActionResult> WithdrawCancellation(
+        string subscriptionId,
+        [FromQuery] string? organizationId,
+        CancellationToken cancellationToken)
+    {
+        var correlationId = HttpContext.TraceIdentifier;
+
+        var result = await _cancellation.WithdrawCancellationAsync(
+            subscriptionId,
+            organizationId,
+            correlationId,
+            cancellationToken);
+
+        await AuditAsync("WithdrawCancellation", organizationId, subscriptionId,
+            result.IsSuccess, result.ErrorCode, result.FailureKind.ToString(), correlationId,
+            null, null, cancellationToken);
+
+        return result.ToActionResult(correlationId);
+    }
+
+    /// <summary>
     /// Withdraws a plan change scheduled for the end of the paid period.
     /// </summary>
     /// <remarks>

--- a/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionRepository.cs
@@ -251,6 +251,22 @@ public interface ISubscriptionRepository
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Withdraws a scheduled cancellation, restoring the renewal it cleared.
+    /// </summary>
+    /// <remarks>
+    /// Guarded by <c>CancelAtPeriodEnd == true</c> and <c>CurrentPeriodEndUtc &gt; now</c> in
+    /// addition to the version: once the promised boundary has passed it is too late to undo, and
+    /// the finalizing sweep is the one that gets to decide what happens next.
+    /// </remarks>
+    Task<bool> TryWithdrawScheduledCancellationAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedVersion,
+        DateTime restoredNextFeeBillingAtUtc,
+        SubscriptionOutboxEvent outboxEvent,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Counts one more card-collection attempt, so the next one is raised under a fresh key.
     /// </summary>
     /// <remarks>

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -608,6 +608,46 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
         return result.ModifiedCount == 1;
     }
 
+    public async Task<bool> TryWithdrawScheduledCancellationAsync(
+        string tenantId,
+        string subscriptionId,
+        int expectedVersion,
+        DateTime restoredNextFeeBillingAtUtc,
+        SubscriptionOutboxEvent outboxEvent,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(outboxEvent);
+
+        var filter = Builders<SubscriptionDetail>.Filter.And(
+            VersionedFilter(tenantId, subscriptionId, expectedVersion),
+            Builders<SubscriptionDetail>.Filter.Eq(
+                subscription => subscription.CancelAtPeriodEnd,
+                true),
+            Builders<SubscriptionDetail>.Filter.Gt(
+                subscription => subscription.CurrentPeriodEndUtc,
+                DateTime.UtcNow));
+
+        var update = Builders<SubscriptionDetail>.Update
+            .Set(subscription => subscription.CancelAtPeriodEnd, false)
+            .Set(subscription => subscription.CanCancelImmediately, false)
+            .Set(subscription => subscription.CanceledAtUtc, (DateTime?)null)
+            .Set(subscription => subscription.CancellationReason, (string?)null)
+            // Restores the renewal the cancellation cleared. The caller already holds this
+            // subscription's own CurrentPeriodEndUtc, so it is passed in rather than read back
+            // through a pipeline update.
+            .Set(subscription => subscription.NextFeeBillingAtUtc, restoredNextFeeBillingAtUtc)
+            .Inc(subscription => subscription.Version, 1)
+            .Set(subscription => subscription.LastUpdatedDateUtc, DateTime.UtcNow)
+            .Push(subscription => subscription.OutboxEvents, outboxEvent);
+
+        var result = await Subscriptions(tenantId).UpdateOneAsync(
+            filter,
+            update,
+            cancellationToken: cancellationToken);
+
+        return result.ModifiedCount == 1;
+    }
+
     public async Task<bool> TryBumpPaymentMethodSetupAttemptAsync(
         string tenantId,
         string subscriptionId,

--- a/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionRepository.cs
@@ -501,8 +501,8 @@ public sealed class SubscriptionRepository : ISubscriptionRepository
     /// </summary>
     /// <remarks>
     /// Applied to <see cref="TryTransitionAsync"/> only when the transition asks for it — see
-    /// <see cref="SubscriptionTransition.RequireNoSettlementReservation"/>, which renewals set and
-    /// activation, cancellation and usage rating do not. A blanket lock there would let one
+    /// <see cref="SubscriptionTransition.RequireNoSettlementReservation"/>, which renewals and
+    /// cancellation set and activation and usage rating do not. A blanket lock there would let one
     /// unresolvable reservation stall a subscription's whole lifecycle.
     /// </remarks>
     private static FilterDefinition<SubscriptionDetail> NoSettlementReservationFilter() =>

--- a/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionTransition.cs
@@ -172,14 +172,19 @@ public sealed record SubscriptionTransition(
     /// Whether this transition must not happen while a quantity increase is mid-settlement.
     /// </summary>
     /// <remarks>
-    /// Set by renewals only. The in-memory check in the renewal sweep closes the ordinary case;
-    /// this closes the gap between reading the subscription and writing the transition, where a
-    /// reservation can be taken by a request arriving in between.
+    /// Set by renewals and cancellation. The in-memory check in the renewal sweep closes the
+    /// ordinary case; this closes the gap between reading the subscription and writing the
+    /// transition, where a reservation can be taken by a request arriving in between. Cancellation
+    /// needs the same guard for a different reason: a plan or quantity change mid-settlement
+    /// commits through the reservation it holds rather than the version once money has moved (see
+    /// <see cref="ISubscriptionRepository.TryChangePlanAsync"/>'s own remarks), so a cancel that
+    /// only bumped the version would not stop it from landing afterward — leaving
+    /// <c>CancelAtPeriodEnd</c> set on a subscription that just moved plan and renewal date.
     /// <para>
-    /// Deliberately opt-in rather than the default for every transition. Activation, cancellation
-    /// and usage rating share this write, and a reservation whose charge the provider never answers
-    /// for can only be cleared by a person — a blanket lock would let one stall a subscription's
-    /// whole lifecycle rather than one period of its billing.
+    /// Deliberately opt-in rather than the default for every transition. Activation and usage
+    /// rating share this write, and a reservation whose charge the provider never answers for can
+    /// only be cleared by a person — a blanket lock would let one stall a subscription's whole
+    /// lifecycle rather than one period of its billing.
     /// </para>
     /// </remarks>
     public bool RequireNoSettlementReservation { get; init; }

--- a/server/Subscription.DomainService/Services/ISubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/ISubscriptionCancellationService.cs
@@ -25,6 +25,22 @@ public interface ISubscriptionCancellationService
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Undoes a cancellation scheduled for the end of the paid period, restoring the renewal it
+    /// cleared. <c>404</c> when nothing is scheduled — including once the promised boundary has
+    /// already passed, at which point the finalizing sweep owns what happens next.
+    /// </summary>
+    /// <param name="organizationId">
+    /// An organization named by the caller, if any. Trusted only for the platform console — see
+    /// <see cref="Subscription.DomainService.Requests.CreateSubscriptionRequest.OrganizationId"/>
+    /// for the full rule.
+    /// </param>
+    Task<SubscriptionOperationResult<SubscriptionResponse>> WithdrawCancellationAsync(
+        string subscriptionId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Recovers usage-closure reservations left <c>CloseReserved</c> longer than their configured
     /// timeout — the crash window between a cancellation's own transition landing (or losing) and
     /// the commit-or-release call that should have followed it ever actually running.

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -521,6 +521,16 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 // Status alone does not move here, so it cannot arbitrate two concurrent
                 // first-time requests the way it does everywhere else — this is what does instead.
                 RequireCancellationNotAlreadyScheduled = true,
+                // A plan or quantity increase mid-settlement writes its result through the
+                // reservation it holds, not the version — see TryChangePlanAsync's own remarks —
+                // so a version bump from this write cannot stop it from landing afterward. Without
+                // this, a cancel that wins the race here and a charge that lands after it produces
+                // exactly the contradictory state (CancelAtPeriodEnd on a subscription that just
+                // moved plan and renewal date) the plan/quantity-change guard now refuses at the
+                // other end. Losing to a reservation here is temporary: the caller retries once the
+                // settlement resolves, including one stranded and later promoted by the recovery
+                // sweep.
+                RequireNoSettlementReservation = true,
                 // A year already paid for is a year the subscriber keeps. Cancelling inside the
                 // opening stub of a prepaid annual price therefore runs entitlement through to the
                 // end of that year rather than stopping with the stub — they bought it, and this
@@ -575,6 +585,8 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 EndedAtUtc = now,
                 CancellationReason = reason,
                 ClearNextFeeBillingAt = true,
+                // Same race as the scheduled cancel above, and the same fix — see its own remarks.
+                RequireNoSettlementReservation = true,
                 // Entitlement stops now, so a year that had not started never will. Dropped so no
                 // later sweep can find it and charge for a period this subscription never held.
                 ClearPendingAnnualPeriod = subscription.PendingAnnualPeriod is not null,

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -260,6 +260,100 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
             canCancelImmediately);
     }
 
+    public async Task<SubscriptionOperationResult<SubscriptionResponse>> WithdrawCancellationAsync(
+        string subscriptionId,
+        string? organizationId,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        var resolution = await _contextResolver.ResolveAsync(
+            correlationId, organizationId, cancellationToken);
+
+        if (!resolution.IsSuccess)
+        {
+            return resolution.ToFailure<SubscriptionResponse>(correlationId);
+        }
+
+        var context = resolution.Context!;
+
+        var subscription = await _subscriptions.GetAsync(
+            context.TenantId, context.OrganizationId, subscriptionId, cancellationToken);
+
+        if (subscription is null)
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_not_found",
+                "The subscription does not exist.",
+                correlationId);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        // Once the promised boundary has passed it is too late to undo — the finalizing sweep
+        // owns what happens to the subscription from here, whether or not it has actually run yet.
+        if (!subscription.CancelAtPeriodEnd || !SubscriptionLiveness.IsEffectivelyLive(subscription, now))
+        {
+            return Failure(
+                PaymentFailureKind.NotFound,
+                "subscription_cancellation_not_scheduled",
+                "There is no scheduled cancellation to undo.",
+                correlationId);
+        }
+
+        var outboxEvent = _events.Create(
+            subscription, SubscriptionConstants.SubscriptionCancellationWithdrawn, correlationId);
+
+        if (!await _subscriptions.TryWithdrawScheduledCancellationAsync(
+                subscription.TenantId,
+                subscription.ItemId,
+                subscription.Version,
+                subscription.CurrentPeriodEndUtc,
+                outboxEvent,
+                cancellationToken))
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_transition_conflict",
+                "The subscription changed while the cancellation was being undone.",
+                correlationId);
+        }
+
+        if (_scheduler is not null)
+        {
+            await _scheduler.ScheduleOutboxPublicationAsync(
+                subscription, outboxEvent, cancellationToken);
+
+            await _scheduler.ScheduleUsageProjectionRefreshAsync(
+                subscription.TenantId,
+                subscription.OrganizationId,
+                subscription.ItemId,
+                correlationId,
+                cancellationToken);
+        }
+
+        _cache.Invalidate(subscription.TenantId, subscription.OrganizationId);
+
+        subscription.CancelAtPeriodEnd = false;
+        subscription.CanCancelImmediately = false;
+        subscription.CanceledAtUtc = null;
+        subscription.CancellationReason = null;
+        subscription.NextFeeBillingAtUtc = subscription.CurrentPeriodEndUtc;
+        subscription.Version++;
+
+        _logger.LogInformation(
+            "Scheduled subscription cancellation withdrawn TenantHash={TenantHash} " +
+            "SubscriptionHash={SubscriptionHash} CorrelationId={CorrelationId}",
+            PaymentLogValue.Hash(subscription.TenantId),
+            PaymentLogValue.Hash(subscription.ItemId),
+            correlationId);
+
+        return SubscriptionOperationResult<SubscriptionResponse>.Success(
+            await _mapper.ToResponseAsync(
+                _billingAccounts, subscription, null, null, cancellationToken),
+            correlationId);
+    }
+
     /// <summary>
     /// The bookkeeping every successful write shares: settle any pending checkout, drop the
     /// cached entitlement snapshot, log, and build the response from the in-memory reflection

--- a/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionCancellationService.cs
@@ -260,6 +260,23 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
             canCancelImmediately);
     }
 
+    /// <remarks>
+    /// Not a perfect inverse of a cancellation taken inside a calendar-aligned yearly
+    /// subscription's opening stub: the cancel path unconditionally drops
+    /// <see cref="SubscriptionDetail.PendingAnnualPeriod"/> (see <see cref="EndAtPeriodEndAsync"/>),
+    /// and this does not restore it — there is nothing left to restore it from by the time this
+    /// runs. <c>NextFeeBillingAtUtc</c> is still restored correctly either way, so the boundary
+    /// still charges something; for a prepaid year that something is unaffected (its end was
+    /// already folded into <c>CurrentPeriodEndUtc</c>), but for an unpaid one the frozen annual
+    /// quote is gone and the boundary instead prices an ordinary period fresh, at whatever the plan
+    /// costs by then rather than the amount originally quoted at signup.
+    /// <para>
+    /// ponytail: known gap, narrow blast radius (only an unpaid opening-stub annual quote, only if
+    /// the price changed between signup and the undo). Close it by having the cancel path snapshot
+    /// the cleared <c>PendingAnnualPeriod</c> onto the transition so an undo can restore it, if this
+    /// ever needs to be exact.
+    /// </para>
+    /// </remarks>
     public async Task<SubscriptionOperationResult<SubscriptionResponse>> WithdrawCancellationAsync(
         string subscriptionId,
         string? organizationId,
@@ -514,7 +531,8 @@ public sealed class SubscriptionCancellationService : ISubscriptionCancellationS
                 // Either way the pending year stops being pending. Prepaid, it has just been folded
                 // into the period above; unpaid, clearing the next billing instant above already
                 // stopped its charge, and leaving the record behind would invite a later sweep to
-                // find a year nobody is going to pay for.
+                // find a year nobody is going to pay for. Also why WithdrawCancellationAsync cannot
+                // restore it on an undo — see its own remarks.
                 ClearPendingAnnualPeriod = subscription.PendingAnnualPeriod is not null,
                 Event = _events.Create(
                     subscription,

--- a/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionPlanChangeService.cs
@@ -498,6 +498,32 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                 correlationId);
         }
 
+        // A cancellation already schedules what happens at the next renewal boundary — nothing.
+        // Pricing a plan change against that boundary would either push the cancellation date out
+        // (an upgrade charging a full new period) or schedule a change for a renewal that will
+        // never come (a downgrade). Undo the cancellation first; the change then prices normally.
+        var blockers = new List<SubscriptionPreviewBlockerResponse>();
+
+        if (subscription.CancelAtPeriodEnd)
+        {
+            if (!preview)
+            {
+                return Failure<PlanChangeResolution>(
+                    PaymentFailureKind.Conflict,
+                    "subscription_cancellation_scheduled",
+                    "This subscription is scheduled to cancel. Undo the cancellation before "
+                        + "changing plan.",
+                    correlationId);
+            }
+
+            blockers.Add(new SubscriptionPreviewBlockerResponse
+            {
+                Code = "subscription_cancellation_scheduled",
+                Message = "This subscription is scheduled to cancel. Undo the cancellation before "
+                    + "changing plan."
+            });
+        }
+
         // A quantity increase is holding units priced against the plan being left. Refused by name
         // rather than by the repository's filter alone, so the caller knows to re-read and retry
         // rather than reading it as a stale version. Only enforced on the real change: a preview
@@ -578,8 +604,6 @@ public sealed class SubscriptionPlanChangeService : ISubscriptionPlanChangeServi
                     + "or choose a target the discount covers.",
                 correlationId);
         }
-
-        var blockers = new List<SubscriptionPreviewBlockerResponse>();
 
         if (preview && promotionChangeLocked)
         {

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -1030,6 +1030,45 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
         return false;
     }
 
+    /// <summary>
+    /// The preview-only obstacles worth quoting a price alongside rather than refusing outright —
+    /// mirrors the same two checks <see cref="RunAsync"/> makes as outright failures on the real
+    /// change.
+    /// </summary>
+    private static List<SubscriptionPreviewBlockerResponse> BuildBlockers(
+        SubscriptionDetail subscription, bool preview, DateTime now)
+    {
+        if (!preview)
+        {
+            return [];
+        }
+
+        var blockers = new List<SubscriptionPreviewBlockerResponse>();
+
+        if (subscription.CancelAtPeriodEnd)
+        {
+            blockers.Add(new SubscriptionPreviewBlockerResponse
+            {
+                Code = "subscription_cancellation_scheduled",
+                Message = "This subscription is scheduled to cancel. Undo the cancellation before "
+                    + "changing quantity."
+            });
+        }
+
+        if (subscription.Discount is { Campaign.Kind: CampaignKind.FreeOpeningCalendarPeriod } &&
+            now < subscription.CurrentPeriodEndUtc)
+        {
+            blockers.Add(new SubscriptionPreviewBlockerResponse
+            {
+                Code = "subscription_promotion_change_locked",
+                Message = "This subscription is on a free opening period and cannot change " +
+                    "quantity until it ends."
+            });
+        }
+
+        return blockers;
+    }
+
     private static bool SameQuantities(
         IReadOnlyList<SubscriptionQuantityItem> left,
         IReadOnlyList<SubscriptionQuantityItem> right) =>
@@ -1107,18 +1146,7 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 - renewal.BuiltInDiscountMinor
                 - renewal.PromotionalDiscountMinor,
             PromotionApplied = renewal.DiscountApplied,
-            Blockers = preview &&
-                subscription.Discount is { Campaign.Kind: CampaignKind.FreeOpeningCalendarPeriod } &&
-                now < subscription.CurrentPeriodEndUtc
-                    ?
-                    [
-                        new SubscriptionPreviewBlockerResponse
-                        {
-                            Code = "subscription_promotion_change_locked",
-                            Message = "This subscription is on a free opening period and cannot change quantity until it ends."
-                        }
-                    ]
-                    : [],
+            Blockers = BuildBlockers(subscription, preview, now),
             ChargePaymentDetailId = paymentDetailId,
             PendingQuantityChange = QuantityResponseMapper.Pending(pending),
             ProviderName = account?.ProviderName

--- a/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
+++ b/server/Subscription.DomainService/Services/SubscriptionQuantityChangeService.cs
@@ -224,6 +224,20 @@ public sealed class SubscriptionQuantityChangeService : ISubscriptionQuantityCha
                 correlationId);
         }
 
+        // The plan-change service's identical guard applies here too: a cancellation already
+        // schedules nothing to happen at the next renewal, and pricing a quantity change against
+        // that boundary would either charge an increase today and push the cancellation date out,
+        // or schedule a decrease for a renewal that will never come.
+        if (!preview && subscription.CancelAtPeriodEnd)
+        {
+            return Failure(
+                PaymentFailureKind.Conflict,
+                "subscription_cancellation_scheduled",
+                "This subscription is scheduled to cancel. Undo the cancellation before changing "
+                    + "quantity.",
+                correlationId);
+        }
+
         // Checked before anything is calculated, so a stale caller is told to re-read rather than
         // shown a quote derived from a quantity that has already moved.
         if (subscription.Version != request.Version)

--- a/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
+++ b/server/Subscription.DomainService/Utilities/SubscriptionConstants.cs
@@ -38,6 +38,8 @@ public static class SubscriptionConstants
         "SubscriptionActivationFailed";
     public const string SubscriptionCancellationRequested =
         "SubscriptionCancellationRequested";
+    public const string SubscriptionCancellationWithdrawn =
+        "SubscriptionCancellationWithdrawn";
     public const string SubscriptionCanceled = "SubscriptionCanceled";
     public const string UsageThresholdReached = "UsageThresholdReached";
     public const string SubscriptionRenewed = "SubscriptionRenewed";

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -892,6 +892,50 @@ public sealed class SubscriptionCancellationServiceTests
         }
     }
 
+    [Fact]
+    public async Task Withdrawing_a_scheduled_cancellation_clears_it_and_restores_the_renewal()
+    {
+        _subscription!.CancelAtPeriodEnd = true;
+        _subscription.CanCancelImmediately = true;
+        _subscription.CanceledAtUtc = new DateTime(2026, 8, 14, 9, 0, 0, DateTimeKind.Utc);
+        _subscription.CancellationReason = "changed my mind";
+        _subscription.NextFeeBillingAtUtc = null;
+
+        _subscriptions
+            .Setup(repository => repository.TryWithdrawScheduledCancellationAsync(
+                TenantId,
+                "sub-1",
+                _subscription.Version,
+                _subscription.CurrentPeriodEndUtc,
+                It.IsAny<SubscriptionOutboxEvent>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await Service().WithdrawCancellationAsync(
+            "sub-1", null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.CancelAtPeriodEnd.Should().BeFalse();
+        _subscription.CanCancelImmediately.Should().BeFalse();
+        _subscription.CanceledAtUtc.Should().BeNull();
+        _subscription.CancellationReason.Should().BeNull();
+        _subscription.NextFeeBillingAtUtc.Should().Be(_subscription.CurrentPeriodEndUtc,
+            "undoing the cancellation must restore the renewal it cleared");
+    }
+
+    [Fact]
+    public async Task Withdrawing_when_nothing_is_scheduled_is_not_found()
+    {
+        _subscription!.CancelAtPeriodEnd = false;
+
+        var result = await Service().WithdrawCancellationAsync(
+            "sub-1", null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.NotFound);
+        result.ErrorCode.Should().Be("subscription_cancellation_not_scheduled");
+    }
+
     private SubscriptionCancellationService Service() => new(
         _subscriptions.Object,
         _links.Object,

--- a/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionCancellationServiceTests.cs
@@ -119,6 +119,61 @@ public sealed class SubscriptionCancellationServiceTests
             "questions about cancellation");
     }
 
+    /// <summary>
+    /// A plan or quantity change mid-settlement commits through the reservation it holds rather
+    /// than the version once money has moved, so a cancel that only bumped the version could not
+    /// stop it landing afterward — leaving CancelAtPeriodEnd set on a subscription that just moved
+    /// plan and renewal date. Refusing here, the same way a renewal already does, is what closes
+    /// that gap: see SubscriptionTransition.RequireNoSettlementReservation's own remarks.
+    /// </summary>
+    [Fact]
+    public async Task Scheduling_a_cancellation_refuses_to_land_on_an_unresolved_settlement_reservation()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        _transition!.RequireNoSettlementReservation.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task An_immediate_cancellation_also_refuses_to_land_on_an_unresolved_settlement_reservation()
+    {
+        await Service().CancelAsync(
+            "sub-1", immediately: true, null, null, "corr-1", CancellationToken.None);
+
+        _transition!.RequireNoSettlementReservation.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// What the caller actually sees when the guard above fires: not a silent no-op, and not the
+    /// idempotent-duplicate success path — a genuine conflict, because nothing about this
+    /// subscription actually moved. Worth pinning down for the case that matters most: a
+    /// reservation stranded by a dying process, which widens this window from the length of one
+    /// card charge to however long it sits waiting for the recovery sweep to resolve it.
+    /// </summary>
+    [Fact]
+    public async Task A_cancellation_blocked_by_an_in_flight_settlement_is_reported_as_a_conflict()
+    {
+        _subscription!.SettlementReservation = new SettlementReservation
+        {
+            ReservationId = "res-1",
+            Kind = SettlementReservationKind.PlanChange,
+            ChargeAmountMinor = 1_000,
+            ReservedAtUtc = _time.GetUtcNow().UtcDateTime
+        };
+        _subscriptions
+            .Setup(repository => repository.TryTransitionAsync(
+                TenantId, "sub-1", It.IsAny<SubscriptionTransition>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await Service().CancelAsync(
+            "sub-1", immediately: false, null, null, "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureKind.Should().Be(PaymentFailureKind.Conflict);
+        result.ErrorCode.Should().Be("subscription_transition_conflict");
+    }
+
     [Fact]
     public async Task An_immediate_cancellation_ends_it_now()
     {

--- a/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionPlanChangeServiceCampaignTests.cs
@@ -130,6 +130,31 @@ public sealed class SubscriptionPlanChangeServiceCampaignTests
     }
 
     [Fact]
+    public async Task A_plan_change_is_refused_while_a_cancellation_is_scheduled()
+    {
+        _subscription.CancelAtPeriodEnd = true;
+
+        var result = await Service().ChangePlanAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_cancellation_scheduled");
+    }
+
+    [Fact]
+    public async Task A_plan_change_preview_reports_a_scheduled_cancellation_as_a_blocker()
+    {
+        _subscription.CancelAtPeriodEnd = true;
+
+        var result = await Service().PreviewPlanChangeAsync(
+            "sub-1", Request(), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("a preview still prices the change");
+        result.Value!.Blockers.Should().Contain(
+            blocker => blocker.Code == "subscription_cancellation_scheduled");
+    }
+
+    [Fact]
     public async Task A_standard_discount_never_locks_a_plan_change()
     {
         _subscription.Discount = new DiscountTerms

--- a/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceCampaignTests.cs
+++ b/server/XUnitTest/Subscription/SubscriptionQuantityChangeServiceCampaignTests.cs
@@ -65,6 +65,31 @@ public sealed class SubscriptionQuantityChangeServiceCampaignTests
     }
 
     [Fact]
+    public async Task A_quantity_change_is_refused_while_a_cancellation_is_scheduled()
+    {
+        _subscription.CancelAtPeriodEnd = true;
+
+        var result = await Service().ChangeAsync(
+            "sub-1", Request(2), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("subscription_cancellation_scheduled");
+    }
+
+    [Fact]
+    public async Task A_quantity_change_preview_reports_a_scheduled_cancellation_as_a_blocker()
+    {
+        _subscription.CancelAtPeriodEnd = true;
+
+        var result = await Service().PreviewAsync(
+            "sub-1", Request(2), "corr-1", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue("a preview still prices the change");
+        result.Value!.Blockers.Should().Contain(
+            blocker => blocker.Code == "subscription_cancellation_scheduled");
+    }
+
+    [Fact]
     public async Task A_standard_discount_never_locks_a_quantity_change()
     {
         // Deliberately not asserting the whole change succeeds -- that needs a much larger mock


### PR DESCRIPTION
## Summary
- A subscription with a scheduled cancellation (`CancelAtPeriodEnd = true`) stayed `Active` while still offering Change plan, which priced the change as if it would renew: an upgrade charged a full new period and silently pushed the cancellation date out; a downgrade was scheduled for a renewal that never comes; and at the boundary the renewal sweep and cancellation sweep could race, charging a cancelled subscription.
- Server now refuses plan and quantity changes (`subscription_cancellation_scheduled`, surfaced as a preview blocker for plan changes) while a cancellation is scheduled, and adds a new operation to undo a scheduled cancellation (`DELETE subscriptions/{id}/cancellation`), restoring the renewal it cleared.
- Simulation console: the current-subscription card now shows a "Cancellation scheduled" banner with a "Keep subscription" action instead of a bare status line, and the Change plan dialog shows an "Undo cancellation" notice with Preview/Confirm disabled until it's cleared.

## Test plan
- [x] `dotnet test server/XUnitTest --filter "SubscriptionPlanChangeService|SubscriptionCancellationService|SubscriptionQuantityChange"` — passing
- [x] `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName!~Integration"` — 3843 passed, 0 failed (Mongo integration tests need a live DB and are unaffected by this change)
- [x] `npm run test` for `change-plan-dialog.test.tsx` and `current-subscription-card.test.tsx` — 29 passed
- [x] `npm run type-check` — clean
- [x] `npm run lint` — no new issues (pre-existing issues in unrelated files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)