### PR TITLE
feat(subscription): publish entitlement terms for direct-Mongo readers

### DIFF
--- a/server/Subscription.DomainService/Entities/SubscriptionEntitlementsCurrent.cs
+++ b/server/Subscription.DomainService/Entities/SubscriptionEntitlementsCurrent.cs
@@ -1,0 +1,97 @@
+using MongoDB.Bson.Serialization.Attributes;
+using Subscription.DomainService.Enums;
+
+namespace Subscription.DomainService.Entities;
+
+/// <summary>
+/// The published entitlement terms of one subscription, shaped for reading.
+/// </summary>
+/// <remarks>
+/// A denormalized copy of <see cref="Plan.Entitlements"/> and <see cref="Plan.FeaturesJson"/>,
+/// published whenever <see cref="IUsageProjectionPublisher.RefreshAsync"/> runs — the same trigger
+/// that keeps <see cref="SubscriptionUsageCurrent"/> current, for the same reason: it lets a consumer
+/// with no API access, only read access to Mongo, answer "what can this subscription do?" with one
+/// point read instead of resolving the subscription and joining its plan.
+/// <para>
+/// One row per subscription, not per meter: an entitlement's terms — its key, its kind, its cap —
+/// are plan-wide, and a plan with no metered entitlement at all still has to be discoverable here,
+/// which a field folded onto <see cref="SubscriptionUsageCurrent"/> could never be for such a plan.
+/// </para>
+/// <para>
+/// <b>It is not an authority and must never be used as one.</b> For a <see cref="EntitlementLimitKind.Count"/>
+/// entitlement the balance drawn against it lives on <see cref="SubscriptionUsageCurrent"/>, and only
+/// recording usage through the enforcement path settles a race over it. This document answers "what
+/// are the terms", never "how much is left" — a reader after that still needs the meter's own
+/// projection, or the API, for the balance.
+/// </para>
+/// </remarks>
+[BsonIgnoreExtraElements]
+public sealed class SubscriptionEntitlementsCurrent
+{
+    /// <summary>The subscription's own id. One document per subscription.</summary>
+    [BsonId]
+    public string ItemId { get; set; } = string.Empty;
+
+    public string TenantId { get; set; } = string.Empty;
+
+    public string OrganizationId { get; set; } = string.Empty;
+
+    public string SubscriptionId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The subscription's status when this was published, so a reader can tell a live grant from
+    /// one frozen by cancellation without joining to the subscription.
+    /// </summary>
+    public SubscriptionStatus SubscriptionStatus { get; set; }
+
+    public string PlanId { get; set; } = string.Empty;
+
+    public string PlanCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The plan's own feature bag, verbatim. Stored, versioned and served; never interpreted here —
+    /// see <see cref="Plan.FeaturesJson"/>. This is what lets one product ship flags another has
+    /// never heard of, for a reader with no API to ask.
+    /// </summary>
+    public string? FeaturesJson { get; set; }
+
+    /// <summary>Every entitlement the plan grants, in plan order.</summary>
+    public List<SubscriptionEntitlementCurrentItem> Entitlements { get; set; } = [];
+
+    /// <summary>
+    /// <c>SubscriptionDetail.Version</c> at the moment this was published.
+    /// </summary>
+    /// <remarks>
+    /// The whole ordering story: unlike <see cref="SubscriptionUsageCurrent"/>, there is only one
+    /// version here, because this document carries nothing a metered recording ever moves — only
+    /// terms the subscription's own version already governs.
+    /// </remarks>
+    public long SubscriptionVersion { get; set; }
+
+    /// <summary>
+    /// The shape of this document, so a consumer reading it directly can refuse an unfamiliar one
+    /// rather than silently misread a field that changed meaning.
+    /// </summary>
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+    public DateTime UpdatedAtUtc { get; set; }
+
+    public const int CurrentSchemaVersion = 1;
+}
+
+/// <summary>One entitlement's terms, copied from <see cref="PlanEntitlement"/>.</summary>
+public sealed class SubscriptionEntitlementCurrentItem
+{
+    /// <summary>The product's own key, such as <c>pep_screening</c>. Never interpreted here.</summary>
+    public string Key { get; set; } = string.Empty;
+
+    public EntitlementLimitKind LimitKind { get; set; }
+
+    /// <summary>The cap, when the kind is a count. Never a balance — see this type's remarks.</summary>
+    public decimal? Limit { get; set; }
+
+    /// <summary>The meter that draws this entitlement down, when the kind is a count.</summary>
+    public string? MeterKey { get; set; }
+
+    public string? UnitLabel { get; set; }
+}

--- a/server/Subscription.DomainService/Repositories/ISubscriptionEntitlementsCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/ISubscriptionEntitlementsCurrentRepository.cs
@@ -1,0 +1,29 @@
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+/// <summary>
+/// The published entitlement-terms projection. See <see cref="SubscriptionEntitlementsCurrent"/>.
+/// </summary>
+public interface ISubscriptionEntitlementsCurrentRepository
+{
+    Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Publishes one subscription's entitlement terms, unless a newer version is already stored.
+    /// </summary>
+    /// <remarks>
+    /// Conditional on <see cref="SubscriptionEntitlementsCurrent.SubscriptionVersion"/> being newer
+    /// than what is stored, the same reasoning <c>ISubscriptionUsageCurrentRepository.TryPublishAsync</c>
+    /// applies: the highest version wins rather than the last writer, so a refresh delayed behind a
+    /// later plan change cannot overwrite it with older terms.
+    /// </remarks>
+    Task<bool> TryPublishAsync(
+        SubscriptionEntitlementsCurrent document,
+        CancellationToken cancellationToken);
+
+    Task<SubscriptionEntitlementsCurrent?> GetAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionCollections.cs
@@ -30,6 +30,12 @@ internal static class SubscriptionCollections
     /// hand it the enforcement authority for metered billing.
     /// </remarks>
     public const string UsageCurrent = "SubscriptionUsageCurrent";
+
+    /// <summary>
+    /// The published entitlement-terms projection, read directly by consumers outside this service.
+    /// See <see cref="Entities.SubscriptionEntitlementsCurrent"/>.
+    /// </summary>
+    public const string EntitlementsCurrent = "SubscriptionEntitlementsCurrent";
     public const string PaymentLinks = "SubscriptionPaymentLinks";
     public const string UsageInvoices = "SubscriptionUsageInvoices";
     public const string AuditEvents = "SubscriptionAuditEvents";

--- a/server/Subscription.DomainService/Repositories/SubscriptionEntitlementsCurrentRepository.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionEntitlementsCurrentRepository.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using Blocks.Genesis;
+using MongoDB.Driver;
+using Subscription.DomainService.Entities;
+
+namespace Subscription.DomainService.Repositories;
+
+public sealed class SubscriptionEntitlementsCurrentRepository : ISubscriptionEntitlementsCurrentRepository
+{
+    private readonly IDbContextProvider _dbContextProvider;
+    private readonly ConcurrentDictionary<string, byte> _indexedTenants = new();
+
+    public SubscriptionEntitlementsCurrentRepository(IDbContextProvider dbContextProvider) =>
+        _dbContextProvider = dbContextProvider;
+
+    public async Task EnsureIndexesAsync(string tenantId, CancellationToken cancellationToken)
+    {
+        if (_indexedTenants.ContainsKey(tenantId))
+        {
+            return;
+        }
+
+        await Current(tenantId).Indexes.CreateManyAsync(
+            SubscriptionIndexDefinitions.CreateEntitlementsCurrentIndexes(),
+            cancellationToken);
+
+        _indexedTenants.TryAdd(tenantId, 0);
+    }
+
+    public async Task<bool> TryPublishAsync(
+        SubscriptionEntitlementsCurrent document,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        await EnsureIndexesAsync(document.TenantId, cancellationToken);
+
+        var collection = Current(document.TenantId);
+
+        // One version to order by, so a plain conditional replace suffices -- unlike the usage
+        // projection, nothing here moves on any track but the subscription's own version.
+        var filter = Builders<SubscriptionEntitlementsCurrent>.Filter.And(
+            Builders<SubscriptionEntitlementsCurrent>.Filter.Eq(
+                current => current.ItemId,
+                document.ItemId),
+            Builders<SubscriptionEntitlementsCurrent>.Filter.Lt(
+                current => current.SubscriptionVersion,
+                document.SubscriptionVersion));
+
+        var result = await collection.ReplaceOneAsync(
+            filter,
+            document,
+            cancellationToken: cancellationToken);
+
+        if (result.ModifiedCount == 1)
+        {
+            return true;
+        }
+
+        try
+        {
+            await collection.InsertOneAsync(document, cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (MongoWriteException exception)
+            when (exception.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Somebody published between the replace above and this insert. One more try, since it
+            // may now have something newer to contribute; if it does not, it correctly changes
+            // nothing.
+            var retried = await collection.ReplaceOneAsync(
+                filter,
+                document,
+                cancellationToken: cancellationToken);
+
+            return retried.ModifiedCount == 1;
+        }
+    }
+
+    public async Task<SubscriptionEntitlementsCurrent?> GetAsync(
+        string tenantId,
+        string subscriptionId,
+        CancellationToken cancellationToken) =>
+        await Current(tenantId)
+            .Find(Builders<SubscriptionEntitlementsCurrent>.Filter.Eq(
+                current => current.ItemId,
+                subscriptionId))
+            .FirstOrDefaultAsync(cancellationToken);
+
+    private IMongoCollection<SubscriptionEntitlementsCurrent> Current(string tenantId) =>
+        SubscriptionCollections.Of<SubscriptionEntitlementsCurrent>(
+            _dbContextProvider,
+            tenantId,
+            SubscriptionCollections.EntitlementsCurrent);
+}

--- a/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
+++ b/server/Subscription.DomainService/Repositories/SubscriptionIndexDefinitions.cs
@@ -436,6 +436,24 @@ public static class SubscriptionIndexDefinitions
             })
     ];
 
+    public const string EntitlementsCurrentReadIndexName =
+        "ix_entitlements_current_org_subscription";
+
+    /// <summary>
+    /// The entitlement-terms projection's index. One document per subscription, addressed by its
+    /// own <c>_id</c>, so the only other query shape a direct consumer needs is the
+    /// organization-scoped one this covers.
+    /// </summary>
+    public static IReadOnlyCollection<CreateIndexModel<SubscriptionEntitlementsCurrent>>
+        CreateEntitlementsCurrentIndexes() =>
+    [
+        new(
+            Builders<SubscriptionEntitlementsCurrent>.IndexKeys
+                .Ascending(current => current.OrganizationId)
+                .Ascending(current => current.SubscriptionId),
+            new CreateIndexOptions { Name = EntitlementsCurrentReadIndexName })
+    ];
+
     public const string UsagePeriodClaimLookupIndexName =
         "ix_usage_period_claim_tenant_subscription_period";
     public const string UsagePeriodClaimRecoveryIndexName =

--- a/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
+++ b/server/Subscription.DomainService/Services/UsageProjectionPublisher.cs
@@ -21,6 +21,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
     private readonly IOptionsMonitor<SubscriptionOptions> _options;
     private readonly ILogger<UsageProjectionPublisher> _logger;
     private readonly TimeProvider _time;
+    private readonly ISubscriptionEntitlementsCurrentRepository? _entitlements;
 
     public UsageProjectionPublisher(
         ISubscriptionUsageCurrentRepository current,
@@ -30,7 +31,11 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         IOptionsMonitor<SubscriptionOptions> options,
         ILogger<UsageProjectionPublisher> logger,
         TimeProvider? time = null,
-        UsageProjectionMetrics? metrics = null)
+        UsageProjectionMetrics? metrics = null,
+        // Optional, like every collaborator threaded through this class: a caller or test that
+        // constructs this publisher unaware the entitlements projection exists must keep compiling
+        // and keep behaving as before.
+        ISubscriptionEntitlementsCurrentRepository? entitlements = null)
     {
         _current = current;
         _usage = usage;
@@ -40,6 +45,7 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         _logger = logger;
         _time = time ?? TimeProvider.System;
         _metrics = metrics ?? UsageProjectionMetrics.Shared;
+        _entitlements = entitlements;
     }
 
     public async Task<UsageProjectionOutcome> PublishAsync(
@@ -255,6 +261,10 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         // than only of what the plan currently implies.
         published += await ReconcileStoredRowsAsync(subscription, windows, correlationId, cancellationToken);
 
+        // Unconditional on windows.Count: a plan with no metered entitlement at all has no window
+        // to piggyback this on, and would otherwise never get an entitlements row published.
+        await PublishEntitlementsAsync(subscription, correlationId, cancellationToken);
+
         if (windows.Count == 0 && published == 0)
         {
             return 0;
@@ -428,6 +438,69 @@ public sealed class UsageProjectionPublisher : IUsageProjectionPublisher
         UpdatedAtUtc = _time.GetUtcNow().UtcDateTime,
         ExpiresAtUtc = row.ExpiresAtUtc
     };
+
+    /// <summary>
+    /// Publishes this subscription's entitlement terms, so a direct-Mongo reader can see them
+    /// without an API call. Best-effort: this is a read model derived entirely from the
+    /// subscription already in hand, so a write failure here must not fail the refresh that is
+    /// keeping the usage projection itself current.
+    /// </summary>
+    private async Task PublishEntitlementsAsync(
+        SubscriptionDetail subscription,
+        string correlationId,
+        CancellationToken cancellationToken)
+    {
+        if (_entitlements is null)
+        {
+            return;
+        }
+
+        var document = new SubscriptionEntitlementsCurrent
+        {
+            ItemId = subscription.ItemId,
+            TenantId = subscription.TenantId,
+            OrganizationId = subscription.OrganizationId,
+            SubscriptionId = subscription.ItemId,
+            SubscriptionStatus = subscription.Status,
+            PlanId = subscription.Plan.PlanId,
+            PlanCode = subscription.Plan.Code,
+            FeaturesJson = subscription.Plan.FeaturesJson,
+            Entitlements = subscription.Plan.Entitlements
+                .Select(entitlement => new SubscriptionEntitlementCurrentItem
+                {
+                    Key = entitlement.Key,
+                    LimitKind = entitlement.LimitKind,
+                    Limit = entitlement.Limit,
+                    MeterKey = entitlement.MeterKey,
+                    UnitLabel = entitlement.UnitLabel
+                })
+                .ToList(),
+            SubscriptionVersion = subscription.Version,
+            SchemaVersion = SubscriptionEntitlementsCurrent.CurrentSchemaVersion,
+            UpdatedAtUtc = _time.GetUtcNow().UtcDateTime
+        };
+
+        try
+        {
+            await WithTransientRetryAsync(
+                () => _entitlements.TryPublishAsync(document, cancellationToken),
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Failed to publish the entitlements projection; the next refresh will retry " +
+                "TenantHash={TenantHash} SubscriptionHash={SubscriptionHash} CorrelationId={CorrelationId}",
+                PaymentLogValue.Hash(subscription.TenantId),
+                PaymentLogValue.Hash(subscription.ItemId),
+                correlationId);
+        }
+    }
 
     /// <summary>
     /// Every meter's window containing <paramref name="asOfUtc"/>.

--- a/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
+++ b/server/Subscription.DomainService/Utilities/ApplicationServiceCollectionExtensions.cs
@@ -77,6 +77,9 @@ public static class ApplicationServiceCollectionExtensions
             ISubscriptionUsageCurrentRepository,
             SubscriptionUsageCurrentRepository>();
         services.AddSingleton<
+            ISubscriptionEntitlementsCurrentRepository,
+            SubscriptionEntitlementsCurrentRepository>();
+        services.AddSingleton<
             ISubscriptionPaymentLinkRepository,
             SubscriptionPaymentLinkRepository>();
         services.AddSingleton<

--- a/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
+++ b/server/XUnitTest/Subscription/UsageProjectionPublisherTests.cs
@@ -28,11 +28,13 @@ public sealed class UsageProjectionPublisherTests
     private readonly Mock<ISubscriptionUsageCurrentRepository> _current = new();
     private readonly Mock<ISubscriptionUsageRepository> _usage = new();
     private readonly Mock<ISubscriptionWorkScheduler> _scheduler = new();
+    private readonly Mock<ISubscriptionEntitlementsCurrentRepository> _entitlements = new();
     private readonly ControlledTimeProvider _time =
         new(new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero));
 
     private readonly List<SubscriptionUsageCurrent> _published = [];
     private readonly List<SubscriptionUsageCurrent> _seeded = [];
+    private readonly List<SubscriptionEntitlementsCurrent> _publishedEntitlements = [];
 
     public UsageProjectionPublisherTests()
     {
@@ -67,6 +69,13 @@ public sealed class UsageProjectionPublisherTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((0L, 0L));
+
+        _entitlements
+            .Setup(repository => repository.TryPublishAsync(
+                It.IsAny<SubscriptionEntitlementsCurrent>(), It.IsAny<CancellationToken>()))
+            .Callback((SubscriptionEntitlementsCurrent document, CancellationToken _) =>
+                _publishedEntitlements.Add(document))
+            .ReturnsAsync(true);
     }
 
     [Fact]
@@ -290,6 +299,49 @@ public sealed class UsageProjectionPublisherTests
             repository => repository.GetCounterAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    /// <summary>
+    /// So a direct-Mongo reader can answer "what can this subscription do" without an API call — the
+    /// same reasoning the usage projection exists for, applied to entitlement terms rather than
+    /// meter balances.
+    /// </summary>
+    [Fact]
+    public async Task Refreshing_publishes_the_plans_entitlements_and_features()
+    {
+        await Publisher().RefreshAsync(
+            Subscription(), _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        var document = _publishedEntitlements.Should().ContainSingle().Subject;
+        document.ItemId.Should().Be("sub-1");
+        document.SubscriptionId.Should().Be("sub-1");
+        document.PlanCode.Should().Be("pro");
+        document.FeaturesJson.Should().Be("""{"advancedReporting":true}""");
+        document.Entitlements.Should().HaveCount(2);
+        document.Entitlements.Should().Contain(entitlement =>
+            entitlement.Key == "screening" &&
+            entitlement.LimitKind == EntitlementLimitKind.Count &&
+            entitlement.Limit == 100 &&
+            entitlement.MeterKey == "screening");
+        document.Entitlements.Should().Contain(entitlement =>
+            entitlement.Key == "sso" &&
+            entitlement.LimitKind == EntitlementLimitKind.Boolean);
+    }
+
+    /// <summary>
+    /// A plan whose only entitlements are boolean has no metered window to piggyback this on, so the
+    /// publish must not be conditioned on <c>CurrentWindows</c> yielding anything.
+    /// </summary>
+    [Fact]
+    public async Task A_subscription_with_no_meters_still_gets_its_entitlements_published()
+    {
+        var subscription = Subscription();
+        subscription.Plan.Meters.Clear();
+
+        await Publisher().RefreshAsync(
+            subscription, _time.GetUtcNow().UtcDateTime, "corr-1", CancellationToken.None);
+
+        _publishedEntitlements.Should().ContainSingle();
     }
 
     /// <summary>
@@ -630,7 +682,8 @@ public sealed class UsageProjectionPublisherTests
         _scheduler.Object,
         new OptionsStub(),
         NullLogger<UsageProjectionPublisher>.Instance,
-        _time);
+        _time,
+        entitlements: _entitlements.Object);
 
     private static SubscriptionUsageCounter Counter(
         long balance,
@@ -674,6 +727,7 @@ public sealed class UsageProjectionPublisherTests
         {
             PlanId = "plan-1",
             Code = "pro",
+            FeaturesJson = """{"advancedReporting":true}""",
             Meters =
             [
                 Meter(),
@@ -684,6 +738,22 @@ public sealed class UsageProjectionPublisherTests
                     IncludedQuantity = 500,
                     OverageAllowed = false,
                     ResetPolicy = MeterResetPolicy.Never
+                }
+            ],
+            Entitlements =
+            [
+                new PlanEntitlement
+                {
+                    Key = "screening",
+                    LimitKind = EntitlementLimitKind.Count,
+                    Limit = 100,
+                    MeterKey = "screening",
+                    UnitLabel = "screening"
+                },
+                new PlanEntitlement
+                {
+                    Key = "sso",
+                    LimitKind = EntitlementLimitKind.Boolean
                 }
             ]
         },


### PR DESCRIPTION
## Summary
- Follows up on the discussion around `SubscriptionUsageCurrent`: the requirement was to let a direct-Mongo reader (no API access) see a subscription's entitlement keys and the plan's feature bag without an API call.
- `SubscriptionUsageCurrent` is keyed per `(subscription, meter, period)`, so it can't carry this alone: a plan with no metered entitlement has no row at all, and a plan that does would need every entitlement duplicated onto every meter's row just to make them discoverable.
- Adds a sibling projection, `SubscriptionEntitlementsCurrent` — one row per subscription, carrying the plan's entitlement keys, limit kinds, capped limits, the meter key each count entitlement draws down, and the plan's `FeaturesJson` bag verbatim.
- Published from inside `UsageProjectionPublisher.RefreshAsync`, the same method that already keeps the usage projection current, so it rides every existing trigger (activation, cancellation, plan change, the repair sweep, the backfill) with **no new call sites** — including the free/card-free-trial path fixed in #491. Publish is unconditional on the subscription having any metered window at all, so a plan with only boolean entitlements still gets a row. Best-effort: a publish failure here is logged and does not fail the caller.
- New collection `SubscriptionEntitlementsCurrent`, one index (`OrganizationId`, `SubscriptionId`). Ordered by `SubscriptionVersion` alone — unlike the usage projection there is only one version track here, since nothing metered ever moves this document.
- This document is not an authority for a metered entitlement's balance — that stays on `SubscriptionUsageCurrent` / the enforcement path. It only answers "what are the terms."

## Test plan
- [x] Added `Refreshing_publishes_the_plans_entitlements_and_features` and `A_subscription_with_no_meters_still_gets_its_entitlements_published` to `UsageProjectionPublisherTests`
- [x] `dotnet test server/XUnitTest/XUnitTest.csproj --filter "FullyQualifiedName~UsageProjectionPublisherTests"` — 22/22 passed
- [x] `dotnet build server/Subscription.DomainService/Subscription.DomainService.csproj` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)